### PR TITLE
WIP: containInAnyOrderOnly assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,7 +1197,6 @@ Some assertion functions which I miss myself will follow in the next version.
 They are listed in the [Roadmap](#roadmap) below.
 
 Atrium does not support (yet):
-- contains assertion functions for `Map` (you can use `assert(map.entries)` in the meantime -- or `keys`/`values` if your assertion is only about keys or values)
 - infinite `Iterable`s
 
 # FAQ

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-common/src/main/kotlin/ch/tutteli/atrium/api/cc/de_CH/mapAssertions.kt
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-common/src/main/kotlin/ch/tutteli/atrium/api/cc/de_CH/mapAssertions.kt
@@ -49,7 +49,7 @@ inline fun <K, reified V: Any, T: Map<K, V?>> Assert<T>.enthaeltNullable(entry: 
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-fun <K, V : Any, T: Map<K, V>> Assert<T>.enthaeltInEinOrdnenNur(entry: Pair<K, V>, vararg otherEntries: Pair<K, V>)
+fun <K, V : Any, T: Map<K, V>> Assert<T>.enthaeltInBeliebigerReihenfolgeNur(entry: Pair<K, V>, vararg otherEntries: Pair<K, V>)
     = addAssertion(AssertImpl.map.containsInAnyOrderOnly(this, entry glue otherEntries))
 
 
@@ -62,7 +62,7 @@ fun <K, V : Any, T: Map<K, V>> Assert<T>.enthaeltInEinOrdnenNur(entry: Pair<K, V
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-inline fun <K, reified V: Any, T: Map<K, V?>> Assert<T>.enthaeltInEinOrdnenNurNullable(entry: Pair<K, V?>, vararg otherEntries: Pair<K, V?>)
+inline fun <K, reified V: Any, T: Map<K, V?>> Assert<T>.enthaeltInBeliebigerReihenfolgeNurNullable(entry: Pair<K, V?>, vararg otherEntries: Pair<K, V?>)
     = addAssertion(AssertImpl.map.containsInAnyOrderOnlyNullable(this, V::class, entry glue otherEntries))
 
 /**

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-common/src/main/kotlin/ch/tutteli/atrium/api/cc/de_CH/mapAssertions.kt
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-common/src/main/kotlin/ch/tutteli/atrium/api/cc/de_CH/mapAssertions.kt
@@ -39,6 +39,32 @@ fun <K, V : Any, T: Map<K, V>> Assert<T>.enthaelt(entry: Pair<K, V>, vararg othe
 inline fun <K, reified V: Any, T: Map<K, V?>> Assert<T>.enthaeltNullable(entry: Pair<K, V?>, vararg otherEntries: Pair<K, V?>)
     = addAssertion(AssertImpl.map.containsNullable(this, V::class, entry glue otherEntries))
 
+
+/**
+ * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains a key as defined by [keyValuePair]'s [Pair.first]
+ * with a corresponding value as defined by [keyValuePair]'s [Pair.second] -- optionally the same assertions
+ * are created for the [otherPairs] and asserts that [Assert.subject][AssertionPlant.subject] contains only keys defined
+ * in [keyValuePair], [otherPairs]
+ *
+ * @return This plant to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+fun <K, V : Any, T: Map<K, V>> Assert<T>.enthaeltInEinOrdnenNur(entry: Pair<K, V>, vararg otherEntries: Pair<K, V>)
+    = addAssertion(AssertImpl.map.containsInAnyOrderOnly(this, entry glue otherEntries))
+
+
+/**
+ * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains a key as defined by [keyValuePair]'s [Pair.first]
+ * with a corresponding value as defined by [keyValuePair]'s [Pair.second] -- optionally the same assertions
+ * are created for the [otherPairs] and asserts that [Assert.subject][AssertionPlant.subject] contains only keys defined
+ * in [keyValuePair], [otherPairs]
+ *
+ * @return This plant to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+inline fun <K, reified V: Any, T: Map<K, V?>> Assert<T>.enthaeltInEinOrdnenNurNullable(entry: Pair<K, V?>, vararg otherEntries: Pair<K, V?>)
+    = addAssertion(AssertImpl.map.containsInAnyOrderOnlyNullable(this, V::class, entry glue otherEntries))
+
 /**
  * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains a key as defined by [keyValue]'s [KeyValue.key]
  * with a corresponding value which holds all assertions [keyValue]'s [KeyValue.valueAssertionCreator] might create.

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/de_CH/MapAssertionsSpec.kt
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/de_CH/MapAssertionsSpec.kt
@@ -10,8 +10,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     AssertionVerbFactory,
     containsFun.name to Assert<Map<String, Int>>::enthaelt,
     containsNullableFun.name to Assert<Map<String?, Int?>>::enthaeltNullable,
-    containsInAnyOrderOnlyFun.name to Assert<Map<String, Int>>::enthaeltInEinOrdnenNur,
-    containsInAnyOrderOnlyNullableFun.name to Assert<Map<String?, Int?>>::enthaeltInEinOrdnenNurNullable,
+    containsInAnyOrderOnlyFun.name to Assert<Map<String, Int>>::enthaeltInBeliebigerReihenfolgeNur,
+    containsInAnyOrderOnlyNullableFun.name to Assert<Map<String?, Int?>>::enthaeltInBeliebigerReihenfolgeNurNullable,
     "${containsKeyWithValueAssertionsFun.name} ${KeyValue::class.simpleName}" to Assert<Map<String, Int>>::enthaelt,
     "${containsKeyWithNullableValueAssertionsFun.name} ${KeyNullableValue::class.simpleName}" to Assert<Map<String?, Int?>>::enthaeltNullable,
     Assert<Map<String, *>>::enthaeltKey.name to Assert<Map<String, *>>::enthaeltKey,
@@ -25,8 +25,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     companion object {
         private val containsFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaelt
         private val containsNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltNullable
-        private val containsInAnyOrderOnlyFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaeltInEinOrdnenNur
-        private val containsInAnyOrderOnlyNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltInEinOrdnenNurNullable
+        private val containsInAnyOrderOnlyFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaeltInBeliebigerReihenfolgeNur
+        private val containsInAnyOrderOnlyNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltInBeliebigerReihenfolgeNurNullable
         private val containsKeyWithValueAssertionsFun : KFunction3<Assert<Map<String, Int>>, KeyValue<String, Int>, Array<out KeyValue<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaelt
         private val containsKeyWithNullableValueAssertionsFun : KFunction3<Assert<Map<String?, Int?>>, KeyNullableValue<String?, Int>, Array<out KeyNullableValue<String?, Int>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltNullable
     }

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/de_CH/MapAssertionsSpec.kt
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/de_CH/MapAssertionsSpec.kt
@@ -10,6 +10,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     AssertionVerbFactory,
     containsFun.name to Assert<Map<String, Int>>::enthaelt,
     containsNullableFun.name to Assert<Map<String?, Int?>>::enthaeltNullable,
+    containsInAnyOrderOnlyFun.name to Assert<Map<String, Int>>::enthaeltInEinOrdnenNur,
+    containsInAnyOrderOnlyNullableFun.name to Assert<Map<String?, Int?>>::enthaeltInEinOrdnenNurNullable,
     "${containsKeyWithValueAssertionsFun.name} ${KeyValue::class.simpleName}" to Assert<Map<String, Int>>::enthaelt,
     "${containsKeyWithNullableValueAssertionsFun.name} ${KeyNullableValue::class.simpleName}" to Assert<Map<String?, Int?>>::enthaeltNullable,
     Assert<Map<String, *>>::enthaeltKey.name to Assert<Map<String, *>>::enthaeltKey,
@@ -23,6 +25,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     companion object {
         private val containsFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaelt
         private val containsNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltNullable
+        private val containsInAnyOrderOnlyFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaeltInEinOrdnenNur
+        private val containsInAnyOrderOnlyNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltInEinOrdnenNurNullable
         private val containsKeyWithValueAssertionsFun : KFunction3<Assert<Map<String, Int>>, KeyValue<String, Int>, Array<out KeyValue<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::enthaelt
         private val containsKeyWithNullableValueAssertionsFun : KFunction3<Assert<Map<String?, Int?>>, KeyNullableValue<String?, Int>, Array<out KeyNullableValue<String?, Int>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::enthaeltNullable
     }

--- a/apis/cc-en_GB/atrium-api-cc-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/en_GB/mapAssertions.kt
+++ b/apis/cc-en_GB/atrium-api-cc-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/en_GB/mapAssertions.kt
@@ -72,6 +72,30 @@ inline fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsNullable(keyVal
     = addAssertion(AssertImpl.map.containsKeyWithNullableValueAssertions(this, V::class, keyValue glue otherKeyValues))
 
 /**
+ * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains a key as defined by [keyValuePair]'s [Pair.first]
+ * with a corresponding value as defined by [keyValuePair]'s [Pair.second] -- optionally the same assertions
+ * are created for the [otherPairs] and asserts that [Assert.subject][AssertionPlant.subject] contains only keys defined
+ * in [keyValuePair], [otherPairs]
+ *
+ * @return This plant to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+fun <K, V : Any, T: Map<K, V>> Assert<T>.containsInAnyOrderOnly(keyValuePair: Pair<K, V>, vararg otherPairs: Pair<K, V>)
+    = addAssertion(AssertImpl.map.containsInAnyOrderOnly(this, keyValuePair glue otherPairs))
+
+/**
+ * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains a key as defined by [keyValuePair]'s [Pair.first]
+ * with a corresponding value as defined by [keyValuePair]'s [Pair.second] -- optionally the same assertions
+ * are created for the [otherPairs] and asserts that [Assert.subject][AssertionPlant.subject] contains only keys defined
+ * in [keyValuePair], [otherPairs]
+ *
+ * @return This plant to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+inline fun <K, reified V: Any, T: Map<K, V?>> Assert<T>.containsInAnyOrderOnlyNullable(keyNullableValuePair: Pair<K, V?>, vararg otherEntries: Pair<K, V?>)
+    = addAssertion(AssertImpl.map.containsInAnyOrderOnlyNullable(this, V::class, keyNullableValuePair glue otherEntries))
+
+/**
  * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains the given [key].
  *
  * @return This plant to support a fluent API.

--- a/apis/cc-en_GB/atrium-api-cc-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/en_GB/MapAssertionsSpec.kt
+++ b/apis/cc-en_GB/atrium-api-cc-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/en_GB/MapAssertionsSpec.kt
@@ -10,6 +10,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     AssertionVerbFactory,
     containsFun.name to Assert<Map<String, Int>>::contains,
     containsNullableFun.name to Assert<Map<String?, Int?>>::containsNullable,
+    containsInAnyOrderOnlyFun.name to Assert<Map<String, Int>>::containsInAnyOrderOnly,
+    containsInAnyOrderOnlyNullableFun.name to Assert<Map<String?, Int?>>::containsInAnyOrderOnlyNullable,
     "${containsKeyWithValueAssertionsFun.name} ${KeyValue::class.simpleName}" to Assert<Map<String, Int>>::contains,
     "${containsKeyWithNullableValueAssertionsFun.name} ${KeyNullableValue::class.simpleName}" to Assert<Map<String?, Int?>>::containsNullable,
     Assert<Map<String, *>>::containsKey.name to Assert<Map<String, *>>::containsKey,
@@ -23,6 +25,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     companion object {
         private val containsFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::contains
         private val containsNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::containsNullable
+        private val containsInAnyOrderOnlyFun : KFunction3<Assert<Map<String, Int>>, Pair<String, Int>, Array<out Pair<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::containsInAnyOrderOnly
+        private val containsInAnyOrderOnlyNullableFun : KFunction3<Assert<Map<String?, Int?>>, Pair<String?, Int?>, Array<out Pair<String?, Int?>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::containsInAnyOrderOnlyNullable
         private val containsKeyWithValueAssertionsFun : KFunction3<Assert<Map<String, Int>>, KeyValue<String, Int>, Array<out KeyValue<String, Int>>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::contains
         private val containsKeyWithNullableValueAssertionsFun : KFunction3<Assert<Map<String?, Int?>>, KeyNullableValue<String?, Int>, Array<out KeyNullableValue<String?, Int>>, Assert<Map<String?, Int?>>> = Assert<Map<String?, Int?>>::containsNullable
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/mapAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/mapAssertions.kt
@@ -36,6 +36,8 @@ infix fun <K, V : Any, T: Map<K, V>> Assert<T>.contains(keyValuePair: Pair<K, V>
 infix fun <K, V : Any, T: Map<K, V>> Assert<T>.contains(keyValuePairs: Pairs<K, V>)
     = addAssertion(AssertImpl.map.contains(this, keyValuePairs.toList()))
 
+
+
 /**
  * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains a key as defined by [keyValuePair]'s [Pair.first]
  * with a corresponding value as defined by [keyValuePair]'s [Pair.second].
@@ -110,6 +112,27 @@ inline infix fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsNullable(
  */
 inline infix fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsNullable(keyValues: All<KeyNullableValue<K, V>>)
     = addAssertion(AssertImpl.map.containsKeyWithNullableValueAssertions(this, V::class, keyValues.toList()))
+
+/**
+ * Makes the assertion that [Assert.subject][AssertionPlant.subject] only contains keys as defined by [keyValuePairs]'s [Pair.first]
+ * with a corresponding values as defined by [keyValuePairs]'s [Pair.second].
+ *
+ *
+ * @return This plant to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+infix fun <K, V : Any, T: Map<K, V>> Assert<T>.containsInAnyOrderOnly(keyValuePairs: List<Pair<K, V>>)
+    =addAssertion(AssertImpl.map.containsInAnyOrderOnly(this, keyValuePairs.toList()))
+
+/**
+ * Makes the assertion that [Assert.subject][AssertionPlant.subject] only contains keys as defined by [keyValuePairs]'s [Pair.first]
+ * with a corresponding values as defined by [keyValuePairs]'s [Pair.second].
+ *
+ * @return This plant to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+inline infix fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsInAnyOrderOnlyNullable(keyValuePairs: List<Pair<K, V?>>)
+    = addAssertion(AssertImpl.map.containsInAnyOrderOnlyNullable(this, V::class, keyValuePairs.toList()))
 
 /**
  * Makes the assertion that [Assert.subject][AssertionPlant.subject] contains the given [key].

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/mapAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/mapAssertions.kt
@@ -121,9 +121,8 @@ inline infix fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsNullable(
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-infix fun <K, V : Any, T: Map<K, V>> Assert<T>.containsInAnyOrderOnly(keyValuePairs: List<Pair<K, V>>)
-    =addAssertion(AssertImpl.map.containsInAnyOrderOnly(this, keyValuePairs.toList()))
-
+infix fun <K, V : Any, T: Map<K, V>> Assert<T>.containsInAnyOrderOnly(keyValuePairs: Pairs<K, V>)
+    = addAssertion(AssertImpl.map.containsInAnyOrderOnly(this, keyValuePairs.toList()))
 /**
  * Makes the assertion that [Assert.subject][AssertionPlant.subject] only contains keys as defined by [keyValuePairs]'s [Pair.first]
  * with a corresponding values as defined by [keyValuePairs]'s [Pair.second].
@@ -131,7 +130,7 @@ infix fun <K, V : Any, T: Map<K, V>> Assert<T>.containsInAnyOrderOnly(keyValuePa
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-inline infix fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsInAnyOrderOnlyNullable(keyValuePairs: List<Pair<K, V?>>)
+inline infix fun <K, reified V : Any, T: Map<K, V?>> Assert<T>.containsInAnyOrderOnlyNullable(keyValuePairs: Pairs<K, V?>)
     = addAssertion(AssertImpl.map.containsInAnyOrderOnlyNullable(this, V::class, keyValuePairs.toList()))
 
 /**

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/MapAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/MapAssertionsSpec.kt
@@ -7,10 +7,13 @@ import ch.tutteli.atrium.domain.creating.map.KeyValue
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import kotlin.reflect.KFunction2
 
+
 class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     AssertionVerbFactory,
     containsFun.name to Companion::contains,
     containsNullableFun.name to Companion::containsNullable,
+    Assert<Map<String, Int>>::containsInAnyOrderOnly.name to Companion::contains, //TODO FIX cant map to containsInAnyOrderOnly
+    Assert<Map<String, Int>>::containsInAnyOrderOnlyNullable.name to Companion::containsNullable, //TODO FIX cant map to containsInAnyOrderOnlyNullable
     "${containsKeyWithValueAssertionsFun.name} ${KeyValue::class.simpleName}" to Companion::containsKeyWithValueAssertions,
     "${containsKeyWithNullableValueAssertionsFun.name} ${KeyNullableValue::class.simpleName}" to Companion::containsKeyWithNullableValueAssertions,
     Assert<Map<String, Int>>::containsKey.name to Companion::containsKey,
@@ -39,6 +42,9 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
                 plant containsNullable Pairs(pair, *otherPairs)
             }
         }
+
+        private fun containsInAnyOrderOnly(plant: Assert<Map<String, Int>>, pairs: List<Pair<String, Int>>) = plant containsInAnyOrderOnly pairs
+        private fun containsInAnyOrderOnlyNullable(plant: Assert<Map<String, Int?>>, pairs: List<Pair<String, Int?>>) = plant containsInAnyOrderOnlyNullable  pairs
 
         private val containsKeyWithValueAssertionsFun : KFunction2<Assert<Map<String, Int>>, KeyValue<String, Int>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::contains
         private fun containsKeyWithValueAssertions(plant: Assert<Map<String, Int>>, keyValue: KeyValue<String, Int>, otherKeyValues: Array<out KeyValue<String, Int>>): Assert<Map<String, Int>> {

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/MapAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/MapAssertionsSpec.kt
@@ -12,8 +12,8 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
     AssertionVerbFactory,
     containsFun.name to Companion::contains,
     containsNullableFun.name to Companion::containsNullable,
-    Assert<Map<String, Int>>::containsInAnyOrderOnly.name to Companion::contains, //TODO FIX cant map to containsInAnyOrderOnly
-    Assert<Map<String, Int>>::containsInAnyOrderOnlyNullable.name to Companion::containsNullable, //TODO FIX cant map to containsInAnyOrderOnlyNullable
+    Assert<Map<String, Int>>::containsInAnyOrderOnly.name to Companion::containsInAnyOrderOnly,
+    Assert<Map<String, Int?>>::containsInAnyOrderOnlyNullable.name to Companion::containsInAnyOrderOnlyNullable,
     "${containsKeyWithValueAssertionsFun.name} ${KeyValue::class.simpleName}" to Companion::containsKeyWithValueAssertions,
     "${containsKeyWithNullableValueAssertionsFun.name} ${KeyNullableValue::class.simpleName}" to Companion::containsKeyWithNullableValueAssertions,
     Assert<Map<String, Int>>::containsKey.name to Companion::containsKey,
@@ -43,8 +43,11 @@ class MapAssertionsSpec : ch.tutteli.atrium.spec.integration.MapAssertionsSpec(
             }
         }
 
-        private fun containsInAnyOrderOnly(plant: Assert<Map<String, Int>>, pairs: List<Pair<String, Int>>) = plant containsInAnyOrderOnly pairs
-        private fun containsInAnyOrderOnlyNullable(plant: Assert<Map<String, Int?>>, pairs: List<Pair<String, Int?>>) = plant containsInAnyOrderOnlyNullable  pairs
+        private fun containsInAnyOrderOnly(plant: Assert<Map<String, Int>>, pair: Pair<String, Int>, otherPairs: Array<out Pair<String, Int>>)
+            = plant containsInAnyOrderOnly Pairs(pair, *otherPairs)
+
+        private fun containsInAnyOrderOnlyNullable(plant: Assert<Map<String?, Int?>>, pair: Pair<String?, Int?>, otherPairs: Array<out Pair<String?, Int?>>)
+            = plant containsInAnyOrderOnlyNullable  Pairs(pair, *otherPairs)
 
         private val containsKeyWithValueAssertionsFun : KFunction2<Assert<Map<String, Int>>, KeyValue<String, Int>, Assert<Map<String, Int>>> = Assert<Map<String, Int>>::contains
         private fun containsKeyWithValueAssertions(plant: Assert<Map<String, Int>>, keyValue: KeyValue<String, Int>, otherKeyValues: Array<out KeyValue<String, Int>>): Assert<Map<String, Int>> {

--- a/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/MapAssertions.kt
+++ b/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/MapAssertions.kt
@@ -23,6 +23,8 @@ val mapAssertions by lazy { loadSingleService(MapAssertions::class) }
 interface MapAssertions {
     fun <K, V: Any> contains(plant: AssertionPlant<Map<K, V>>, keyValuePairs: List<Pair<K, V>>): Assertion
     fun <K, V: Any> containsNullable(plant: AssertionPlant<Map<K, V?>>, type: KClass<V>, keyValuePairs: List<Pair<K, V?>>): Assertion
+    fun <K, V: Any> containsInAnyOrderOnly(plant: AssertionPlant<Map<K, V>>, keyValuePairs: List<Pair<K, V>>): Assertion
+    fun <K, V: Any> containsInAnyOrderOnlyNullable(plant: AssertionPlant<Map<K, V?>>, type: KClass<V>, keyValuePairs: List<Pair<K, V?>>): Assertion
     fun <K, V: Any> containsKeyWithValueAssertions(plant: AssertionPlant<Map<K, V>>, keyValues: List<KeyValue<K, V>>): Assertion
     fun <K, V: Any> containsKeyWithNullableValueAssertions(plant: AssertionPlant<Map<K, V?>>, type: KClass<V>, keyValues: List<KeyNullableValue<K, V>>): Assertion
     fun <K> containsKey(plant: AssertionPlant<Map<K, *>>, key: K): Assertion

--- a/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/MapAssertionsBuilder.kt
+++ b/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/MapAssertionsBuilder.kt
@@ -31,6 +31,12 @@ object MapAssertionsBuilder : MapAssertions {
     override inline fun <K, V: Any> containsNullable(plant: AssertionPlant<Map<K, V?>>, type: KClass<V>, keyValuePairs: List<Pair<K, V?>>): Assertion
         = mapAssertions.containsNullable(plant, type, keyValuePairs)
 
+    override inline fun <K, V: Any> containsInAnyOrderOnly(plant: AssertionPlant<Map<K, V>>, keyValuePairs: List<Pair<K, V>>): Assertion
+        = mapAssertions.containsInAnyOrderOnly(plant, keyValuePairs)
+
+    override inline fun <K, V: Any> containsInAnyOrderOnlyNullable(plant: AssertionPlant<Map<K, V?>>, type: KClass<V>, keyValuePairs: List<Pair<K, V?>>): Assertion
+        = mapAssertions.containsInAnyOrderOnlyNullable(plant, type, keyValuePairs)
+
     override inline fun <K, V : Any> containsKeyWithValueAssertions(
         plant: AssertionPlant<Map<K, V>>,
         keyValues: List<KeyValue<K, V>>
@@ -41,6 +47,7 @@ object MapAssertionsBuilder : MapAssertions {
         type: KClass<V>,
         keyValues: List<KeyNullableValue<K, V>>
     ) = mapAssertions.containsKeyWithNullableValueAssertions(plant, type, keyValues)
+
 
     override inline fun <K> containsKey(plant: AssertionPlant<Map<K, *>>, key: K)
         = mapAssertions.containsKey(plant, key)

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/mapAssertions.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/mapAssertions.kt
@@ -139,7 +139,11 @@ private  fun <K, V, M, A : BaseAssertionPlant<V, A>, C : BaseCollectingAssertion
     }
     val onlyAssertions = listOf<Assertion>(AssertImpl
         .builder
-        .createDescriptive(DescriptionMapAssertion.MAP_CONTAINS_ONLY, plant.subject) { plant.subject.size <= pairs.size })
+        .list
+        .withDescriptionAndEmptyRepresentation(DescriptionMapAssertion.MAP_CONTAINS_ONLY)
+        .withAssertions(createMismatchAssertionsForInAnyOrderOnly(pairs, plant))
+        .build())
+       
 
     val assertions = keyValueAssertions.plus(onlyAssertions)
     AssertImpl.builder.list
@@ -185,6 +189,13 @@ private fun <K, V> createGetParameterObject(
         plant.subject[key] as V
     }
 )
+
+private fun <K, V> createMismatchAssertionsForInAnyOrderOnly(pairs: List<Pair<K, V>>, plant: AssertionPlant<Map<K, V>>) : List<Assertion> { // TODO check this implementation please
+    val pairsKeys = pairs.map { it.first }.toList()
+    return plant.subject.map {AssertImpl.builder
+        .createDescriptive(DescriptionMapAssertion.MAP_KEYS_MISMATCH, it.key) {pairsKeys.contains(it.key)}
+    }.toList()
+}
 
 fun _hasSize(plant: AssertionPlant<Map<*, *>>, size: Int): Assertion = AssertImpl.collector.collect(plant) {
     property(Map<*, *>::size) { toBe(size) }

--- a/domain/robstoll/atrium-domain-robstoll-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/MapAssertionsImpl.kt
+++ b/domain/robstoll/atrium-domain-robstoll-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/MapAssertionsImpl.kt
@@ -23,6 +23,15 @@ class MapAssertionsImpl : MapAssertions {
         keyValuePairs: List<Pair<K, V?>>
     ) = _containsNullable(plant, type, keyValuePairs)
 
+    override fun <K, V: Any> containsInAnyOrderOnly(plant: AssertionPlant<Map<K, V>>, keyValuePairs: List<Pair<K, V>>)
+        = _containsInAnyOrderOnly(plant, keyValuePairs)
+
+    override fun <K, V: Any> containsInAnyOrderOnlyNullable(
+        plant: AssertionPlant<Map<K, V?>>,
+        type: KClass<V>,
+        keyValuePairs: List<Pair<K, V?>>
+    ) = _containsInAnyOrderOnlyNullable(plant, type, keyValuePairs)
+
     override fun <K, V : Any> containsKeyWithValueAssertions(
         plant: AssertionPlant<Map<K, V>>,
         keyValues: List<KeyValue<K, V>>

--- a/misc/atrium-spec/src/main/kotlin/ch/tutteli/atrium/spec/integration/MapAssertionsSpec.kt
+++ b/misc/atrium-spec/src/main/kotlin/ch/tutteli/atrium/spec/integration/MapAssertionsSpec.kt
@@ -117,7 +117,8 @@ abstract class MapAssertionsSpec(
     val toBeDescr = DescriptionAnyAssertion.TO_BE.getDefault()
     val keyDoesNotExist = DescriptionMapAssertion.KEY_DOES_NOT_EXIST.getDefault()
     val lessThanDescr = DescriptionComparableAssertion.IS_LESS_THAN.getDefault()
-    val notOnlyDescr = DescriptionMapAssertion.MAP_CONTAINS_ONLY.getDefault()
+    val onlyDescr = DescriptionMapAssertion.MAP_CONTAINS_ONLY.getDefault()
+    val keyMismatchDescr = DescriptionMapAssertion.MAP_KEYS_MISMATCH.getDefault()
 
     fun entry(key: String): String
         = String.format(DescriptionMapAssertion.ENTRY_WITH_KEY.getDefault(), "\"$key\"")
@@ -210,7 +211,6 @@ abstract class MapAssertionsSpec(
                     fluent.containsInAnyOrderOnlyFun(it.first(), it.drop(1).toTypedArray())
                 }
             }
-
             test("{a to 1, b to 3, c to 4} throws AssertionError, reports b and c") {
                 expect {
                     fluent.containsInAnyOrderOnlyFun("a" to 1, arrayOf("b" to 3, "c" to 4))
@@ -226,11 +226,12 @@ abstract class MapAssertionsSpec(
                     }
                 }
             }
-            test("{a to 1} throws AssertionError, reports size mismatch") {
+            test("{a to 1} throws AssertionError, reports keys mismatch") {
                 expect {
                     fluent.containsInAnyOrderOnlyFun("a" to 1, arrayOf())
                 }.toThrow<AssertionError>{
-                    messageContains(notOnlyDescr)
+                    messageContains(onlyDescr)
+                    messageContains("$keyMismatchDescr: \"b\"")
                 }
             }
         }
@@ -263,11 +264,21 @@ abstract class MapAssertionsSpec(
                     }
                 }
             }
-            test("{a to null, null to 2} throws AssertionError, reports size mismatch") {
+            test("{a to null, null to 2} throws AssertionError,  reports keys mismatch") {
                 expect {
-                    nullableFluent.containsInAnyOrderOnlyNullableFun("a" to null, arrayOf("null" to 2))
+                    nullableFluent.containsInAnyOrderOnlyNullableFun("a" to null, arrayOf(null to 1))
                 }.toThrow<AssertionError>{
-                    messageContains(notOnlyDescr)
+                    messageContains(onlyDescr)
+                    messageContains("$keyMismatchDescr: \"b\"")
+                }
+            }
+
+            test("{a to null, null to 2} throws AssertionError,  reports keys mismatch") {
+                expect {
+                    nullableFluent.containsInAnyOrderOnlyNullableFun("a" to null, arrayOf("b" to 2))
+                }.toThrow<AssertionError>{
+                    messageContains(onlyDescr)
+                    messageContains("$keyMismatchDescr: \"null\"")
                 }
             }
         }

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
@@ -13,4 +13,5 @@ enum class DescriptionMapAssertion(override val value: String) : StringBasedTran
     CONTAINS_NOT_KEY("enthält nicht den Key"),
     ENTRY_WITH_KEY("Eintrag %s"),
     KEY_DOES_NOT_EXIST("❗❗ Key existiert nicht"),
+    MAP_CONTAINS_ONLY("map enthält Key, die nicht bestätigt wurden")
 }

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
@@ -13,5 +13,6 @@ enum class DescriptionMapAssertion(override val value: String) : StringBasedTran
     CONTAINS_NOT_KEY("enthält nicht den Key"),
     ENTRY_WITH_KEY("Eintrag %s"),
     KEY_DOES_NOT_EXIST("❗❗ Key existiert nicht"),
-    MAP_CONTAINS_ONLY("map enthält Key, die nicht bestätigt wurden")
+    MAP_CONTAINS_ONLY("map enthält Key, die nicht bestätigt wurden"), //TODO this is google translation please take a look
+    MAP_KEYS_MISMATCH("Key nicht übereinstimmend")  //TODO this is google translation please take a look
 }

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
@@ -13,5 +13,6 @@ enum class DescriptionMapAssertion(override val value: String) : StringBasedTran
     CONTAINS_NOT_KEY("does not contain key"),
     ENTRY_WITH_KEY("entry %s"),
     KEY_DOES_NOT_EXIST("❗❗ key does not exist"),
-    MAP_CONTAINS_ONLY("map contains keys that was not asserted")
+    MAP_CONTAINS_ONLY("map contains keys that was not asserted"),
+    MAP_KEYS_MISMATCH("key mismatched")
 }

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionMapAssertion.kt
@@ -13,4 +13,5 @@ enum class DescriptionMapAssertion(override val value: String) : StringBasedTran
     CONTAINS_NOT_KEY("does not contain key"),
     ENTRY_WITH_KEY("entry %s"),
     KEY_DOES_NOT_EXIST("❗❗ key does not exist"),
+    MAP_CONTAINS_ONLY("map contains keys that was not asserted")
 }


### PR DESCRIPTION
Implemented containInAnyOrderOnly assertion in modules: cc-de_CH, cc-en_GB, infix-cc-en_GB
Add tests for containInAnyOrderOnly assertion
Fix documentation about map contains
----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
