### PR TITLE
Add elementsOf function for contains.inAnyOrder

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableContainsInAnyOrderCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableContainsInAnyOrderCreators.kt
@@ -93,3 +93,21 @@ fun <E : Any, T : Iterable<E?>> IterableContains.CheckerOption<E?, T, InAnyOrder
         assertionCreatorOrNull glue otherAssertionCreatorsOrNulls
     )
 )
+
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the [expectedIterable]
+ * shall be searched within the [Iterable].
+ *
+ * @param expectedIterable The [Iterable] in which one of the items is expected to be contained within the [Iterable].
+ *
+ * @return The [Expect] for which the assertion was built to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.9.0
+ */
+inline fun <reified E, T : Iterable<E>> IterableContains.CheckerOption<E, T, InAnyOrderSearchBehaviour>.elementsOf(
+    expectedIterable: Iterable<E>
+): Expect<T> {
+    require(expectedIterable.iterator().hasNext()) { "Collection can not be empty" }
+    return values(expectedIterable.first(), *expectedIterable.drop(1).toTypedArray())
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInAnyOrderAtLeast1ElementsOfAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInAnyOrderAtLeast1ElementsOfAssertionsSpec.kt
@@ -1,0 +1,38 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.include
+import org.spekframework.spek2.Spek
+
+class IterableContainsInAnyOrderAtLeast1ElementsOfAssertionsSpec : Spek({
+    include(BuilderSpec)
+}) {
+    object BuilderSpec : ch.tutteli.atrium.specs.integration.IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec(
+        getContainsPair(),
+        getContainsNullablePair(),
+        "◆ ",
+        "[Atrium][Builder] "
+    )
+
+    companion object : IterableContainsSpecBase() {
+        fun getContainsPair() = "$contains.$inAnyOrder.$atLeast(1).$inAnyOrderElementsOf" to Companion::containsValues
+
+        private fun containsValues(
+            expect: Expect<Iterable<Double>>,
+            a: Double,
+            aX: Array<out Double>
+        ): Expect<Iterable<Double>> =
+            expect.contains.inAnyOrder.atLeast(1).elementsOf(listOf(a, *aX))
+
+        fun getContainsNullablePair() =
+            "$contains.$inAnyOrder.$atLeast(1).$inAnyOrderElementsOf" to Companion::containsNullableValues
+
+        private fun containsNullableValues(
+            expect: Expect<Iterable<Double?>>,
+            a: Double?,
+            aX: Array<out Double?>
+        ): Expect<Iterable<Double?>> =
+            expect.contains.inAnyOrder.atLeast(1).elementsOf(listOf(a, *aX))
+
+    }
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsSpecBase.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsSpecBase.kt
@@ -5,7 +5,12 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.utils.Group
 import ch.tutteli.atrium.domain.creating.iterable.contains.IterableContains
-import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.*
+import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
+import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAnyOrderSearchBehaviour
+import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
+import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedWithinSearchBehaviour
+import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
+import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
 import ch.tutteli.atrium.specs.notImplemented
 import kotlin.reflect.KFunction4
 import kotlin.reflect.KProperty
@@ -25,6 +30,7 @@ abstract class IterableContainsSpecBase {
     protected val inAnyOrder = IterableContains.Builder<*, *, NoOpSearchBehaviour>::inAnyOrder.name
     protected val inAnyOrderValues = IterableContains.CheckerOption<Int, Iterable<Int>, InAnyOrderSearchBehaviour>::values.name
     protected val inAnyOrderEntries = IterableContains.CheckerOption<Int, Iterable<Int>, InAnyOrderSearchBehaviour>::entries.name
+    protected val inAnyOrderElementsOf = IterableContains.CheckerOption<Int, Iterable<Int>, InAnyOrderSearchBehaviour>::elementsOf.name
     protected val inAnyOrderOnlyValues = IterableContains.Builder<Int, Iterable<Int>, InAnyOrderOnlySearchBehaviour>::values.name
     protected val inAnyOrderOnlyEntries = IterableContains.Builder<Int, Iterable<Int>, InAnyOrderOnlySearchBehaviour>::entries.name
     protected val inOrder = IterableContains.Builder<*, *, NoOpSearchBehaviour>::inOrder.name


### PR DESCRIPTION
Discussed in #129 
Added `elementsOf` function for `contains.inAnyOrder`
Function allows you to search in `Iterable` entries that exists in expected `Iterable`

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
