### PR TITLE
Fuse describe of similar functions in PathAssertionsSpec

### DIFF
--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -144,18 +144,18 @@ abstract class PathAssertionsSpec(
         }
     }
 
-    describeFun(endsWith.name) {
+    describeFun(endsWith.name, endsNotWith.name) {
         val endsWithFun = endsWith.lambda
+        val endsNotWithFun = endsNotWith.lambda
+
         context("ends with") {
             it("does not throw") {
                 expect(Paths.get("/not/existed/for/test"))
                     .endsWithFun(Paths.get("for/test"))
             }
-        }
-        val expectedMessageIfNotEndsWith = "${DescriptionPathAssertion.ENDS_WITH.getDefault()}:"
 
-        context("not ends with") {
             it("throws an AssertionError") {
+                val expectedMessageIfNotEndsWith = "${DescriptionPathAssertion.ENDS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/not/existed/for/test"))
                         .endsWithFun(Paths.get("/for/test"))
@@ -164,11 +164,8 @@ abstract class PathAssertionsSpec(
                 }
             }
         }
-    }
 
-    describeFun(endsNotWith.name) {
-        val endsNotWithFun = endsNotWith.lambda
-        context("path ends with") {
+        context("path ends not with") {
             it("throws an AssertionError") {
                 expect {
                     expect(Paths.get("/path/ends/with/this"))
@@ -177,9 +174,7 @@ abstract class PathAssertionsSpec(
                     messageContains("${DescriptionPathAssertion.ENDS_NOT_WITH.getDefault()}:")
                 }
             }
-        }
 
-        context("path does not end with") {
             it("does not throw") {
                 expect(Paths.get("/path/ends/with/this"))
                     .endsNotWithFun(Paths.get("with/another"))

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -131,35 +131,33 @@ abstract class PathAssertionsSpec(
         val endsWithFun = endsWith.lambda
         val endsNotWithFun = endsNotWith.lambda
 
-        context("ends with") {
-            it("${endsWith.name} does not throw") {
-                expect(Paths.get("/not/existed/for/test"))
+        context("path '/some/path/for/test'") {
+            it("${endsWith.name} 'for/test' does not throw") {
+                expect(Paths.get("/some/path/for/test"))
                     .endsWithFun(Paths.get("for/test"))
             }
 
-            it("${endsWith.name} throws an AssertionError") {
+            it("${endsWith.name} 'for/another' throws an AssertionError") {
                 expect {
-                    expect(Paths.get("/not/existed/for/test"))
-                        .endsWithFun(Paths.get("/for/test"))
+                    expect(Paths.get("/some/path/for/test"))
+                        .endsWithFun(Paths.get("for/another"))
                 }.toThrow<AssertionError> {
                     messageContains("${DescriptionPathAssertion.ENDS_WITH.getDefault()}:")
                 }
             }
-        }
 
-        context("path ends not with") {
-            it("${endsNotWith.name} throws an AssertionError") {
+            it("${endsNotWith.name} 'for/test' throws an AssertionError") {
                 expect {
-                    expect(Paths.get("/path/ends/with/this"))
-                        .endsNotWithFun(Paths.get("with/this"))
+                    expect(Paths.get("/some/path/for/test"))
+                        .endsNotWithFun(Paths.get("for/test"))
                 }.toThrow<AssertionError> {
                     messageContains("${DescriptionPathAssertion.ENDS_NOT_WITH.getDefault()}:")
                 }
             }
 
-            it("${endsNotWith.name} does not throw") {
-                expect(Paths.get("/path/ends/with/this"))
-                    .endsNotWithFun(Paths.get("with/another"))
+            it("${endsNotWith.name} 'for/another' does not throw") {
+                expect(Paths.get("/some/path/for/test"))
+                    .endsNotWithFun(Paths.get("for/another"))
             }
         }
     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -34,9 +34,10 @@ abstract class PathAssertionsSpec(
     fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, funName, body = body)
 
-    describeFun(exists.name) {
+    describeFun(exists.name, existsNot.name) {
         val existsFun = exists.lambda
-        context("non existing") {
+        val existsNotFun = existsNot.lambda
+        context("exists") {
             it("throws an AssertionError") {
                 expect {
                     expect(Paths.get("nonExistingFile")).existsFun()
@@ -46,32 +47,20 @@ abstract class PathAssertionsSpec(
                     )
                 }
             }
-        }
-        context("existing file") {
+
             it("does not throw") {
                 val file = tempFolder.newFile("test")
                 expect(file).existsFun()
             }
-        }
-        context("existing folder") {
+
             it("does not throw") {
                 val file = tempFolder.newFolder("test")
                 expect(file).existsFun()
             }
         }
-    }
 
-    describeFun(existsNot.name) {
-        val existsNotFun = existsNot.lambda
-        context("non existing") {
-            it("does not throw") {
-                expect(Paths.get("nonExistingFile")).existsNotFun()
-            }
-        }
-
-        val expectedMessageIfExisting = "${NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
-
-        context("existing file") {
+        context("does not exist") {
+            val expectedMessageIfExisting = "${NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
             it("throws an AssertionError") {
                 val file = tempFolder.newFile("exists-though-shouldnt")
                 expect {
@@ -80,9 +69,7 @@ abstract class PathAssertionsSpec(
                     messageContains(expectedMessageIfExisting)
                 }
             }
-        }
 
-        context("existing folder") {
             it("throws an AssertionError") {
                 val folder = tempFolder.newFolder("exists-though-shouldnt")
                 expect {
@@ -90,6 +77,10 @@ abstract class PathAssertionsSpec(
                 }.toThrow<AssertionError> {
                     messageContains(expectedMessageIfExisting)
                 }
+            }
+
+            it("does not throw") {
+                expect(Paths.get("nonExistingFile")).existsNotFun()
             }
         }
     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -38,12 +38,12 @@ abstract class PathAssertionsSpec(
         val existsFun = exists.lambda
         val existsNotFun = existsNot.lambda
         context("file exists") {
-            it("${exists.name} does not throw when file exists") {
+            it("${exists.name} does not throw") {
                 val file = tempFolder.newFile("test")
                 expect(file).existsFun()
             }
 
-            it("${existsNot.name} throws an AssertionError when file exists") {
+            it("${existsNot.name} throws an AssertionError") {
                 val file = tempFolder.newFile("exists-though-shouldnt")
                 expect {
                     expect(file).existsNotFun()
@@ -54,13 +54,13 @@ abstract class PathAssertionsSpec(
         }
 
         context("folder exists") {
-            it("${exists.name} does not throw when folder exists") {
+            it("${exists.name} does not throw") {
                 val file = tempFolder.newFolder("test")
                 expect(file).existsFun()
             }
 
 
-            it("${existsNot.name} throws an AssertionError when folder exists") {
+            it("${existsNot.name} throws an AssertionError") {
                 val folder = tempFolder.newFolder("exists-though-shouldnt")
                 expect {
                     expect(folder).existsNotFun()
@@ -71,7 +71,7 @@ abstract class PathAssertionsSpec(
         }
 
         context("file does not exist") {
-            it("${exists.name} throws an AssertionError when file does not exist") {
+            it("${exists.name} throws an AssertionError") {
                 expect {
                     expect(Paths.get("nonExistingFile")).existsFun()
                 }.toThrow<AssertionError> {
@@ -81,7 +81,7 @@ abstract class PathAssertionsSpec(
                 }
             }
 
-            it("${existsNot.name} does not throw when file does not exist") {
+            it("${existsNot.name} does not throw") {
                 expect(Paths.get("nonExistingFile")).existsNotFun()
             }
         }
@@ -91,12 +91,12 @@ abstract class PathAssertionsSpec(
         val startsWithFun = startsWith.lambda
         val startsNotWithFun = startsNotWith.lambda
         context("starts with") {
-            it("${startsWith.name} does not throw when tested path starts with expected path") {
+            it("${startsWith.name} does not throw") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsWithFun(Paths.get("/some/path/"))
             }
 
-            it("${startsWith.name} throws an AssertionError when tested path does not start with expected path") {
+            it("${startsWith.name} throws an AssertionError") {
                 val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
@@ -108,7 +108,7 @@ abstract class PathAssertionsSpec(
         }
 
         context("does not start with") {
-            it("${startsNotWith.name} does not throw when tested path does not start with expected path") {
+            it("${startsNotWith.name} does not throw") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/other/path/"))
             }
@@ -118,7 +118,7 @@ abstract class PathAssertionsSpec(
                     .startsNotWithFun(Paths.get("/some/pa"))
             }
 
-            it("${startsNotWith.name} throws an AssertionError when tested path starts with expected path") {
+            it("${startsNotWith.name} throws an AssertionError") {
                 val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
@@ -135,12 +135,12 @@ abstract class PathAssertionsSpec(
         val endsNotWithFun = endsNotWith.lambda
 
         context("ends with") {
-            it("${endsWith.name} does not throw when tested path ends with expected path") {
+            it("${endsWith.name} does not throw") {
                 expect(Paths.get("/not/existed/for/test"))
                     .endsWithFun(Paths.get("for/test"))
             }
 
-            it("${endsWith.name} throws an AssertionError when tested path does not end with expected path") {
+            it("${endsWith.name} throws an AssertionError") {
                 val expectedMessageIfNotEndsWith = "${DescriptionPathAssertion.ENDS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/not/existed/for/test"))
@@ -152,7 +152,7 @@ abstract class PathAssertionsSpec(
         }
 
         context("path ends not with") {
-            it("${endsNotWith.name} throws an AssertionError when tested path ends with expected path") {
+            it("${endsNotWith.name} throws an AssertionError") {
                 expect {
                     expect(Paths.get("/path/ends/with/this"))
                         .endsNotWithFun(Paths.get("with/this"))
@@ -161,7 +161,7 @@ abstract class PathAssertionsSpec(
                 }
             }
 
-            it("${endsNotWith.name} does not throw when tested path does not end with expected path") {
+            it("${endsNotWith.name} does not throw") {
                 expect(Paths.get("/path/ends/with/this"))
                     .endsNotWithFun(Paths.get("with/another"))
             }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -94,19 +94,17 @@ abstract class PathAssertionsSpec(
         }
     }
 
-    describeFun(startsWith.name) {
+    describeFun(startsWith.name, startsNotWith.name) {
         val startsWithFun = startsWith.lambda
+        val startsNotWithFun = startsNotWith.lambda
         context("starts with") {
             it("does not throw") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsWithFun(Paths.get("/some/path/"))
             }
-        }
 
-        val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
-
-        context("does not start with") {
             it("throws an AssertionError") {
+                val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsWithFun(Paths.get("/other/path"))
@@ -115,25 +113,20 @@ abstract class PathAssertionsSpec(
                 }
             }
         }
-    }
 
-    describeFun(startsNotWith.name) {
-        val startsNotWithFun = startsNotWith.lambda
         context("does not start with") {
             it("does not throw") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/other/path/"))
             }
+
             it("does not match partials") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/some/pa"))
             }
-        }
 
-        val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
-
-        context("starts with") {
             it("throws an AssertionError") {
+                val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsNotWithFun(Paths.get("/some/path"))

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -37,8 +37,8 @@ abstract class PathAssertionsSpec(
     describeFun(exists.name, existsNot.name) {
         val existsFun = exists.lambda
         val existsNotFun = existsNot.lambda
-        context("exists") {
-            it("throws an AssertionError") {
+        context("file or folder exists") {
+            it("${exists.name} throws an AssertionError when file does not exist") {
                 expect {
                     expect(Paths.get("nonExistingFile")).existsFun()
                 }.toThrow<AssertionError> {
@@ -48,20 +48,20 @@ abstract class PathAssertionsSpec(
                 }
             }
 
-            it("does not throw") {
+            it("${exists.name} does not throw when file exists") {
                 val file = tempFolder.newFile("test")
                 expect(file).existsFun()
             }
 
-            it("does not throw") {
+            it("${exists.name} does not throw when folder exists") {
                 val file = tempFolder.newFolder("test")
                 expect(file).existsFun()
             }
         }
 
-        context("does not exist") {
+        context("file or folder does not exist") {
             val expectedMessageIfExisting = "${NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
-            it("throws an AssertionError") {
+            it("${existsNot.name} throws an AssertionError when file exists") {
                 val file = tempFolder.newFile("exists-though-shouldnt")
                 expect {
                     expect(file).existsNotFun()
@@ -70,7 +70,7 @@ abstract class PathAssertionsSpec(
                 }
             }
 
-            it("throws an AssertionError") {
+            it("${existsNot.name} throws an AssertionError when folder exists") {
                 val folder = tempFolder.newFolder("exists-though-shouldnt")
                 expect {
                     expect(folder).existsNotFun()
@@ -79,7 +79,7 @@ abstract class PathAssertionsSpec(
                 }
             }
 
-            it("does not throw") {
+            it("${existsNot.name} does not throw when file does not exist") {
                 expect(Paths.get("nonExistingFile")).existsNotFun()
             }
         }
@@ -89,12 +89,12 @@ abstract class PathAssertionsSpec(
         val startsWithFun = startsWith.lambda
         val startsNotWithFun = startsNotWith.lambda
         context("starts with") {
-            it("does not throw") {
+            it("${startsWith.name} does not throw when tested path starts with expected path") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsWithFun(Paths.get("/some/path/"))
             }
 
-            it("throws an AssertionError") {
+            it("${startsWith.name} throws an AssertionError when tested path does not start with expected path") {
                 val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
@@ -106,17 +106,17 @@ abstract class PathAssertionsSpec(
         }
 
         context("does not start with") {
-            it("does not throw") {
+            it("${startsNotWith.name} does not throw when tested path does not start with expected path") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/other/path/"))
             }
 
-            it("does not match partials") {
+            it("${startsNotWith.name} does not match partials") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/some/pa"))
             }
 
-            it("throws an AssertionError") {
+            it("${startsNotWith.name} throws an AssertionError when tested path starts with expected path") {
                 val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
@@ -133,12 +133,12 @@ abstract class PathAssertionsSpec(
         val endsNotWithFun = endsNotWith.lambda
 
         context("ends with") {
-            it("does not throw") {
+            it("${endsWith.name} does not throw when tested path ends with expected path") {
                 expect(Paths.get("/not/existed/for/test"))
                     .endsWithFun(Paths.get("for/test"))
             }
 
-            it("throws an AssertionError") {
+            it("${endsWith.name} throws an AssertionError when tested path does not end with expected path") {
                 val expectedMessageIfNotEndsWith = "${DescriptionPathAssertion.ENDS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/not/existed/for/test"))
@@ -150,7 +150,7 @@ abstract class PathAssertionsSpec(
         }
 
         context("path ends not with") {
-            it("throws an AssertionError") {
+            it("${endsNotWith.name} throws an AssertionError when tested path ends with expected path") {
                 expect {
                     expect(Paths.get("/path/ends/with/this"))
                         .endsNotWithFun(Paths.get("with/this"))
@@ -159,7 +159,7 @@ abstract class PathAssertionsSpec(
                 }
             }
 
-            it("does not throw") {
+            it("${endsNotWith.name} does not throw when tested path does not end with expected path") {
                 expect(Paths.get("/path/ends/with/this"))
                     .endsNotWithFun(Paths.get("with/another"))
             }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -87,19 +87,22 @@ abstract class PathAssertionsSpec(
         }
     }
 
-    describeFun(startsWith.name, startsNotWith.name) {
+    describeFun(startsWith.name, startsNotWith.name, endsWith.name, endsNotWith.name) {
         val startsWithFun = startsWith.lambda
         val startsNotWithFun = startsNotWith.lambda
+        val endsWithFun = endsWith.lambda
+        val endsNotWithFun = endsNotWith.lambda
 
-        context("path '/some/path/for/test'") {
+        val expectPath = "/some/path/for/test"
+        context("path '$expectPath'") {
             it("${startsWith.name} '/some/path/' does not throw") {
-                expect(Paths.get("/some/path/for/test"))
+                expect(Paths.get(expectPath))
                     .startsWithFun(Paths.get("/some/path/"))
             }
 
             it("${startsWith.name} '/other/path' throws an AssertionError") {
                 expect {
-                    expect(Paths.get("/some/path/for/test"))
+                    expect(Paths.get(expectPath))
                         .startsWithFun(Paths.get("/other/path"))
                 }.toThrow<AssertionError> {
                     messageContains("${DescriptionPathAssertion.STARTS_WITH.getDefault()}:")
@@ -107,39 +110,32 @@ abstract class PathAssertionsSpec(
             }
 
             it("${startsNotWith.name} '/other/path' does not throw") {
-                expect(Paths.get("/some/path/for/test"))
+                expect(Paths.get(expectPath))
                     .startsNotWithFun(Paths.get("/other/path"))
             }
 
             it("${startsNotWith.name} '/some/pa' does not match partials") {
-                expect(Paths.get("/some/path/for/test"))
+                expect(Paths.get(expectPath))
                     .startsNotWithFun(Paths.get("/some/pa"))
             }
 
             it("${startsNotWith.name} '/some/path' throws an AssertionError") {
                 expect {
-                    expect(Paths.get("/some/path/for/test"))
+                    expect(Paths.get(expectPath))
                         .startsNotWithFun(Paths.get("/some/path"))
                 }.toThrow<AssertionError> {
                     messageContains("${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:")
                 }
             }
-        }
-    }
 
-    describeFun(endsWith.name, endsNotWith.name) {
-        val endsWithFun = endsWith.lambda
-        val endsNotWithFun = endsNotWith.lambda
-
-        context("path '/some/path/for/test'") {
             it("${endsWith.name} 'for/test' does not throw") {
-                expect(Paths.get("/some/path/for/test"))
+                expect(Paths.get(expectPath))
                     .endsWithFun(Paths.get("for/test"))
             }
 
             it("${endsWith.name} 'for/another' throws an AssertionError") {
                 expect {
-                    expect(Paths.get("/some/path/for/test"))
+                    expect(Paths.get(expectPath))
                         .endsWithFun(Paths.get("for/another"))
                 }.toThrow<AssertionError> {
                     messageContains("${DescriptionPathAssertion.ENDS_WITH.getDefault()}:")
@@ -148,7 +144,7 @@ abstract class PathAssertionsSpec(
 
             it("${endsNotWith.name} 'for/test' throws an AssertionError") {
                 expect {
-                    expect(Paths.get("/some/path/for/test"))
+                    expect(Paths.get(expectPath))
                         .endsNotWithFun(Paths.get("for/test"))
                 }.toThrow<AssertionError> {
                     messageContains("${DescriptionPathAssertion.ENDS_NOT_WITH.getDefault()}:")
@@ -156,7 +152,7 @@ abstract class PathAssertionsSpec(
             }
 
             it("${endsNotWith.name} 'for/another' does not throw") {
-                expect(Paths.get("/some/path/for/test"))
+                expect(Paths.get(expectPath))
                     .endsNotWithFun(Paths.get("for/another"))
             }
         }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -90,13 +90,14 @@ abstract class PathAssertionsSpec(
     describeFun(startsWith.name, startsNotWith.name) {
         val startsWithFun = startsWith.lambda
         val startsNotWithFun = startsNotWith.lambda
-        context("starts with") {
-            it("${startsWith.name} does not throw") {
+
+        context("path '/some/path/for/test'") {
+            it("${startsWith.name} '/some/path/' does not throw") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsWithFun(Paths.get("/some/path/"))
             }
 
-            it("${startsWith.name} throws an AssertionError") {
+            it("${startsWith.name} '/other/path' throws an AssertionError") {
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsWithFun(Paths.get("/other/path"))
@@ -104,20 +105,18 @@ abstract class PathAssertionsSpec(
                     messageContains("${DescriptionPathAssertion.STARTS_WITH.getDefault()}:")
                 }
             }
-        }
 
-        context("does not start with") {
-            it("${startsNotWith.name} does not throw") {
+            it("${startsNotWith.name} '/other/path' does not throw") {
                 expect(Paths.get("/some/path/for/test"))
-                    .startsNotWithFun(Paths.get("/other/path/"))
+                    .startsNotWithFun(Paths.get("/other/path"))
             }
 
-            it("${startsNotWith.name} does not match partials") {
+            it("${startsNotWith.name} '/some/pa' does not match partials") {
                 expect(Paths.get("/some/path/for/test"))
                     .startsNotWithFun(Paths.get("/some/pa"))
             }
 
-            it("${startsNotWith.name} throws an AssertionError") {
+            it("${startsNotWith.name} '/some/path' throws an AssertionError") {
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsNotWithFun(Paths.get("/some/path"))

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -97,12 +97,11 @@ abstract class PathAssertionsSpec(
             }
 
             it("${startsWith.name} throws an AssertionError") {
-                val expectedMessageIfNotStartsWith = "${DescriptionPathAssertion.STARTS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsWithFun(Paths.get("/other/path"))
                 }.toThrow<AssertionError> {
-                    messageContains(expectedMessageIfNotStartsWith)
+                    messageContains("${DescriptionPathAssertion.STARTS_WITH.getDefault()}:")
                 }
             }
         }
@@ -119,12 +118,11 @@ abstract class PathAssertionsSpec(
             }
 
             it("${startsNotWith.name} throws an AssertionError") {
-                val expectedMessageIfStartsWith = "${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/some/path/for/test"))
                         .startsNotWithFun(Paths.get("/some/path"))
                 }.toThrow<AssertionError> {
-                    messageContains(expectedMessageIfStartsWith)
+                    messageContains("${DescriptionPathAssertion.STARTS_NOT_WITH.getDefault()}:")
                 }
             }
         }
@@ -141,12 +139,11 @@ abstract class PathAssertionsSpec(
             }
 
             it("${endsWith.name} throws an AssertionError") {
-                val expectedMessageIfNotEndsWith = "${DescriptionPathAssertion.ENDS_WITH.getDefault()}:"
                 expect {
                     expect(Paths.get("/not/existed/for/test"))
                         .endsWithFun(Paths.get("/for/test"))
                 }.toThrow<AssertionError> {
-                    messageContains(expectedMessageIfNotEndsWith)
+                    messageContains("${DescriptionPathAssertion.ENDS_WITH.getDefault()}:")
                 }
             }
         }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -37,7 +37,40 @@ abstract class PathAssertionsSpec(
     describeFun(exists.name, existsNot.name) {
         val existsFun = exists.lambda
         val existsNotFun = existsNot.lambda
-        context("file or folder exists") {
+        context("file exists") {
+            it("${exists.name} does not throw when file exists") {
+                val file = tempFolder.newFile("test")
+                expect(file).existsFun()
+            }
+
+            it("${existsNot.name} throws an AssertionError when file exists") {
+                val file = tempFolder.newFile("exists-though-shouldnt")
+                expect {
+                    expect(file).existsNotFun()
+                }.toThrow<AssertionError> {
+                    messageContains("${NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}")
+                }
+            }
+        }
+
+        context("folder exists") {
+            it("${exists.name} does not throw when folder exists") {
+                val file = tempFolder.newFolder("test")
+                expect(file).existsFun()
+            }
+
+
+            it("${existsNot.name} throws an AssertionError when folder exists") {
+                val folder = tempFolder.newFolder("exists-though-shouldnt")
+                expect {
+                    expect(folder).existsNotFun()
+                }.toThrow<AssertionError> {
+                    messageContains("${NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}")
+                }
+            }
+        }
+
+        context("file does not exist") {
             it("${exists.name} throws an AssertionError when file does not exist") {
                 expect {
                     expect(Paths.get("nonExistingFile")).existsFun()
@@ -45,37 +78,6 @@ abstract class PathAssertionsSpec(
                     messageContains(
                         "${TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
                     )
-                }
-            }
-
-            it("${exists.name} does not throw when file exists") {
-                val file = tempFolder.newFile("test")
-                expect(file).existsFun()
-            }
-
-            it("${exists.name} does not throw when folder exists") {
-                val file = tempFolder.newFolder("test")
-                expect(file).existsFun()
-            }
-        }
-
-        context("file or folder does not exist") {
-            val expectedMessageIfExisting = "${NOT_TO.getDefault()}: ${DescriptionPathAssertion.EXIST.getDefault()}"
-            it("${existsNot.name} throws an AssertionError when file exists") {
-                val file = tempFolder.newFile("exists-though-shouldnt")
-                expect {
-                    expect(file).existsNotFun()
-                }.toThrow<AssertionError> {
-                    messageContains(expectedMessageIfExisting)
-                }
-            }
-
-            it("${existsNot.name} throws an AssertionError when folder exists") {
-                val folder = tempFolder.newFolder("exists-though-shouldnt")
-                expect {
-                    expect(folder).existsNotFun()
-                }.toThrow<AssertionError> {
-                    messageContains(expectedMessageIfExisting)
                 }
             }
 


### PR DESCRIPTION
Fuse describe of similar functions in `PathAssertionsSpec` #200 

--
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
