### PR TITLE
switch to 'implement' instead of 'compile' in build.gradle where possible

### DIFF
--- a/apis/atrium-api-cc-en_UK/build.gradle
+++ b/apis/atrium-api-cc-en_UK/build.gradle
@@ -3,10 +3,10 @@ description = 'Deprecated, use atrium-api-cc-en_GB-jvm instead.'
 ext.jacoco_additional = [prefixedProject('translations-en_GB-jvm')]
 
 dependencies {
-    compile prefixedProject('domain-api-deprecated')
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-api-deprecated')
+    api prefixedProject('domain-builders-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }

--- a/apis/atrium-api-cc-infix-en_UK/build.gradle
+++ b/apis/atrium-api-cc-infix-en_UK/build.gradle
@@ -3,10 +3,10 @@ description = 'Deprecated, use atrium-api-cc-infix-en_GB-jvm instead.'
 ext.jacoco_additional = [prefixedProject('translations-en_GB-jvm')]
 
 dependencies {
-    compile prefixedProject('domain-api-deprecated')
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-api-deprecated')
+    api prefixedProject('domain-builders-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-android/build.gradle
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-android/build.gradle
@@ -4,15 +4,15 @@ description = 'An assertion function API in de_CH with a focus on code completio
         'start creating an assertion + code completion + . + code completion + . + and so on.'
 
 dependencies {
-    compile prefixedProject('domain-api-deprecated')
-    compile prefixedProject('domain-builders-android')
+    api prefixedProject('domain-api-deprecated')
+    api prefixedProject('domain-builders-android')
 
     testRuntimeOnly prefixedProject('domain-robstoll-android')
     testRuntimeOnly prefixedProject('core-robstoll-android')
-    testCompile(prefixedProject('spec')) {
+    testImplementation(prefixedProject('spec')) {
         exclude module: "${rootProject.name}-translations-en_GB-android"
     }
-    testCompile prefixedProject('translations-de_CH-android')
+    testImplementation prefixedProject('translations-de_CH-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-common/build.gradle
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-common/build.gradle
@@ -1,5 +1,5 @@
 description = 'An assertion function API in de_CH with a focus on code completion as common module.'
 
 dependencies {
-    compile prefixedProject('domain-builders-common')
+    api prefixedProject('domain-builders-common')
 }

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-js/build.gradle
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-js/build.gradle
@@ -4,5 +4,5 @@ description = 'An assertion function API in de_CH with a focus on code completio
         'start creating an assertion + code completion + . + code completion + . + and so on.'
 
 dependencies {
-    compile prefixedProject('domain-builders-js')
+    api prefixedProject('domain-builders-js')
 }

--- a/apis/cc-de_CH/atrium-api-cc-de_CH-jvm/build.gradle
+++ b/apis/cc-de_CH/atrium-api-cc-de_CH-jvm/build.gradle
@@ -12,15 +12,15 @@ ext.jacoco_additional = [
 ]
 
 dependencies {
-    compile prefixedProject('domain-api-deprecated')
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-api-deprecated')
+    api prefixedProject('domain-builders-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile(prefixedProject('spec')) {
+    testImplementation(prefixedProject('spec')) {
         exclude module: "${rootProject.name}-translations-en_GB-jvm"
     }
-    testCompile prefixedProject('translations-de_CH-jvm')
+    testImplementation prefixedProject('translations-de_CH-jvm')
 }
 
 //TODO should not be necessary https://youtrack.jetbrains.com/issue/KT-28124

--- a/apis/cc-en_GB/atrium-api-cc-en_GB-android/build.gradle
+++ b/apis/cc-en_GB/atrium-api-cc-en_GB-android/build.gradle
@@ -4,11 +4,11 @@ description = 'An assertion function API in en_GB with a focus on code completio
         'start creating an assertion + code completion + . + code completion + . + and so on.'
 
 dependencies {
-    compile prefixedProject('domain-builders-android')
+    api prefixedProject('domain-builders-android')
 
     testRuntimeOnly prefixedProject('domain-robstoll-android')
     testRuntimeOnly prefixedProject('core-robstoll-android')
-    testCompile prefixedProject('verbs-internal-android')
+    testImplementation prefixedProject('verbs-internal-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/apis/cc-en_GB/atrium-api-cc-en_GB-common/build.gradle
+++ b/apis/cc-en_GB/atrium-api-cc-en_GB-common/build.gradle
@@ -1,5 +1,5 @@
 description = 'An assertion function API in en_GB with a focus on code completion as common module.'
 
 dependencies {
-    compile prefixedProject('domain-builders-common')
+    api prefixedProject('domain-builders-common')
 }

--- a/apis/cc-en_GB/atrium-api-cc-en_GB-js/build.gradle
+++ b/apis/cc-en_GB/atrium-api-cc-en_GB-js/build.gradle
@@ -4,5 +4,5 @@ description = 'An assertion function API in en_GB with a focus on code completio
         'start creating an assertion + code completion + . + code completion + . + and so on.'
 
 dependencies {
-    compile prefixedProject('domain-builders-js')
+    api prefixedProject('domain-builders-js')
 }

--- a/apis/cc-en_GB/atrium-api-cc-en_GB-jvm/build.gradle
+++ b/apis/cc-en_GB/atrium-api-cc-en_GB-jvm/build.gradle
@@ -12,11 +12,11 @@ ext.jacoco_additional = [
 ]
 
 dependencies {
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-builders-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }
 
 //TODO should not be necessary https://youtrack.jetbrains.com/issue/KT-28124

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-android/build.gradle
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-android/build.gradle
@@ -2,11 +2,11 @@ description = 'An API in en_GB with a focus on code completion and infix functio
         'It provides a fluent API in en_GB which is designed to ease the usage of code completion.'
 
 dependencies {
-    compile prefixedProject('domain-builders-android')
+    api prefixedProject('domain-builders-android')
 
     testRuntimeOnly prefixedProject('domain-robstoll-android')
     testRuntimeOnly prefixedProject('core-robstoll-android')
-    testCompile prefixedProject('verbs-internal-android')
+    testImplementation prefixedProject('verbs-internal-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/build.gradle
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/build.gradle
@@ -1,5 +1,5 @@
 description = 'An API in en_GB with a focus on code completion and infix functions as common module.'
 
 dependencies {
-    compile prefixedProject('domain-builders-common')
+    api prefixedProject('domain-builders-common')
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-js/build.gradle
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-js/build.gradle
@@ -2,5 +2,5 @@ description = 'An API in en_GB with a focus on code completion and infix functio
         'It provides a fluent API in en_GB which is designed to ease the usage of code completion.'
 
 dependencies {
-    compile prefixedProject('domain-builders-js')
+    api prefixedProject('domain-builders-js')
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/build.gradle
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/build.gradle
@@ -10,11 +10,11 @@ ext.jacoco_additional = [
 ]
 
 dependencies {
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-builders-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }
 
 //TODO should not be necessary https://youtrack.jetbrains.com/issue/KT-28124

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-android/build.gradle
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-android/build.gradle
@@ -4,13 +4,13 @@ description = 'A fluent assertion function API in en_GB with a focus on code com
         'start creating an assertion + code completion + . + code completion + . + and so on.'
 
 dependencies {
-    compile prefixedProject('domain-builders-android')
+    api prefixedProject('domain-builders-android')
 
     testRuntimeOnly prefixedProject('domain-robstoll-android')
     testRuntimeOnly prefixedProject('core-robstoll-android')
-    testCompile prefixedProject('verbs-internal-android')
+    testImplementation prefixedProject('verbs-internal-android')
     //TODO #26 remove as soon as we have ported all assertion functions to Expect
-    testCompile prefixedProject('api-cc-en_GB-android')
+    testImplementation prefixedProject('api-cc-en_GB-android')
 }
 
 //TODO remove once all specs are migrated to spek2 and apply spek plugin with version 2.1.x

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/build.gradle
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/build.gradle
@@ -1,12 +1,12 @@
 description = 'A fluent assertion function API in en_GB with a focus on code completion as common module.'
 
 dependencies {
-    compile prefixedProject('domain-builders-common')
+    api prefixedProject('domain-builders-common')
 
     testRuntimeOnly prefixedProject('domain-robstoll-common')
     testRuntimeOnly prefixedProject('core-robstoll-common')
     testImplementation prefixedProject('verbs-internal-common')
 
     //TODO #26 remove as soon as we have ported all assertion functions to Expect
-    testCompile prefixedProject('api-cc-en_GB-common') 
+    testImplementation prefixedProject('api-cc-en_GB-common')
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-js/build.gradle
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-js/build.gradle
@@ -4,9 +4,9 @@ description = 'An assertion function API in en_GB with a focus on code completio
         'start creating an assertion + code completion + . + code completion + . + and so on.'
 
 dependencies {
-    compile prefixedProject('domain-builders-js')
+    api prefixedProject('domain-builders-js')
 
-    testCompile prefixedProject('verbs-internal-js')
+    testImplementation prefixedProject('verbs-internal-js')
     //TODO #26 remove as soon as we have ported all assertion functions to Expect
-    testCompile prefixedProject('api-cc-en_GB-js')
+    testImplementation prefixedProject('api-cc-en_GB-js')
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/build.gradle
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/build.gradle
@@ -12,13 +12,13 @@ ext.jacoco_additional = [
 ]
 
 dependencies {
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-builders-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
     //TODO #26 remove as soon as we have ported all assertion functions to Expect
-    testCompile prefixedProject('api-cc-en_GB-jvm')
+    testImplementation prefixedProject('api-cc-en_GB-jvm')
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ configureAndroidProjects()
 configure(subprojects - multiplatformProjects - jsExamples) {
     apply plugin: 'kotlin'
     dependencies {
-        compile kotlinStdlib()
+        implementation kotlinStdlib()
     }
 
 }
@@ -198,7 +198,7 @@ configure(jacocoMulti.jacocoProjects + getAndroidProjects()) {
     spek.version = '1.1.5'
 
     dependencies {
-        testCompile mockito(), excludeKotlin
+        testImplementation mockito(), excludeKotlin
     }
 
     afterEvaluate {
@@ -241,8 +241,8 @@ configure(bundleSmokeTests) {
 
     dependencies {
         //I don't see how to set up compileTestKotlin with --patch-module, so we have put the module-info.java directly in src/test/kotlin instead
-        testCompile bundle
-        testCompile prefixedProject('verbs-jvm')
+        testImplementation bundle
+        testImplementation prefixedProject('verbs-jvm')
     }
 }
 

--- a/bundles/atrium-cc-en_UK-robstoll/build.gradle
+++ b/bundles/atrium-cc-en_UK-robstoll/build.gradle
@@ -2,16 +2,16 @@ description = 'Represents a deprecated convenience module which merely bundles d
     'Use atrium-cc-en_GB-robstoll once you have migrated all deprecated entities, this module will be removed with 1.0.0'
 
 dependencies {
-    compile prefixedProject('verbs-jvm')
-    compile prefixedProject('api-cc-en_GB-jvm')
-    compile prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-cc-en_GB-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
     runtimeOnly prefixedProject('domain-robstoll-jvm')
     runtimeOnly prefixedProject('core-robstoll-jvm')
 
     //TODO remove with 1.0.0
-    compile prefixedProject('api-cc-en_UK')
-    compile prefixedProject('assertions')
-    compile prefixedProject('core-api-deprecated')
-    compile prefixedProject('core-robstoll-deprecated')
-    compile prefixedProject('translations-en_UK-deprecated')
+    api prefixedProject('api-cc-en_UK')
+    implementation prefixedProject('assertions')
+    api prefixedProject('core-api-deprecated')
+    implementation prefixedProject('core-robstoll-deprecated')
+    implementation prefixedProject('translations-en_UK-deprecated')
 }

--- a/bundles/atrium-cc-infix-en_UK-robstoll/build.gradle
+++ b/bundles/atrium-cc-infix-en_UK-robstoll/build.gradle
@@ -2,16 +2,16 @@ description = 'Represents a deprecated convenience module which merely bundles d
     'Use atrium-cc-infix-en_GB-robstoll once you have migrated all deprecated entities, this module will be removed with 1.0.0'
 
 dependencies {
-    compile prefixedProject('verbs-jvm')
-    compile prefixedProject('api-cc-infix-en_GB-jvm')
-    compile prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-cc-infix-en_GB-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
     runtimeOnly prefixedProject('domain-robstoll-jvm')
     runtimeOnly prefixedProject('core-robstoll-jvm')
 
     //TODO remove with 1.0.0
-    compile prefixedProject('api-cc-infix-en_UK')
-    compile prefixedProject('assertions')
-    compile prefixedProject('core-api-deprecated')
-    compile prefixedProject('core-robstoll-deprecated')
-    compile prefixedProject('translations-en_UK-deprecated')
+    api prefixedProject('api-cc-infix-en_UK')
+    implementation prefixedProject('assertions')
+    api prefixedProject('core-api-deprecated')
+    implementation prefixedProject('core-robstoll-deprecated')
+    implementation prefixedProject('translations-en_UK-deprecated')
 }

--- a/bundles/cc-de_CH-robstoll/atrium-cc-de_CH-robstoll-common/build.gradle
+++ b/bundles/cc-de_CH-robstoll/atrium-cc-de_CH-robstoll-common/build.gradle
@@ -1,10 +1,10 @@
 description = 'Represents a convenience module which merely bundles dependencies as common module.'
 
 dependencies {
-    compile prefixedProject('verbs-common')
-    compile prefixedProject('api-cc-de_CH-common')
-    compile prefixedProject('domain-builders-common')
-    compile prefixedProject('translations-de_CH-common')
+    api prefixedProject('verbs-common')
+    api prefixedProject('api-cc-de_CH-common')
+    api prefixedProject('domain-builders-common')
+    implementation prefixedProject('translations-de_CH-common')
     runtimeOnly prefixedProject('domain-robstoll-common')
     runtimeOnly prefixedProject('core-robstoll-common')
 }

--- a/bundles/cc-de_CH-robstoll/atrium-cc-de_CH-robstoll-js/build.gradle
+++ b/bundles/cc-de_CH-robstoll/atrium-cc-de_CH-robstoll-js/build.gradle
@@ -1,11 +1,11 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JS platform.'
 
 dependencies {
-    compile prefixedProject('verbs-js')
-    compile prefixedProject('api-cc-de_CH-js')
-    compile prefixedProject('domain-builders-js')
-    compile prefixedProject('translations-de_CH-js')
+    api prefixedProject('verbs-js')
+    api prefixedProject('api-cc-de_CH-js')
+    api prefixedProject('domain-builders-js')
+    implementation prefixedProject('translations-de_CH-js')
     //TODO should be runtimeOnly but due to https://youtrack.jetbrains.com/issue/KT-27797 it cannot be
-    compile prefixedProject('domain-robstoll-js')
-    compile prefixedProject('core-robstoll-js')
+    implementation prefixedProject('domain-robstoll-js')
+    implementation prefixedProject('core-robstoll-js')
 }

--- a/bundles/cc-de_CH-robstoll/atrium-cc-de_CH-robstoll-jvm/build.gradle
+++ b/bundles/cc-de_CH-robstoll/atrium-cc-de_CH-robstoll-jvm/build.gradle
@@ -1,16 +1,16 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('verbs-jvm')
-    compile prefixedProject('api-cc-de_CH-jvm')
-    compile prefixedProject('domain-builders-jvm')
-    compile prefixedProject('translations-de_CH-jvm')
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-cc-de_CH-jvm')
+    api prefixedProject('domain-builders-jvm')
+    implementation prefixedProject('translations-de_CH-jvm')
     runtimeOnly prefixedProject('domain-robstoll-jvm')
     runtimeOnly prefixedProject('core-robstoll-jvm')
 
     //TODO remove with 1.0.0
-    compile prefixedProject('assertions')
-    compile prefixedProject('core-api-deprecated')
-    compile prefixedProject('core-robstoll-deprecated')
-    compile prefixedProject('translations-de_CH-deprecated')
+    implementation prefixedProject('assertions')
+    api prefixedProject('core-api-deprecated')
+    implementation prefixedProject('core-robstoll-deprecated')
+    implementation prefixedProject('translations-de_CH-deprecated')
 }

--- a/bundles/cc-en_GB-robstoll/atrium-cc-en_GB-robstoll-common/build.gradle
+++ b/bundles/cc-en_GB-robstoll/atrium-cc-en_GB-robstoll-common/build.gradle
@@ -1,13 +1,13 @@
 description = 'Represents a convenience module which merely bundles dependencies as common module.'
 
 dependencies {
-    compile prefixedProject('verbs-common')
-    compile prefixedProject('api-cc-en_GB-common')
-    compile prefixedProject('domain-builders-common')
-    compile prefixedProject('translations-en_GB-common')
+    api prefixedProject('verbs-common')
+    api prefixedProject('api-cc-en_GB-common')
+    api prefixedProject('domain-builders-common')
+    implementation prefixedProject('translations-en_GB-common')
     runtimeOnly prefixedProject('domain-robstoll-common')
     runtimeOnly prefixedProject('core-robstoll-common')
 
     // here to ease migration; so that ReplaceWith of @Deprecated work
-    compile prefixedProject('api-fluent-en_GB-common')
+    api prefixedProject('api-fluent-en_GB-common')
 }

--- a/bundles/cc-en_GB-robstoll/atrium-cc-en_GB-robstoll-js/build.gradle
+++ b/bundles/cc-en_GB-robstoll/atrium-cc-en_GB-robstoll-js/build.gradle
@@ -1,14 +1,14 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JS platform.'
 
 dependencies {
-    compile prefixedProject('verbs-js')
-    compile prefixedProject('api-cc-en_GB-js')
-    compile prefixedProject('domain-builders-js')
-    compile prefixedProject('translations-en_GB-js')
+    api prefixedProject('verbs-js')
+    api prefixedProject('api-cc-en_GB-js')
+    api prefixedProject('domain-builders-js')
+    implementation prefixedProject('translations-en_GB-js')
     //TODO should be runtimeOnly but due to https://youtrack.jetbrains.com/issue/KT-27797 it cannot be
-    compile prefixedProject('domain-robstoll-js')
-    compile prefixedProject('core-robstoll-js')
+    implementation prefixedProject('domain-robstoll-js')
+    implementation prefixedProject('core-robstoll-js')
 
     // here to ease migration; so that ReplaceWith of @Deprecated work
-    compile prefixedProject('api-fluent-en_GB-js')
+    api prefixedProject('api-fluent-en_GB-js')
 }

--- a/bundles/cc-en_GB-robstoll/atrium-cc-en_GB-robstoll-jvm/build.gradle
+++ b/bundles/cc-en_GB-robstoll/atrium-cc-en_GB-robstoll-jvm/build.gradle
@@ -1,13 +1,13 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('verbs-jvm')
-    compile prefixedProject('api-cc-en_GB-jvm')
-    compile prefixedProject('domain-builders-jvm')
-    compile prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-cc-en_GB-jvm')
+    api prefixedProject('domain-builders-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
     runtimeOnly prefixedProject('domain-robstoll-jvm')
     runtimeOnly prefixedProject('core-robstoll-jvm')
 
     // here to ease migration; so that ReplaceWith of @Deprecated work
-    compile prefixedProject('api-fluent-en_GB-jvm')
+    api prefixedProject('api-fluent-en_GB-jvm')
 }

--- a/bundles/cc-infix-en_GB-robstoll/atrium-cc-infix-en_GB-robstoll-common/build.gradle
+++ b/bundles/cc-infix-en_GB-robstoll/atrium-cc-infix-en_GB-robstoll-common/build.gradle
@@ -1,10 +1,10 @@
 description = 'Represents a convenience module which merely bundles dependencies as common module.'
 
 dependencies {
-    compile prefixedProject('verbs-common')
-    compile prefixedProject('api-cc-infix-en_GB-common')
-    compile prefixedProject('domain-builders-common')
-    compile prefixedProject('translations-en_GB-common')
+    api prefixedProject('verbs-common')
+    api prefixedProject('api-cc-infix-en_GB-common')
+    api prefixedProject('domain-builders-common')
+    implementation prefixedProject('translations-en_GB-common')
     runtimeOnly prefixedProject('domain-robstoll-common')
     runtimeOnly prefixedProject('core-robstoll-common')
 }

--- a/bundles/cc-infix-en_GB-robstoll/atrium-cc-infix-en_GB-robstoll-js/build.gradle
+++ b/bundles/cc-infix-en_GB-robstoll/atrium-cc-infix-en_GB-robstoll-js/build.gradle
@@ -1,11 +1,11 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JS platform.'
 
 dependencies {
-    compile prefixedProject('verbs-js')
-    compile prefixedProject('api-cc-infix-en_GB-js')
-    compile prefixedProject('domain-builders-js')
-    compile prefixedProject('translations-en_GB-js')
+    api prefixedProject('verbs-js')
+    api prefixedProject('api-cc-infix-en_GB-js')
+    api prefixedProject('domain-builders-js')
+    implementation prefixedProject('translations-en_GB-js')
     //TODO should be runtimeOnly but due to https://youtrack.jetbrains.com/issue/KT-27797 it cannot be
-    compile prefixedProject('domain-robstoll-js')
-    compile prefixedProject('core-robstoll-js')
+    implementation prefixedProject('domain-robstoll-js')
+    implementation prefixedProject('core-robstoll-js')
 }

--- a/bundles/cc-infix-en_GB-robstoll/atrium-cc-infix-en_GB-robstoll-jvm/build.gradle
+++ b/bundles/cc-infix-en_GB-robstoll/atrium-cc-infix-en_GB-robstoll-jvm/build.gradle
@@ -1,10 +1,10 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('verbs-jvm')
-    compile prefixedProject('api-cc-infix-en_GB-jvm')
-    compile prefixedProject('domain-builders-jvm')
-    compile prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-cc-infix-en_GB-jvm')
+    api prefixedProject('domain-builders-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
     runtimeOnly prefixedProject('domain-robstoll-jvm')
     runtimeOnly prefixedProject('core-robstoll-jvm')
 }

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB-common/build.gradle
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB-common/build.gradle
@@ -1,10 +1,10 @@
 description = 'Represents a convenience module which merely bundles dependencies as common module.'
 
 dependencies {
-    compile prefixedProject('verbs-common')
-    compile prefixedProject('api-fluent-en_GB-common')
-    compile prefixedProject('domain-builders-common')
-    compile prefixedProject('translations-en_GB-common')
+    api prefixedProject('verbs-common')
+    api prefixedProject('api-fluent-en_GB-common')
+    api prefixedProject('domain-builders-common')
+    implementation prefixedProject('translations-en_GB-common')
     runtimeOnly prefixedProject('domain-robstoll-common')
     runtimeOnly prefixedProject('core-robstoll-common')
 }

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB-js/build.gradle
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB-js/build.gradle
@@ -1,11 +1,11 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JS platform.'
 
 dependencies {
-    compile prefixedProject('verbs-js')
-    compile prefixedProject('api-fluent-en_GB-js')
-    compile prefixedProject('domain-builders-js')
-    compile prefixedProject('translations-en_GB-js')
+    api prefixedProject('verbs-js')
+    api prefixedProject('api-fluent-en_GB-js')
+    api prefixedProject('domain-builders-js')
+    implementation prefixedProject('translations-en_GB-js')
     //TODO should be runtimeOnly but due to https://youtrack.jetbrains.com/issue/KT-27797 it cannot be
-    compile prefixedProject('domain-robstoll-js')
-    compile prefixedProject('core-robstoll-js')
+    implementation prefixedProject('domain-robstoll-js')
+    implementation prefixedProject('core-robstoll-js')
 }

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB-jvm/build.gradle
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB-jvm/build.gradle
@@ -1,10 +1,10 @@
 description = 'Represents a convenience module which merely bundles dependencies for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('verbs-jvm')
-    compile prefixedProject('api-fluent-en_GB-jvm')
-    compile prefixedProject('domain-builders-jvm')
-    compile prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-fluent-en_GB-jvm')
+    api prefixedProject('domain-builders-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
     runtimeOnly prefixedProject('domain-robstoll-jvm')
     runtimeOnly prefixedProject('core-robstoll-jvm')
 }

--- a/core/api/atrium-core-api-android/build.gradle
+++ b/core/api/atrium-core-api-android/build.gradle
@@ -1,11 +1,11 @@
 description = 'API of the core of Atrium for Android.'
 
 dependencies {
-    compile kbox(), excludeKotlin
-    compile kotlinReflect()
+    implementation kbox(), excludeKotlin
+    implementation kotlinReflect()
 
-    testCompile prefixedProject('cc-infix-en_GB-robstoll-android')
-    testCompile prefixedProject('verbs-internal-android')
+    testImplementation prefixedProject('cc-infix-en_GB-robstoll-android')
+    testImplementation prefixedProject('verbs-internal-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/core/api/atrium-core-api-common/build.gradle
+++ b/core/api/atrium-core-api-common/build.gradle
@@ -1,8 +1,8 @@
 description = 'API of the core of Atrium as common module'
 
 dependencies {
-    compile "ch.tutteli.kbox:kbox-common:$kbox_version", excludeKotlin
+    implementation "ch.tutteli.kbox:kbox-common:$kbox_version", excludeKotlin
 
-    testCompile prefixedProject('api-cc-infix-en_GB-common')
-    testCompile prefixedProject('verbs-internal-common')
+    testImplementation prefixedProject('api-cc-infix-en_GB-common')
+    testImplementation prefixedProject('verbs-internal-common')
 }

--- a/core/api/atrium-core-api-js/build.gradle
+++ b/core/api/atrium-core-api-js/build.gradle
@@ -1,8 +1,8 @@
 description = 'API of the core of Atrium for the JS platform.'
 
 dependencies {
-    compile "ch.tutteli.kbox:kbox-js:$kbox_version", excludeKotlin
+    implementation "ch.tutteli.kbox:kbox-js:$kbox_version", excludeKotlin
 
-    testCompile prefixedProject('cc-infix-en_GB-robstoll-js')
-    testCompile prefixedProject('verbs-internal-js')
+    testImplementation prefixedProject('cc-infix-en_GB-robstoll-js')
+    testImplementation prefixedProject('verbs-internal-js')
 }

--- a/core/api/atrium-core-api-jvm/build.gradle
+++ b/core/api/atrium-core-api-jvm/build.gradle
@@ -1,9 +1,9 @@
 description = 'API of the core of Atrium for the JVM platform.'
 
 dependencies {
-    compile kbox(), excludeKotlin
-    compile kotlinReflect()
+    implementation kbox(), excludeKotlin
+    implementation kotlinReflect()
 
-    testCompile prefixedProject('cc-infix-en_GB-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('cc-infix-en_GB-robstoll-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }

--- a/core/atrium-core-api-deprecated/build.gradle
+++ b/core/atrium-core-api-deprecated/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains the deprecated IAtriumFactory'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
 }

--- a/core/atrium-core-robstoll-deprecated/build.gradle
+++ b/core/atrium-core-robstoll-deprecated/build.gradle
@@ -1,7 +1,7 @@
 description = 'Contains the deprecated AtriumFactory'
 
 dependencies {
-    compile prefixedProject('core-api-deprecated')
-    compile prefixedProject('core-api-jvm')
-    compile prefixedProject('core-robstoll-lib-jvm')
+    api prefixedProject('core-api-deprecated')
+    api prefixedProject('core-api-jvm')
+    implementation prefixedProject('core-robstoll-lib-jvm')
 }

--- a/core/robstoll-lib/atrium-core-robstoll-lib-common/build.gradle
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-common/build.gradle
@@ -4,8 +4,8 @@ description = 'Contains the bits and pieces behind robstoll\'s <rstoll@tutteli.c
     'Atrium, then you should depend on atrium-core-robstoll-common instead.'
 
 dependencies {
-    compile "ch.tutteli.kbox:kbox-common:$kbox_version", excludeKotlin
-    compile prefixedProject('core-api-common')
+    implementation "ch.tutteli.kbox:kbox-common:$kbox_version", excludeKotlin
+    api prefixedProject('core-api-common')
 
     // it is up to the consumer of atrium-core-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-common')

--- a/core/robstoll-lib/atrium-core-robstoll-lib-js/build.gradle
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-js/build.gradle
@@ -4,14 +4,14 @@ description = 'Contains the bits and pieces behind robstoll\'s <rstoll@tutteli.c
     'Atrium, then you should depend on atrium-core-robstoll instead.'
 
 dependencies {
-    compile "ch.tutteli.kbox:kbox-js:$kbox_version", excludeKotlin
-    compile prefixedProject('core-api-js')
+    implementation "ch.tutteli.kbox:kbox-js:$kbox_version", excludeKotlin
+    api prefixedProject('core-api-js')
 
     // it is up to the consumer of atrium-core-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-js')
     
-    testCompile prefixedProject('api-cc-en_GB-js')
-    testCompile prefixedProject('verbs-internal-js')
+    testImplementation prefixedProject('api-cc-en_GB-js')
+    testImplementation prefixedProject('verbs-internal-js')
 
     testRuntimeOnly prefixedProject('domain-robstoll-js')
     testRuntimeOnly prefixedProject('core-robstoll-js')

--- a/core/robstoll-lib/atrium-core-robstoll-lib-jvm/build.gradle
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-jvm/build.gradle
@@ -4,13 +4,13 @@ description = 'Contains the bits and pieces behind robstoll\'s <rstoll@tutteli.c
     'Atrium, then you should depend on atrium-core-robstoll instead.'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
     
     // it is up to the consumer of atrium-core-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-jvm')
 
-    testCompile prefixedProject('api-cc-en_GB-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('api-cc-en_GB-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')

--- a/core/robstoll/atrium-core-robstoll-android/build.gradle
+++ b/core/robstoll/atrium-core-robstoll-android/build.gradle
@@ -1,8 +1,8 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the core of Atrium for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('core-api-android')
-    compile prefixedProject('core-robstoll-lib-android')
+    api prefixedProject('core-api-android')
+    implementation prefixedProject('core-robstoll-lib-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/core/robstoll/atrium-core-robstoll-common/build.gradle
+++ b/core/robstoll/atrium-core-robstoll-common/build.gradle
@@ -1,6 +1,6 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the core of Atrium as common module.'
 
 dependencies {
-    compile prefixedProject('core-api-common')
-    compile prefixedProject('core-robstoll-lib-common')
+    api prefixedProject('core-api-common')
+    implementation prefixedProject('core-robstoll-lib-common')
 }

--- a/core/robstoll/atrium-core-robstoll-js/build.gradle
+++ b/core/robstoll/atrium-core-robstoll-js/build.gradle
@@ -1,6 +1,6 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the core of Atrium for the JS platform.'
 
 dependencies {
-    compile prefixedProject('core-api-js')
-    compile prefixedProject('core-robstoll-lib-js')
+    api prefixedProject('core-api-js')
+    implementation prefixedProject('core-robstoll-lib-js')
 }

--- a/core/robstoll/atrium-core-robstoll-jvm/build.gradle
+++ b/core/robstoll/atrium-core-robstoll-jvm/build.gradle
@@ -1,6 +1,6 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the core of Atrium for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
-    compile prefixedProject('core-robstoll-lib-jvm')
+    api prefixedProject('core-api-jvm')
+    implementation prefixedProject('core-robstoll-lib-jvm')
 }

--- a/domain/api/atrium-domain-api-android/build.gradle
+++ b/domain/api/atrium-domain-api-android/build.gradle
@@ -1,7 +1,7 @@
 description = 'API of the domain of Atrium for Android.'
 
 dependencies {
-    compile prefixedProject('core-api-android')
+    api prefixedProject('core-api-android')
 
     // it is up to the consumer of atrium-domain-api which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-android')

--- a/domain/api/atrium-domain-api-common/build.gradle
+++ b/domain/api/atrium-domain-api-common/build.gradle
@@ -1,7 +1,7 @@
 description = 'API of the domain of Atrium as common module.'
 
 dependencies {
-    compile prefixedProject('core-api-common')
+    api prefixedProject('core-api-common')
 
     // it is up to the consumer of atrium-domain-api which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-common')

--- a/domain/api/atrium-domain-api-js/build.gradle
+++ b/domain/api/atrium-domain-api-js/build.gradle
@@ -1,7 +1,7 @@
 description = 'API of the domain of Atrium for the JS platform.'
 
 dependencies {
-    compile prefixedProject('core-api-js')
+    api prefixedProject('core-api-js')
 
     // it is up to the consumer of atrium-domain-api which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-js')

--- a/domain/api/atrium-domain-api-jvm/build.gradle
+++ b/domain/api/atrium-domain-api-jvm/build.gradle
@@ -1,7 +1,7 @@
 description = 'API of the domain of Atrium for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
 
     // it is up to the consumer of atrium-domain-api which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-jvm')

--- a/domain/atrium-domain-api-deprecated/build.gradle
+++ b/domain/atrium-domain-api-deprecated/build.gradle
@@ -1,7 +1,7 @@
 description = 'Deprecated API of the domain of Atrium.'
 
 dependencies {
-    compile prefixedProject('domain-api-jvm')
+    api prefixedProject('domain-api-jvm')
 
     // it is up to the consumer of atrium-domain-deprecated which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-jvm')

--- a/domain/builders/atrium-domain-builders-android/build.gradle
+++ b/domain/builders/atrium-domain-builders-android/build.gradle
@@ -1,15 +1,15 @@
 description = 'Contains base classes for sophisticated assertion builders which can be re-used in APIs for Android.'
 
 dependencies {
-    compile prefixedProject('domain-api-android')
+    api prefixedProject('domain-api-android')
 
     // it is up to the consumer of atrium-domain-builders which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-android')
 
     testRuntimeOnly prefixedProject('domain-robstoll-android')
     testRuntimeOnly prefixedProject('core-robstoll-android')
-    testCompile prefixedProject('api-cc-en_GB-android')
-    testCompile prefixedProject('verbs-internal-android')
+    testImplementation prefixedProject('api-cc-en_GB-android')
+    testImplementation prefixedProject('verbs-internal-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/domain/builders/atrium-domain-builders-common/build.gradle
+++ b/domain/builders/atrium-domain-builders-common/build.gradle
@@ -1,7 +1,7 @@
 description = 'Contains base classes for sophisticated assertion builders which can be re-used in APIs as common module'
 
 dependencies {
-    compile prefixedProject('domain-api-common')
+    api prefixedProject('domain-api-common')
 
     // it is up to the consumer of atrium-domain-builders which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-common')

--- a/domain/builders/atrium-domain-builders-js/build.gradle
+++ b/domain/builders/atrium-domain-builders-js/build.gradle
@@ -1,10 +1,10 @@
 description = 'Contains base classes for sophisticated assertion builders which can be re-used in APIs for the JS platform.'
 
 dependencies {
-    compile prefixedProject('domain-api-js')
+    api prefixedProject('domain-api-js')
 
     // it is up to the consumer of atrium-domain-builders which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-js')
 
-    testCompile prefixedProject('verbs-internal-js')
+    testImplementation prefixedProject('verbs-internal-js')
 }

--- a/domain/builders/atrium-domain-builders-jvm/build.gradle
+++ b/domain/builders/atrium-domain-builders-jvm/build.gradle
@@ -1,15 +1,15 @@
 description = 'Contains base classes for sophisticated assertion builders which can be re-used in APIs for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('domain-api-jvm')
+    api prefixedProject('domain-api-jvm')
 
     // it is up to the consumer of atrium-domain-builders which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-jvm')
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('api-cc-en_GB-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('api-cc-en_GB-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }
 
 //TODO should not be necessary https://youtrack.jetbrains.com/issue/KT-28124

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-android/build.gradle
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-android/build.gradle
@@ -4,26 +4,26 @@ description = 'Contains the bits and pieces behind robstoll\'s <rstoll@tutteli.c
         'If you are a consumer of Atrium, then you should depend on atrium-domain-robstoll instead.'
 
 dependencies {
-    compile prefixedProject('domain-builders-android')
+    api prefixedProject('domain-builders-android')
 
     // we need cc-en_GB for compilation and for runtime but we do not want that depending modules have cc-en_GB
     // automatically in their compile classpath. Thus:
     compileOnly prefixedProject('api-fluent-en_GB-android') // for us
     runtimeOnly prefixedProject('api-fluent-en_GB-android') // for depending modules
-    testCompile prefixedProject('api-fluent-en_GB-android') // for us in tests
+    testImplementation prefixedProject('api-fluent-en_GB-android') // for us in tests
 
     // it is up to the consumer of atrium-domain-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-android')
-    compile kbox(), excludeKotlin
+    implementation kbox(), excludeKotlin
 
     //TODO remove with 1.0.0
     compileOnly prefixedProject('api-cc-en_GB-android') // for us
     runtimeOnly prefixedProject('api-cc-en_GB-android') // for depending modules
-    testCompile prefixedProject('api-cc-en_GB-android') // for us in tests
+    testImplementation prefixedProject('api-cc-en_GB-android') // for us in tests
 
     testRuntimeOnly prefixedProject('domain-robstoll-android')
     testRuntimeOnly prefixedProject('core-robstoll-android')
-    testCompile prefixedProject('verbs-internal-android')
+    testImplementation prefixedProject('verbs-internal-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-common/build.gradle
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-common/build.gradle
@@ -4,20 +4,20 @@ description = 'Contains the bits and pieces behind robstoll\'s <rstoll@tutteli.c
         'If you are a consumer of Atrium, then you should depend on atrium-domain-robstoll instead.'
 
 dependencies {
-    compile prefixedProject('domain-builders-common')
+    api prefixedProject('domain-builders-common')
 
     // we need api-fluent-en_GB for compilation and for runtime but we do not want that depending modules have it
     // automatically in their compile classpath. Thus:
     compileOnly prefixedProject('api-fluent-en_GB-common') // for us
     runtimeOnly prefixedProject('api-fluent-en_GB-common') // for depending modules
-    testCompile prefixedProject('api-fluent-en_GB-common') // for us in tests
+    testImplementation prefixedProject('api-fluent-en_GB-common') // for us in tests
 
     // it is up to the consumer of atrium-domain-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-common')
-    compile "ch.tutteli.kbox:kbox-common:$kbox_version", excludeKotlin
+    implementation "ch.tutteli.kbox:kbox-common:$kbox_version", excludeKotlin
 
     //TODO remove with 1.0.0
     compileOnly prefixedProject('api-cc-en_GB-common') // for us
     runtimeOnly prefixedProject('api-cc-en_GB-common') // for depending modules
-    testCompile prefixedProject('api-cc-en_GB-common') // for us in tests
+    testImplementation prefixedProject('api-cc-en_GB-common') // for us in tests
 }

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-js/build.gradle
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-js/build.gradle
@@ -4,7 +4,7 @@ description = 'Contains the bits and pieces behind robstoll\'s <rstoll@tutteli.c
         'If you are a consumer of Atrium, then you should depend on atrium-domain-robstoll instead.'
 
 dependencies {
-    compile prefixedProject('domain-builders-js')
+    api prefixedProject('domain-builders-js')
 
     // we need api-fluent-en_GB for compilation and for runtime but we do not want that depending modules have it
     // automatically in their compile classpath. Thus:
@@ -13,7 +13,7 @@ dependencies {
 
     // it is up to the consumer of atrium-domain-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-js')
-    compile "ch.tutteli.kbox:kbox-js:$kbox_version", excludeKotlin
+    implementation "ch.tutteli.kbox:kbox-js:$kbox_version", excludeKotlin
 
     // TODO remove with 1.0.0
     compileOnly prefixedProject('api-cc-en_GB-js') // for us

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/build.gradle
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/build.gradle
@@ -9,26 +9,26 @@ ext.jacoco_additional = [
 ]
 
 dependencies {
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-builders-jvm')
 
     // we need api-fluent-en_GB for compilation and for runtime but we do not want that depending modules have it
     // automatically in their compile classpath. Thus:
     compileOnly prefixedProject('api-fluent-en_GB-jvm') // for us
     runtimeOnly prefixedProject('api-fluent-en_GB-jvm') // for depending modules
-    testCompile prefixedProject('api-fluent-en_GB-jvm') // for us in tests
+    testImplementation prefixedProject('api-fluent-en_GB-jvm') // for us in tests
 
     // it is up to the consumer of atrium-domain-robstoll-lib which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-jvm')
-    compile kbox(), excludeKotlin
+    implementation kbox(), excludeKotlin
 
     //TODO remove with 1.0.0
     compileOnly prefixedProject('api-cc-en_GB-jvm') // for us
     runtimeOnly prefixedProject('api-cc-en_GB-jvm') // for depending modules
-    testCompile prefixedProject('api-cc-en_GB-jvm') // for us in tests
+    testImplementation prefixedProject('api-cc-en_GB-jvm') // for us in tests
 
     testRuntimeOnly prefixedProject('domain-robstoll-jvm')
     testRuntimeOnly prefixedProject('core-robstoll-jvm')
-    testCompile prefixedProject('verbs-internal-jvm')
+    testImplementation prefixedProject('verbs-internal-jvm')
 }
 
 //TODO should not be necessary https://youtrack.jetbrains.com/issue/KT-28124

--- a/domain/robstoll/atrium-domain-robstoll-android/build.gradle
+++ b/domain/robstoll/atrium-domain-robstoll-android/build.gradle
@@ -1,8 +1,8 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the domain (assertion functions and builders) of Atrium for Android.'
 
 dependencies {
-    compile prefixedProject('domain-api-android')
-    compile prefixedProject('domain-robstoll-lib-android')
+    api prefixedProject('domain-api-android')
+    implementation prefixedProject('domain-robstoll-lib-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/domain/robstoll/atrium-domain-robstoll-common/build.gradle
+++ b/domain/robstoll/atrium-domain-robstoll-common/build.gradle
@@ -1,6 +1,6 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the domain of Atrium as common module'
 
 dependencies {
-    compile prefixedProject('domain-api-common')
-    compile prefixedProject('domain-robstoll-lib-common')
+    api prefixedProject('domain-api-common')
+    implementation prefixedProject('domain-robstoll-lib-common')
 }

--- a/domain/robstoll/atrium-domain-robstoll-js/build.gradle
+++ b/domain/robstoll/atrium-domain-robstoll-js/build.gradle
@@ -1,6 +1,6 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the domain (assertion functions and builders) of Atrium for the JS platform.'
 
 dependencies {
-    compile prefixedProject('domain-api-js')
-    compile prefixedProject('domain-robstoll-lib-js')
+    api prefixedProject('domain-api-js')
+    implementation prefixedProject('domain-robstoll-lib-js')
 }

--- a/domain/robstoll/atrium-domain-robstoll-jvm/build.gradle
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/build.gradle
@@ -1,6 +1,6 @@
 description = 'robstoll\'s <rstoll@tutteli.ch> implementation of the domain (assertion functions and builders) of Atrium for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('domain-api-jvm')
-    compile prefixedProject('domain-robstoll-lib-jvm')
+    api prefixedProject('domain-api-jvm')
+    implementation prefixedProject('domain-robstoll-lib-jvm')
 }

--- a/misc/atrium-assertions/build.gradle
+++ b/misc/atrium-assertions/build.gradle
@@ -1,10 +1,10 @@
 description = 'A deprecated module, you should not longer rely on it; will be removed with 1.0.0\nLook at the suggested replacements'
 
 dependencies {
-    compile prefixedProject('domain-api-jvm')
-    compile prefixedProject('domain-api-deprecated')
+    api prefixedProject('domain-api-jvm')
+    api prefixedProject('domain-api-deprecated')
     compileOnly prefixedProject('domain-robstoll-jvm')
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
     // it is up to the consumer of atrium-assertions which atrium-translations module is used at runtime
     compileOnly prefixedProject('translations-en_GB-jvm')
 }

--- a/misc/atrium-bc-test/build.gradle
+++ b/misc/atrium-bc-test/build.gradle
@@ -1,4 +1,4 @@
-//Enable if you need to check the task tree, gr task taskTree --no-repeat
+ //Enable if you need to check the task tree, gr task taskTree --no-repeat
 //plugins {
 //    id "com.dorongold.task-tree" version "1.3.1"
 //}
@@ -21,8 +21,8 @@ dependencies {
     common mockito(), excludeKotlin
     common kotlinStdlib()
 
-    compile configurations.common.dependencies
-    compile prefixedProject('core-api-jvm')
+    implementation configurations.common.dependencies
+    api prefixedProject('core-api-jvm')
 }
 
 def bbcTests = task("bbcTests", group: 'Verification') {

--- a/misc/atrium-spec/build.gradle
+++ b/misc/atrium-spec/build.gradle
@@ -2,16 +2,16 @@ description = 'Provides specifications of Atrium -- an assertion framework for K
         ' be reused by implementations of Atrium, to verify that they fulfill the specification.'
 
 dependencies {
-    compile prefixedProject('domain-api-jvm')
-    compile prefixedProject('core-api-jvm')
-    compile prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-api-jvm')
+    api prefixedProject('core-api-jvm')
+    api prefixedProject('domain-builders-jvm')
 
     // we need cc-en_GB for compilation and for runtime but we do not want that depending modules have cc-en_GB
     // automatically in their compile classpath. Thus:
     compileOnly prefixedProject('api-cc-en_GB-jvm') // for us
     runtimeOnly prefixedProject('api-cc-en_GB-jvm') // for depending modules
 
-    compile prefixedProject('translations-en_GB-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
 }
 
 // spek is required (not the platform) because we are specifying abstract Specs here
@@ -20,6 +20,6 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.spek:spek-api:$spek_version", excludeKotlin
-    compile mockito(), excludeKotlin
+    implementation "org.jetbrains.spek:spek-api:$spek_version", excludeKotlin
+    implementation mockito(), excludeKotlin
 }

--- a/misc/examples/js/mocha/build.gradle
+++ b/misc/examples/js/mocha/build.gradle
@@ -22,12 +22,12 @@ repositories {
     // maven { url "http://dl.bintray.com/robstoll/tutteli-jars" }
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-js"
     
-    testCompile "org.jetbrains.kotlin:kotlin-test-js"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-js"
     //delete this and the following line and uncomment the next line (Atrium uses a project dependency, you won't)
-    testCompile prefixedProject('cc-en_GB-robstoll-js')
-    //testCompile("ch.tutteli.atrium:$atrium_api:$atrium_version")
+    testImplementation prefixedProject('cc-en_GB-robstoll-js')
+    //testImplementation("ch.tutteli.atrium:$atrium_api:$atrium_version")
 }
 
 // we only configure compileTestKotlin2Js and not compileKotlin2Js as well

--- a/misc/specs/atrium-specs-android/build.gradle
+++ b/misc/specs/atrium-specs-android/build.gradle
@@ -2,9 +2,9 @@ description = 'Provides specifications of Atrium (for the Android platform) whic
     'APIs and domain/core-implementations of Atrium, to verify that they fulfill the specification.'
 
 dependencies {
-    implementation prefixedProject('domain-api-android')
-    implementation prefixedProject('core-api-android')
-    implementation prefixedProject('domain-builders-android')
+    api prefixedProject('domain-api-android')
+    api prefixedProject('core-api-android')
+    api prefixedProject('domain-builders-android')
 
     // we need cc-en_GB for compilation and for runtime but we do not want that depending modules have cc-en_GB
     // automatically in their compile classpath. Thus:
@@ -19,13 +19,13 @@ dependencies {
 }
 
 dependencies {
-    compile "ch.tutteli.kbox:kbox-android:$kbox_version"
+    implementation "ch.tutteli.kbox:kbox-android:$kbox_version"
     
     //spek2 requires stdlib-jdk8 and kotlin-reflect
     runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     runtimeOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    compile "org.spekframework.spek2:spek-dsl-jvm:$spek2_version", excludeKotlin
+    implementation "org.spekframework.spek2:spek-dsl-jvm:$spek2_version", excludeKotlin
     runtimeOnly "org.spekframework.spek2:spek-runner-junit5:$spek2_version", excludeKotlin
 }
 

--- a/misc/specs/atrium-specs-common/build.gradle
+++ b/misc/specs/atrium-specs-common/build.gradle
@@ -2,9 +2,9 @@ description = 'Provides specifications of Atrium (as common module) which can be
     'APIs and domain/core-implementations of Atrium, to verify that they fulfill the specification.'
 
 dependencies {
-    implementation prefixedProject('domain-api-common')
-    implementation prefixedProject('core-api-common')
-    implementation prefixedProject('domain-builders-common')
+    api prefixedProject('domain-api-common')
+    api prefixedProject('core-api-common')
+    api prefixedProject('domain-builders-common')
 
     // we need cc-en_GB for compilation and for runtime but we do not want that depending modules have cc-en_GB
     // automatically in their compile classpath. Thus:
@@ -19,6 +19,6 @@ dependencies {
 }
 
 dependencies {
-    compile "org.spekframework.spek2:spek-dsl-metadata:$spek2_version"
-    compile "ch.tutteli.kbox:kbox-common:$kbox_version"
+    implementation "org.spekframework.spek2:spek-dsl-metadata:$spek2_version"
+    implementation "ch.tutteli.kbox:kbox-common:$kbox_version"
 }

--- a/misc/specs/atrium-specs-js/build.gradle
+++ b/misc/specs/atrium-specs-js/build.gradle
@@ -2,9 +2,9 @@ description = 'Provides specifications of Atrium (for the JS platforms) which ca
     'APIs and domain/core-implementations of Atrium, to verify that they fulfill the specification.'
 
 dependencies {
-    implementation prefixedProject('domain-api-js')
-    implementation prefixedProject('core-api-js')
-    implementation prefixedProject('domain-builders-js')
+    api prefixedProject('domain-api-js')
+    api prefixedProject('core-api-js')
+    api prefixedProject('domain-builders-js')
 
     // we need cc-en_GB for compilation and for runtime but we do not want that depending modules have cc-en_GB
     // automatically in their compile classpath. Thus:
@@ -19,6 +19,6 @@ dependencies {
 }
 
 dependencies {
-    compile "ch.tutteli.kbox:kbox-js:$kbox_version"
+    implementation "ch.tutteli.kbox:kbox-js:$kbox_version"
     //TODO use spek2 js artifact as soon as the following is released: https://github.com/spekframework/spek/issues/706
 }

--- a/misc/specs/atrium-specs-jvm/build.gradle
+++ b/misc/specs/atrium-specs-jvm/build.gradle
@@ -2,9 +2,9 @@ description = 'Provides specifications of Atrium (for the JVM platform) which ca
     'APIs and domain/core-implementations of Atrium, to verify that they fulfill the specification.'
 
 dependencies {
-    implementation prefixedProject('domain-api-jvm')
-    implementation prefixedProject('core-api-jvm')
-    implementation prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-api-jvm')
+    api prefixedProject('core-api-jvm')
+    api prefixedProject('domain-builders-jvm')
 
     // we need cc-en_GB for compilation and for runtime but we do not want that depending modules have cc-en_GB
     // automatically in their compile classpath. Thus:
@@ -27,6 +27,6 @@ dependencies {
     runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     runtimeOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    compile "org.spekframework.spek2:spek-dsl-jvm:$spek2_version", excludeKotlin
+    implementation "org.spekframework.spek2:spek-dsl-jvm:$spek2_version", excludeKotlin
     runtimeOnly "org.spekframework.spek2:spek-runner-junit5:$spek2_version", excludeKotlin
 }

--- a/misc/verbs-internal/atrium-verbs-internal-android/build.gradle
+++ b/misc/verbs-internal/atrium-verbs-internal-android/build.gradle
@@ -1,13 +1,13 @@
 description = 'Specifies the internally used assertion verbs for Android.'
 
 dependencies {
-    compile prefixedProject('core-api-android')
-    compile prefixedProject('domain-builders-android')
-    compile prefixedProject('spec')
-    compile prefixedProject('specs-android')
+    api prefixedProject('core-api-android')
+    api prefixedProject('domain-builders-android')
+    implementation prefixedProject('spec')
+    implementation prefixedProject('specs-android')
 
-    testCompile prefixedProject('domain-robstoll-android')
-    testCompile prefixedProject('core-robstoll-android')
+    testImplementation prefixedProject('domain-robstoll-android')
+    testImplementation prefixedProject('core-robstoll-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/misc/verbs-internal/atrium-verbs-internal-common/build.gradle
+++ b/misc/verbs-internal/atrium-verbs-internal-common/build.gradle
@@ -1,10 +1,10 @@
 description = 'Specifies the internally used assertion verbs as common module'
 
 dependencies {
-    compile prefixedProject('core-api-common')
-    compile prefixedProject('domain-builders-common')
-    compile prefixedProject('specs-common')
+    api prefixedProject('core-api-common')
+    api prefixedProject('domain-builders-common')
+    implementation prefixedProject('specs-common')
 
-    testCompile prefixedProject('domain-robstoll-common')
-    testCompile prefixedProject('core-robstoll-common')
+    testImplementation prefixedProject('domain-robstoll-common')
+    testImplementation prefixedProject('core-robstoll-common')
 }

--- a/misc/verbs-internal/atrium-verbs-internal-js/build.gradle
+++ b/misc/verbs-internal/atrium-verbs-internal-js/build.gradle
@@ -1,11 +1,11 @@
 description = 'Specifies the internally used assertion verbs for the JS platform'
 
 dependencies {
-    compile prefixedProject('core-api-js')
-    compile prefixedProject('domain-builders-js')
-    compile prefixedProject('translations-en_GB-js')
-    compile prefixedProject('specs-js')
+    api prefixedProject('core-api-js')
+    api prefixedProject('domain-builders-js')
+    implementation prefixedProject('translations-en_GB-js')
+    implementation prefixedProject('specs-js')
 
-    testCompile prefixedProject('domain-robstoll-js')
-    testCompile prefixedProject('core-robstoll-js')
+    testImplementation prefixedProject('domain-robstoll-js')
+    testImplementation prefixedProject('core-robstoll-js')
 }

--- a/misc/verbs-internal/atrium-verbs-internal-jvm/build.gradle
+++ b/misc/verbs-internal/atrium-verbs-internal-jvm/build.gradle
@@ -1,11 +1,11 @@
 description = 'Specifies the internally used assertion verbs'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
-    compile prefixedProject('domain-builders-jvm')
-    compile prefixedProject('spec')
-    compile prefixedProject('specs-jvm')
+    api prefixedProject('core-api-jvm')
+    api prefixedProject('domain-builders-jvm')
+    implementation prefixedProject('spec')
+    implementation prefixedProject('specs-jvm')
 
-    testCompile prefixedProject('domain-robstoll-jvm')
-    testCompile prefixedProject('core-robstoll-jvm')
+    testImplementation prefixedProject('domain-robstoll-jvm')
+    testImplementation prefixedProject('core-robstoll-jvm')
 }

--- a/misc/verbs/atrium-verbs-android/build.gradle
+++ b/misc/verbs/atrium-verbs-android/build.gradle
@@ -1,10 +1,10 @@
 description = 'Assertion verbs for Atrium for Android.'
 
 dependencies {
-    compile prefixedProject('domain-builders-android')
-    compile prefixedProject('core-api-android')
+    api prefixedProject('domain-builders-android')
+    api prefixedProject('core-api-android')
 
-    testCompile prefixedProject('spec')
+    testImplementation prefixedProject('spec')
     testRuntime prefixedProject('domain-robstoll-android')
     testRuntime prefixedProject('core-robstoll-android')
 }

--- a/misc/verbs/atrium-verbs-common/build.gradle
+++ b/misc/verbs/atrium-verbs-common/build.gradle
@@ -1,8 +1,8 @@
 description = 'Assertion verbs for Atrium as common module.'
 
 dependencies {
-    compile prefixedProject('domain-builders-common')
-    compile prefixedProject('core-api-common')
+    api prefixedProject('domain-builders-common')
+    api prefixedProject('core-api-common')
 
     testRuntime prefixedProject('domain-robstoll-common')
     testRuntime prefixedProject('core-robstoll-common')

--- a/misc/verbs/atrium-verbs-js/build.gradle
+++ b/misc/verbs/atrium-verbs-js/build.gradle
@@ -1,8 +1,8 @@
 description = 'Assertion verbs for Atrium for the JS platform.'
 
 dependencies {
-    compile prefixedProject('domain-builders-js')
-    compile prefixedProject('core-api-js')
+    api prefixedProject('domain-builders-js')
+    api prefixedProject('core-api-js')
 
     testRuntime prefixedProject('domain-robstoll-js')
     testRuntime prefixedProject('core-robstoll-js')

--- a/misc/verbs/atrium-verbs-jvm/build.gradle
+++ b/misc/verbs/atrium-verbs-jvm/build.gradle
@@ -1,10 +1,10 @@
 description = 'Assertion verbs for Atrium for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('domain-builders-jvm')
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('domain-builders-jvm')
+    api prefixedProject('core-api-jvm')
 
-    testCompile prefixedProject('spec')
+    testImplementation prefixedProject('spec')
     testRuntime prefixedProject('domain-robstoll-jvm')
     testRuntime prefixedProject('core-robstoll-jvm')
 }

--- a/translations/atrium-translations-de_CH-deprecated/build.gradle
+++ b/translations/atrium-translations-de_CH-deprecated/build.gradle
@@ -1,6 +1,6 @@
 description = "Deprecated translation project - use ${rootProject.name}-translations-de_CH-jvm instead."
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
-    compile prefixedProject('translations-de_CH-jvm')
+    api prefixedProject('core-api-jvm')
+    implementation prefixedProject('translations-de_CH-jvm')
 }

--- a/translations/atrium-translations-en_UK-deprecated/build.gradle
+++ b/translations/atrium-translations-en_UK-deprecated/build.gradle
@@ -1,6 +1,6 @@
 description = "Deprecated translation project - use ${rootProject.name}-translations-en_GB-jvm instead."
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
-    compile prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('core-api-jvm')
+    implementation prefixedProject('translations-en_GB-jvm')
 }

--- a/translations/de_CH/atrium-translations-de_CH-android/build.gradle
+++ b/translations/de_CH/atrium-translations-de_CH-android/build.gradle
@@ -1,7 +1,7 @@
 description = 'Contains translations for Atrium in de_CH for Android.'
 
 dependencies {
-    compile prefixedProject('core-api-android')
+    api prefixedProject('core-api-android')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/translations/de_CH/atrium-translations-de_CH-common/build.gradle
+++ b/translations/de_CH/atrium-translations-de_CH-common/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains translations for Atrium in de_CH as common module.'
 
 dependencies {
-    compile prefixedProject('core-api-common')
+    api prefixedProject('core-api-common')
 }

--- a/translations/de_CH/atrium-translations-de_CH-js/build.gradle
+++ b/translations/de_CH/atrium-translations-de_CH-js/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains translations for Atrium in de_CH for the JS platform.'
 
 dependencies {
-    compile prefixedProject('core-api-js')
+    api prefixedProject('core-api-js')
 }

--- a/translations/de_CH/atrium-translations-de_CH-jvm/build.gradle
+++ b/translations/de_CH/atrium-translations-de_CH-jvm/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains translations for Atrium in de_CH for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
 }

--- a/translations/en_GB/atrium-translations-en_GB-android/build.gradle
+++ b/translations/en_GB/atrium-translations-en_GB-android/build.gradle
@@ -1,7 +1,7 @@
 description = 'Contains translations for Atrium in en_GB for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
 }
 
 srcAndResourcesFromJvmProject(project)

--- a/translations/en_GB/atrium-translations-en_GB-common/build.gradle
+++ b/translations/en_GB/atrium-translations-en_GB-common/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains translations for Atrium in en_GB as common module.'
 
 dependencies {
-    compile prefixedProject('core-api-common')
+    api prefixedProject('core-api-common')
 }

--- a/translations/en_GB/atrium-translations-en_GB-js/build.gradle
+++ b/translations/en_GB/atrium-translations-en_GB-js/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains translations for Atrium in en_GB for the JS platform.'
 
 dependencies {
-    compile prefixedProject('core-api-js')
+    api prefixedProject('core-api-js')
 }

--- a/translations/en_GB/atrium-translations-en_GB-jvm/build.gradle
+++ b/translations/en_GB/atrium-translations-en_GB-jvm/build.gradle
@@ -1,5 +1,5 @@
 description = 'Contains translations for Atrium in en_GB for the JVM platform.'
 
 dependencies {
-    compile prefixedProject('core-api-jvm')
+    api prefixedProject('core-api-jvm')
 }


### PR DESCRIPTION
Following changes were announced with Gradle 3.0:
1) The 'compile' configuration is now deprecated and should be replaced by 'implementation'.
2) The 'testCompile' configuration is now deprecated and should be replaced by' testImplementation'.


----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
