### PR TITLE
Reword number of occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ expect(listOf(1, 2, 2, 4)).contains(2, 3)
 expect: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
   ⚬ an entry which is: 3        (kotlin.Int <1234789>)
-    ⚬ ▶ number of occurrences: 0
+    ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
 ```
 </ex-collection-short-1>
@@ -977,12 +977,12 @@ expect: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
   ⚬ an entry which: 
       » is less than: 0        (kotlin.Int <1234789>)
-    ⚬ ▶ number of occurrences: 0
+    ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
   ⚬ an entry which: 
       » is greater than: 2        (kotlin.Int <1234789>)
       » is less than: 4        (kotlin.Int <1234789>)
-    ⚬ ▶ number of occurrences: 0
+    ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
 ```
 </ex-collection-short-2>
@@ -1015,7 +1015,7 @@ expect: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
   ⚬ an entry which: 
       » is less than: 0        (kotlin.Int <1234789>)
-    ⚬ ▶ number of occurrences: 0
+    ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
 ```
 </ex-collection-any>
@@ -1031,7 +1031,7 @@ expect: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ does not contain: 
   ⚬ an entry which: 
       » is greater than: 2        (kotlin.Int <1234789>)
-    ✘ ▶ number of occurrences: 2
+    ✘ ▶ number of such entries: 2
         ◾ is: 0        (kotlin.Int <1234789>)
     ✔ ▶ has at least one element: true
         ◾ is: true
@@ -1152,7 +1152,7 @@ expect: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
   ⚬ an entry which: 
       » is less than: 3        (kotlin.Int <1234789>)
-    ⚬ ▶ number of occurrences: 3
+    ⚬ ▶ number of such entries: 3
         ◾ is at most: 2
 ```
 </ex-collection-builder-3>
@@ -1292,7 +1292,7 @@ expect: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
     ◾ does not contain: 
       ⚬ an entry which: 
           » is greater than: 1        (kotlin.Int <1234789>)
-        ✘ ▶ number of occurrences: 1
+        ✘ ▶ number of such entries: 1
             ◾ is: 0        (kotlin.Int <1234789>)
         ✔ ▶ has at least one element: true
             ◾ is: true
@@ -1512,7 +1512,7 @@ expect: "calling myNullableFun with ..."        <1234789>
     ◾ is instance of type: String (kotlin.String) -- Class: java.lang.String
       » contains: 
         ⚬ value: "min"        <1234789>
-          ⚬ ▶ number of occurrences: -1
+          ⚬ ▶ number of matches: -1
               ◾ is at least: 1
 ◆ ▶ myNullableFun(2147483647): "2147483647"        <1234789>
     ◾ equals: "max"        <1234789>
@@ -1643,7 +1643,7 @@ expect: () -> kotlin.Nothing        (readme.examples.ReadmeSpec2$1$31$1 <1234789
             » is instance of type: String (kotlin.String) -- Class: java.lang.String
             » contains: 
               ⚬ value: "no no no"        <1234789>
-                ⚬ ▶ number of occurrences: -1
+                ⚬ ▶ number of matches: -1
                     ◾ is at least: 1
       » Properties of the unexpected IllegalArgumentException
         » message: "no no no..."        <1234789>

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -19,7 +19,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     IGNORING_CASE("%s, ignoring case"),
     MATCHES("matches entirely"),
     MISMATCHES("does not match entirely"),
-    NUMBER_OF_OCCURRENCES("number of occurrences"),
+    NUMBER_OF_OCCURRENCES("number of matches"),
     STARTS_WITH("starts with"),
     STARTS_NOT_WITH("does not start with"),
     STRING_MATCHING_REGEX("string matching regex"),

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -24,7 +24,7 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     IN_ORDER_ONLY_GROUPED("%s only, in order, grouped"),
     INDEX("index %s"),
     INDEX_FROM_TO("index %s..%s"),
-    NUMBER_OF_OCCURRENCES("number of occurrences"),
+    NUMBER_OF_OCCURRENCES("number of such entries"),
     SIZE_EXCEEDED("❗❗ hasNext() returned false"),
     @Deprecated("Will be removed with 0.10.0")
     CANNOT_EVALUATE_SUBJECT_EMPTY_ITERABLE("$COULD_NOT_EVALUATE_DEFINED_ASSERTIONS -- `Iterable` has no next entry.\n$VISIT_COULD_NOT_EVALUATE_ASSERTIONS"),


### PR DESCRIPTION
This pull request caters to the rewording for Iterable contains.inAnyOrder from 
`number of occurrences` to `number of such entries` in the `DescriptionIterableAssertion`  and to `number of matches` in `DescriptionCharSequenceAssertion`

I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
