### PR TITLE
#232 add sequenceAssertions to new infix API

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl.changeSubject
  * Turns `Expect<E, T : Sequence<E>>` into `Expect<Iterable<E>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `returnValueOf(Sequence::asIterable)` if you want to show the transformation in reporting.
+ * Use `feature(Sequence::asIterable)` if you want to show the transformation in reporting.
  *
  * @return The newly created [AssertionPlant] for the transformed subject.
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
@@ -1,0 +1,26 @@
+import ch.tutteli.atrium.creating.AssertionPlant
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl.changeSubject
+
+/**
+ * Turns `Expect<E, T : Sequence<E>>` into `Expect<Iterable<E>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `returnValueOf(Sequence::asIterable)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [AssertionPlant] for the transformed subject.
+ */
+fun <E, T : Sequence<E>> Expect<T>.asIterable(): Expect<Iterable<E>>
+    = changeSubject(this).unreported { it.asIterable() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [Iterable].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(Sequence::asIterable, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return This assertion container to support a fluent API.
+ */
+infix fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
+    apply { asIterable().addAssertionsCreatedBy(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
@@ -8,7 +8,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl.changeSubject
  * The transformation as such is not reflected in reporting.
  * Use `feature(Sequence::asIterable)` if you want to show the transformation in reporting.
  *
- * @return The newly created [AssertionPlant] for the transformed subject.
+ * @return The newly created [Expect] for the transformed subject.
  */
 fun <E, T : Sequence<E>> Expect<T>.asIterable(): Expect<Iterable<E>>
     = changeSubject(this).unreported { it.asIterable() }


### PR DESCRIPTION
Hello, are these the right functions that need to be added to infix api? Also, looks like I can't find SequenceFeatureAssertionsSpec.kt, but I found IterableAnyAssertionsSpec which contains `asIterable`.
----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
