### PR TITLE
Optional isEmpty spec

### DIFF
--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/OptionalAssertionsSpec.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/OptionalAssertionsSpec.kt
@@ -1,0 +1,20 @@
+package ch.tutteli.atrium.api.fluent.en_GB.jdk8
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.fun0
+import ch.tutteli.atrium.specs.integration.OptionalAssertionsSpec
+import ch.tutteli.atrium.specs.notImplemented
+import java.util.*
+
+class OptionalAssertionsSpec : OptionalAssertionsSpec (
+    isEmpty = fun0(Expect<Optional<Any>>::isEmpty)
+) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        val o1: Expect<Optional<Any>> = notImplemented()
+        val o2: Expect<out Optional<Any>> = notImplemented()
+
+        o1.isEmpty()
+        o2.isEmpty()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -356,6 +356,7 @@ createRegisterJsServicesTask('core-robstoll-js', 'ch.tutteli.atrium.core.robstol
 createRegisterJsServicesTask('domain-robstoll-js', 'ch.tutteli.atrium.domain.robstoll') {
     !(it in [
         'ch.tutteli.atrium.domain.creating.BigDecimalAssertions',
+        'ch.tutteli.atrium.domain.creating.OptionalAssertions',
         'ch.tutteli.atrium.domain.creating.PathAssertions',
         'ch.tutteli.atrium.domain.creating.LocalDateAssertions',
         'ch.tutteli.atrium.domain.creating.LocalDateTimeAssertions',

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/optionalAssertions.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/optionalAssertions.kt
@@ -2,30 +2,11 @@ package ch.tutteli.atrium.domain.robstoll.lib.creating
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.translations.DescriptionBasic.IS
+import ch.tutteli.atrium.translations.DescriptionOptionalAssertion.EMPTY
 import java.util.*
 
-//TODO #47 remove annotation
-@Suppress("UNUSED_PARAMETER")
 fun <E, T: Optional<E>> _isEmpty(assertionContainer: Expect<T>): Assertion =
-    TODO(
-        """
-        #47 create a feature assertion for Optional<T>::isEmpty and assert it to be true
-        Notice, there is a bug in the new-type-inference https://youtrack.jetbrains.com/issue/KT-32851
-        the bug is only within IDEA, check gradle if it works
-
-        Also note that JDK11 provides Optional.isEmpty but jdk8 does not yet, implement the check in terms of `isPresent`
-        However, in reporting we would like to see something like
-        expect: Optional[1]
-        - is: empty
-
-        and not
-
-        expect: Optional[1]
-        - isPresent: true
-          - to be: false
-
-        Which means we should provide a custom Description (which is translatable). For this create:
-        - DescriptionOptionalAssertion in atrium-translations-en_GB-common (copy DescriptionCollectionAssertion enum and adapt)
-        - don't forget to add it also for atrium-translations-de_CH-common  
-        """
-    )
+    ExpectImpl.builder.createDescriptive(assertionContainer, IS, RawString.create(EMPTY)) { !it.isPresent }

--- a/domain/robstoll/atrium-domain-robstoll-jvm/src/main/resources/META-INF/services/ch.tutteli.atrium.domain.creating.OptionalAssertions
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/src/main/resources/META-INF/services/ch.tutteli.atrium.domain.creating.OptionalAssertions
@@ -1,0 +1,1 @@
+ch.tutteli.atrium.domain.robstoll.creating.OptionalAssertionsImpl

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/OptionalAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/OptionalAssertionsSpec.kt
@@ -1,0 +1,44 @@
+package ch.tutteli.atrium.specs.integration
+
+import ch.tutteli.atrium.api.fluent.en_GB.messageContains
+import ch.tutteli.atrium.api.fluent.en_GB.toThrow
+import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.specs.Fun0
+import ch.tutteli.atrium.specs.describeFunTemplate
+import ch.tutteli.atrium.specs.isDescr
+import ch.tutteli.atrium.specs.lambda
+import ch.tutteli.atrium.specs.name
+import ch.tutteli.atrium.translations.DescriptionOptionalAssertion.EMPTY
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.Suite
+import java.lang.AssertionError
+import java.util.Optional
+
+abstract class OptionalAssertionsSpec (
+    isEmpty: Fun0<Optional<Any>>,
+    describePrefix: String = "[Atrium] "
+) : Spek({
+
+    fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
+        describeFunTemplate(describePrefix, funName, body = body)
+
+    describeFun(isEmpty.name) {
+        val isEmptyFun = isEmpty.lambda
+
+        context("is empty") {
+            it ("does not throw") {
+                val emptyValue = Optional.empty<Any>()
+                expect(emptyValue).isEmptyFun()
+            }
+
+            it ("throws an AssertionError") {
+                val nonEmptyValue: Optional<Any> = Optional.of(2)
+                expect {
+                    expect(nonEmptyValue).isEmptyFun()
+                }.toThrow<AssertionError> {
+                    messageContains("$isDescr: ${EMPTY.getDefault()}")
+                }
+            }
+        }
+    }
+})

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/OptionalAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/OptionalAssertionsSpec.kt
@@ -3,11 +3,7 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.messageContains
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
-import ch.tutteli.atrium.specs.Fun0
-import ch.tutteli.atrium.specs.describeFunTemplate
-import ch.tutteli.atrium.specs.isDescr
-import ch.tutteli.atrium.specs.lambda
-import ch.tutteli.atrium.specs.name
+import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionOptionalAssertion.EMPTY
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
@@ -18,6 +14,11 @@ abstract class OptionalAssertionsSpec (
     isEmpty: Fun0<Optional<Any>>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
+
+    include(object : SubjectLessSpec<Optional<Any>>(
+        "$describePrefix[Path] ",
+        isEmpty.forSubjectLess()
+    ) {})
 
     fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, funName, body = body)

--- a/translations/de_CH/atrium-translations-de_CH-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionOptionalAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionOptionalAssertion.kt
@@ -1,0 +1,7 @@
+package ch.tutteli.atrium.translations
+
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+
+enum class DescriptionOptionalAssertion(override val value: String) : StringBasedTranslatable {
+    EMPTY("leer"),
+}

--- a/translations/en_GB/atrium-translations-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionOptionalAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionOptionalAssertion.kt
@@ -1,0 +1,7 @@
+package ch.tutteli.atrium.translations
+
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+
+enum class DescriptionOptionalAssertion(override val value: String) : StringBasedTranslatable {
+    EMPTY("empty"),
+}


### PR DESCRIPTION
Made Optional.isEmpty working by implementing `_isEmpty` and added tests to show usage.

Closes #47 

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
