### PR TITLE
Add path resolve shortcut

### DIFF
--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -156,6 +156,29 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
     ExpectImpl.path.parent(this).addToInitial(assertionCreator)
 
+/**
+ * Expects that [other] resolve against this [Path] and creates an [Expect] for the resolved [Path]
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
+    ExpectImpl.path.resolve(this, other).getExpectOfFeature()
+
+/**
+ * Expect that [other] resolve against this [Path] and that the resolved [Path] holds all assertions the
+ * given [assertionCreator] creates for it and returns this assertion container.
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
+    ExpectImpl.path.resolve(this, other).addToInitial(assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Path]) is readable;

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathFeatureAssertionsSpec.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathFeatureAssertionsSpec.kt
@@ -1,14 +1,14 @@
 package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.notImplemented
-import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.*
 import java.nio.file.Path
 
 class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatureAssertionsSpec(
     property<Path, Path>(Expect<Path>::parent),
     fun1<Path, Expect<Path>.() -> Unit>(Expect<Path>::parent),
+    feature1<Path, String, Path>(Expect<Path>::resolve),
+    fun2<Path, String,  Expect<Path>.() -> Unit>(Expect<Path>::resolve),
     property<Path, String>(Expect<Path>::fileName),
     fun1<Path, Expect<String>.() -> Unit>(Expect<Path>::fileName),
     property<Path, String>(Expect<Path>::fileNameWithoutExtension),
@@ -31,5 +31,8 @@ class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatur
 
         a1.extension
         a1 = a1.extension { }
+
+        a1.resolve("test")
+        a1.resolve("test", {})
     }
 }

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/pathAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/pathAssertions.kt
@@ -158,6 +158,17 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 infix fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
     ExpectImpl.path.parent(this).addToInitial(assertionCreator)
 
+/**
+ * Expects that [other] resolve against this [Path] and creates an [Expect] for the resolved [Path]
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect].
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
+    ExpectImpl.path.resolve(this, other).getExpectOfFeature()
 
 /**
  * Expects that the subject of the assertion (a [Path]) is readable;

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/PathFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/PathFeatureAssertionsSpec.kt
@@ -1,15 +1,15 @@
 package ch.tutteli.atrium.api.infix.en_GB.jdk8
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.notImplemented
-import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.nio.file.Path
 
 class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatureAssertionsSpec(
     property<Path, Path>(Expect<Path>::parent),
     fun1<Path, Expect<Path>.() -> Unit>(Expect<Path>::parent),
+    feature1<Path, String, Path>(Expect<Path>::resolve),
+    fun2<Path, String,  Expect<Path>.() -> Unit>(Expect<Path>::resolve), //resolve with assertionCreator not implemented in this API
     property<Path, String>(Expect<Path>::fileName),
     fun1<Path, Expect<String>.() -> Unit>(Expect<Path>::fileName),
     property<Path, String>(Expect<Path>::fileNameWithoutExtension),
@@ -34,5 +34,10 @@ class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatur
 
         a1.parent
         a1 parent {}
+
+        a1 resolve "test"
     }
 }
+
+private fun <T: Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.() -> Unit): Expect<Path> =
+    (this resolve other).addAssertionsCreatedBy(assertionCreator)

--- a/domain/api/atrium-domain-api-jvm/src/main/kotlin/ch/tutteli/atrium/domain/creating/PathAssertions.kt
+++ b/domain/api/atrium-domain-api-jvm/src/main/kotlin/ch/tutteli/atrium/domain/creating/PathAssertions.kt
@@ -24,6 +24,7 @@ interface PathAssertions {
     fun <T : Path> extension(expect: Expect<T>): ExtractedFeaturePostStep<T, String>
     fun <T : Path> fileNameWithoutExtension(expect: Expect<T>): ExtractedFeaturePostStep<T, String>
     fun <T : Path> parent(expect: Expect<T>): ExtractedFeaturePostStep<T, Path>
+    fun <T : Path> resolve(expect: Expect<T>, other: String): ExtractedFeaturePostStep<T, Path>
 
     fun <T : Path> startsWith(expect: Expect<T>, expected: Path): Assertion
     fun <T : Path> startsNotWith(expect: Expect<T>, expected: Path): Assertion
@@ -37,4 +38,5 @@ interface PathAssertions {
     fun <T : Path> isWritable(expect: Expect<T>): Assertion
     fun <T : Path> isRegularFile(expect: Expect<T>): Assertion
     fun <T : Path> isDirectory(expect: Expect<T>): Assertion
+
 }

--- a/domain/builders/atrium-domain-builders-jvm/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/PathAssertionsBuilder.kt
+++ b/domain/builders/atrium-domain-builders-jvm/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/PathAssertionsBuilder.kt
@@ -48,6 +48,9 @@ object PathAssertionsBuilder : PathAssertions {
     override inline fun <T : Path> parent(expect: Expect<T>) =
         pathAssertions.parent(expect)
 
+    override inline fun <T : Path> resolve(expect: Expect<T>, other: String) =
+        pathAssertions.resolve<T>(expect, other)
+
     override inline fun <T : Path> isReadable(expect: Expect<T>) =
         pathAssertions.isReadable(expect)
 

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/pathAssertions.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/pathAssertions.kt
@@ -395,5 +395,8 @@ fun <T : Path> _parent(expect: Expect<T>): ExtractedFeaturePostStep<T, Path> =
         .withoutOptions()
         .build()
 
+fun <T : Path> _resolve(expect: Expect<T>, other: String): ExtractedFeaturePostStep<T, Path> =
+    ExpectImpl.feature.f1<T, String, Path>(expect, Path::resolve, other)
+
 fun <T : Path> _extension(expect: Expect<T>): ExtractedFeaturePostStep<T, String> =
     ExpectImpl.feature.manualFeature(expect, EXTENSION) { extension }

--- a/domain/robstoll/atrium-domain-robstoll-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/PathAssertionsImpl.kt
+++ b/domain/robstoll/atrium-domain-robstoll-jvm/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/PathAssertionsImpl.kt
@@ -30,6 +30,7 @@ class PathAssertionsImpl : PathAssertions {
         _fileNameWithoutExtension(expect)
 
     override fun <T : Path> parent(expect: Expect<T>) = _parent(expect)
+    override fun <T : Path> resolve(expect: Expect<T>, other: String) = _resolve(expect, other)
 
     override fun <T : Path> isReadable(expect: Expect<T>) = _isReadable(expect)
     override fun <T : Path> isWritable(expect: Expect<T>) = _isWritable(expect)

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathFeatureAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathFeatureAssertionsSpec.kt
@@ -16,6 +16,8 @@ import java.nio.file.Paths
 abstract class PathFeatureAssertionsSpec(
     parentFeature: Feature0<Path, Path>,
     parent: Fun1<Path, Expect<Path>.() -> Unit>,
+    resolveFeature: Feature1<Path, String, Path>,
+    resolve: Fun2<Path, String, Expect<Path>.() -> Unit>,
     fileNameFeature: Feature0<Path, String>,
     fileName: Fun1<Path, Expect<String>.() -> Unit>,
     fileNameWithoutExtensionFeature: Feature0<Path, String>,
@@ -30,6 +32,8 @@ abstract class PathFeatureAssertionsSpec(
     include(object : SubjectLessSpec<Path>(describePrefix,
         parentFeature.forSubjectLess().adjustName { "$it feature" },
         parent.forSubjectLess { },
+        resolveFeature.forSubjectLess("test").adjustName { "$it feature" },
+        resolve.forSubjectLess("test") { toBe(Paths.get("a/my.txt")) },
         fileNameFeature.forSubjectLess().adjustName { "$it feature" },
         fileName.forSubjectLess { },
         fileNameWithoutExtensionFeature.forSubjectLess().adjustName { "$it feature" },
@@ -104,6 +108,49 @@ abstract class PathFeatureAssertionsSpec(
             }
         }
     }
+
+    describeFun("val ${resolveFeature.name}") {
+        val resolveVal = resolveFeature.lambda
+
+        context("Folder resolved from root") {
+            it("toBe(folder.resolve) holds") {
+                val resolvedFolder = tempFolder.newDirectory("resolve")
+                val rootFolder = resolvedFolder.parent
+                expect(rootFolder).resolveVal("resolve").toBe(resolvedFolder)
+            }
+            it("toBe(folder) fails") {
+                expect {
+                    val resolvedFolder = tempFolder.newDirectory("resolve")
+                    val rootFolder = resolvedFolder.parent
+                    expect(rootFolder).resolveVal("notResolved").toBe(resolvedFolder)
+                }.toThrow<AssertionError> {
+                    messageContains("notResolved")
+                }
+            }
+        }
+    }
+
+    describeFun("fun ${resolve.name}") {
+        val resolveFun = resolve.lambda
+
+        context("Folder resolved from root") {
+            it("toBe(folder.resolve) holds") {
+                val resolvedFolder = tempFolder.newDirectory("resolve")
+                val rootFolder = resolvedFolder.parent
+                expect(rootFolder).resolveFun("resolve") { toBe(resolvedFolder) }
+            }
+            it("toBe(folder) fails") {
+                expect {
+                    val resolvedFolder = tempFolder.newDirectory("resolve")
+                    val rootFolder = resolvedFolder.parent
+                    expect(rootFolder).resolveFun("notResolved"){ toBe(resolvedFolder) }
+                }.toThrow<AssertionError> {
+                    messageContains("notResolved")
+                }
+            }
+        }
+    }
+
 
     describeFun("val ${fileNameFeature.name}") {
         val fileNameVal = fileNameFeature.lambda


### PR DESCRIPTION
I'm kind of blocked and I want to make sure I'm going somewhere with this. So, before I go further, I would like to:
- Confirm that the usage of ExpectImpl.feature.f1 is correct in pathAssertions.kt 
- Maybe have an hint on how to make PathAssertionsImpl compile. I suspect something wrong with the generics...

Thanks!

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
