### PR TITLE
rename `assertion container` to `Expect`

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
@@ -8,7 +8,7 @@ import ch.tutteli.atrium.reporting.Reporter
 /**
  * Expects that the subject of the assertion is (equal to) [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T> Expect<T>.toBe(expected: T) = addAssertion(ExpectImpl.any.toBe(this, expected))
@@ -16,7 +16,7 @@ fun <T> Expect<T>.toBe(expected: T) = addAssertion(ExpectImpl.any.toBe(this, exp
 /**
  * Expects that the subject of the assertion is not (equal to) [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T> Expect<T>.notToBe(expected: T) = addAssertion(ExpectImpl.any.notToBe(this, expected))
@@ -24,7 +24,7 @@ fun <T> Expect<T>.notToBe(expected: T) = addAssertion(ExpectImpl.any.notToBe(thi
 /**
  * Expects that the subject of the assertion is the same instance as [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T> Expect<T>.isSameAs(expected: T) = addAssertion(ExpectImpl.any.isSame(this, expected))
@@ -32,7 +32,7 @@ fun <T> Expect<T>.isSameAs(expected: T) = addAssertion(ExpectImpl.any.isSame(thi
 /**
  * Expects that the subject of the assertion is not the same instance as [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T> Expect<T>.isNotSameAs(expected: T) = addAssertion(ExpectImpl.any.isNotSame(this, expected))
@@ -47,7 +47,7 @@ fun <T> Expect<T>.isNotSameAs(expected: T) = addAssertion(ExpectImpl.any.isNotSa
  * else notToBeNull(assertionCreatorOrNull)
  * ```
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified T : Any> Expect<T?>.toBeNullIfNullGivenElse(
@@ -59,7 +59,7 @@ inline fun <reified T : Any> Expect<T?>.toBeNullIfNullGivenElse(
  *
  * It delegates to [isA] with [T] as type.
  *
- * @return An assertion container with the non-nullable type [T] (was `T?` before).
+ * @return An [Expect] with the non-nullable type [T] (was `T?` before).
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress(/* less magic */ "RemoveExplicitTypeArguments")
@@ -71,7 +71,7 @@ inline fun <reified T : Any> Expect<T?>.notToBeNull(): Expect<T> = isA<T>()
  *
  * It delegates to [isA] with [T] as type.
  *
