### PR TITLE
Shortcuts for path existance

### DIFF
--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-jdk8/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-jdk8/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -6,13 +6,24 @@ import ch.tutteli.atrium.domain.builders.path
 import java.nio.file.Path
 
 /**
- * Expects that the subject of the assertion (a [Path]) exists.
+ * Expects that the subject of the assertion (a [Path]) exists; meaning that there is a file system entry at the location the [Path] points to.
  *
- * Shortcut for more or less something like `feature(Files::exists, arrayOf()) { toBe(true) }`
- * depends on the underlying implementation though.
+ * This matcher _resolves_ symbolic links.
+ * Therefore, if a symbolic link exists at the location the subject points to, search will continue at the location the symbolic point at.
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Path> Expect<T>.exists(): Expect<T> = addAssertion(ExpectImpl.path.exists(this))
+
+/**
+ * Expects that the subject of the assertion (a [Path]) does not exist; meaning that there is no file system entry at the location the [Path] points to.
+ *
+ * This matcher _resolves_ symbolic links.
+ * Therefore, if a symbolic link exists at the location the subject points to, search will continue at the location the symbolic point at.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+fun <T : Path> Expect<T>.existsNot(): Expect<T> = addAssertion(ExpectImpl.path.existsNot(this))
 

--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-jdk8/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-jdk8/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -2,11 +2,9 @@ package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun0
-import org.spekframework.spek2.meta.Ignore
 import java.nio.file.Path
 
-//TODO #108 remove @Ignore
-@Ignore
 class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpec(
-    fun0(Expect<Path>::exists)
+    fun0(Expect<Path>::exists),
+    fun0(Expect<Path>::existsNot)
 )

--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,10 @@ def createRegisterJsServicesTask(String projectName, String packageName, Functio
 
 createRegisterJsServicesTask('core-robstoll-js', 'ch.tutteli.atrium.core.robstoll') { true }
 createRegisterJsServicesTask('domain-robstoll-js', 'ch.tutteli.atrium.domain.robstoll') {
-    it != 'ch.tutteli.atrium.domain.creating.BigDecimalAssertions'
+    !(it in [
+        'ch.tutteli.atrium.domain.creating.BigDecimalAssertions',
+        'ch.tutteli.atrium.domain.creating.PathAssertions'
+    ])
 }
 createRegisterJsServicesTask('domain-builders-js', 'ch.tutteli.atrium.domain.builders') { true }
 createRegisterJsServicesTask('verbs-internal-js', 'ch.tutteli.atrium.verbs.internal') { true }

--- a/domain/api/atrium-domain-api-jvm/src/main/kotlin/ch/tutteli/atrium/domain/creating/PathAssertions.kt
+++ b/domain/api/atrium-domain-api-jvm/src/main/kotlin/ch/tutteli/atrium/domain/creating/PathAssertions.kt
@@ -17,5 +17,6 @@ val pathAssertions by lazy { loadSingleService(PathAssertions::class) }
  * which an implementation of the domain of Atrium has to provide.
  */
 interface PathAssertions {
-    fun <T: Path> exists(assertionContainer: Expect<T>): Assertion
+    fun <T : Path> exists(assertionContainer: Expect<T>): Assertion
+    fun <T : Path> existsNot(subjectProvider: Expect<T>): Assertion
 }

--- a/domain/builders/atrium-domain-builders-jvm/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/PathAssertionsBuilder.kt
+++ b/domain/builders/atrium-domain-builders-jvm/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/PathAssertionsBuilder.kt
@@ -14,7 +14,6 @@ import java.nio.file.Path
  * which in turn delegates to the implementation via [loadSingleService].
  */
 object PathAssertionsBuilder : PathAssertions {
-
     override inline fun <T : Path> exists(assertionContainer: Expect<T>) = pathAssertions.exists(assertionContainer)
-
+    override inline fun <T : Path> existsNot(subjectProvider: Expect<T>) = pathAssertions.existsNot(subjectProvider)
 }

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/pathAssertions.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/pathAssertions.kt
@@ -2,15 +2,16 @@ package ch.tutteli.atrium.domain.robstoll.lib.creating
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.translations.DescriptionAnyAssertion.NOT_TO
+import ch.tutteli.atrium.translations.DescriptionAnyAssertion.TO
+import ch.tutteli.atrium.translations.DescriptionPathAssertion.EXIST
+import ch.tutteli.niok.exists
+import ch.tutteli.niok.notExists
 import java.nio.file.Path
 
-//TODO #104 remove annotation
-@Suppress("UNUSED_PARAMETER")
 fun <T : Path> _exists(assertionContainer: Expect<T>): Assertion =
