### PR TITLE
#319: zonedDateTimeAssertions for thew new infix API

### DIFF
--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/zonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/zonedDateTimeAssertions.kt
@@ -1,0 +1,104 @@
+@file:Suppress(
+    "FINAL_UPPER_BOUND" /* remove once https://youtrack.jetbrains.com/issue/KT-34257 is fixed */,
+    "JAVA_MODULE_DOES_NOT_READ_UNNAMED_MODULE" /* TODO remove once https://youtrack.jetbrains.com/issue/KT-35343 is fixed */
+)
+
+package ch.tutteli.atrium.api.infix.en_GB.jdk8
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.domain.builders.zonedDateTime
+import java.time.DayOfWeek
+import java.time.ZonedDateTime
+
+/**
+ * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ *
+ * @since 0.10.0
+ */
+val <T : ZonedDateTime> Expect<T>.year: Expect<Int>
+    get() = ExpectImpl.zonedDateTime.year(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ZonedDateTime> Expect<T>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
+    ExpectImpl.zonedDateTime.year(this).addToInitial(assertionCreator)
+
+/**
+ * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
+ * of the subject of the assertion, so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ *
+ * @since 0.10.0
+ */
+val <T : ZonedDateTime> Expect<T>.month: Expect<Int>
+    get() = ExpectImpl.zonedDateTime.month(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ZonedDateTime> Expect<T>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
+    ExpectImpl.zonedDateTime.month(this).addToInitial(assertionCreator)
+
+/**
+ * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
+ * of the subject of the assertion, so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ *
+ * @since 0.10.0
+ */
+val <T : ZonedDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
+    get() = ExpectImpl.zonedDateTime.dayOfWeek(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ZonedDateTime> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<T> =
+    ExpectImpl.zonedDateTime.dayOfWeek(this).addToInitial(assertionCreator)
+
+/**
+ * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
+ * of the subject of the assertion, so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ *
+ * @since 0.10.0
+ */
+val <T : ZonedDateTime> Expect<T>.day: Expect<Int>
+    get() = ExpectImpl.zonedDateTime.day(this).getExpectOfFeature()
+
+/**
+ * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ZonedDateTime> Expect<T>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
+    ExpectImpl.zonedDateTime.day(this).addToInitial(assertionCreator)

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/module/module-info.java
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/module/module-info.java
@@ -5,5 +5,5 @@ module ch.tutteli.atrium.api.infix.en_GB.jdk8 {
     requires kotlin.stdlib;
     requires java.base;
 
-//    exports ch.tutteli.atrium.api.infix.en_GB.jdk8;
+    exports ch.tutteli.atrium.api.infix.en_GB.jdk8;
 }

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/ZonedDateTimeFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/ZonedDateTimeFeatureAssertionsSpec.kt
@@ -1,0 +1,36 @@
+package ch.tutteli.atrium.api.infix.en_GB.jdk8
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.property
+import java.time.DayOfWeek
+import java.time.ZonedDateTime
+
+class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeFeatureAssertionsSpec(
+    property<ZonedDateTime, Int>(Expect<ZonedDateTime>::year),
+    fun1<ZonedDateTime, Expect<Int>.() -> Unit>(Expect<ZonedDateTime>::year),
+    property<ZonedDateTime, Int>(Expect<ZonedDateTime>::month),
+    fun1<ZonedDateTime, Expect<Int>.() -> Unit>(Expect<ZonedDateTime>::month),
+    property<ZonedDateTime, Int>(Expect<ZonedDateTime>::day),
+    fun1<ZonedDateTime, Expect<Int>.() -> Unit>(Expect<ZonedDateTime>::day),
+    property<ZonedDateTime, DayOfWeek>(Expect<ZonedDateTime>::dayOfWeek),
+    fun1<ZonedDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<ZonedDateTime>::dayOfWeek)
+) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var a1: Expect<ZonedDateTime> = notImplemented()
+
+        a1.year
+        a1 = a1 year { }
+
+        a1.month
+        a1 = a1 month { }
+
+        a1.dayOfWeek
+        a1 = a1 dayOfWeek { }
+
+        a1.day
+        a1 = a1 day { }
+    }
+}


### PR DESCRIPTION

Followed intructions from the issue:

- [X] copy and adjust the file zonedDateTimeAssertions.kt from atrium-api-fluent-en_GB-jdk8-jvm to atrium-api-infix-en_GB-jdk8-jvm
- [X] uncomment `exports ch.tutteli.atrium.api.infix.en_GB.jdk8` in module-info.java
- [X] copy and adjust `ZonedDateTimeAssertionsSpec.kt`
- [X] (not mentioned in the issue): changed the `@sinse` from 0.9.0 to 0.10.0 as this change will only be available in 0.10.0


----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
