### PR TITLE
#315: add chronoZonedDateTimeAssertions for thew new infix API

### DIFF
--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/chronoZonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/chronoZonedDateTimeAssertions.kt
@@ -1,0 +1,69 @@
+@file:Suppress("JAVA_MODULE_DOES_NOT_READ_UNNAMED_MODULE" /* TODO remove once https://youtrack.jetbrains.com/issue/KT-35343 is fixed */)
+
+package ch.tutteli.atrium.api.infix.en_GB.jdk8
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.domain.builders.chronoZonedDateTime
+import java.time.chrono.ChronoLocalDate
+import java.time.chrono.ChronoZonedDateTime
+
+/**
+ * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * is before the [expected] [ChronoZonedDateTime].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(expected: ChronoZonedDateTime<*>): Expect<T> =
+    addAssertion(ExpectImpl.chronoZonedDateTime.isBefore(this, expected))
+
+/**
+ * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * is before or equals the [expected] [ChronoZonedDateTime].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(expected: ChronoZonedDateTime<*>): Expect<T> =
+    addAssertion(ExpectImpl.chronoZonedDateTime.isBeforeOrEqual(this, expected))
+
+/**
+ * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * is after the [expected] [ChronoZonedDateTime].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(expected: ChronoZonedDateTime<*>): Expect<T> =
+    addAssertion(ExpectImpl.chronoZonedDateTime.isAfter(this, expected))
+
+/**
+ * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * is after or equal the [expected] [ChronoZonedDateTime].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(expected: ChronoZonedDateTime<*>): Expect<T> =
+    addAssertion(ExpectImpl.chronoZonedDateTime.isAfterOrEqual(this, expected))
+
+/**
+ * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * is equal to the [expected] [ChronoZonedDateTime].
+ *
+ * @return This assertion container to support a fluent API.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.10.0
+ */
+infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isEqual(expected: ChronoZonedDateTime<*>): Expect<T> =
+    addAssertion(ExpectImpl.chronoZonedDateTime.isEqual(this, expected))

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/ChronoZonedDateTimeAssertionSpec.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/ChronoZonedDateTimeAssertionSpec.kt
@@ -1,0 +1,76 @@
+package ch.tutteli.atrium.api.infix.en_GB.jdk8
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.notImplemented
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.time.chrono.ChronoLocalDate
+import java.time.chrono.ChronoZonedDateTime
+
+class ChronoZonedDateTimeAssertionSpec : ch.tutteli.atrium.specs.integration.ChronoZonedDateTimeAssertionSpec(
+    fun1(Expect<ChronoZonedDateTime<*>>::isBefore),
+    fun1(Expect<ChronoZonedDateTime<*>>::isBeforeOrEqual),
+    fun1(Expect<ChronoZonedDateTime<*>>::isAfter),
+    fun1(Expect<ChronoZonedDateTime<*>>::isAfterOrEqual),
+    fun1(Expect<ChronoZonedDateTime<*>>::isEqual)
+) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        val chronoZonedDateTime: ChronoZonedDateTime<*> = notImplemented()
+        var a1: Expect<ChronoZonedDateTime<ChronoLocalDate>> = notImplemented()
+        var a2: Expect<ChronoZonedDateTime<LocalDate>> = notImplemented()
+        var a3: Expect<ChronoZonedDateTime<*>> = notImplemented()
+        var a4: Expect<ZonedDateTime> = notImplemented()
+
+
+        a1 =a1 isBefore ZonedDateTime.now()
+        a1 =a1 isBeforeOrEqual ZonedDateTime.now()
+        a1 =a1 isAfter ZonedDateTime.now()
+        a1 =a1 isAfterOrEqual ZonedDateTime.now()
+        a1 =a1 isEqual ZonedDateTime.now()
+
+        a2 =a2 isBefore ZonedDateTime.now()
+        a2 =a2 isBeforeOrEqual ZonedDateTime.now()
+        a2 =a2 isAfter ZonedDateTime.now()
+        a2 =a2 isAfterOrEqual ZonedDateTime.now()
+        a2 =a2 isEqual ZonedDateTime.now()
+
+        a3 =a3 isBefore ZonedDateTime.now()
+        a3 =a3 isBeforeOrEqual ZonedDateTime.now()
+        a3 =a3 isAfter ZonedDateTime.now()
+        a3 =a3 isAfterOrEqual ZonedDateTime.now()
+        a3 =a3 isEqual ZonedDateTime.now()
+
+        a4 =a4 isBefore ZonedDateTime.now()
+        a4 =a4 isBeforeOrEqual ZonedDateTime.now()
+        a4 =a4 isAfter ZonedDateTime.now()
+        a4 =a4 isAfterOrEqual ZonedDateTime.now()
+        a4 =a4 isEqual ZonedDateTime.now()
+
+
+        a1 =a1 isBefore chronoZonedDateTime
+        a1 =a1 isBeforeOrEqual chronoZonedDateTime
+        a1 =a1 isAfter chronoZonedDateTime
+        a1 =a1 isAfterOrEqual chronoZonedDateTime
+        a1 =a1 isEqual chronoZonedDateTime
+
+        a2 =a2 isBefore chronoZonedDateTime
+        a2 =a2 isBeforeOrEqual chronoZonedDateTime
+        a2 =a2 isAfter chronoZonedDateTime
+        a2 =a2 isAfterOrEqual chronoZonedDateTime
+        a2 =a2 isEqual chronoZonedDateTime
+
+        a3 =a3 isBefore chronoZonedDateTime
+        a3 =a3 isBeforeOrEqual chronoZonedDateTime
+        a3 =a3 isAfter chronoZonedDateTime
+        a3 =a3 isAfterOrEqual chronoZonedDateTime
+        a3 =a3 isEqual chronoZonedDateTime
+
+        a4 =a4 isBefore chronoZonedDateTime
+        a4 =a4 isBeforeOrEqual chronoZonedDateTime
+        a4 =a4 isAfter chronoZonedDateTime
+        a4 =a4 isAfterOrEqual chronoZonedDateTime
+        a4 =a4 isEqual chronoZonedDateTime
+    }
+}


### PR DESCRIPTION
Fixes #315

Followed intructions from the issue:
* copy and adjust the file chronoZonedDateTimeAssertions.kt from atrium-api-fluent-en_GB-jdk8-jvm to atrium-api-infix-en_GB-jdk8-jvm
*  module-info.java already had uncommented `exports ch.tutteli.atrium.api.infix.en_GB.jdk8`
* change `@sinse` from 0.9.0 to 0.10.0
* copy the ChronoZonedDateTimeAssertionSpec.kt from atrium-api-fluent-en_GB-jdk8-jvm to atrium-api-infix-en_GB-jdk8-jvm (the description incorrectly said "ChronoZonedDateTimeAssertion_s_Spec.kt" with an "s")



----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
