### PR TITLE
[#230] Add mapEntryAssertions for the new infix API

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
@@ -1,0 +1,56 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+
+/**
+ * Expects that the property [Map.Entry.key] of the subject of the assertion
+ * is equal to the given [key] and the property [Map.Entry.value] is equal to the given [value].
+ *
+ * Kind of a shortcut for `and { key { this toBe key }; value { this toBe value } }` where `and` denotes an assertion group
+ * block. Yet, the actual behaviour depends on implementation - could also be fail fast for instance or augment
+ * reporting etc.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K, V>): Expect<T> =
+    addAssertion(ExpectImpl.map.entry.isKeyValue(this, keyValuePair.first, keyValuePair.second))
+
+/**
+ * Creates an [Expect] for the property [Map.Entry.key] of the subject of the assertion,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ */
+val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
+    get() = ExpectImpl.map.entry.key(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [Map.Entry.key] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
+    ExpectImpl.map.entry.key(this).addToInitial(assertionCreator)
+
+/**
+ * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ */
+val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
+    get() = ExpectImpl.map.entry.value(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [Map.Entry.value] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ */
+infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
+    ExpectImpl.map.entry.value(this).addToInitial(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryAssertionsSpec.kt
@@ -1,0 +1,40 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.name
+import ch.tutteli.atrium.specs.notImplemented
+
+class MapEntryAssertionsSpec : ch.tutteli.atrium.specs.integration.MapEntryAssertionsSpec(
+    fun1(Expect<Map.Entry<String, Int>>::isKeyValue).name to Companion::isKeyValue,
+    fun1(Expect<Map.Entry<String?, Int?>>::isKeyValue).name to Companion::isKeyValueNullable
+) {
+    companion object {
+        fun isKeyValue(expect: Expect<Map.Entry<String, Int>>, key: String, value: Int)
+            = expect isKeyValue (key to value)
+
+        fun isKeyValueNullable(expect: Expect<Map.Entry<String?, Int?>>, key: String?, value: Int?)
+            = expect isKeyValue (key to value)
+    }
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        val a1: Expect<Map.Entry<String, Int>> = notImplemented()
+        val a2: Expect<Map.Entry<String?, Int>> = notImplemented()
+        val a3: Expect<Map.Entry<String, Int?>> = notImplemented()
+        val a4: Expect<Map.Entry<String?, Int?>> = notImplemented()
+
+        val star: Expect<Map.Entry<*, *>> = notImplemented()
+
+        a1 isKeyValue ("a" to 1)
+        a2 isKeyValue ("a" to 1)
+        a3 isKeyValue ("a" to 1)
+        a4 isKeyValue ("a" to 1)
+        star isKeyValue ("a" to 1)
+
+        a2 isKeyValue (null to 1)
+        a3 isKeyValue ("a" to null)
+        a4 isKeyValue (null to null)
+        star isKeyValue (null to null)
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryFeatureAssertionsSpec.kt
@@ -1,0 +1,49 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.property
+
+class MapEntryFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.MapEntryFeatureAssertionsSpec(
+    property<Map.Entry<String, Int>, String>(Expect<Map.Entry<String, Int>>::key),
+    fun1<Map.Entry<String, Int>, Expect<String>.() -> Unit>(Expect<Map.Entry<String, Int>>::key),
+    property<Map.Entry<String, Int>, Int>(Expect<Map.Entry<String, Int>>::value),
+    fun1<Map.Entry<String, Int>, Expect<Int>.() -> Unit>(Expect<Map.Entry<String, Int>>::value),
+    property<Map.Entry<String?, Int?>, String?>(Expect<Map.Entry<String?, Int?>>::key),
+    fun1<Map.Entry<String?, Int?>, Expect<String?>.() -> Unit>(Expect<Map.Entry<String?, Int?>>::key),
+    property<Map.Entry<String?, Int?>, Int?>(Expect<Map.Entry<String?, Int?>>::value),
+    fun1<Map.Entry<String?, Int?>, Expect<Int?>.() -> Unit>(Expect<Map.Entry<String?, Int?>>::value)
+) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var a1: Expect<Map.Entry<CharSequence, Number>> = notImplemented()
+        var a2: Expect<Map.Entry<CharSequence?, Number>> = notImplemented()
+        var a3: Expect<Map.Entry<CharSequence, Number?>> = notImplemented()
+        var a4: Expect<Map.Entry<CharSequence?, Number?>> = notImplemented()
+
+        var star: Expect<Map.Entry<*, *>> = notImplemented()
+
+        a1.key
+        a2.key
+        a3.key
+        a4.key
+        star.key
+        a1 = a1 key { }
+        a2 = a2 key { }
+        a3 = a3 key { }
+        a4 = a4 key { }
+        star = star key { }
+
+        a1.value
+        a2.value
+        a3.value
+        a4.value
+        star.value
+        a1 = a1 value { }
+        a2 = a2 value { }
+        a3 = a3 value { }
+        a4 = a4 value { }
+        star = star value { }
+    }
+}


### PR DESCRIPTION
----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
