### PR TITLE
Path starts (not) with

### DIFF
--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -6,6 +6,28 @@ import ch.tutteli.atrium.domain.builders.path
 import java.nio.file.Path
 
 /**
+ * Expects that the subject of the assertion (a [Path]) starts with the expected [Path].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.9.0
+ */
+fun <T : Path> Expect<T>.startsWith(expected: Path): Expect<T> =
+    addAssertion(ExpectImpl.path.startsWith(this, expected))
+
+/**
+ * Expects that the subject of the assertion (a [Path]) does not start with the expected [Path].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.9.0
+ */
+fun <T : Path> Expect<T>.startsNotWith(expected: Path): Expect<T> =
+    addAssertion(ExpectImpl.path.startsNotWith(this, expected))
+
+/**
  * Expects that the subject of the assertion (a [Path]) ends with the expected [Path].
  *
  * @return This assertion container to support a fluent API.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -17,7 +17,7 @@ fun <T : Path> Expect<T>.startsWith(expected: Path): Expect<T> =
     addAssertion(ExpectImpl.path.startsWith(this, expected))
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not start with the expected [Path].
+ * Expects that the subject of the assertion (a [Path]) does not start with the [expected] [Path].
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.domain.builders.path
 import java.nio.file.Path
 
 /**
- * Expects that the subject of the assertion (a [Path]) starts with the expected [Path].
+ * Expects that the subject of the assertion (a [Path]) starts with the [expected] [Path].
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -10,6 +10,8 @@ import java.nio.file.Paths
 class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpec(
     fun0(Expect<Path>::exists),
     fun0(Expect<Path>::existsNot),
+    fun1(Expect<Path>::startsWith),
+    fun1(Expect<Path>::startsNotWith),
     fun1(Expect<Path>::endsWith)
 ){
     @Suppress("unused", "UNUSED_VALUE")

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -25,6 +25,12 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
         a2.existsNot()
         a2.existsNot()
 
+        a1.startsWith(Paths.get("a"))
+        a2.startsWith(Paths.get("a"))
+
+        a1.startsNotWith(Paths.get("a"))
+        a2.startsNotWith(Paths.get("a"))
+
         a1.endsWith(Paths.get("a"))
         a2.endsWith(Paths.get("a"))
     }

--- a/domain/api/atrium-domain-api-jvm/src/main/kotlin/ch/tutteli/atrium/domain/creating/PathAssertions.kt
+++ b/domain/api/atrium-domain-api-jvm/src/main/kotlin/ch/tutteli/atrium/domain/creating/PathAssertions.kt
@@ -18,6 +18,9 @@ val pathAssertions by lazy { loadSingleService(PathAssertions::class) }
  * which an implementation of the domain of Atrium has to provide.
  */
 interface PathAssertions {
+    fun <T: Path> startsWith(assertionContainer: Expect<T>, expected: Path): Assertion
+    fun <T: Path> startsNotWith(assertionContainer: Expect<T>, expected: Path): Assertion
+
     fun <T : Path> endsWith(assertionContainer: Expect<T>, expected: Path): Assertion
 
     fun <T : Path> exists(assertionContainer: Expect<T>): Assertion

--- a/domain/builders/atrium-domain-builders-jvm/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/PathAssertionsBuilder.kt
+++ b/domain/builders/atrium-domain-builders-jvm/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/PathAssertionsBuilder.kt
@@ -14,6 +14,12 @@ import java.nio.file.Path
  * which in turn delegates to the implementation via [loadSingleService].
  */
 object PathAssertionsBuilder : PathAssertions {
+    override fun <T : Path> startsWith(assertionContainer: Expect<T>, expected: Path) =
+        pathAssertions.startsWith(assertionContainer, expected)
+
+    override fun <T : Path> startsNotWith(assertionContainer: Expect<T>, expected: Path) =
+        pathAssertions.startsNotWith(assertionContainer, expected)
+
     override fun <T : Path> endsWith(assertionContainer: Expect<T>, expected: Path) =
         pathAssertions.endsWith(assertionContainer, expected)
 

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/pathAssertions.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/pathAssertions.kt
@@ -14,6 +14,12 @@ import ch.tutteli.niok.fileNameWithoutExtension
 import ch.tutteli.niok.notExists
 import java.nio.file.Path
 
+fun <T: Path> _startsWith(assertionContainer: Expect<T>, expected: Path): Assertion =
+    ExpectImpl.builder.createDescriptive(assertionContainer, STARTS_WITH, expected) { it.startsWith(expected) }
+
+fun <T: Path> _startsNotWith(assertionContainer: Expect<T>, expected: Path): Assertion =
+    ExpectImpl.builder.createDescriptive(assertionContainer, STARTS_NOT_WITH, expected) { !it.startsWith(expected) }
+
 fun <T : Path> _endsWith(assertionContainer: Expect<T>, expected: Path): Assertion =
     ExpectImpl.builder.createDescriptive(assertionContainer, ENDS_WITH, expected) { it.endsWith(expected) }
 

--- a/domain/robstoll/atrium-domain-robstoll-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/PathAssertionsImpl.kt
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/PathAssertionsImpl.kt
@@ -2,14 +2,15 @@ package ch.tutteli.atrium.domain.robstoll.creating
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.creating.PathAssertions
-import ch.tutteli.atrium.domain.robstoll.lib.creating._endsWith
-import ch.tutteli.atrium.domain.robstoll.lib.creating._exists
-import ch.tutteli.atrium.domain.robstoll.lib.creating._existsNot
-import ch.tutteli.atrium.domain.robstoll.lib.creating._fileNameWithoutExtension
-import ch.tutteli.atrium.domain.robstoll.lib.creating._parent
+import ch.tutteli.atrium.domain.robstoll.lib.creating.*
 import java.nio.file.Path
 
 class PathAssertionsImpl : PathAssertions {
+    override fun <T : Path> startsWith(assertionContainer: Expect<T>, expected: Path) =
+        _startsWith(assertionContainer, expected)
+
+    override fun <T : Path> startsNotWith(assertionContainer: Expect<T>, expected: Path) =
+        _startsNotWith(assertionContainer, expected)
 
     override fun <T : Path> endsWith(assertionContainer: Expect<T>, expected: Path) =
         _endsWith(assertionContainer, expected)

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -101,11 +101,24 @@ abstract class PathAssertionsSpec(
                     .startsWithFun(Paths.get("/some/path/"))
             }
         }
+
+        val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
+
+        context("does not start with") {
+            it("throws an AssertionException") {
+                expect {
+                    expect(Paths.get("/some/path/for/test"))
+                        .startsWithFun(Paths.get("/other/path"))
+                }.toThrow<AssertionError> {
+                    messageContains(expectedMessageIfNotStartsWith)
+                }
+            }
+        }
     }
 
     describeFun(startsNotWith.name) {
         val startsNotWithFun = startsNotWith.lambda
-        context("starts not with") {
+        context("does not start with") {
             it("does not throw") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/other/path/"))
@@ -113,6 +126,19 @@ abstract class PathAssertionsSpec(
             it("does not match partials") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/some/pa"))
+            }
+        }
+
+        val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
+
+        context("starts with") {
+            it("throws an AssertionException") {
+                expect {
+                    expect(Paths.get("/some/path/for/test"))
+                        .startsNotWithFun(Paths.get("/some/path"))
+                }.toThrow<AssertionError> {
+                    messageContains(expectedMessageIfStartsWith)
+                }
             }
         }
     }
@@ -139,4 +165,3 @@ abstract class PathAssertionsSpec(
         }
     }
 })
