### PR TITLE
#116 migrate spek

### DIFF
--- a/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
@@ -11,18 +11,16 @@ import ch.tutteli.atrium.reporting.translating.UsingDefaultTranslator
 import ch.tutteli.atrium.specs.reporting.ObjectFormatterSpec
 import ch.tutteli.atrium.api.verbs.internal.AssertionVerb
 import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.context
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
-import org.jetbrains.spek.api.include
+import io.mockk.*
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+//import org.jetbrains.spek.api.dsl.on
+//import ch.tutteli.atrium.specs.include
 import kotlin.reflect.KClass
 
 //TODO #116 migrate spek1 to spek2 - move to common module
 object DetailedObjectFormatterSpec : Spek({
-    include(AtriumsObjectFormatterSpec)
+    include(object: AtriumsObjectFormatterSpec)
 
     val testee = DetailedObjectFormatter(UsingDefaultTranslator())
 

--- a/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
@@ -10,208 +10,172 @@ import ch.tutteli.atrium.reporting.translating.Translator
 import ch.tutteli.atrium.reporting.translating.UsingDefaultTranslator
 import ch.tutteli.atrium.specs.reporting.ObjectFormatterSpec
 import ch.tutteli.atrium.api.verbs.internal.AssertionVerb
-// import com.nhaarman.mockitokotlin2.doReturn
-// import com.nhaarman.mockitokotlin2.mock
-// import org.jetbrains.spek.api.Spek
-// import org.jetbrains.spek.api.dsl.context
-// import org.jetbrains.spek.api.dsl.describe
-// import org.jetbrains.spek.api.dsl.it
-// import org.jetbrains.spek.api.dsl.on
-// import org.jetbrains.spek.api.include
-
 import io.mockk.*
 import org.spekframework.spek2.Spek
-
-import org.spekframework.spek2.style.gherkin.Feature
-//import org.spekframework.spek2.style.specification.describe
-//import org.jetbrains.spek.api.dsl.on
-//import ch.tutteli.atrium.specs.include
+import org.spekframework.spek2.style.specification.describe
 import kotlin.reflect.KClass
 
-//TODO #116 migrate spek1 to spek2 - move to common module
 object DetailedObjectFormatterSpec : Spek({
     include(AtriumsObjectFormatterSpec)
 
     val testee = DetailedObjectFormatter(UsingDefaultTranslator())
 
-    Feature("format") {
+    describe("format") {
 
-        Scenario("data types") {
-            lateinit var result: String
-            When("a ${Char::class.simpleName}") {
-                result = testee.format('a')
-            }
-
-            Then("it returns the ${Char::class.simpleName} in apostrophes") {
+        context("a ${Char::class.simpleName}") {
+            val result = testee.format('a')
+            it("returns the ${Char::class.simpleName} in apostrophes") {
                 expect(result).toBe("'a'")
             }
+        }
 
-            Given("a ${Boolean::class.simpleName}") {
-            }
-
-            Then("it returns the toString representation of the ${Boolean::class.simpleName}") {
+        context("a ${Boolean::class.simpleName}") {
+            it("returns the toString representation of the ${Boolean::class.simpleName}") {
                 expect(testee.format(true)).toBe("true")
                 expect(testee.format(false)).toBe("false")
             }
         }
 
-    // describe("format") {
+        context("a ${String::class.simpleName}") {
+            it("returns two quotes including identity hash if empty ${String::class.simpleName}") {
+                val string = ""
+                val result = testee.format(string)
+                expect(result).toBe("\"\"" + INDENT + "<${System.identityHashCode(string)}>")
+            }
+            it("returns the ${String::class.simpleName} in quotes including identity hash") {
+                val string = "atrium"
+                val result = testee.format(string)
+                expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
+            }
+            it("returns line breaks (does not escape") {
+                val string = "atrium\nAn assertion framework for Kotlin"
+                val result = testee.format(string)
+                expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
+            }
+        }
 
-    //     on("a ${Char::class.simpleName}") {
-    //         val result = testee.format('a')
-    //         it("returns the ${Char::class.simpleName} in apostrophes") {
-    //             expect(result).toBe("'a'")
-    //         }
-    //     }
+        val typeNameAndHash = "including type name and identity hash"
 
-    //     on("a ${Boolean::class.simpleName}") {
-    //         it("returns the toString representation of the ${Boolean::class.simpleName}") {
-    //             expect(testee.format(true)).toBe("true")
-    //             expect(testee.format(false)).toBe("false")
-    //         }
-    //     }
+        context("a ${CharSequence::class.simpleName} besides ${String::class.simpleName}") {
+            it("returns two quotes $typeNameAndHash if empty ${CharSequence::class.simpleName}") {
+                val value = StringBuilder("")
+                val result = testee.format(value)
+                expect(result).toBe(
+                    "\"\"" + INDENT
+                        + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
+                )
+            }
+            it("returns ${CharSequence::class.simpleName} in quotes $typeNameAndHash") {
+                val value = StringBuilder("atrium")
+                val result = testee.format(value)
+                expect(result).toBe(
+                    "\"$value\"" + INDENT
+                        + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
+                )
+            }
+        }
 
-        // on("a ${String::class.simpleName}") {
-        //     it("returns two quotes including identity hash if empty ${String::class.simpleName}") {
-        //         val string = ""
-        //         val result = testee.format(string)
-        //         expect(result).toBe("\"\"" + INDENT + "<${System.identityHashCode(string)}>")
-        //     }
-        //     it("returns the ${String::class.simpleName} in quotes including identity hash") {
-        //         val string = "atrium"
-        //         val result = testee.format(string)
-        //         expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
-        //     }
-        //     it("returns line breaks (does not escape") {
-        //         val string = "atrium\nAn assertion framework for Kotlin"
-        //         val result = testee.format(string)
-        //         expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
-        //     }
-        // }
+        context("a ${StringBasedRawString::class.simpleName}") {
+            val result = testee.format(RawString.create("hello"))
+            it("returns the containing string") {
+                expect(result).toBe("hello")
+            }
+        }
 
-        // val typeNameAndHash = "including type name and identity hash"
+        context("a ${TranslatableBasedRawString::class.simpleName}") {
+            val translation = "es gilt"
+            val translator = mockk<Translator> {
+                every { translate(AssertionVerb.EXPECT) } returns translation
+            }
+            val testeeWithMockedTranslation = DetailedObjectFormatter(translator)
+            val result = testeeWithMockedTranslation.format(RawString.create(AssertionVerb.EXPECT))
+            it("returns the translated string") {
+                expect(result).toBe(translation)
+            }
+        }
 
-        // on("a ${CharSequence::class.simpleName} besides ${String::class.simpleName}") {
-        //     it("returns two quotes $typeNameAndHash if empty ${CharSequence::class.simpleName}") {
-        //         val value = StringBuilder("")
-        //         val result = testee.format(value)
-        //         expect(result).toBe(
-        //             "\"\"" + INDENT
-        //                 + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
-        //         )
-        //     }
-        //     it("returns ${CharSequence::class.simpleName} in quotes $typeNameAndHash") {
-        //         val value = StringBuilder("atrium")
-        //         val result = testee.format(value)
-        //         expect(result).toBe(
-        //             "\"$value\"" + INDENT
-        //                 + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
-        //         )
-        //     }
-        // }
+        context("an enum") {
+            val enum = AssertionVerb.EXPECT
+            val result = testee.format(enum)
+            it("returns its toString representation together with its Class.name but without System.identityHash") {
+                expect(result).toBe("EXPECT" + INDENT + "(${enum::class.java.name})")
+            }
+        }
 
+        context("a Throwable") {
+            val result = testee.format(AssertionError("blablabla"))
+            it("returns only its Class.name") {
+                expect(result).toBe(AssertionError::class.java.name)
+            }
+        }
 
-        // on("a ${StringBasedRawString::class.simpleName}") {
-        //     val result = testee.format(RawString.create("hello"))
-        //     it("returns the containing string") {
-        //         expect(result).toBe("hello")
-        //     }
-        // }
+        context("a ${Class::class.simpleName}") {
+            val result = testee.format(DetailedObjectFormatterSpec::class.java)
+            it("returns its simpleName and name in parenthesis") {
+                val clazz = DetailedObjectFormatterSpec::class.java
+                expect(result).toBe("${clazz.simpleName} (${clazz.name})")
+            }
+        }
 
-        // on("a ${TranslatableBasedRawString::class.simpleName}") {
-        //     val translation = "es gilt"
-        //     val translator = mockk<Translator> {
-        //         every { translate(AssertionVerb.EXPECT) } returns translation
-        //     }
-        //     val testeeWithMockedTranslation = DetailedObjectFormatter(translator)
-        //     val result = testeeWithMockedTranslation.format(RawString.create(AssertionVerb.EXPECT))
-        //     it("returns the translated string") {
-        //         expect(result).toBe(translation)
-        //     }
-        // }
+        context("on a ${KClass::class.simpleName}") {
 
-        // on("an enum") {
-        //     val enum = AssertionVerb.EXPECT
-        //     val result = testee.format(enum)
-        //     it("returns its toString representation together with its Class.name but without System.identityHash") {
-        //         expect(result).toBe("EXPECT" + INDENT + "(${enum::class.java.name})")
-        //     }
-        // }
+            context("java Class is the same (no special Kotlin class)") {
+                val result = testee.format(DetailedObjectFormatterSpec::class)
+                it("returns the simpleName and qualified in parenthesis") {
+                    val clazz = DetailedObjectFormatterSpec::class
+                    expect(result).toBe("${clazz.java.simpleName} (${clazz.java.name})")
+                    expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName})")
+                }
+            }
 
-        // on("a Throwable") {
-        //     val result = testee.format(AssertionError("blablabla"))
-        //     it("returns only its Class.name") {
-        //         expect(result).toBe(AssertionError::class.java.name)
-        //     }
-        // }
+            context("a primitive Kotlin wrapper class (java Class is not the same)") {
+                val result = testee.format(Int::class)
+                it("returns the simpleName and qualified in parenthesis including java's simpleName") {
+                    val clazz = Int::class
+                    expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.simpleName}")
+                }
+            }
 
-        // on("a ${Class::class.simpleName}") {
-        //     val result = testee.format(DetailedObjectFormatterSpec::class.java)
-        //     it("returns its simpleName and name in parenthesis") {
-        //         val clazz = DetailedObjectFormatterSpec::class.java
-        //         expect(result).toBe("${clazz.simpleName} (${clazz.name})")
-        //     }
-        // }
+            context("a non primitive Kotlin class (java Class is not the same)") {
+                val result = testee.format(CharSequence::class)
+                it("returns the simpleName and qualified in parenthesis including java's name") {
+                    val clazz = CharSequence::class
+                    expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.name}")
+                }
+            }
+        }
 
-        // group("on a ${KClass::class.simpleName}") {
+        mapOf(
+            java.lang.Byte::class.java.simpleName to 1.toByte(),
+            java.lang.Short::class.java.simpleName to 1.toShort(),
+            java.lang.Integer::class.java.simpleName to 1,
+            java.lang.Long::class.java.simpleName to 1L,
+            java.lang.Float::class.java.simpleName to 1.0f,
+            java.lang.Double::class.java.simpleName to 1.0
+        ).forEach { (typeName, value) ->
+            context(typeName) {
+                val result = testee.format(value)
+                it("returns subject's toString() $typeNameAndHash") {
+                    expect(result).toBe(
+                        value.toString() + INDENT
+                            + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
+                    )
+                }
+            }
+        }
 
-        //     context("java Class is the same (no special Kotlin class)") {
-        //         val result = testee.format(DetailedObjectFormatterSpec::class)
-        //         it("returns the simpleName and qualified in parenthesis") {
-        //             val clazz = DetailedObjectFormatterSpec::class
-        //             expect(result).toBe("${clazz.java.simpleName} (${clazz.java.name})")
-        //             expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName})")
-        //         }
-        //     }
-
-        //     context("a primitive Kotlin wrapper class (java Class is not the same)") {
-        //         val result = testee.format(Int::class)
-        //         it("returns the simpleName and qualified in parenthesis including java's simpleName") {
-        //             val clazz = Int::class
-        //             expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.simpleName}")
-        //         }
-        //     }
-
-        //     context("a non primitive Kotlin class (java Class is not the same)") {
-        //         val result = testee.format(CharSequence::class)
-        //         it("returns the simpleName and qualified in parenthesis including java's name") {
-        //             val clazz = CharSequence::class
-        //             expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.name}")
-        //         }
-        //     }
-        // }
-
-        // mapOf(
-        //     java.lang.Byte::class.java.simpleName to 1.toByte(),
-        //     java.lang.Short::class.java.simpleName to 1.toShort(),
-        //     java.lang.Integer::class.java.simpleName to 1,
-        //     java.lang.Long::class.java.simpleName to 1L,
-        //     java.lang.Float::class.java.simpleName to 1.0f,
-        //     java.lang.Double::class.java.simpleName to 1.0
-        // ).forEach { (typeName, value) ->
-        //     on(typeName) {
-        //         val result = testee.format(value)
-        //         it("returns subject's toString() $typeNameAndHash") {
-        //             expect(result).toBe(
-        //                 value.toString() + INDENT
-        //                     + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
-        //             )
-        //         }
-        //     }
-        // }
-
-        // on("an anonymous class") {
-        //     val anonymous = object : Any() {
-        //         override fun toString(): String = "anonymous type"
-        //     }
-        //     val result = testee.format(anonymous)
-        //     it("returns subject's toString() $typeNameAndHash") {
-        //         expect(result).toBe(
-        //             anonymous.toString() + INDENT
-        //                 + "(${anonymous::class.java.name} <${System.identityHashCode(anonymous)}>)"
-        //         )
-        //     }
-        // }
+        context("an anonymous class") {
+            val anonymous = object : Any() {
+                override fun toString(): String = "anonymous type"
+            }
+            val result = testee.format(anonymous)
+            it("returns subject's toString() $typeNameAndHash") {
+                expect(result).toBe(
+                    anonymous.toString() + INDENT
+                        + "(${anonymous::class.java.name} <${System.identityHashCode(anonymous)}>)"
+                )
+            }
+        }
     }
 }) {
     object AtriumsObjectFormatterSpec : ObjectFormatterSpec(::DetailedObjectFormatter)

--- a/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
@@ -10,177 +10,208 @@ import ch.tutteli.atrium.reporting.translating.Translator
 import ch.tutteli.atrium.reporting.translating.UsingDefaultTranslator
 import ch.tutteli.atrium.specs.reporting.ObjectFormatterSpec
 import ch.tutteli.atrium.api.verbs.internal.AssertionVerb
-import com.nhaarman.mockitokotlin2.doReturn
+// import com.nhaarman.mockitokotlin2.doReturn
+// import com.nhaarman.mockitokotlin2.mock
+// import org.jetbrains.spek.api.Spek
+// import org.jetbrains.spek.api.dsl.context
+// import org.jetbrains.spek.api.dsl.describe
+// import org.jetbrains.spek.api.dsl.it
+// import org.jetbrains.spek.api.dsl.on
+// import org.jetbrains.spek.api.include
+
 import io.mockk.*
 import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+
+import org.spekframework.spek2.style.gherkin.Feature
+//import org.spekframework.spek2.style.specification.describe
 //import org.jetbrains.spek.api.dsl.on
 //import ch.tutteli.atrium.specs.include
 import kotlin.reflect.KClass
 
 //TODO #116 migrate spek1 to spek2 - move to common module
 object DetailedObjectFormatterSpec : Spek({
-    include(object: AtriumsObjectFormatterSpec)
+    include(AtriumsObjectFormatterSpec)
 
     val testee = DetailedObjectFormatter(UsingDefaultTranslator())
 
-    describe("format") {
+    Feature("format") {
 
-        on("a ${Char::class.simpleName}") {
-            val result = testee.format('a')
-            it("returns the ${Char::class.simpleName} in apostrophes") {
+        Scenario("data types") {
+            lateinit var result: String
+            When("a ${Char::class.simpleName}") {
+                result = testee.format('a')
+            }
+
+            Then("it returns the ${Char::class.simpleName} in apostrophes") {
                 expect(result).toBe("'a'")
             }
-        }
 
-        on("a ${Boolean::class.simpleName}") {
-            it("returns the toString representation of the ${Boolean::class.simpleName}") {
+            Given("a ${Boolean::class.simpleName}") {
+            }
+
+            Then("it returns the toString representation of the ${Boolean::class.simpleName}") {
                 expect(testee.format(true)).toBe("true")
                 expect(testee.format(false)).toBe("false")
             }
         }
 
-        on("a ${String::class.simpleName}") {
-            it("returns two quotes including identity hash if empty ${String::class.simpleName}") {
-                val string = ""
-                val result = testee.format(string)
-                expect(result).toBe("\"\"" + INDENT + "<${System.identityHashCode(string)}>")
-            }
-            it("returns the ${String::class.simpleName} in quotes including identity hash") {
-                val string = "atrium"
-                val result = testee.format(string)
-                expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
-            }
-            it("returns line breaks (does not escape") {
-                val string = "atrium\nAn assertion framework for Kotlin"
-                val result = testee.format(string)
-                expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
-            }
-        }
+    // describe("format") {
 
-        val typeNameAndHash = "including type name and identity hash"
+    //     on("a ${Char::class.simpleName}") {
+    //         val result = testee.format('a')
+    //         it("returns the ${Char::class.simpleName} in apostrophes") {
+    //             expect(result).toBe("'a'")
+    //         }
+    //     }
 
-        on("a ${CharSequence::class.simpleName} besides ${String::class.simpleName}") {
-            it("returns two quotes $typeNameAndHash if empty ${CharSequence::class.simpleName}") {
-                val value = StringBuilder("")
-                val result = testee.format(value)
-                expect(result).toBe(
-                    "\"\"" + INDENT
-                        + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
-                )
-            }
-            it("returns ${CharSequence::class.simpleName} in quotes $typeNameAndHash") {
-                val value = StringBuilder("atrium")
-                val result = testee.format(value)
-                expect(result).toBe(
-                    "\"$value\"" + INDENT
-                        + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
-                )
-            }
-        }
+    //     on("a ${Boolean::class.simpleName}") {
+    //         it("returns the toString representation of the ${Boolean::class.simpleName}") {
+    //             expect(testee.format(true)).toBe("true")
+    //             expect(testee.format(false)).toBe("false")
+    //         }
+    //     }
+
+        // on("a ${String::class.simpleName}") {
+        //     it("returns two quotes including identity hash if empty ${String::class.simpleName}") {
+        //         val string = ""
+        //         val result = testee.format(string)
+        //         expect(result).toBe("\"\"" + INDENT + "<${System.identityHashCode(string)}>")
+        //     }
+        //     it("returns the ${String::class.simpleName} in quotes including identity hash") {
+        //         val string = "atrium"
+        //         val result = testee.format(string)
+        //         expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
+        //     }
+        //     it("returns line breaks (does not escape") {
+        //         val string = "atrium\nAn assertion framework for Kotlin"
+        //         val result = testee.format(string)
+        //         expect(result).toBe("\"$string\"" + INDENT + "<${System.identityHashCode(string)}>")
+        //     }
+        // }
+
+        // val typeNameAndHash = "including type name and identity hash"
+
+        // on("a ${CharSequence::class.simpleName} besides ${String::class.simpleName}") {
+        //     it("returns two quotes $typeNameAndHash if empty ${CharSequence::class.simpleName}") {
+        //         val value = StringBuilder("")
+        //         val result = testee.format(value)
+        //         expect(result).toBe(
+        //             "\"\"" + INDENT
+        //                 + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
+        //         )
+        //     }
+        //     it("returns ${CharSequence::class.simpleName} in quotes $typeNameAndHash") {
+        //         val value = StringBuilder("atrium")
+        //         val result = testee.format(value)
+        //         expect(result).toBe(
+        //             "\"$value\"" + INDENT
+        //                 + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
+        //         )
+        //     }
+        // }
 
 
-        on("a ${StringBasedRawString::class.simpleName}") {
-            val result = testee.format(RawString.create("hello"))
-            it("returns the containing string") {
-                expect(result).toBe("hello")
-            }
-        }
+        // on("a ${StringBasedRawString::class.simpleName}") {
+        //     val result = testee.format(RawString.create("hello"))
+        //     it("returns the containing string") {
+        //         expect(result).toBe("hello")
+        //     }
+        // }
 
-        on("a ${TranslatableBasedRawString::class.simpleName}") {
-            val translation = "es gilt"
-            val translator = mock<Translator> {
-                on { translate(AssertionVerb.EXPECT) } doReturn translation
-            }
-            val testeeWithMockedTranslation = DetailedObjectFormatter(translator)
-            val result = testeeWithMockedTranslation.format(RawString.create(AssertionVerb.EXPECT))
-            it("returns the translated string") {
-                expect(result).toBe(translation)
-            }
-        }
+        // on("a ${TranslatableBasedRawString::class.simpleName}") {
+        //     val translation = "es gilt"
+        //     val translator = mockk<Translator> {
+        //         every { translate(AssertionVerb.EXPECT) } returns translation
+        //     }
+        //     val testeeWithMockedTranslation = DetailedObjectFormatter(translator)
+        //     val result = testeeWithMockedTranslation.format(RawString.create(AssertionVerb.EXPECT))
+        //     it("returns the translated string") {
+        //         expect(result).toBe(translation)
+        //     }
+        // }
 
-        on("an enum") {
-            val enum = AssertionVerb.EXPECT
-            val result = testee.format(enum)
-            it("returns its toString representation together with its Class.name but without System.identityHash") {
-                expect(result).toBe("EXPECT" + INDENT + "(${enum::class.java.name})")
-            }
-        }
+        // on("an enum") {
+        //     val enum = AssertionVerb.EXPECT
+        //     val result = testee.format(enum)
+        //     it("returns its toString representation together with its Class.name but without System.identityHash") {
+        //         expect(result).toBe("EXPECT" + INDENT + "(${enum::class.java.name})")
+        //     }
+        // }
 
-        on("a Throwable") {
-            val result = testee.format(AssertionError("blablabla"))
-            it("returns only its Class.name") {
-                expect(result).toBe(AssertionError::class.java.name)
-            }
-        }
+        // on("a Throwable") {
+        //     val result = testee.format(AssertionError("blablabla"))
+        //     it("returns only its Class.name") {
+        //         expect(result).toBe(AssertionError::class.java.name)
+        //     }
+        // }
 
-        on("a ${Class::class.simpleName}") {
-            val result = testee.format(DetailedObjectFormatterSpec::class.java)
-            it("returns its simpleName and name in parenthesis") {
-                val clazz = DetailedObjectFormatterSpec::class.java
-                expect(result).toBe("${clazz.simpleName} (${clazz.name})")
-            }
-        }
+        // on("a ${Class::class.simpleName}") {
+        //     val result = testee.format(DetailedObjectFormatterSpec::class.java)
+        //     it("returns its simpleName and name in parenthesis") {
+        //         val clazz = DetailedObjectFormatterSpec::class.java
+        //         expect(result).toBe("${clazz.simpleName} (${clazz.name})")
+        //     }
+        // }
 
-        group("on a ${KClass::class.simpleName}") {
+        // group("on a ${KClass::class.simpleName}") {
 
-            context("java Class is the same (no special Kotlin class)") {
-                val result = testee.format(DetailedObjectFormatterSpec::class)
-                it("returns the simpleName and qualified in parenthesis") {
-                    val clazz = DetailedObjectFormatterSpec::class
-                    expect(result).toBe("${clazz.java.simpleName} (${clazz.java.name})")
-                    expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName})")
-                }
-            }
+        //     context("java Class is the same (no special Kotlin class)") {
+        //         val result = testee.format(DetailedObjectFormatterSpec::class)
+        //         it("returns the simpleName and qualified in parenthesis") {
+        //             val clazz = DetailedObjectFormatterSpec::class
+        //             expect(result).toBe("${clazz.java.simpleName} (${clazz.java.name})")
+        //             expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName})")
+        //         }
+        //     }
 
-            context("a primitive Kotlin wrapper class (java Class is not the same)") {
-                val result = testee.format(Int::class)
-                it("returns the simpleName and qualified in parenthesis including java's simpleName") {
-                    val clazz = Int::class
-                    expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.simpleName}")
-                }
-            }
+        //     context("a primitive Kotlin wrapper class (java Class is not the same)") {
+        //         val result = testee.format(Int::class)
+        //         it("returns the simpleName and qualified in parenthesis including java's simpleName") {
+        //             val clazz = Int::class
+        //             expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.simpleName}")
+        //         }
+        //     }
 
-            context("a non primitive Kotlin class (java Class is not the same)") {
-                val result = testee.format(CharSequence::class)
-                it("returns the simpleName and qualified in parenthesis including java's name") {
-                    val clazz = CharSequence::class
-                    expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.name}")
-                }
-            }
-        }
+        //     context("a non primitive Kotlin class (java Class is not the same)") {
+        //         val result = testee.format(CharSequence::class)
+        //         it("returns the simpleName and qualified in parenthesis including java's name") {
+        //             val clazz = CharSequence::class
+        //             expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.name}")
+        //         }
+        //     }
+        // }
 
-        mapOf(
-            java.lang.Byte::class.java.simpleName to 1.toByte(),
-            java.lang.Short::class.java.simpleName to 1.toShort(),
-            java.lang.Integer::class.java.simpleName to 1,
-            java.lang.Long::class.java.simpleName to 1L,
-            java.lang.Float::class.java.simpleName to 1.0f,
-            java.lang.Double::class.java.simpleName to 1.0
-        ).forEach { (typeName, value) ->
-            on(typeName) {
-                val result = testee.format(value)
-                it("returns subject's toString() $typeNameAndHash") {
-                    expect(result).toBe(
-                        value.toString() + INDENT
-                            + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
-                    )
-                }
-            }
-        }
+        // mapOf(
+        //     java.lang.Byte::class.java.simpleName to 1.toByte(),
+        //     java.lang.Short::class.java.simpleName to 1.toShort(),
+        //     java.lang.Integer::class.java.simpleName to 1,
+        //     java.lang.Long::class.java.simpleName to 1L,
+        //     java.lang.Float::class.java.simpleName to 1.0f,
+        //     java.lang.Double::class.java.simpleName to 1.0
+        // ).forEach { (typeName, value) ->
+        //     on(typeName) {
+        //         val result = testee.format(value)
+        //         it("returns subject's toString() $typeNameAndHash") {
+        //             expect(result).toBe(
+        //                 value.toString() + INDENT
+        //                     + "(${value::class.qualifiedName} <${System.identityHashCode(value)}>)"
+        //             )
+        //         }
+        //     }
+        // }
 
-        on("an anonymous class") {
-            val anonymous = object : Any() {
-                override fun toString(): String = "anonymous type"
-            }
-            val result = testee.format(anonymous)
-            it("returns subject's toString() $typeNameAndHash") {
-                expect(result).toBe(
-                    anonymous.toString() + INDENT
-                        + "(${anonymous::class.java.name} <${System.identityHashCode(anonymous)}>)"
-                )
-            }
-        }
+        // on("an anonymous class") {
+        //     val anonymous = object : Any() {
+        //         override fun toString(): String = "anonymous type"
+        //     }
+        //     val result = testee.format(anonymous)
+        //     it("returns subject's toString() $typeNameAndHash") {
+        //         expect(result).toBe(
+        //             anonymous.toString() + INDENT
+        //                 + "(${anonymous::class.java.name} <${System.identityHashCode(anonymous)}>)"
+        //         )
+        //     }
+        // }
     }
 }) {
     object AtriumsObjectFormatterSpec : ObjectFormatterSpec(::DetailedObjectFormatter)

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/ObjectFormatterSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/ObjectFormatterSpec.kt
@@ -9,32 +9,27 @@ import ch.tutteli.atrium.reporting.StringBasedRawString
 import ch.tutteli.atrium.reporting.translating.TranslatableBasedRawString
 import ch.tutteli.atrium.reporting.translating.Translator
 import ch.tutteli.atrium.specs.AssertionVerb
-import ch.tutteli.atrium.specs.describeFun
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.SpecBody
-import org.jetbrains.spek.api.dsl.context
-import org.jetbrains.spek.api.dsl.it
+import ch.tutteli.atrium.specs.describeFunTemplate
+import io.mockk.*
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.Suite
 
-//TODO #116 migrate spek1 to spek2 - move to specs-common
 abstract class ObjectFormatterSpec(
     testeeFactory: (Translator) -> ObjectFormatter,
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
-    fun describeFun(vararg funName: String, body: SpecBody.() -> Unit) =
-        describeFun(describePrefix, funName, body = body)
+    fun describeFunTemplate(vararg funName: String, body: Suite.() -> Unit) =
+        describeFunTemplate(describePrefix, funName, body = body)
 
     val translatable = AssertionVerb.ASSERT
     val translatedText = "es gilt"
-    val translator = mock<Translator> {
-        on { translate(any()) } doReturn (translatedText)
+    val translator = mockk<Translator> {
+        every { translate(any()) } returns (translatedText)
     }
     val testee = testeeFactory(translator)
 
-    describeFun(testee::format.name) {
+    describeFunTemplate(testee::format.name) {
 
         context("`null`") {
             val i: Int? = null

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/ObjectFormatterSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/ObjectFormatterSpec.kt
@@ -19,7 +19,7 @@ abstract class ObjectFormatterSpec(
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
-    fun describeFunTemplate(vararg funName: String, body: Suite.() -> Unit) =
+    fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, funName, body = body)
 
     val translatable = AssertionVerb.ASSERT
@@ -29,7 +29,7 @@ abstract class ObjectFormatterSpec(
     }
     val testee = testeeFactory(translator)
 
-    describeFunTemplate(testee::format.name) {
+    describeFun(testee::format.name) {
 
         context("`null`") {
             val i: Int? = null


### PR DESCRIPTION
Started working on DetailedObjectFormatterSpec class
Unfortunately I'm getting compile errors but cant find any references online or examples to proceed with resolution

First error related to usage of include keyword: "Expecting a class body".

I tried this command: include(object: AtriumsObjectFormatterSpec() {}) but got a different error: "Type mismatch: inferred type is <no name provided> but Spek was expected"

@robstoll would appreciate your feedback and advice on how to proceed


----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
