### PR TITLE
cleanup, remove `returns this`, order fun

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
@@ -40,7 +40,8 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
 
 /**
  * Expects that the property [Collection.size] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
@@ -27,44 +27,53 @@ val <E, T : Iterable<E>> Expect<T>.containsNot: NotCheckerOption<E, T, NotSearch
     get() = NotCheckerOptionImpl(ExpectImpl.iterable.containsNotBuilder(this))
 
 /**
- * Expects that the property min of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * Creates an [Expect] for the result of calling `min()` on the subject of the assertion,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect] for the extracted feature.
+ *
+ * @since 0.9.0
+ */
+fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(): Expect<E> =
+    ExpectImpl.iterable.min(this).getExpectOfFeature()
+
+/**
+ * Expects that the result of calling `min()` on the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
     ExpectImpl.iterable.min(this).addToInitial(assertionCreator)
 
+
 /**
- * Creates an [Expect] for the property min of the subject of the assertion,
+ * Creates an [Expect] for the result of calling `max()` on the subject of the assertion,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
+ *
  * @since 0.9.0
  */
-fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(): Expect<E> = ExpectImpl.iterable.min(this).getExpectOfFeature()
+fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> =
+    ExpectImpl.iterable.max(this).getExpectOfFeature()
 
 /**
- * Expects that the property max of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * Expects that the result of calling `max()` on  the subject of the assertion
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
     ExpectImpl.iterable.max(this).addToInitial(assertionCreator)
-
-/**
- * Creates an [Expect] for the property max of the subject of the assertion,
- * so that further fluent calls are assertions about it.
- *
- * @return The newly created [Expect] for the extracted feature.
- * @since 0.9.0
- */
-fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> = ExpectImpl.iterable.max(this).getExpectOfFeature()
 
 /**
  * Expects that the subject of the assertion (an [Iterable]) contains the

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
@@ -10,7 +10,8 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  * @return The newly created [Expect] for the element at position [index].
  * @throws AssertionError Might throw an [AssertionError] if the given [index] is out of bound.
  */
-fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> = ExpectImpl.list.get(this, index).getExpectOfFeature()
+fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
+    ExpectImpl.list.get(this, index).getExpectOfFeature()
 
 /**
  * Expects that the given [index] is within the bounds of the subject of the assertion (a [List]) and that

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
@@ -106,19 +106,18 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Ex
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
-    get() = keys(this).getExpectOfFeature()
+    get() = ExpectImpl.feature.property(this, Map<out K, *>::keys).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
-    keys(this).addToInitial(assertionCreator)
-
-private fun <K, T : Map<out K, *>> keys(e: Expect<T>) = ExpectImpl.feature.property(e, Map<out K, *>::keys)
+    ExpectImpl.feature.property(this, Map<out K, *>::keys).addToInitial(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
@@ -127,19 +126,18 @@ private fun <K, T : Map<out K, *>> keys(e: Expect<T>) = ExpectImpl.feature.prope
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
-    get() = values().getExpectOfFeature()
+    get() = ExpectImpl.feature.property(this, Map<out Any?, V>::values).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
-    values().addToInitial(assertionCreator)
-
-private fun <K, V, T : Map<out K, V>> Expect<T>.values() = ExpectImpl.feature.property(this, Map<out K, V>::values)
+    ExpectImpl.feature.property(this, Map<out K, V>::values).addToInitial(assertionCreator)
 
 /**
  * Turns `Expect<Map<K, V>>` into `Expect<Set<Map.Entry<K, V>>>`.
@@ -154,12 +152,12 @@ fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(): Expect<Set<Map.Entry<K, V>>
 
 /**
  * Turns `Expect<Map<K, V>>` into `Expect<Set<Map.Entry<K, V>>>` and expects that it holds all assertions the given
- * [assertionCreator] creates.
+ * [assertionCreator] creates for it.
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature { f(it::entries) }` if you want to show the transformation in reporting.
  *
- * @return The newly created [Expect] for the transformed subject.
+ * @return An [Expect] for the current subject of the assertion.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -28,7 +28,8 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
 
 /**
  * Expects that the property [Map.Entry.key] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
 
 /**
  * Expects that the property [Map.Entry.value] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
@@ -9,12 +9,13 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  *
  * @return The newly created [Expect] for the extracted feature.
  */