-

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -16,6 +16,8 @@ import java.nio.file.Paths
 abstract class PathAssertionsSpec(
     exists: Fun0<Path>,
     existsNot: Fun0<Path>,
+    startsWith: Fun1<Path, Path>,
+    startsNotWith: Fun1<Path, Path>,
     endsWith: Fun1<Path, Path>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
@@ -87,6 +89,30 @@ abstract class PathAssertionsSpec(
                 }.toThrow<AssertionError> {
                     messageContains(expectedMessageIfExisting)
                 }
+            }
+        }
+    }
+
+    describeFun(startsWith.name) {
+        val startsWithFun = startsWith.lambda
+        context("starts with") {
+            it("does not throw") {
+                expect(Paths.get("/some/path/for/test"))
+                    .startsWithFun(Paths.get("/some/path/"))
+            }
+        }
+    }
+
+    describeFun(startsNotWith.name) {
+        val startsNotWithFun = startsNotWith.lambda
+        context("starts not with") {
+            it("does not throw") {
+                expect(Paths.get("/some/path/for/test"))
+                    .startsNotWithFun(Paths.get("/other/path/"))
+            }
+            it("does not match partials") {
+                expect(Paths.get("/some/path/for/test"))
+                    .startsNotWithFun(Paths.get("/some/pa"))
             }
         }
     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -105,7 +105,7 @@ abstract class PathAssertionsSpec(
         val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
 
         context("does not start with") {
-            it("throws an AssertionException") {
+            it("throws an AssertionError") {
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsWithFun(Paths.get("/other/path"))

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -132,7 +132,7 @@ abstract class PathAssertionsSpec(
         val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
 
         context("starts with") {
-            it("throws an AssertionException") {
+            it("throws an AssertionError") {
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsNotWithFun(Paths.get("/some/path"))

--- a/translations/de_CH/atrium-translations-de_CH-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionPathAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionPathAssertion.kt
@@ -8,4 +8,6 @@ enum class DescriptionPathAssertion(override val value: String) : StringBasedTra
     ENDS_WITH("endet mit"),
     PARENT("übergeordneter Pfad"),
     FILE_NAME_WITHOUT_EXTENSION("Dateiname ohne Endung"),
+    STARTS_WITH("beginnt mit"),
+    STARTS_NOT_WITH("beginnt nicht mit"),
 }

--- a/translations/en_GB/atrium-translations-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionPathAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionPathAssertion.kt
@@ -7,5 +7,7 @@ enum class DescriptionPathAssertion(override val value: String) : StringBasedTra
     EXIST("exist"),
     ENDS_WITH("ends with"),
     PARENT("parent"),
-    FILE_NAME_WITHOUT_EXTENSION("file name without extension")
+    FILE_NAME_WITHOUT_EXTENSION("file name without extension"),
+    STARTS_WITH("starts with"),
+    STARTS_NOT_WITH("does not start with"),
 }


### PR DESCRIPTION
Add `path starts with` and `path starts not with` assertions, including translations and some tests to show functionality.

Closes #187 
Closes #189 

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
