### PR TITLE
update spek specification link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -113,7 +113,7 @@ However, here a few hints in order that your pull request is merged quickly.
 2. Try to write code in a similar style as the existing 
    (We suggest you copy something existing and modify it).
 3. Write readable code and express comments with code rather than comments.
-4. Provide tests in form of [Spek](https://spekframework.org/docs/latest/) specifications.
+4. Provide tests in form of [Spek](https://spekframework.org/specification/) specifications.
 5. Write your commit message in an [imperative style](https://chris.beams.io/posts/git-commit/).     
 
 ## Pull Request Checklist


### PR DESCRIPTION
The link to spec specification is giving 404.
----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