-val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
-    get() = ExpectImpl.pair.first(this).getExpectOfFeature()
+val <K, T : Pair<K, *>> Expect<T>.first
+    get() : Expect<K> = ExpectImpl.pair.first(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.first] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -28,12 +29,13 @@ fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Uni
  *
  * @return The newly created [Expect] for the extracted feature.
  */
-val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
-    get() = ExpectImpl.pair.second(this).getExpectOfFeature()
+val <V, T : Pair<*, V>> Expect<T>.second
+    get() : Expect<V> = ExpectImpl.pair.second(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.second] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableAssertions.kt
@@ -14,7 +14,8 @@ val <T : Throwable> Expect<T>.message: Expect<String>
 
 /**
  * Expects that the property [Throwable.message] of the subject of the assertion is not null and
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateAssertions.kt
@@ -24,7 +24,8 @@ val <T : LocalDate> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <T : LocalDate> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -70,7 +72,8 @@ val <T : LocalDate> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -94,7 +97,8 @@ val <T : LocalDate> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/localDateTimeAssertions.kt
@@ -24,7 +24,8 @@ val <T : LocalDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <T : LocalDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -70,7 +72,8 @@ val <T : LocalDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -93,7 +96,8 @@ val <T : LocalDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -95,7 +95,8 @@ val <T : Path> Expect<T>.fileName: Expect<String>
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -122,7 +123,7 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
  * (provided via [niok](https://github.com/robstoll/niok))
  * of the subject of the assertion holds all assertions the given [assertionCreator] creates for it
- * and returns this [Expect].
+ * and returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -146,7 +147,7 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent] and that the parent holds all assertions the
- * given [assertionCreator] creates for it and returns this [Expect].
+ * given [assertionCreator] creates for it and returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -170,7 +171,7 @@ fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
 
 /**
  * Expects that [other] resolves against this [Path] and that the resolved [Path] holds all assertions the
- * given [assertionCreator] creates for it and returns this [Expect].
+ * given [assertionCreator] creates for it and returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -269,7 +270,8 @@ val <T : Path> Expect<T>.extension: Expect<String>
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/zonedDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/extensions/jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/zonedDateTimeAssertions.kt
@@ -24,7 +24,8 @@ val <T : ZonedDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <T : ZonedDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -70,7 +72,8 @@ val <T : ZonedDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -93,7 +96,8 @@ val <T : ZonedDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
@@ -31,7 +31,8 @@ val <T : Collection<*>> Expect<T>.size get(): Expect<Int> = ExpectImpl.collectio
 
 /**
  * Expects that the property [Collection.size] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
@@ -1,7 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyWithCreator
-import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.ExpectImpl
 
@@ -114,19 +113,18 @@ fun <K, V> key(key: K, assertionCreator: Expect<V>.() -> Unit) = KeyWithCreator(
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
-    get() = keys(this).getExpectOfFeature()
+    get() = ExpectImpl.feature.property(this, Map<out K, *>::keys).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
-    keys(this).addToInitial(assertionCreator)
-
-private fun <K, T : Map<out K, *>> keys(e: Expect<T>) = ExpectImpl.feature.property(e, Map<out K, *>::keys)
+    ExpectImpl.feature.property(this, Map<out K, *>::keys).addToInitial(assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Map]) is an empty [Map].
@@ -153,19 +151,18 @@ infix fun <T : Map<*, *>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty:
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
-    get() = values().getExpectOfFeature()
+    get() = ExpectImpl.feature.property(this, Map<out Any?, V>::values).getExpectOfFeature()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
-    values().addToInitial(assertionCreator)
-
-private fun <K, V, T : Map<out K, V>> Expect<T>.values() = ExpectImpl.feature.property(this, Map<out K, V>::values)
+    ExpectImpl.feature.property(this, Map<out K, V>::values).addToInitial(assertionCreator)
 
 /**
  * Turns `Expect<Map<K, V>>` into `Expect<Set<Map.Entry<K, V>>>`.
@@ -180,12 +177,12 @@ fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(): Expect<Set<Map.Entry<K, V>>
 
 /**
  * Turns `Expect<Map<K, V>>` into `Expect<Set<Map.Entry<K, V>>>` and expects that it holds all assertions the given
- * [assertionCreator] creates.
+ * [assertionCreator] creates for it.
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature { f(it::entries) }` if you want to show the transformation in reporting.
  *
- * @return The newly created [Expect] for the transformed subject.
+ * @return An [Expect] for the current subject of the assertion.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
@@ -28,7 +28,8 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
 
 /**
  * Expects that the property [Map.Entry.key] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
 
 /**
  * Expects that the property [Map.Entry.value] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
@@ -9,11 +9,13 @@ import ch.tutteli.atrium.domain.builders.ExpectImpl
  *
  * @return The newly created [Expect] for the extracted feature.
  */
