### PR TITLE
undo renaming of MapAssertionsSpec class

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapAssertionsSpec.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.utils.mapArguments
 import ch.tutteli.atrium.specs.*
 
-class MapExpectionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
+class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
     fun2(Companion::contains),
     fun2(Companion::contains).name to Companion::containsNullable,
     "${fun2(Companion::contains).name} ${KeyValue::class.simpleName}" to Companion::containsKeyWithValueAssertions,


### PR DESCRIPTION
While working on #229, `MapAssertionsSpec` was accidentally renamed to `MapExceptionsSpec`. As all tests passed, this error was unfortunately never noticed. This change reverts it back to `MapAssertionsSpec`.

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
