### PR TITLE
Migrate DelegatingAssertionCheckerSpec.kt to spek2

### DIFF
--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/checking/DelegatingAssertionCheckerSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/checking/DelegatingAssertionCheckerSpec.kt
@@ -10,9 +10,7 @@ import ch.tutteli.atrium.creating.AssertionHolder
 import ch.tutteli.atrium.creating.AssertionPlant
 import ch.tutteli.atrium.specs.AssertionVerb
 import ch.tutteli.atrium.specs.describeFunTemplate
-import io.mockk.slot
-import io.mockk.spyk
-import io.mockk.verify
+import io.mockk.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 
@@ -40,7 +38,7 @@ abstract class DelegatingAssertionCheckerSpec(
     describeFun("check") {
         context("empty assertion list") {
             it("does not throw an exception") {
-                val testee = testeeFactory(spyk())
+                val testee = testeeFactory(mockk(relaxed = true))
                 testee.check(assertionVerb, 1, listOf())
             }
         }
@@ -54,7 +52,9 @@ abstract class DelegatingAssertionCheckerSpec(
             context(description) {
                 it("adds the assertion(s) to the subject plant") {
                     //arrange
-                    val subjectFactory = spyk<AssertionPlant<Int>>()
+                    val subjectFactory = mockk<AssertionPlant<Int>>()
+                    every { subjectFactory.addAssertion(any()) } returns subjectFactory
+
                     val testee = testeeFactory(subjectFactory)
                     //act
                     testee.check(assertionVerb, 1, assertions)


### PR DESCRIPTION
As suggested I started migrating some few specs in misc/specs/atrium-specs-jvm and their connected classes.

Regarding the comment 
> TODO #116 migrate spek1 to spek2 - move to specs-common

inside some classes and the task of moving the specs into specs-common, I ran into a problem:
If I refactor (move) a JVM-specific spec into the common module, the Kotlin stdlib is missing. 
So I'm unsure whether I should only move non Kotlin dependent specs being to specs-common (and I just ignore "move to specs-common") or specs-common should depend on Kotlin-stdlib?
This question also applies to specs in atrium-domain-robstoll-lib-jvm and atrium-core-robstoll-lib-jvm (e.g. `AssertionFormatterControllerSpec ` in `atrium-core-robstoll-lib-jvm.ch.tutteli.atrium.core.robstoll.lib.reporting`).

Furthermore I had to add a new extension function (`Root.include` in `SpecBodyExtensions.kt`) to provide the same syntax in `TextIndentBasedAssertionGroupFormatterSpec`. 

I would greatly appreciate some help and feedback.

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