- * @return An assertion container with the non-nullable type [T] (was `T?` before)
+ * @return An [Expect] with the non-nullable type [T] (was `T?` before)
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress(/* less magic */ "RemoveExplicitTypeArguments")
@@ -94,7 +94,7 @@ inline fun <reified T : Any> Expect<T?>.notToBeNull(noinline assertionCreator: E
  * the element type is actually `String`. Or in other words
  * `assert(listOf(1, 2)).isA<List<String>>{}` holds, even though `List<Int>` is clearly not a `List<String>`.
  *
- * @return An assertion container with the new type [TSub].
+ * @return An [Expect] with the new type [TSub].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified TSub : Any> Expect<*>.isA(): Expect<TSub> =
@@ -138,7 +138,7 @@ inline fun <reified TSub : Any> Expect<*>.isA(): Expect<TSub> =
  * the element type is actually `String`. Or in other words
  * `assert(listOf(1, 2)).isA<List<String>>{}` holds, even though `List<Int>` is clearly not a `List<String>`.
  *
- * @return An assertion container with the new type [TSub].
+ * @return An [Expect] with the new type [TSub].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified TSub : Any> Expect<*>.isA(noinline assertionCreator: Expect<TSub>.() -> Unit): Expect<TSub> =
@@ -152,7 +152,7 @@ inline fun <reified TSub : Any> Expect<*>.isA(noinline assertionCreator: Expect<
  * asserts that 1 is greater than 0. If the first assertion fails, then usually (depending on the configured
  * [AssertionChecker]) the second assertion is not evaluated.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  */
 inline val <T> Expect<T>.and: Expect<T> get() = this
 
@@ -164,6 +164,6 @@ inline val <T> Expect<T>.and: Expect<T> get() = this
  * second one is evaluated as a whole. Meaning, even though 1 is not even, it still evaluates that 1 is greater than 1.
  * Hence the reporting might (depending on the configured [Reporter]) contain both failing sub-assertions.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  */
 infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit) = addAssertionsCreatedBy(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
@@ -47,7 +47,7 @@ val <T : CharSequence> Expect<T>.containsNot: NotCheckerOption<T, NotSearchBehav
  * instead of:
  *   `contains('a', 'a')`
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case [expected] or one of the [otherExpected] is not a
  *   [CharSequence], [Number] or [Char].
@@ -64,7 +64,7 @@ fun <T : CharSequence> Expect<T>.contains(expected: Any, vararg otherExpected: A
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.containsNot(expected: Any, vararg otherExpected: Any) =
@@ -90,7 +90,7 @@ fun <T : CharSequence> Expect<T>.containsNot(expected: Any, vararg otherExpected
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatterns: String): Expect<T> =
@@ -116,7 +116,7 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatt
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -127,7 +127,7 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: Regex, vararg otherPatte
 /**
  * Expects that the subject of the assertion (a [CharSequence]) starts with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence) =
@@ -136,7 +136,7 @@ fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence) =
 /**
  * Expects that the subject of the assertion (a [CharSequence]) starts with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -146,7 +146,7 @@ fun <T : CharSequence> Expect<T>.startsWith(expected: Char) = startsWith(expecte
 /**
  * Expects that the subject of the assertion (a [CharSequence]) does not start with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence) =
@@ -155,7 +155,7 @@ fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence) =
 /**
  * Expects that the subject of the assertion (a [CharSequence]) does not start with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -166,7 +166,7 @@ fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char) = startsNotWith(e
 /**
  * Expects that the subject of the assertion (a [CharSequence]) ends with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence) =
@@ -175,7 +175,7 @@ fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence) =
 /**
  * Expects that the subject of the assertion (a [CharSequence]) ends with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -185,7 +185,7 @@ fun <T : CharSequence> Expect<T>.endsWith(expected: Char) = endsWith(expected.to
 /**
  * Expects that the subject of the assertion (a [CharSequence]) does not end with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence) =
@@ -194,7 +194,7 @@ fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence) =
 /**
  * Expects that the subject of the assertion (a [CharSequence]) does not end with [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -205,7 +205,7 @@ fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char) = endsNotWith(expec
 /**
  * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isEmpty].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.isEmpty() = addAssertion(ExpectImpl.charSequence.isEmpty(this))
@@ -213,7 +213,7 @@ fun <T : CharSequence> Expect<T>.isEmpty() = addAssertion(ExpectImpl.charSequenc
 /**
  * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isNotEmpty].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.isNotEmpty() = addAssertion(ExpectImpl.charSequence.isNotEmpty(this))
@@ -221,7 +221,7 @@ fun <T : CharSequence> Expect<T>.isNotEmpty() = addAssertion(ExpectImpl.charSequ
 /**
  * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isNotBlank].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : CharSequence> Expect<T>.isNotBlank() = addAssertion(ExpectImpl.charSequence.isNotBlank(this))
@@ -229,7 +229,7 @@ fun <T : CharSequence> Expect<T>.isNotBlank() = addAssertion(ExpectImpl.charSequ
 /**
  * Expects that the subject of the assertion (a [CharSequence]) matches the given [expected] [Regex].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -240,7 +240,7 @@ fun <T : CharSequence> Expect<T>.matches(expected: Regex) =
 /**
  * Expects that the subject of the assertion (a [CharSequence]) mismatches the given [expected] [Regex].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
 /**
  * Expects that the subject of the assertion (a [Collection]) is an empty [Collection].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Collection<*>> Expect<T>.isEmpty() = addAssertion(ExpectImpl.collection.isEmpty(this))
@@ -14,7 +14,7 @@ fun <T : Collection<*>> Expect<T>.isEmpty() = addAssertion(ExpectImpl.collection
 /**
  * Expects that the subject of the assertion (a [Collection]) is not an empty [Collection].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Collection<*>> Expect<T>.isNotEmpty() = addAssertion(ExpectImpl.collection.isNotEmpty(this))
@@ -22,9 +22,9 @@ fun <T : Collection<*>> Expect<T>.isNotEmpty() = addAssertion(ExpectImpl.collect
 /**
  * Expects that the subject of the assertion (a [Collection]) has the given [expected] size.
  *
- * Shortcut for `expected.toBe(expectedSize)`.
+ * Shortcut for `size.toBe(expected)`.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Collection<*>> Expect<T>.hasSize(expected: Int) = size { toBe(expected) }
@@ -33,16 +33,16 @@ fun <T : Collection<*>> Expect<T>.hasSize(expected: Int) = size { toBe(expected)
  * Creates an [Expect] for the property [Collection.size] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <T : Collection<*>> Expect<T>.size: Expect<Int>
     get() = ExpectImpl.collection.size(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Collection.size] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableAssertions.kt
@@ -7,7 +7,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * Expects that the subject of the assertion is less than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T) =
@@ -17,7 +17,7 @@ fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T) =
  * Expects that the subject of the assertion is less than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T) =
@@ -27,7 +27,7 @@ fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T) =
  * Expects that the subject of the assertion is greater than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T) =
@@ -37,7 +37,7 @@ fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T) =
  * Expects that the subject of the assertion is greater than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T) =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/expectExtensions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/expectExtensions.kt
@@ -20,6 +20,8 @@ annotation class ExperimentalWithOptions
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
  * In case [Expect.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 fun <T> RootExpect<T>.withRepresentation(textRepresentation: String): Expect<T> =
@@ -36,6 +38,8 @@ fun <T> RootExpect<T>.withRepresentation(textRepresentation: String): Expect<T> 
  * a `String` and does the wrapping for you.
  *
  * In case [Expect.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 fun <T> RootExpect<T>.withRepresentation(representationProvider: (T) -> Any): Expect<T> =
@@ -44,6 +48,8 @@ fun <T> RootExpect<T>.withRepresentation(representationProvider: (T) -> Any): Ex
 /**
  * Uses the given [configuration]-lambda to create an [ExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 fun <T> RootExpect<T>.withOptions(configuration: ExpectBuilder.OptionsChooser<T>.() -> Unit): Expect<T> =
@@ -53,6 +59,8 @@ fun <T> RootExpect<T>.withOptions(configuration: ExpectBuilder.OptionsChooser<T>
 //in the same go we should get rid of  ReportingAssertionContainer.AssertionCheckerDecorator, rename it respectively.
 /**
  * Uses the given [options] to override (parts) of the existing configuration.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 @UseExperimental(ExperimentalExpectConfig::class)
@@ -73,6 +81,8 @@ fun <T> RootExpect<T>.withOptions(options: ExpectOptions<T>): Expect<T> = coreFa
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
  * In case [Expect.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: String): Expect<R> =
@@ -89,6 +99,8 @@ fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: String): E
  * a `String` and does the wrapping for you.
  *
  * In case [Expect.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 fun <T, R> FeatureExpect<T, R>.withRepresentation(representationProvider: (R) -> Any): Expect<R> =
@@ -97,6 +109,8 @@ fun <T, R> FeatureExpect<T, R>.withRepresentation(representationProvider: (R) ->
 /**
  * Uses the given [configuration]-lambda to create an [ExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExtractorBuilder.OptionsChooser<R>.() -> Unit): Expect<R> =
@@ -104,6 +118,8 @@ fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExtractorBuilde
 
 /**
  * Uses the given [options] to override (parts) of the existing configuration.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 @UseExperimental(ExperimentalExpectConfig::class)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/featureAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/featureAssertions.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.*
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the given [property].
+ * @return The newly created [Expect] for the given [property].
  *
  * @since 0.9.0
  */
@@ -26,7 +26,7 @@ fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect<T, R>
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -42,7 +42,7 @@ fun <T, R> Expect<T>.feature(
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly created [Expect] for the return value of calling [f] on the current subject of the assertion.
  *
  * @since 0.9.0
  */
@@ -55,7 +55,7 @@ fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -72,7 +72,7 @@ fun <T, R> Expect<T>.feature(
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly created [Expect] for the return value of calling [f] on the current subject of the assertion.
  *
  * @since 0.9.0
  */
@@ -88,7 +88,7 @@ fun <T, A1, R> Expect<T>.feature(
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -106,7 +106,7 @@ fun <T, A1, R> Expect<T>.feature(
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly created [Expect] for the return value of calling [f] on the current subject of the assertion.
  *
  * @since 0.9.0
  */
@@ -122,7 +122,7 @@ fun <T, A1, A2, R> Expect<T>.feature(
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -140,7 +140,7 @@ fun <T, A1, A2, R> Expect<T>.feature(
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly created [Expect] for the return value of calling [f] on the current subject of the assertion.
  *
  * @since 0.9.0
  */
@@ -156,7 +156,7 @@ fun <T, A1, A2, A3, R> Expect<T>.feature(
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -174,7 +174,7 @@ fun <T, A1, A2, A3, R> Expect<T>.feature(
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly created [Expect] for the return value of calling [f] on the current subject of the assertion.
  *
  * @since 0.9.0
  */
@@ -190,7 +190,7 @@ fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -208,7 +208,7 @@ fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return An [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly [Expect] for the return value of calling [f] on the current subject of the assertion.
  *
  * @since 0.9.0
  */
@@ -224,7 +224,7 @@ fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -245,7 +245,7 @@ fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
  * @param provider Extracts the feature where the subject of the assertion is available via
  *   implicit parameter `it`.
  *
- * @return An [Expect] for the extracted feature.
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -262,7 +262,7 @@ fun <T, R> Expect<T>.feature(description: String, provider: T.() -> R): FeatureE
  * @param provider Extracts the feature where the subject of the assertion is available via
  *   implicit parameter `it`.
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0
@@ -284,7 +284,7 @@ fun <T, R> Expect<T>.feature(
  *   implicit parameter `it`. Usually you use [f][MetaFeatureOption.f] to create a [MetaFeature],
  *   e.g. `feature { f(it::size) }`
  *
- * @return An [Expect] for the extracted feature.
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -301,7 +301,7 @@ fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFeature<R
  * @param provider You need to create a [MetaFeature] where the subject of the assertion is available via
  *   implicit parameter `it`. Usually you use [MetaFeatureOption.f] to create a [MetaFeature], e.g. `f(it::size)`
  *
- * @return The current [Expect].
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] in case the created [AssertionGroup] does not hold.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointAssertions.kt
@@ -18,7 +18,7 @@ import kotlin.jvm.JvmName
  *
  * | `subject of the assertion` - [expected] | ≤ [tolerance]
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun Expect<Float>.toBeWithErrorTolerance(expected: Float, tolerance: Float) =
@@ -34,7 +34,7 @@ fun Expect<Float>.toBeWithErrorTolerance(expected: Float, tolerance: Float) =
  *
  * | `subject of the assertion` - [expected] | ≤ [tolerance]
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun Expect<Double>.toBeWithErrorTolerance(expected: Double, tolerance: Double) =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fun0Assertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fun0Assertions.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * For instance `toThrow<MyException<String>>` would only check if the subject is a `MyException` without checking if
  * the element type is actually `String`.
  *
- * @return An assertion container with the new type [TExpected].
+ * @return An [Expect] with the new type [TExpected].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(): Expect<TExpected> =
@@ -46,7 +46,7 @@ inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(): Exp
  * For instance `toThrow<MyException<String>>` would only check if the subject is a `MyException` without checking if
  * the element type is actually `String`.
  *
- * @return An assertion container with the new type [TExpected].
+ * @return An [Expect] with the new type [TExpected].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
@@ -58,6 +58,7 @@ inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
  * Expects that no [Throwable] is thrown at all when calling the subject (a lambda with arity 0, i.e. without arguments)
  * and changes the subject of the assertion to the return value of type [R].
  *
+ * @return An [Expect] with the new type [R].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <R, T : () -> R> Expect<T>.notToThrow(): Expect<R> = ExpectImpl.fun0.isNotThrowing(this).getExpectOfFeature()
@@ -66,6 +67,7 @@ fun <R, T : () -> R> Expect<T>.notToThrow(): Expect<R> = ExpectImpl.fun0.isNotTh
  * Expects that no [Throwable] is thrown at all when calling the subject (a lambda with arity 0, i.e. without arguments)
  * and that the corresponding return value holds all assertions the given [assertionCreator] creates.
  *
+ * @return An [Expect] with the new type [R].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <R, T : () -> R> Expect<T>.notToThrow(

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
@@ -28,9 +28,9 @@ val <E, T : Iterable<E>> Expect<T>.containsNot: NotCheckerOption<E, T, NotSearch
 
 /**
  * Expects that the property min of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @since 0.9.0
  */
@@ -41,16 +41,16 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: Expect<
  * Creates an [Expect] for the property min of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(): Expect<E> = ExpectImpl.iterable.min(this).getExpectOfFeature()
 
 /**
  * Expects that the property max of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @since 0.9.0
  */
@@ -61,7 +61,7 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(assertionCreator: Expect<
  * Creates an [Expect] for the property max of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> = ExpectImpl.iterable.max(this).getExpectOfFeature()
@@ -81,7 +81,7 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> = ExpectImpl
  * instead of:
  *   `contains('a', 'a')`
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E, T : Iterable<E>> Expect<T>.contains(expected: E, vararg otherExpected: E): Expect<T> =
@@ -98,7 +98,7 @@ fun <E, T : Iterable<E>> Expect<T>.contains(expected: E, vararg otherExpected: E
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
@@ -118,7 +118,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull: (Expe
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.contains(
@@ -136,7 +136,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.contains(
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E, vararg otherExpected: E): Expect<T> =
@@ -157,7 +157,7 @@ fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E, vararg otherExpe
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
@@ -181,7 +181,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(assertionCreatorOrNull
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
@@ -196,7 +196,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
  *
  *  It is a shortcut for `containsNot.values(expected, *otherExpected)`
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E, vararg otherExpected: E) =
@@ -209,7 +209,7 @@ fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E, vararg otherExpected
  *
  * It is a shortcut for `contains.inAnyOrder.atLeast(1).entry(assertionCreatorOrNull)`
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.any(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
@@ -223,7 +223,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.any(assertionCreatorOrNull: (Expect<E>
  *
  *  It is a shortcut for `containsNot.entry(assertionCreatorOrNull)`
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.none(assertionCreatorOrNull: (Expect<E>.() -> Unit)?) =
@@ -235,7 +235,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.none(assertionCreatorOrNull: (Expect<E
  * that every element holds all assertions created by the [assertionCreatorOrNull] or that all elements are `null`
  * in case [assertionCreatorOrNull] is defined as `null`.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.all(assertionCreatorOrNull: (Expect<E>.() -> Unit)?) =
@@ -244,7 +244,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.all(assertionCreatorOrNull: (Expect<E>
 /**
  * Expects that the subject of the assertion (an [Iterable]) has at least one element.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -254,7 +254,7 @@ fun <E, T : Iterable<E>> Expect<T>.hasNext() = addAssertion(ExpectImpl.iterable.
 /**
  * Expects that the subject of the assertion (an [Iterable]) does not have next element.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
@@ -16,7 +16,7 @@ fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> = ExpectImpl.list.get(
  * Expects that the given [index] is within the bounds of the subject of the assertion (a [List]) and that
  * the element at that position holds all assertions the given [assertionCreator] creates for it.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the given [index] is out of bound.
  */
 fun <E, T : List<E>> Expect<T>.get(index: Int, assertionCreator: Expect<E>.() -> Unit): Expect<T> =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
@@ -14,7 +14,7 @@ import ch.tutteli.kbox.glue
  * defined as `'a' to 1` and one of the [otherPairs] is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.contains(
@@ -33,7 +33,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.contains(
  * defined as `Key('a') { isGreaterThan(0) }` and one of the [otherKeyValues] is defined as `Key('a') { isLessThan(2) }`
  * , then both match, even though they match the same entry.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
@@ -46,7 +46,7 @@ inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
 /**
  * Expects that the subject of the assertion (a [Map]) contains the given [key].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, T : Map<out K, *>> Expect<T>.containsKey(key: K) = addAssertion(ExpectImpl.map.containsKey(this, key))
@@ -54,7 +54,7 @@ fun <K, T : Map<out K, *>> Expect<T>.containsKey(key: K) = addAssertion(ExpectIm
 /**
  * Expects that the subject of the assertion (a [Map]) does not contain the given [key].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K) = addAssertion(ExpectImpl.map.containsNotKey(this, key))
@@ -63,7 +63,7 @@ fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K) = addAssertion(Expec
 /**
  * Expects that the subject of the assertion (a [Map]) is an empty [Map].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Map<*, *>> Expect<T>.isEmpty() = addAssertion(ExpectImpl.map.isEmpty(this))
@@ -71,7 +71,7 @@ fun <T : Map<*, *>> Expect<T>.isEmpty() = addAssertion(ExpectImpl.map.isEmpty(th
 /**
  * Expects that the subject of the assertion (a [Map]) is not an empty [Map].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Map<*, *>> Expect<T>.isNotEmpty() = addAssertion(ExpectImpl.map.isNotEmpty(this))
@@ -82,7 +82,7 @@ fun <T : Map<*, *>> Expect<T>.isNotEmpty() = addAssertion(ExpectImpl.map.isNotEm
  * creates an [Expect] for the corresponding value and returns the newly created assertion container,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect] for the feature.
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the given [key] does not exist.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
@@ -92,7 +92,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
  * Expects that the subject of the assertion (a [Map]) contains the given [key] and that
  * the corresponding value holds all assertions the given [assertionCreator] creates for it.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if a created [Assertion]s (by calling [assertionCreator])
  *   does not hold.
  */
@@ -103,16 +103,16 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Ex
  * Creates an [Expect] for the property [Map.keys] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect] for the feature.
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
     get() = keys(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
@@ -124,16 +124,16 @@ private fun <K, T : Map<out K, *>> keys(e: Expect<T>) = ExpectImpl.feature.prope
  * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect] for the feature.
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
     get() = values().getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -11,7 +11,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * block. Yet, the actual behaviour depends on implementation - could also be fail fast for instance or augment
  * reporting etc.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
@@ -21,16 +21,16 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T
  * Creates an [Expect] for the property [Map.Entry.key] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = ExpectImpl.map.entry.key(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.Entry.key] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
@@ -40,16 +40,16 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> 
  * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = ExpectImpl.map.entry.value(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.Entry.value] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
@@ -7,16 +7,16 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * Creates an [Expect] for the property [Pair.first] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
     get() = ExpectImpl.pair.first(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.first] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
@@ -26,16 +26,16 @@ fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Uni
  * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
     get() = ExpectImpl.pair.second(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.second] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Pair<K, V>> Expect<T>.second(assertionCreator: Expect<V>.() -> Unit): Expect<T> =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceAssertions.kt
@@ -21,7 +21,7 @@ fun <E, T : Sequence<E>> Expect<T>.asIterable(): Expect<Iterable<E>> =
  * The transformation as such is not reflected in reporting.
  * Use `feature(Sequence::asIterable, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  */
 fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
     apply { asIterable().addAssertionsCreatedBy(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.creating.Expect
  * Expects that the property [Throwable.message] of the subject of the assertion is not null,
  * creates an [Expect] for it and returns it.
  *
- * @return The newly created [Expect] for the property [Throwable.message] of the subject of the assertion
+ * @return The newly created [Expect] for the property [Throwable.message] of the subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 val <T : Throwable> Expect<T>.message: Expect<String>
@@ -14,9 +14,9 @@ val <T : Throwable> Expect<T>.message: Expect<String>
 
 /**
  * Expects that the property [Throwable.message] of the subject of the assertion is not null and
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Throwable> Expect<T>.message(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
@@ -33,7 +33,7 @@ fun <T : Throwable> Expect<T>.message(assertionCreator: Expect<String>.() -> Uni
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed
  * (this function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : Throwable> Expect<T>.messageContains(expected: Any, vararg otherExpected: Any): Expect<T> =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/bigDecimalAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/bigDecimalAssertions.kt
@@ -46,7 +46,7 @@ fun <T : BigDecimal?> Expect<T>.toBe(expected: T): Nothing = throw PleaseUseRepl
 /**
  * Expects that the subject of the assertion (a [BigDecimal]) is `null`.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @JvmName("toBeNull")
@@ -87,7 +87,7 @@ fun <T : BigDecimal> Expect<T>.notToBe(expected: T): Nothing = throw PleaseUseRe
  * - `expect(BigDecimal("10")).isEqualIncludingScale(BigDecimal("10.0"))` does not hold.
  * - `expect(BigDecimal("10")).isNumericallyEqualTo(BigDecimal("10.0"))` holds.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : BigDecimal> Expect<T>.isNumericallyEqualTo(expected: T) =
@@ -105,7 +105,7 @@ fun <T : BigDecimal> Expect<T>.isNumericallyEqualTo(expected: T) =
  * - `expect(BigDecimal("10")).isNotEqualIncludingScale(BigDecimal("10.0"))` holds.
  * - `expect(BigDecimal("10")).isNotNumericallyEqualTo(BigDecimal("10.0"))`  does not hold.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T) =
@@ -121,7 +121,7 @@ fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T) =
  * - `expect(BigDecimal("10")).isEqualIncludingScale(BigDecimal("10.0"))` does not hold.
  * - `expect(BigDecimal("10")).isNumericallyEqualTo(BigDecimal("10.0"))` holds.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : BigDecimal> Expect<T>.isEqualIncludingScale(expected: T) =
@@ -136,7 +136,7 @@ fun <T : BigDecimal> Expect<T>.isEqualIncludingScale(expected: T) =
  * - `expect(BigDecimal("10")).isNotEqualIncludingScale(BigDecimal("10.0"))` holds.
  * - `expect(BigDecimal("10")).isNotNumericallyEqualTo(BigDecimal("10.0"))`  does not hold.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : BigDecimal> Expect<T>.isNotEqualIncludingScale(expected: T) =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
@@ -18,7 +18,7 @@ import java.math.BigDecimal
  *
  * | `subject of the assertion` - [expected] | ≤ [tolerance]
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <T : BigDecimal> Expect<T>.toBeWithErrorTolerance(expected: BigDecimal, tolerance: BigDecimal) =

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/chronoLocalDateAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/chronoLocalDateAssertions.kt
@@ -11,7 +11,7 @@ import java.time.chrono.ChronoLocalDate
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is before the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -23,7 +23,7 @@ fun <T : ChronoLocalDate> Expect<T>.isBefore(expected: ChronoLocalDate): Expect<
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is before or equal the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -36,7 +36,7 @@ fun <T : ChronoLocalDate> Expect<T>.isBeforeOrEqual(expected: ChronoLocalDate): 
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is after the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -48,7 +48,7 @@ fun <T : ChronoLocalDate> Expect<T>.isAfter(expected: ChronoLocalDate): Expect<T
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is after or equal the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -60,7 +60,7 @@ fun <T : ChronoLocalDate> Expect<T>.isAfterOrEqual(expected: ChronoLocalDate): E
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is equal to the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/chronoLocalDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/chronoLocalDateTimeAssertions.kt
@@ -12,7 +12,7 @@ import java.time.chrono.ChronoLocalDateTime
  * Expects that the subject of the assertion (a [ChronoLocalDateTime])
  * is before the [expected] [ChronoLocalDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -24,7 +24,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(expected: 
  * Expects that the subject of the assertion (a [ChronoLocalDateTime])
  * is before or equal the [expected] [ChronoLocalDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -37,7 +37,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
  * Expects that the subject of the assertion (a [ChronoLocalDateTime])
  * is after the [expected] [ChronoLocalDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -50,7 +50,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * Expects that the subject of the assertion (a [ChronoLocalDateTime])
  * is after or equal the [expected] [ChronoLocalDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -63,7 +63,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
  * Expects that the subject of the assertion (a [ChronoLocalDateTime])
  * is equal to the [expected] [ChronoLocalDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/chronoZonedDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/chronoZonedDateTimeAssertions.kt
@@ -12,7 +12,7 @@ import java.time.chrono.ChronoZonedDateTime
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is before the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -25,7 +25,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -38,7 +38,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is after the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -51,7 +51,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is after or equal the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -64,7 +64,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is equal to the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/fileAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/fileAssertions.kt
@@ -27,7 +27,7 @@ fun <T : File> Expect<T>.asPath(): Expect<Path> =
  * The transformation as such is not reflected in reporting.
  * Use `feature(File::toPath, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateAssertions.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
  * Creates an [Expect] for the property [LocalDate.year][LocalDate.getYear] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -24,9 +24,9 @@ val <T : LocalDate> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -38,7 +38,7 @@ fun <T : LocalDate> Expect<T>.year(assertionCreator: Expect<Int>.() -> Unit): Ex
  * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -47,9 +47,9 @@ val <T : LocalDate> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -61,7 +61,7 @@ fun <T : LocalDate> Expect<T>.month(assertionCreator: Expect<Int>.() -> Unit): E
  * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -70,9 +70,9 @@ val <T : LocalDate> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -85,7 +85,7 @@ fun <T : LocalDate> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -
  * Creates an [Expect] for the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -94,9 +94,9 @@ val <T : LocalDate> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateTimeAssertions.kt
@@ -15,7 +15,7 @@ import java.time.LocalDateTime
  * Creates an [Expect] for the property [LocalDateTime.year][[LocalDateTime.getYear] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -24,9 +24,9 @@ val <T : LocalDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -38,7 +38,7 @@ fun <T : LocalDateTime> Expect<T>.year(assertionCreator: Expect<Int>.() -> Unit)
  * Creates an [Expect] for the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -47,9 +47,9 @@ val <T : LocalDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -61,7 +61,7 @@ fun <T : LocalDateTime> Expect<T>.month(assertionCreator: Expect<Int>.() -> Unit
  * Creates an [Expect] for the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -70,9 +70,9 @@ val <T : LocalDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -84,7 +84,7 @@ fun <T : LocalDateTime> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.
  * Creates an [Expect] for the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -93,9 +93,9 @@ val <T : LocalDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/optionalAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/optionalAssertions.kt
@@ -13,7 +13,7 @@ import java.util.*
  * Shortcut for more or less something like `feature(Optional<T>::isEmpty) { toBe(true) }`
  * depends on the underlying implementation though.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -27,7 +27,7 @@ fun <T : Optional<*>> Expect<T>.isEmpty(): Expect<T> = addAssertion(ExpectImpl.o
  * Shortcut for more or less something like `feature(Optional<T>::get)` but with error handling; yet it
  * depends on the underlying implementation though.
  *
- * @return The newly created [Expect] if the given assertion is success
+ * @return The newly created [Expect] for the inner type [E].
  * @throws AssertionError Might throw an [AssertionError] if the given assertion is not a success.
  *
  * @since 0.9.0
@@ -38,7 +38,7 @@ fun <E, T : Optional<E>> Expect<T>.isPresent(): Expect<E> = ExpectImpl.optional.
  * Expects that the subject of the assertion (an [Optional]) is present and
  * that it holds all assertions the given [assertionCreator] creates.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the given assertions are not success.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -10,7 +10,7 @@ import java.nio.file.Path
 /**
  * Expects that the subject of the assertion (a [Path]) starts with the [expected] [Path].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -21,7 +21,7 @@ fun <T : Path> Expect<T>.startsWith(expected: Path): Expect<T> =
 /**
  * Expects that the subject of the assertion (a [Path]) does not start with the [expected] [Path].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -32,7 +32,7 @@ fun <T : Path> Expect<T>.startsNotWith(expected: Path): Expect<T> =
 /**
  * Expects that the subject of the assertion (a [Path]) ends with the expected [Path].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -44,7 +44,7 @@ fun <T : Path> Expect<T>.endsWith(expected: Path): Expect<T> =
  * Expects that the subject of the assertion (a [Path]) does not end with the expected [Path];
  *
  * @param expected The [Path] provided to the assertion
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -59,7 +59,7 @@ fun <T : Path> Expect<T>.endsNotWith(expected: Path): Expect<T> =
  * This matcher _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -73,7 +73,7 @@ fun <T : Path> Expect<T>.exists(): Expect<T> = addAssertion(ExpectImpl.path.exis
  * This matcher _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -85,7 +85,7 @@ fun <T : Path> Expect<T>.existsNot(): Expect<T> = addAssertion(ExpectImpl.path.e
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -95,9 +95,9 @@ val <T : Path> Expect<T>.fileName: Expect<String>
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -110,7 +110,7 @@ fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): 
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -122,9 +122,9 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
  * (provided via [niok](https://github.com/robstoll/niok))
  * of the subject of the assertion holds all assertions the given [assertionCreator] creates for it
- * and returns this assertion container.
+ * and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -136,7 +136,7 @@ fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<Strin
  * Expects that this [Path] has a [parent][Path.getParent] and creates an [Expect] for it,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -146,9 +146,9 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent] and that the parent holds all assertions the
- * given [assertionCreator] creates for it and returns this assertion container.
+ * given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -160,7 +160,7 @@ fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expe
  * Expects that [other] resolves against this [Path] and creates an [Expect] for the resolved [Path]
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -170,9 +170,9 @@ fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
 
 /**
  * Expects that [other] resolves against this [Path] and that the resolved [Path] holds all assertions the
- * given [assertionCreator] creates for it and returns this assertion container.
+ * given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -193,7 +193,7 @@ fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.(
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -209,7 +209,7 @@ fun <T : Path> Expect<T>.isReadable(): Expect<T> = addAssertion(ExpectImpl.path.
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -228,7 +228,7 @@ fun <T : Path> Expect<T>.isWritable(): Expect<T> = addAssertion(ExpectImpl.path.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -247,7 +247,7 @@ fun <T : Path> Expect<T>.isRegularFile(): Expect<T> = addAssertion(ExpectImpl.pa
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -259,7 +259,7 @@ fun <T : Path> Expect<T>.isDirectory(): Expect<T> = addAssertion(ExpectImpl.path
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -269,9 +269,9 @@ val <T : Path> Expect<T>.extension: Expect<String>
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/zonedDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/zonedDateTimeAssertions.kt
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime
  * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -24,9 +24,9 @@ val <T : ZonedDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -38,7 +38,7 @@ fun <T : ZonedDateTime> Expect<T>.year(assertionCreator: Expect<Int>.() -> Unit)
  * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -47,9 +47,9 @@ val <T : ZonedDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -61,7 +61,7 @@ fun <T : ZonedDateTime> Expect<T>.month(assertionCreator: Expect<Int>.() -> Unit
  * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -70,9 +70,9 @@ val <T : ZonedDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -84,7 +84,7 @@ fun <T : ZonedDateTime> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.
  * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.9.0
  */
@@ -93,9 +93,9 @@ val <T : ZonedDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/resultAssertions.kt
+++ b/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/resultAssertions.kt
@@ -19,7 +19,7 @@ fun <E, T : Result<E>> Expect<T>.isSuccess(): Expect<E> = ExpectImpl.result.isSu
  * Expects that the subject of the assertion (a [Result]) is a Success and
  * that it holds all assertions the given [assertionCreator] creates.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the given assertions are not success.
  *
  * @since 0.9.0
@@ -31,7 +31,7 @@ fun <E, T : Result<E>> Expect<T>.isSuccess(assertionCreator: Expect<E>.() -> Uni
  * Expects that the subject of the assertion (a [Result]) is a Failure and
  * that it encapsulates an exception of type [TExpected].
  *
- * @return An assertion container with the new type [TExpected]
+ * @return An [Expect] with the new type [TExpected]
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
@@ -44,7 +44,7 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.isFailure(): Ex
  * it encapsulates an exception of type [TExpected] and that the exception
  * holds all assertions the given [assertionCreator] creates.
  *
- * @return An assertion container with the new type [TExpected]
+ * @return An [Expect] with the new type [TExpected]
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
@@ -8,7 +8,7 @@ import ch.tutteli.atrium.reporting.Reporter
 /**
  * Expects that the subject of the assertion is (equal to) [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T> Expect<T>.toBe(expected: T) = addAssertion(ExpectImpl.any.toBe(this, expected))
@@ -16,7 +16,7 @@ infix fun <T> Expect<T>.toBe(expected: T) = addAssertion(ExpectImpl.any.toBe(thi
 /**
  * Expects that the subject of the assertion is not (equal to) [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T> Expect<T>.notToBe(expected: T) = addAssertion(ExpectImpl.any.notToBe(this, expected))
@@ -24,7 +24,7 @@ infix fun <T> Expect<T>.notToBe(expected: T) = addAssertion(ExpectImpl.any.notTo
 /**
  * Expects that the subject of the assertion is the same instance as [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T> Expect<T>.isSameAs(expected: T) = addAssertion(ExpectImpl.any.isSame(this, expected))
@@ -32,7 +32,7 @@ infix fun <T> Expect<T>.isSameAs(expected: T) = addAssertion(ExpectImpl.any.isSa
 /**
  * Expects that the subject of the assertion is not the same instance as [expected].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T> Expect<T>.isNotSameAs(expected: T) = addAssertion(ExpectImpl.any.isNotSame(this, expected))
@@ -47,7 +47,7 @@ infix fun <T> Expect<T>.isNotSameAs(expected: T) = addAssertion(ExpectImpl.any.i
  * else notToBeNull(assertionCreatorOrNull)
  * ```
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline infix fun <reified T : Any> Expect<T?>.toBeNullIfNullGivenElse(
@@ -60,7 +60,7 @@ inline infix fun <reified T : Any> Expect<T?>.toBeNullIfNullGivenElse(
  *
  * It delegates to [isA] with [T] as type.
  *
- * @return An assertion container with the non-nullable type [T] (was `T?` before).
+ * @return An [Expect] with the non-nullable type [T] (was `T?` before).
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress(/* less magic */ "RemoveExplicitTypeArguments")
@@ -72,7 +72,7 @@ inline infix fun <reified T : Any> Expect<T?>.notToBeNull(@Suppress("UNUSED_PARA
  *
  * It delegates to [isA] with [T] as type.
  *
- * @return An assertion container with the non-nullable type [T] (was `T?` before)
+ * @return An [Expect] with the non-nullable type [T] (was `T?` before)
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress(/* less magic */ "RemoveExplicitTypeArguments")
@@ -95,7 +95,7 @@ inline infix fun <reified T : Any> Expect<T?>.notToBeNull(noinline assertionCrea
  * the element type is actually `String`. Or in other words
  * `assert(listOf(1, 2)).isA<List<String>>{}` holds, even though `List<Int>` is clearly not a `List<String>`.
  *
- * @return An assertion container with the new type [TSub].
+ * @return An [Expect] with the new type [TSub].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 //TODO make infix and add `o` as parameter as soon as https://youtrack.jetbrains.com/issue/KT-21593 is fixed
@@ -140,7 +140,7 @@ inline fun <reified TSub : Any> Expect<*>.isA(): Expect<TSub> =
  * the element type is actually `String`. Or in other words
  * `assert(listOf(1, 2)).isA<List<String>>{}` holds, even though `List<Int>` is clearly not a `List<String>`.
  *
- * @return An assertion container with the new type [TSub].
+ * @return An [Expect] with the new type [TSub].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline infix fun <reified TSub : Any> Expect<*>.isA(noinline assertionCreator: Expect<TSub>.() -> Unit): Expect<TSub> =
@@ -154,7 +154,7 @@ inline infix fun <reified TSub : Any> Expect<*>.isA(noinline assertionCreator: E
  * asserts that 1 is greater than 0. If the first assertion fails, then usually (depending on the configured
  * [AssertionChecker]) the second assertion is not evaluated.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  *
  * @since 0.10.0
  */
@@ -169,7 +169,7 @@ inline infix fun <T> Expect<T>.and(@Suppress("UNUSED_PARAMETER") o: o): Expect<T
  * second one is evaluated as a whole. Meaning, even though 1 is not even, it still evaluates that 1 is greater than 1.
  * Hence the reporting might (depending on the configured [Reporter]) contain both failing sub-assertions.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  */
 infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit) = addAssertionsCreatedBy(assertionCreator)
 
@@ -190,5 +190,7 @@ infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit) = addAsserti
  *   o ends with "world"
  * }
  * ```
+ *
+ * @return `this`
  */
 inline val <T> Expect<T>.o get() : Expect<T> = this

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
 /**
  * Expects that the subject of the assertion (a [Collection]) is an empty [Collection].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Collection<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty: Empty) =
@@ -15,7 +15,7 @@ infix fun <T : Collection<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty
 /**
  * Expects that the subject of the assertion (a [Collection]) is not an empty [Collection].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Collection<*>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty: Empty) =
@@ -25,15 +25,15 @@ infix fun <T : Collection<*>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") Em
  * Creates an [Expect] for the property [Collection.size] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <T : Collection<*>> Expect<T>.size get(): Expect<Int> = ExpectImpl.collection.size(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Collection.size] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableAssertions.kt
@@ -7,7 +7,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * Expects that the subject of the assertion is less than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T) =
@@ -17,7 +17,7 @@ infix fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T) =
  * Expects that the subject of the assertion is less than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T) =
@@ -27,7 +27,7 @@ infix fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T) =
  * Expects that the subject of the assertion is greater than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T) =
@@ -37,7 +37,7 @@ infix fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T) =
  * Expects that the subject of the assertion is greater than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T) =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/list/get/builders/ListGetStep.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/list/get/builders/ListGetStep.kt
@@ -25,7 +25,7 @@ interface ListGetStep<E, T : List<E>> {
      * Makes the assertion that the given [index] is within the bounds of [Expect.subject] and that
      * the corresponding entry holds all assertions the given [assertionCreator] might create for it.
      *
-     * @return This [Expect] to support a fluent API.
+     * @return An [Expect] for the current subject of the assertion.
      * @throws AssertionError Might throw an [AssertionError] if a created [Expect]s (by calling [assertionCreator])
      *   does not hold.
      * @throws IllegalArgumentException in case the given [assertionCreator] did not create a single assertion.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fun0Assertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fun0Assertions.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * For instance `toThrow<MyException<String>>` would only check if the subject is a `MyException` without checking if
  * the element type is actually `String`.
  *
- * @return An assertion container with the new type [TExpected].
+ * @return An [Expect] with the new type [TExpected].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(): Expect<TExpected> =
@@ -46,7 +46,7 @@ inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(): Exp
  * For instance `toThrow<MyException<String>>` would only check if the subject is a `MyException` without checking if
  * the element type is actually `String`.
  *
- * @return An assertion container with the new type [TExpected].
+ * @return An [Expect] with the new type [TExpected].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline infix fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
@@ -58,6 +58,7 @@ inline infix fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
  * Expects that no [Throwable] is thrown at all when calling the subject (a lambda with arity 0, i.e. without arguments)
  * and changes the subject of the assertion to the return value of type [R].
  *
+ * @return An [Expect] with the new type [R].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <R, T : () -> R> Expect<T>.notToThrow(): Expect<R> = ExpectImpl.fun0.isNotThrowing(this).getExpectOfFeature()
@@ -66,6 +67,7 @@ fun <R, T : () -> R> Expect<T>.notToThrow(): Expect<R> = ExpectImpl.fun0.isNotTh
  * Expects that no [Throwable] is thrown at all when calling the subject (a lambda with arity 0, i.e. without arguments)
  * and that the corresponding return value holds all assertions the given [assertionCreator] creates.
  *
+ * @return An [Expect] with the new type [R].
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <R, T : () -> R> Expect<T>.notToThrow(

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
@@ -8,7 +8,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * that every element holds all assertions created by the [assertionCreatorOrNull] or that all elements are `null`
  * in case [assertionCreatorOrNull] is defined as `null`.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.all(assertionCreatorOrNull: (Expect<E>.() -> Unit)?) =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  *
  * Delegates to 'contains Pairs(keyValuePair)'.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePair: Pair<K, V>) =
@@ -24,7 +24,7 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePair: Pair<K, V>)
  * in [keyValuePairs] is defined as `'a' to 1` and another one is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePairs: Pairs<K, V>): Expect<T> =
@@ -36,7 +36,7 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePairs: Pairs<K, V
  * [KeyValue.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyValue.valueAssertionCreatorOrNull] is defined as `null`
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(keyValue: KeyValue<K, V>): Expect<T> =
@@ -52,7 +52,7 @@ inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(key
  * [keyValues] is defined as `Key('a') { isGreaterThan(0) }` and another one is defined as `Key('a') { isLessThan(2) }`
  * , then both match, even though they match the same entry.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(keyValues: All<KeyValue<K, V>>) =
@@ -61,7 +61,7 @@ inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(key
 /**
  * Expects that the subject of the assertion (a [Map]) contains the given [key].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, T : Map<out K, *>> Expect<T>.containsKey(key: K) = addAssertion(ExpectImpl.map.containsKey(this, key))
@@ -69,7 +69,7 @@ infix fun <K, T : Map<out K, *>> Expect<T>.containsKey(key: K) = addAssertion(Ex
 /**
  * Expects that the subject of the assertion (a [Map]) does not contain the given [key].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K) =
@@ -80,7 +80,7 @@ infix fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K) =
  * creates an [Expect] for the corresponding value and returns the newly created assertion container,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect] for the feature.
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the given [key] does not exist.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
@@ -99,16 +99,16 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: Key<K>): MapGetOp
  * Creates an [Expect] for the property [Map.keys] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect] for the feature.
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
     get() = keys(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
@@ -119,7 +119,7 @@ private fun <K, T : Map<out K, *>> keys(e: Expect<T>) = ExpectImpl.feature.prope
 /**
  * Expects that the subject of the assertion (a [Map]) is an empty [Map].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Map<*, *>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty: Empty) =
@@ -128,7 +128,7 @@ infix fun <T : Map<*, *>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty: Em
 /**
  * Expects that the subject of the assertion (a [Map]) is not an empty [Map].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Map<*, *>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty: Empty) =
@@ -138,16 +138,16 @@ infix fun <T : Map<*, *>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty:
  * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect] for the feature.
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
     get() = values().getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
@@ -11,7 +11,7 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * block. Yet, the actual behaviour depends on implementation - could also be fail fast for instance or augment
  * reporting etc.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K, V>): Expect<T> =
@@ -21,16 +21,16 @@ infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K,
  * Creates an [Expect] for the property [Map.Entry.key] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = ExpectImpl.map.entry.key(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.Entry.key] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
@@ -40,16 +40,16 @@ infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.
  * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = ExpectImpl.map.entry.value(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.Entry.value] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
@@ -7,15 +7,15 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * Creates an [Expect] for the property [Pair.first] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Pair<K, *>> Expect<T>.first get() : Expect<K> = ExpectImpl.pair.first(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.first] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
@@ -25,15 +25,15 @@ infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() 
  * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Pair<*, V>> Expect<T>.second get() : Expect<V> = ExpectImpl.pair.second(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.second] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Pair<K, V>> Expect<T>.second(assertionCreator: Expect<V>.() -> Unit): Expect<T> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
@@ -1,4 +1,3 @@
-import ch.tutteli.atrium.creating.AssertionPlant
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.ExpectImpl.changeSubject
 
@@ -20,7 +19,7 @@ fun <E, T : Sequence<E>> Expect<T>.asIterable(): Expect<Iterable<E>>
  * The transformation as such is not reflected in reporting.
  * Use `feature(Sequence::asIterable, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
     apply { asIterable().addAssertionsCreatedBy(assertionCreator) }

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/chronoLocalDateAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/chronoLocalDateAssertions.kt
@@ -11,7 +11,7 @@ import java.time.chrono.ChronoLocalDate
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is before the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -23,7 +23,7 @@ infix fun <T : ChronoLocalDate> Expect<T>.isBefore(expected: ChronoLocalDate): E
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is before or equal the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -36,7 +36,7 @@ infix fun <T : ChronoLocalDate> Expect<T>.isBeforeOrEqual(expected: ChronoLocalD
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is after the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -48,7 +48,7 @@ infix fun <T : ChronoLocalDate> Expect<T>.isAfter(expected: ChronoLocalDate): Ex
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is after or equal the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -60,7 +60,7 @@ infix fun <T : ChronoLocalDate> Expect<T>.isAfterOrEqual(expected: ChronoLocalDa
  * Expects that the subject of the assertion (a [ChronoLocalDate])
  * is equal to the [expected] [ChronoLocalDate].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/chronoZonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/chronoZonedDateTimeAssertions.kt
@@ -12,7 +12,7 @@ import java.time.chrono.ChronoZonedDateTime
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is before the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -25,7 +25,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -38,7 +38,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is after the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -51,7 +51,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is after or equal the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -64,7 +64,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
  * Expects that the subject of the assertion (a [ChronoZonedDateTime])
  * is equal to the [expected] [ChronoZonedDateTime].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/fileAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/fileAssertions.kt
@@ -27,7 +27,7 @@ fun <T : File> Expect<T>.asPath(): Expect<Path> =
  * The transformation as such is not reflected in reporting.
  * Use `feature(File::toPath, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  *
  * @since 0.10.0
  */

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateAssertions.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
  * Creates an [Expect] for the property [LocalDate.year][LocalDate.getYear] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -24,9 +24,9 @@ val <T : LocalDate> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -38,7 +38,7 @@ infix fun <T : LocalDate> Expect<T>.year(assertionCreator: Expect<Int>.() -> Uni
  * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -47,9 +47,9 @@ val <T : LocalDate> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -61,7 +61,7 @@ infix fun <T : LocalDate> Expect<T>.month(assertionCreator: Expect<Int>.() -> Un
  * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -70,9 +70,9 @@ val <T : LocalDate> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -85,7 +85,7 @@ infix fun <T : LocalDate> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOfWeek
  * Creates an [Expect] for the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -94,9 +94,9 @@ val <T : LocalDate> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateTimeAssertions.kt
@@ -15,7 +15,7 @@ import java.time.LocalDateTime
  * Creates an [Expect] for the property [LocalDateTime.year][[LocalDateTime.getYear] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -24,9 +24,9 @@ val <T : LocalDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -38,7 +38,7 @@ infix fun <T : LocalDateTime> Expect<T>.year(assertionCreator: Expect<Int>.() ->
  * Creates an [Expect] for the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -47,9 +47,9 @@ val <T : LocalDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -61,7 +61,7 @@ infix fun <T : LocalDateTime> Expect<T>.month(assertionCreator: Expect<Int>.() -
  * Creates an [Expect] for the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -70,9 +70,9 @@ val <T : LocalDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -84,7 +84,7 @@ infix fun <T : LocalDateTime> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOf
  * Creates an [Expect] for the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -93,9 +93,9 @@ val <T : LocalDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/pathAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/pathAssertions.kt
@@ -10,7 +10,7 @@ import java.nio.file.Path
 /**
  * Expects that the subject of the assertion (a [Path]) starts with the [expected] [Path].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -21,7 +21,7 @@ infix fun <T : Path> Expect<T>.startsWith(expected: Path): Expect<T> =
 /**
  * Expects that the subject of the assertion (a [Path]) does not start with the [expected] [Path].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -32,7 +32,7 @@ infix fun <T : Path> Expect<T>.startsNotWith(expected: Path): Expect<T> =
 /**
  * Expects that the subject of the assertion (a [Path]) ends with the expected [Path].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -44,7 +44,7 @@ infix fun <T : Path> Expect<T>.endsWith(expected: Path): Expect<T> =
  * Expects that the subject of the assertion (a [Path]) does not end with the expected [Path];
  *
  * @param expected The [Path] provided to the assertion
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -59,7 +59,7 @@ infix fun <T : Path> Expect<T>.endsNotWith(expected: Path): Expect<T> =
  * This matcher _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -74,7 +74,7 @@ infix fun <T : Path> Expect<T>.to(@Suppress("UNUSED_PARAMETER") exist: exist): E
  * This matcher _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -87,7 +87,7 @@ infix fun <T : Path> Expect<T>.notTo(@Suppress("UNUSED_PARAMETER") exist: exist)
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -97,9 +97,9 @@ val <T : Path> Expect<T>.fileName: Expect<String>
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -112,7 +112,7 @@ infix fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> U
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -124,9 +124,9 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
  * (provided via [niok](https://github.com/robstoll/niok))
  * of the subject of the assertion holds all assertions the given [assertionCreator] creates for it
- * and returns this assertion container.
+ * and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -138,7 +138,7 @@ infix fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect
  * Expects that this [Path] has a [parent][Path.getParent] and creates an [Expect] for it,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -148,9 +148,9 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent] and that the parent holds all assertions the
- * given [assertionCreator] creates for it and returns this assertion container.
+ * given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -162,7 +162,7 @@ infix fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit)
  * Expects that [other] resolves against this [Path] and creates an [Expect] for the resolved [Path]
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -183,7 +183,7 @@ infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -200,7 +200,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") readable: read
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -220,7 +220,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") writable: writ
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -240,7 +240,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aRegularFile: 
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -253,7 +253,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aDirectory: aD
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -263,9 +263,9 @@ val <T : Path> Expect<T>.extension: Expect<String>
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/zonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/zonedDateTimeAssertions.kt
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime
  * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -24,9 +24,9 @@ val <T : ZonedDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -38,7 +38,7 @@ infix fun <T : ZonedDateTime> Expect<T>.year(assertionCreator: Expect<Int>.() ->
  * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -47,9 +47,9 @@ val <T : ZonedDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -61,7 +61,7 @@ infix fun <T : ZonedDateTime> Expect<T>.month(assertionCreator: Expect<Int>.() -
  * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -70,9 +70,9 @@ val <T : ZonedDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0
@@ -84,7 +84,7 @@ infix fun <T : ZonedDateTime> Expect<T>.dayOfWeek(assertionCreator: Expect<DayOf
  * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
  * of the subject of the assertion, so that further fluent calls are assertions about it.
  *
- * @return The newly created [Expect].
+ * @return The newly created [Expect] for the extracted feature.
  *
  * @since 0.10.0
  */
@@ -93,9 +93,9 @@ val <T : ZonedDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this assertion container.
+ * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
  *
- * @return This assertion container to support a fluent API.
+ * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.10.0

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/CollectingAssertionContainer.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/CollectingAssertionContainer.kt
@@ -4,12 +4,12 @@ import ch.tutteli.atrium.assertions.Assertion
 
 /**
  * Represents a container for [Assertion] which is intended to serve as receiver object for lambdas which create
- * [Assertion]s, in which this assertion container collects the assertions created this ways.
+ * [Assertion]s, in which this [Expect] collects the assertions created this ways.
  *
  * This container does not offer reporting capabilities in contrast to [ReportingAssertionContainer].
  * It merely offers a method to [getAssertions] (the collected ones).
  *
- * @param T The type of the [subject] of this assertion container.
+ * @param T The type of the [subject] of this [Expect].
  */
 interface CollectingAssertionContainer<T> : Expect<T> {
 

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
@@ -37,7 +37,7 @@ interface Expect<T> : SubjectProvider<T> {
      *
      * @param assertionCreator The receiver function which should create and add assertions to this container.
      *
-     * @return This assertion container to support a fluent API.
+     * @return An [Expect] for the current subject of the assertion.
      * @throws AssertionError Might throw an [AssertionError] depending on the concrete implementation.
      */
     fun addAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): Expect<T>
@@ -47,7 +47,7 @@ interface Expect<T> : SubjectProvider<T> {
      *
      * @param assertion The assertion which will be added to this container.
      *
-     * @return This assertion container to support a fluent API.
+     * @return An [Expect] for the current subject of the assertion.
      *
      * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately
      *   evaluated (see [ReportingAssertionContainer]).
@@ -63,7 +63,7 @@ interface Expect<T> : SubjectProvider<T> {
      * @param expected The expected value, e.g., `5`
      * @param test Indicates whether the assertion holds or fails.
      *
-     * @return This assertion container to support a fluent API.
+     * @return An [Expect] for the current subject of the assertion.
      * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately
      *   evaluated (see [ReportingAssertionContainer]).
      */
@@ -78,7 +78,7 @@ interface Expect<T> : SubjectProvider<T> {
      * @param expected The expected value, e.g., `5`
      * @param test Indicates whether the assertion holds or fails.
      *
-     * @return This assertion container to support a fluent API.
+     * @return An [Expect] for the current subject of the assertion.
      * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately
      *   evaluated (see [ReportingAssertionContainer]).
      */

--- a/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/FeatureExtractor.kt
+++ b/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/FeatureExtractor.kt
@@ -50,7 +50,7 @@ interface FeatureExtractor {
      *   if you want a different representation, then use this parameter where passing `null` still means use the
      *   feature.
      *
-     * @return The newly created [Expect].
+     * @return The newly created [Expect] for the extracted feature.
      */
     fun <T, R> extract(
         originalAssertionContainer: Expect<T>,

--- a/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/SubjectChanger.kt
+++ b/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/SubjectChanger.kt
@@ -44,7 +44,7 @@ interface SubjectChanger {
      *   [Expect]) then you usually pass `this` (so the instance of [Expect]) for this parameter.
      * @param transformation Provides the subject.
      *
-     * @return The newly created [Expect].
+     * @return The newly created [Expect] for the extracted feature.
      */
     fun <T, R> unreported(
         originalAssertionContainer: Expect<T>,
@@ -80,7 +80,7 @@ interface SubjectChanger {
      *   change fails since we can then already show to you (in error reporting) what you wanted to assert about
      *   the new subject (which gives you more context to the error).
      *
-     * @return The newly created [Expect].
+     * @return The newly created [Expect] for the extracted feature.
      */
     fun <T, R> reported(
         originalAssertionContainer: Expect<T>,

--- a/domain/api/extensions/kotlin_1_3/atrium-domain-api-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain/kotlin_1_3/creating/ResultAssertions.kt
+++ b/domain/api/extensions/kotlin_1_3/atrium-domain-api-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain/kotlin_1_3/creating/ResultAssertions.kt
@@ -18,10 +18,10 @@ val resultAssertions by lazy { loadSingleService(ResultAssertions::class) }
  * which an implementation of the domain of Atrium has to provide.
  */
 interface ResultAssertions {
-    fun <E, T : Result<E>> isSuccess(assertionContainer: Expect<T>): ExtractedFeaturePostStep<T, E>
+    fun <E, T : Result<E>> isSuccess(expect: Expect<T>): ExtractedFeaturePostStep<T, E>
 
     fun <TExpected : Throwable> isFailure(
-        assertionContainer: Expect<out Result<*>>,
+        expect: Expect<out Result<*>>,
         expectedType: KClass<TExpected>
     ): ChangedSubjectPostStep<Throwable?, TExpected>
 }

--- a/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/ExpectImpl.kt
+++ b/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/ExpectImpl.kt
@@ -35,8 +35,8 @@ object ExpectImpl {
      * into another representation (e.g. down-cast `Person` to `Student`) then you should use
      * [feature.extractor][NewFeatureAssertionsBuilder.extractor] instead.
      */
-    inline fun <T> changeSubject(originalAssertionContainer: Expect<T>) =
-        SubjectChangerBuilder.create(originalAssertionContainer)
+    inline fun <T> changeSubject(originalExpect: Expect<T>) =
+        SubjectChangerBuilder.create(originalExpect)
 
     @Deprecated("Do no longer use Assert, use Expect instead - this method was introduced in 0.9.0 to ease the migration from Assert to Expect; will be removed with 1.0.0")
     @Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")

--- a/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/SubjectChangerBuilder.kt
+++ b/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/SubjectChangerBuilder.kt
@@ -31,7 +31,7 @@ interface SubjectChangerBuilder {
         /**
          * Entry point to use the [SubjectChangerBuilder].
          */
-        fun <T> create(originalAssertionContainer: Expect<T>): KindStep<T> = KindStepImpl(originalAssertionContainer)
+        fun <T> create(expect: Expect<T>): KindStep<T> = KindStepImpl(expect)
 
         @Deprecated("Do no longer use Assert, use Expect instead - this method was introduced in 0.9.0 to ease the migration from Assert to Expect; will be removed with 1.0.0")
         @Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
@@ -75,7 +75,7 @@ interface SubjectChangerBuilder {
         /**
          * The previously specified assertion container to which the new [Expect] will delegate assertion checking.
          */
-        val originalAssertionContainer: Expect<T>
+        val originalExpect: Expect<T>
 
 
         /**
@@ -85,7 +85,7 @@ interface SubjectChangerBuilder {
          * @return The newly created [Expect] for the new subject.
          */
         fun <R> unreported(transformation: (T) -> R): Expect<R> =
-            subjectChanger.unreported(originalAssertionContainer, transformation)
+            subjectChanger.unreported(originalExpect, transformation)
 
         /**
          * Entry point of the building process to not only change the subject but also report the change in reporting.
@@ -107,11 +107,11 @@ interface SubjectChangerBuilder {
         /**
          * The previously specified assertion container to which the new [Expect] will delegate assertion checking.
          */
-        val originalAssertionContainer: Expect<T>
+        val originalExpect: Expect<T>
 
         /**
          * Uses [DescriptionAnyAssertion.IS_A] as description of the change,
-         * the given [subType] as representation and tries to perform a down-cast of [originalAssertionContainer]'s
+         * the given [subType] as representation and tries to perform a down-cast of [originalExpect]'s
          * [Expect.maybeSubject] to the given type [TSub]
          */
         //TODO once kotlin supports to have type parameters as upper bounds of another type parameter next to `: Any` we should restrict TSub : T & Any
@@ -161,7 +161,7 @@ interface SubjectChangerBuilder {
         /**
          * The previously specified assertion container to which the new [Expect] will delegate assertion checking.
          */
-        val originalAssertionContainer: Expect<T>
+        val originalExpect: Expect<T>
 
         /**
          * The previously specified description which describes the kind of subject change.

--- a/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/impl/subjectchanger/defaultImpls.kt
+++ b/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/impl/subjectchanger/defaultImpls.kt
@@ -13,11 +13,11 @@ import ch.tutteli.atrium.reporting.RawString
 import ch.tutteli.atrium.reporting.translating.Translatable
 
 class KindStepImpl<T>(
-    override val originalAssertionContainer: Expect<T>
+    override val originalExpect: Expect<T>
 ) : SubjectChangerBuilder.KindStep<T> {
 
     override fun reportBuilder(): SubjectChangerBuilder.DescriptionRepresentationStep<T> =
-        SubjectChangerBuilder.DescriptionRepresentationStep.create(originalAssertionContainer)
+        SubjectChangerBuilder.DescriptionRepresentationStep.create(originalExpect)
 }
 
 @Suppress("DEPRECATION")
@@ -26,21 +26,21 @@ class DeprecatedKindStepImpl<T>(
 ) : SubjectChangerBuilder.DeprecatedKindStep<T>
 
 class DescriptionRepresentationStepImpl<T>(
-    override val originalAssertionContainer: Expect<T>
+    override val originalExpect: Expect<T>
 ) : SubjectChangerBuilder.DescriptionRepresentationStep<T> {
 
     override fun withDescriptionAndRepresentation(
         description: Translatable,
         representation: Any?
     ): SubjectChangerBuilder.TransformationStep<T> = SubjectChangerBuilder.TransformationStep.create(
-        originalAssertionContainer,
+        originalExpect,
         description,
         representation ?: RawString.NULL
     )
 }
 
 class TransformationStepImpl<T>(
-    override val originalAssertionContainer: Expect<T>,
+    override val originalExpect: Expect<T>,
     override val description: Translatable,
     override val representation: Any
 ) : SubjectChangerBuilder.TransformationStep<T> {
@@ -72,7 +72,7 @@ class FinalStepImpl<T, R>(
 ) : SubjectChangerBuilder.FinalStep<T, R> {
 
     override fun build(): ChangedSubjectPostStep<T, R> =
-        ChangedSubjectPostStep(transformationStep.originalAssertionContainer,
+        ChangedSubjectPostStep(transformationStep.originalExpect,
             transform = { transformIt(this, None) },
             transformAndApply = { assertionCreator -> transformIt(this, Some(assertionCreator)) }
         )

--- a/domain/builders/extensions/kotlin_1_3/atrium-domain-builders-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/kotlin_1_3/creating/ResultAssertionsBuilder.kt
+++ b/domain/builders/extensions/kotlin_1_3/atrium-domain-builders-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/kotlin_1_3/creating/ResultAssertionsBuilder.kt
@@ -16,12 +16,9 @@ import kotlin.reflect.KClass
  */
 object ResultAssertionsBuilder : ResultAssertions {
 
-    override inline fun <E, T : Result<E>> isSuccess(
-        assertionContainer: Expect<T>
-    ): ExtractedFeaturePostStep<T, E> = resultAssertions.isSuccess(assertionContainer)
+    override inline fun <E, T : Result<E>> isSuccess(expect: Expect<T>): ExtractedFeaturePostStep<T, E> =
+        resultAssertions.isSuccess(expect)
 
-    override fun <TExpected : Throwable> isFailure(
-        assertionContainer: Expect<out Result<*>>,
-        expectedType: KClass<TExpected>
-    ) = resultAssertions.isFailure(assertionContainer, expectedType)
+    override fun <TExpected : Throwable> isFailure(expect: Expect<out Result<*>>, expectedType: KClass<TExpected>) =
+        resultAssertions.isFailure(expect, expectedType)
 }

--- a/domain/robstoll-lib/extensions/kotlin_1_3/atrium-domain-robstoll-lib-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain.robstoll.lib.kotlin_1_3/creating/resultAssertions.kt
+++ b/domain/robstoll-lib/extensions/kotlin_1_3/atrium-domain-robstoll-lib-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain.robstoll.lib.kotlin_1_3/creating/resultAssertions.kt
@@ -26,12 +26,12 @@ fun <E, T : Result<E>> _isSuccess(expect: Expect<T>): ExtractedFeaturePostStep<T
 
 @UseExperimental(ExperimentalWithOptions::class)
 fun <TExpected : Throwable> _isFailure(
-    assertionContainer: Expect<out Result<*>>,
+    expect: Expect<out Result<*>>,
     expectedType: KClass<TExpected>
 ): ChangedSubjectPostStep<Throwable?, TExpected>
 {
     val throwableExpect = ExpectImpl.feature
-        .manualFeature(assertionContainer, EXCEPTION) { exceptionOrNull() }
+        .manualFeature(expect, EXCEPTION) { exceptionOrNull() }
         .getExpectOfFeature()
         .withRepresentation { it ?: RawString.create(IS_NOT_FAILURE) }
 

--- a/domain/robstoll/extensions/kotlin_1_3/atrium-domain-robstoll-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll.kotlin_1_3/creating/ResultAssertionsImpl.kt
+++ b/domain/robstoll/extensions/kotlin_1_3/atrium-domain-robstoll-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll.kotlin_1_3/creating/ResultAssertionsImpl.kt
@@ -1,17 +1,15 @@
 package ch.tutteli.atrium.domain.robstoll.kotlin_1_3.creating
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ChangedSubjectPostStep
 import ch.tutteli.atrium.domain.kotlin_1_3.creating.ResultAssertions
 import ch.tutteli.atrium.domain.robstoll.lib.kotlin_1_3.creating._isFailure
 import ch.tutteli.atrium.domain.robstoll.lib.kotlin_1_3.creating._isSuccess
 import kotlin.reflect.KClass
 
 class ResultAssertionsImpl : ResultAssertions {
-    override fun <E, T : Result<E>> isSuccess(assertionContainer: Expect<T>) = _isSuccess(assertionContainer)
+    override fun <E, T : Result<E>> isSuccess(expect: Expect<T>) =
+        _isSuccess(expect)
 
-    override fun <TExpected : Throwable> isFailure(
-        assertionContainer: Expect<out Result<*>>,
-        expectedType: KClass<TExpected>
-    ) = _isFailure(assertionContainer, expectedType)
+    override fun <TExpected : Throwable> isFailure(expect: Expect<out Result<*>>, expectedType: KClass<TExpected>) =
+        _isFailure(expect, expectedType)
 }


### PR DESCRIPTION
moreover:
- get rid off `to support a fluent API`, that's actually wrong, even
  if we return an Expect for a feature it is still a fluent API
- do not mention that this Expect is returned but one for the current
  subject



----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
