### PR TITLE
Use the updated version of tutteli-gradle-plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
         // test
         jacoco_tool_version = '0.8.2'
-        junit_platform_version = '1.2.0'
+        junit_platform_version = '1.5.1'
         jupiter_version = '5.5.1'
         spek_version = '1.1.5'
         spek2_version = '2.0.6'
@@ -242,20 +242,17 @@ configure(jacocoMulti.jacocoProjects + getAndroidProjects()) {
         }
     }
 
-    //TODO remove once all specs are migrated to spek2
-    junitPlatform {
-        filters {
-            engines {
-                if (project.name != 'atrium-spec') {
-                    include 'spek2'
-                }
-                if (!project.name.startsWith('atrium-specs')) {
-                    include 'spek'
-                }
+    test {
+        //TODO remove once all specs are migrated to spek2
+        options {
+            if (project.name != 'atrium-spec') {
+                includeEngines 'spek2'
+            }
+            if (!project.name.startsWith('atrium-specs')) {
+                includeEngines 'spek'
             }
         }
     }
-
 }
 
 apply from: 'gradle/scripts/gh-pages.gradle'
@@ -401,7 +398,11 @@ def useJupiter(String... projectNames) {
         dependencies {
             testRuntime "org.junit.jupiter:junit-jupiter-engine:$jupiter_version"
         }
-        junitPlatform.filters.engines { include 'junit-jupiter' }
+        test {
+            options {
+                includeEngines 'junit-jupiter'
+            }
+        }
     }
 }
 

--- a/misc/atrium-bc-test/build.gradle
+++ b/misc/atrium-bc-test/build.gradle
@@ -14,9 +14,10 @@ configurations {
 }
 
 dependencies {
-    common "org.junit.platform:junit-platform-gradle-plugin:$junit_platform_version"
     common "org.jetbrains.spek:spek-api:$spek_version", excludeKotlin
     common "org.jetbrains.spek:spek-junit-platform-engine:$spek_version", excludeKotlin
+    common "org.junit.jupiter:junit-jupiter-engine:$jupiter_version"
+    common "org.junit.platform:junit-platform-console:$junit_platform_version"
 
     common mockito(), excludeKotlin
     common kotlinStdlib()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'atrium'
 
 buildscript {
-    gradle.ext.tutteli_plugins_version = '0.27.3'
+    gradle.ext.tutteli_plugins_version = '0.28.0'
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -21,7 +21,6 @@ include {
             self.kotlinJvmJsAndroid(suffix)
         } else {
             self.kotlinJvmJs(suffix)
-
         }
     }
 
@@ -87,13 +86,13 @@ include {
         kotlinJvmJsAndAndroidIfCi(delegate, 'verbs')
         kotlinJvmJsAndAndroidIfCi(delegate, 'verbs-internal')
     }
-    
+
     samples {
         js {
             project('mocha')
         }
     }
-    
+
 
     //TODO remove all below with 1.0.0
     bundles {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'atrium'
 
 buildscript {
-    gradle.ext.tutteli_plugins_version = '0.28.0'
+    gradle.ext.tutteli_plugins_version = '0.28.1'
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
     }


### PR DESCRIPTION
update `tutteli-gradle-plugins` and make minor adaptions to use Gradle’s built-in JUnit support.

closes #126


----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
