### PR TITLE
print error message only once for IntelliJ runners

### DIFF
--- a/core/api/atrium-core-api-jvm/src/main/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
+++ b/core/api/atrium-core-api-jvm/src/main/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
@@ -1,5 +1,6 @@
 package ch.tutteli.atrium.reporting
 
+import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.reporting.AtriumError.Companion
 
 /**
@@ -12,6 +13,44 @@ import ch.tutteli.atrium.reporting.AtriumError.Companion
  * To create such an error you need to use the [AtriumError.Companion.create][Companion.create] function.
  */
 actual class AtriumError internal actual constructor(message: String) : AssertionError(message, null) {
+
+    /**
+     * Usually the error message but an empty string in case of certain test-runners.
+     *
+     * The Spek plugin for Intellij as well as running JUnit tests in IntelliJ print this message and
+     * printStacktrace in addition which uses localizedMessage which in turn usually calls message,
+     * resulting in showing this message twice shortly after each other.
+     * This hack combined with the changed behaviour in [getLocalizedMessage] works around this double error message
+     * in reporting by setting the message to an empty string in case of the aforementioned runners.
+     */
+    override val message: String?
+        get() {
+            val isDoublePrintingTestRunner = Thread.currentThread().stackTrace[2].let {
+                it.className.startsWith("org.jetbrains.spek.tooling.adapter.sm") ||
+                    it.className == "org.gradle.internal.serialize.ExceptionPlaceholder"
+            }
+            return if (isDoublePrintingTestRunner) {
+                ""
+            } else {
+                super.message
+            }
+        }
+
+    /**
+     * Returns `super.message` in order to be not affected by the hack implemented in message
+     */
+    override fun getLocalizedMessage(): String? = super.message
+
+    /**
+     * Returns first [getLocalizedMessage] and then the qualified name of this exception.
+     *
+     * Which has the effect that printStackTrace will show first the error message and then stacktrace including
+     * qualified name - resulting in a tidier report 😊
+     *
+     * One unwanted effect, we show the qualified name even if someone has chosen the following for the gradle runner
+     * showExceptions=true, showStacktrace=false => however, I think that's fine.
+     */
+    override fun toString(): String = localizedMessage + "\n\n" + this::class.fullName
 
     actual companion object {
         /**


### PR DESCRIPTION
JUnit
```
assert: 1        (kotlin.Int <462882660>)
◆ equals: 2        (kotlin.Int <143144795>)

ch.tutteli.atrium.reporting.AtriumError
	at ch.tutteli.atrium.reporting.AtriumErrorKt.createAtriumError(AtriumError.kt:26)
        ....
```

Spek
```
assert: ch.tutteli.atrium.reporting.AtriumError
◆ ▶ cause: null
    ◾ is type or sub-type of: Throwable (kotlin.Throwable) -- Class: java.lang.Throwable

ch.tutteli.atrium.reporting.AtriumError
	at ch.tutteli.atrium.reporting.AtriumErrorKt.createAtriumError(AtriumError.kt:26)
        ....
```


gradle
```
ch.tutteli.atrium.reporting.AtriumErrorSpec > has `null` as cause FAILED
    assert: ch.tutteli.atrium.reporting.AtriumError
    ◆ ▶ cause: null
        ◾ is type or sub-type of: Throwable (kotlin.Throwable) -- Class: java.lang.Throwable

    ch.tutteli.atrium.reporting.AtriumError
        at ch.tutteli.atrium.reporting.AtriumErrorKt.createAtriumError(AtriumError.kt:26)
        ....
```

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
