### PR TITLE
Force locale to en_GB when building examples for readme

### DIFF
--- a/samples/readme-examples/src/main/kotlin/readme/examples/ReadmeTestEngine.kt
+++ b/samples/readme-examples/src/main/kotlin/readme/examples/ReadmeTestEngine.kt
@@ -13,6 +13,7 @@ import org.spekframework.spek2.junit.SpekTestEngine
 import org.spekframework.spek2.runtime.SpekRuntime
 import org.spekframework.spek2.runtime.execution.ExecutionRequest
 import java.nio.file.Paths
+import java.util.Locale
 import org.junit.platform.engine.ExecutionRequest as JUnitExecutionRequest
 
 class ReadmeTestEngine : TestEngine {
@@ -33,6 +34,8 @@ class ReadmeTestEngine : TestEngine {
     }
 
     override fun execute(request: JUnitExecutionRequest) {
+        Locale.setDefault(Locale.UK)
+
         ReporterFactory.specifyFactory(ReadmeReporterFactory.ID)
 
         runSpekWithCustomListener(request)


### PR DESCRIPTION
Fixes robstoll/atrium#211

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