-    TODO(
-        """
-        #104 create a feature assertion for Path::exists and assert it is true.
-        Notice, there is a bug in the new-type-inference https://youtrack.jetbrains.com/issue/KT-32851 
-        the bug is only within IDEA, check gradle if it works
-        """
-    )
+    ExpectImpl.builder.createDescriptive(assertionContainer, TO, RawString.create(EXIST)) { it.exists }
+fun <T : Path> _existsNot(subjectProvider: Expect<T>): Assertion =
+    ExpectImpl.builder.createDescriptive(subjectProvider, NOT_TO, RawString.create(EXIST)) { it.notExists }

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/module/module-info.java
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/module/module-info.java
@@ -3,6 +3,7 @@ module ch.tutteli.atrium.domain.robstoll.lib {
     requires        ch.tutteli.atrium.domain.builders;
     requires static ch.tutteli.atrium.translations.en_GB;
     requires        kotlin.stdlib;
+    requires        ch.tutteli.niok;
 
     //TODO remove with 1.0.0
     requires        ch.tutteli.atrium.api.cc.en_GB;

--- a/domain/robstoll/atrium-domain-robstoll-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/PathAssertionsImpl.kt
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/PathAssertionsImpl.kt
@@ -3,10 +3,11 @@ package ch.tutteli.atrium.domain.robstoll.creating
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.creating.PathAssertions
 import ch.tutteli.atrium.domain.robstoll.lib.creating._exists
+import ch.tutteli.atrium.domain.robstoll.lib.creating._existsNot
 import java.nio.file.Path
 
 
 class PathAssertionsImpl : PathAssertions {
-
-    override fun <T: Path> exists(assertionContainer: Expect<T>) = _exists(assertionContainer)
+    override fun <T : Path> exists(assertionContainer: Expect<T>) = _exists(assertionContainer)
+    override fun <T : Path> existsNot(subjectProvider: Expect<T>) = _existsNot(subjectProvider)
 }

--- a/domain/robstoll/atrium-domain-robstoll-jvm/src/main/resources/META-INF/services/ch.tutteli.atrium.domain.creating.PathAssertions
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/src/main/resources/META-INF/services/ch.tutteli.atrium.domain.creating.PathAssertions
@@ -1,0 +1,1 @@
+ch.tutteli.atrium.domain.robstoll.creating.PathAssertionsImpl

--- a/domain/robstoll/atrium-domain-robstoll-jvm/src/module/module-info.java
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/src/module/module-info.java
@@ -89,4 +89,7 @@ module ch.tutteli.atrium.domain.robstoll {
 
     provides ch.tutteli.atrium.domain.creating.ThrowableAssertions
         with ch.tutteli.atrium.domain.robstoll.creating.ThrowableAssertionsImpl;
+
+    provides ch.tutteli.atrium.domain.creating.PathAssertions
+        with ch.tutteli.atrium.domain.robstoll.creating.PathAssertionsImpl;
 }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionAnyAssertion
+import ch.tutteli.atrium.translations.DescriptionPathAssertion
 import ch.tutteli.spek.extensions.TempFolder
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
@@ -13,6 +14,7 @@ import java.nio.file.Paths
 
 abstract class PathAssertionsSpec(
     exists: Fun0<Path>,
+    existsNot: Fun0<Path>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
@@ -27,17 +29,15 @@ abstract class PathAssertionsSpec(
     fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, funName, body = body)
 
-
     describeFun(exists.name) {
         val existsFun = exists.lambda
         context("non existing") {
-            it("throws AssertionError") {
+            it("throws an AssertionError") {
                 expect {
                     expect(Paths.get("nonExistingFile")).existsFun()
                 }.toThrow<AssertionError> {
                     messageContains(
-                        "exists: false",
-                        "${DescriptionAnyAssertion.TO_BE.getDefault()}: true"
+                        "${DescriptionAnyAssertion.TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
                     )
                 }
             }
@@ -52,6 +52,39 @@ abstract class PathAssertionsSpec(
             it("does not throw") {
                 val file = tempFolder.newFolder("test")
                 expect(file).existsFun()
+            }
+        }
+    }
+
+    describeFun(existsNot.name) {
+        val existsNotFun = existsNot.lambda
+        context("non existing") {
+            it("does not throw") {
+                expect(Paths.get("nonExistingFile")).existsNotFun()
+            }
+        }
+
+        val expectedMessageIfExisting = "${DescriptionAnyAssertion.NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
+
+        context("existing file") {
+            it("throws an AssertionError") {
+                val file = tempFolder.newFile("exists-though-shouldnt")
+                expect {
+                    expect(file).existsNotFun()
+                }.toThrow<AssertionError> {
+                    messageContains(expectedMessageIfExisting)
+                }
+            }
+        }
+
+        context("existing folder") {
+            it("throws an AssertionError") {
+                val folder = tempFolder.newFolder("exists-though-shouldnt")
+                expect {
+                    expect(folder).existsNotFun()
+                }.toThrow<AssertionError> {
+                    messageContains(expectedMessageIfExisting)
+                }
             }
         }
     }

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionAnyAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionAnyAssertion.kt
@@ -7,6 +7,8 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  * Contains the [DescriptiveAssertion.description]s of the assertion functions which are applicable to [Any].
  */
 enum class DescriptionAnyAssertion(override val value: String) : StringBasedTranslatable {
+    TO("to"),
+    NOT_TO("not to"),
     TO_BE("to be"),
     NOT_TO_BE("not to be"),
     IS_A("is instance of type"),

--- a/translations/en_GB/atrium-translations-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionPathAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionPathAssertion.kt
@@ -1,0 +1,7 @@
+package ch.tutteli.atrium.translations
+
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+
+enum class DescriptionPathAssertion(override val value: String) : StringBasedTranslatable {
+    EXIST("exist")
+}


### PR DESCRIPTION
Implements Matchers for `Path#exists` and `Path#existsNot`.

Deviates from the proposed course of action in #108 as so far as I have adapted the message to be less noisy while keeping the same amount of information. The message in this PR match the ones used for `Collection#isEmpty` and the like.

So instead of:

```
expect: notExisting        (sun.nio.fs.UnixPath <749882615>)
◆ ▶ exists: false
    ◾ to be: true
```
this PR creates this message:
```
expect: notExisting        (sun.nio.fs.UnixPath <749882615>)
◆ to: exist
```

just like we get:
```
expect: [not-empty]        (java.util.Collections.SingletonList <1286606146>)
◆ is: empty
```

closes #108 

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
