### PR TITLE
pairAssertions for the new infix API

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
@@ -1,0 +1,40 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+
+/**
+ * Creates an [Expect] for the property [Pair.first] of the subject of the assertion,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ */
+val <K, T : Pair<K, *>> Expect<T>.first get() : Expect<K> = ExpectImpl.pair.first(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [Pair.first] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
+    ExpectImpl.pair.first(this).addToInitial(assertionCreator)
+
+/**
+ * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ */
+val <V, T : Pair<*, V>> Expect<T>.second get() : Expect<V> = ExpectImpl.pair.second(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [Pair.second] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+infix fun <K, V, T : Pair<K, V>> Expect<T>.second(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
+    ExpectImpl.pair.second(this).addToInitial(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairFeatureAssertionsSpec.kt
@@ -1,0 +1,40 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.api.infix.en_GB.*
+
+class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatureAssertionsSpec(
+    property<Pair<String, Int>, String>(Expect<Pair<String, Int>>::first),
+    fun1<Pair<String, Int>, Expect<String>.() -> Unit>(Expect<Pair<String, Int>>::first),
+    property<Pair<String, Int>, Int>(Expect<Pair<String, Int>>::second),
+    fun1<Pair<String, Int>, Expect<Int>.() -> Unit>(Expect<Pair<String, Int>>::second),
+    property<Pair<String?, Int?>, String?>(Expect<Pair<String?, Int?>>::first),
+    fun1<Pair<String?, Int?>, Expect<String?>.() -> Unit>(Expect<Pair<String?, Int?>>::first),
+    property<Pair<String?, Int?>, Int?>(Expect<Pair<String?, Int?>>::second),
+    fun1<Pair<String?, Int?>, Expect<Int?>.() -> Unit>(Expect<Pair<String?, Int?>>::second)
+) {
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var a1: Expect<out Pair<String, Int>> = notImplemented()
+        var a2: Expect<Pair<String?, Int>> = notImplemented()
+        var a3: Expect<Pair<String?, Int?>> = notImplemented()
+
+        a1.first
+        a2.first
+        a3.first
+        a1 = a1 first { }
+        a2 = a2 first { }
+        a3 = a3 first { }
+
+        a1.second
+        a2.second
+        a3.second
+        a1 = a1 second { }
+        a2 = a2 second { }
+        a3 = a3 second { }
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairFeatureAssertionsSpec.kt
@@ -1,9 +1,13 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.AssertionPlantNullable
 import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import kotlin.reflect.KFunction2
+import kotlin.reflect.KProperty1
 import ch.tutteli.atrium.api.infix.en_GB.*
 
 class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatureAssertionsSpec(
@@ -16,25 +20,11 @@ class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatur
     property<Pair<String?, Int?>, Int?>(Expect<Pair<String?, Int?>>::second),
     fun1<Pair<String?, Int?>, Expect<Int?>.() -> Unit>(Expect<Pair<String?, Int?>>::second)
 ) {
+    companion object {
+        fun first(plant: Expect<Pair<String, Int>>, expectationCreator: Expect<String>.() -> Unit) =
+            plant first { expectationCreator() }
 
-    @Suppress("unused", "UNUSED_VALUE")
-    private fun ambiguityTest() {
-        var a1: Expect<out Pair<String, Int>> = notImplemented()
-        var a2: Expect<Pair<String?, Int>> = notImplemented()
-        var a3: Expect<Pair<String?, Int?>> = notImplemented()
-
-        a1.first
-        a2.first
-        a3.first
-        a1 = a1 first { }
-        a2 = a2 first { }
-        a3 = a3 first { }
-
-        a1.second
-        a2.second
-        a3.second
-        a1 = a1 second { }
-        a2 = a2 second { }
-        a3 = a3 second { }
+        fun second(plant: Expect<Pair<String, Int>>, expectationCreator: Expect<Int>.() -> Unit) =
+            plant second { expectationCreator() }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairFeatureAssertionsSpec.kt
@@ -20,6 +20,27 @@ class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatur
     property<Pair<String?, Int?>, Int?>(Expect<Pair<String?, Int?>>::second),
     fun1<Pair<String?, Int?>, Expect<Int?>.() -> Unit>(Expect<Pair<String?, Int?>>::second)
 ) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var a1: Expect<out Pair<String, Int>> = notImplemented()
+        var a2: Expect<Pair<String?, Int>> = notImplemented()
+        var a3: Expect<Pair<String?, Int?>> = notImplemented()
+
+        a1.first
+        a2.first
+        a3.first
+        a1 = a1 first { }
+        a2 = a2 first { }
+        a3 = a3 first { }
+
+        a1.second
+        a2.second
+        a3.second
+        a1 = a1 second { }
+        a2 = a2 second { }
+        a3 = a3 second { }
+    }
+
     companion object {
         fun first(plant: Expect<Pair<String, Int>>, expectationCreator: Expect<String>.() -> Unit) =
             plant first { expectationCreator() }


### PR DESCRIPTION
I am working on issue #231 and I have a question for the following point described in the issue.

> - copy the PairFeatureAssertionsSpec.kt from atrium-api-fluent-en_GB-common to atrium-api-infix- en_GB-common
>   - introduce a function in the companion object for each assertion function so that we see the infix API in action (see AnyAssertionsSpec for an example)

I copied `PairFeatureAssertionsSpec.kt` from `atrium-api-fluent-en_GB-common` to `atrium-api-infix-> en_GB-common` but I don't understand the second nested point "introduce a function in the companion object for each assertion function ...". 

In the first point I simply defined two infix functions `first` and `second`. Should I define two functions inside the companion object for testing these two?

**EDIT**
I confirm that I have read the Contributor Agreements v1.0, agree to be bound on them and confirm that my contribution is compliant.