-val <K, T : Pair<K, *>> Expect<T>.first get() : Expect<K> = ExpectImpl.pair.first(this).getExpectOfFeature()
+val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
+    get() = ExpectImpl.pair.first(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.first] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -27,11 +29,13 @@ infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() 
  *
  * @return The newly created [Expect] for the extracted feature.
  */
-val <V, T : Pair<*, V>> Expect<T>.second get() : Expect<V> = ExpectImpl.pair.second(this).getExpectOfFeature()
+val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
+    get() = ExpectImpl.pair.second(this).getExpectOfFeature()
 
 /**
  * Expects that the property [Pair.second] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapAssertionsSpec.kt
@@ -37,25 +37,25 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
 
         map contains (1 to "a")
         map contains Pairs(1 to "a", 2 to "b")
-        map contains (KeyValue(1) {})
+        map contains KeyValue(1) {}
         map contains All(KeyValue(1) {}, KeyValue(2) {})
         map contains Pairs(1.0 to StringBuilder("a"))
         map contains Pairs(12f to "a", 2L to StringBuilder("b"))
-        map contains (KeyValue(1) {})
+        map contains KeyValue(1) {}
         map contains All(KeyValue(1) {}, KeyValue(2) {})
 
         subMap contains (1 to "a")
         subMap contains Pairs(1 to "a", 2 to "b")
-        subMap contains (KeyValue(1) {})
+        subMap contains KeyValue(1) {}
         subMap contains All(KeyValue(1) {}, KeyValue(2) {})
         subMap contains (1.0 to StringBuilder("a"))
         subMap contains Pairs(12f to "a", 2L to StringBuilder("b"))
-        subMap contains (KeyValue(1) {})
+        subMap contains KeyValue(1) {}
         subMap contains All(KeyValue(1) {}, KeyValue(2) {})
 
         nullableKeyMap contains (1 to "a")
         nullableKeyMap contains Pairs(1 to "a", 2 to "b")
-        nullableKeyMap contains (KeyValue(1) {})
+        nullableKeyMap contains KeyValue(1) {}
         nullableKeyMap contains All(KeyValue(1) {}, KeyValue(2) {})
         nullableKeyMap contains (null to "a")
         nullableKeyMap contains Pairs(null to "a", null to "b")
@@ -66,7 +66,7 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
 
         nullableValueMap contains (1 to "a")
         nullableValueMap contains Pairs(1 to "a", 2 to "b")
-        nullableValueMap contains (KeyValue(1) {})
+        nullableValueMap contains KeyValue(1) {}
         nullableValueMap contains All(KeyValue(1) {}, KeyValue(2) {})
         nullableValueMap contains (1 to null)
         nullableValueMap contains Pairs(1 to null, 2 to null)
@@ -77,7 +77,7 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
 
         nullableKeyValueMap contains (1 to "a")
         nullableKeyValueMap contains Pairs(1 to "a", 2 to "b")
-        nullableKeyValueMap contains (KeyValue(1) {})
+        nullableKeyValueMap contains KeyValue(1) {}
         nullableKeyValueMap contains All(KeyValue(1) {}, KeyValue(2) {})
 
         nullableKeyValueMap contains (null to "a")
@@ -103,7 +103,7 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
 
         readOnlyNullableKeyValueMap contains (1 to "a")
         readOnlyNullableKeyValueMap contains Pairs(1 to "a", 2 to "b")
-        readOnlyNullableKeyValueMap contains (KeyValue(1) {})
+        readOnlyNullableKeyValueMap contains KeyValue(1) {}
         readOnlyNullableKeyValueMap contains All(KeyValue(1) {}, KeyValue(2) {})
 
         readOnlyNullableKeyValueMap contains (null to "a")
@@ -129,7 +129,7 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
 
         readOnlyNullableKeyValueMap contains (1 to "a")
         readOnlyNullableKeyValueMap contains Pairs(1 to "a", 2 to "b")
-        readOnlyNullableKeyValueMap contains (KeyValue(1) {})
+        readOnlyNullableKeyValueMap contains KeyValue(1) {}
         readOnlyNullableKeyValueMap contains All(KeyValue(1) {}, KeyValue(2) {})
 
         starMap contains (null to "a")

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateAssertions.kt
@@ -24,7 +24,8 @@ val <T : LocalDate> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <T : LocalDate> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -70,7 +72,8 @@ val <T : LocalDate> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -94,7 +97,8 @@ val <T : LocalDate> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/localDateTimeAssertions.kt
@@ -24,7 +24,8 @@ val <T : LocalDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <T : LocalDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -70,7 +72,8 @@ val <T : LocalDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -93,7 +96,8 @@ val <T : LocalDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/pathAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/pathAssertions.kt
@@ -97,7 +97,8 @@ val <T : Path> Expect<T>.fileName: Expect<String>
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -124,7 +125,7 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
  * (provided via [niok](https://github.com/robstoll/niok))
  * of the subject of the assertion holds all assertions the given [assertionCreator] creates for it
- * and returns this [Expect].
+ * and returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -148,7 +149,7 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent] and that the parent holds all assertions the
- * given [assertionCreator] creates for it and returns this [Expect].
+ * given [assertionCreator] creates for it and returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -263,7 +264,8 @@ val <T : Path> Expect<T>.extension: Expect<String>
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/zonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/zonedDateTimeAssertions.kt
@@ -24,7 +24,8 @@ val <T : ZonedDateTime> Expect<T>.year: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -47,7 +48,8 @@ val <T : ZonedDateTime> Expect<T>.month: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -70,7 +72,8 @@ val <T : ZonedDateTime> Expect<T>.dayOfWeek: Expect<DayOfWeek>
 
 /**
  * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -93,7 +96,8 @@ val <T : ZonedDateTime> Expect<T>.day: Expect<Int>
 
 /**
  * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
- * holds all assertions the given [assertionCreator] creates for it and returns this [Expect].
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of the assertion.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/ComparableAssertions.kt
+++ b/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/ComparableAssertions.kt
@@ -19,12 +19,12 @@ val comparableAssertions by lazy { loadSingleService(ComparableAssertions::class
 interface ComparableAssertions {
     fun <T1 : Comparable<T2>, T2 : Any?> isLessThan(subjectProvider: SubjectProvider<T1>, expected: T2): Assertion
 
-    //TODO rename to isLessThanOrEqual with 0.1.0
+    //TODO rename to isLessThanOrEqual with 1.0.0
     fun <T1 : Comparable<T2>, T2 : Any?> isLessOrEquals(subjectProvider: SubjectProvider<T1>, expected: T2): Assertion
 
     fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThan(subjectProvider: SubjectProvider<T1>, expected: T2): Assertion
 
-    //TODO rename to isGreaterThanOrEqual with 0.1.0
+    //TODO rename to isGreaterThanOrEqual with 1.0.0
     fun <T1 : Comparable<T2>, T2 : Any?> isGreaterOrEquals(
         subjectProvider: SubjectProvider<T1>,
         expected: T2


### PR DESCRIPTION
In detail:
- follow up to a352716d, we still use  `returns this` in the description
  change to `an [Expect] for the current subject of the assertion`
- fix KDoc of min and max, they are not properties but method calls
- get rid of private funs `values` and `keys` -> not worth the
  code duplication reduction



----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
