### PR TITLE
move functions back into companion in specs

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsSpecBase.kt
@@ -32,7 +32,7 @@ abstract class CharSequenceContainsSpecBase {
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        val a1: Expect<CharSequence> = notImplemented()
+        val a1: Expect<String> = notImplemented()
 
         a1.contains.atLeast(1).value(1)
         a1.contains.atMost(2).values("a", 1)
@@ -53,7 +53,7 @@ abstract class CharSequenceContainsSpecBase {
         a1.contains.ignoringCase.values("a", 'b')
         a1.contains.ignoringCase.regex("a")
         a1.contains.ignoringCase.regex("a", "bl")
-        //TODO add to infix as well as fluent
+        //TODO add (also to infix API)
 //        a1.contains.ignoringCase.elementsOf(listOf(1, 2))("a", "bl")
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CollectionAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CollectionAssertionsSpec.kt
@@ -10,8 +10,8 @@ object CollectionAssertionsSpec : ch.tutteli.atrium.specs.integration.Collection
 ) {
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        val a1: Expect<Collection<Int>> = notImplemented()
-        val a1b: Expect<Collection<Int?>> = notImplemented()
+        val a1: Expect<List<Int>> = notImplemented()
+        val a1b: Expect<Set<Int?>> = notImplemented()
 
         val star: Expect<Collection<*>> = notImplemented()
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CollectionFeatureAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CollectionFeatureAssertionsSpec.kt
@@ -11,10 +11,10 @@ object CollectionFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Col
 ) {
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        var a1: Expect<Collection<Int>> = notImplemented()
-        var a1b: Expect<Collection<Int?>> = notImplemented()
+        var a1: Expect<AbstractList<Int>> = notImplemented()
+        var a1b: Expect<AbstractSet<Int?>> = notImplemented()
 
-        var star: Expect<Collection<*>> = notImplemented()
+        var star: Expect<AbstractCollection<*>> = notImplemented()
 
         a1.size
         a1 = a1.size { }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/Fun0AssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/Fun0AssertionsSpec.kt
@@ -7,12 +7,21 @@ import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withFeatureSuffix
 
 class Fun0AssertionsSpec : ch.tutteli.atrium.specs.integration.Fun0AssertionsSpec(
-    ("toThrow" to ::toThrowFeature).withFeatureSuffix(),
-    "toThrow" to ::toThrow,
+    ("toThrow" to Companion::toThrowFeature).withFeatureSuffix(),
+    "toThrow" to Companion::toThrow,
     feature0<() -> Int, Int>(Expect<() -> Int>::notToThrow),
     feature1<() -> Int, Expect<Int>.() -> Unit, Int>(Expect<() -> Int>::notToThrow),
     "⚬ ", "» "
 ) {
+    companion object {
+        private fun toThrowFeature(expect: Expect<out () -> Any?>) =
+            expect.toThrow<IllegalArgumentException>()
+
+        private fun toThrow(
+            expect: Expect<out () -> Any?>,
+            assertionCreator: Expect<IllegalArgumentException>.() -> Unit
+        ) = expect.toThrow<IllegalArgumentException> { assertionCreator() }
+    }
 
     @Suppress("unused", "UNUSED_VALUE", "UNUSED_VARIABLE")
     private fun ambiguityTest() {
@@ -33,8 +42,3 @@ class Fun0AssertionsSpec : ch.tutteli.atrium.specs.integration.Fun0AssertionsSpe
     }
 }
 
-private fun toThrowFeature(expect: Expect<out () -> Any?>) =
-    expect.toThrow<IllegalArgumentException>()
-
-private fun toThrow(expect: Expect<out () -> Any?>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
-    expect.toThrow<IllegalArgumentException> { assertionCreator() }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ListFeatureAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ListFeatureAssertionsSpec.kt
@@ -11,8 +11,8 @@ object ListFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ListFeatu
 ) {
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        var a1: Expect<List<Int>> = notImplemented()
-        var a1b: Expect<List<Int?>> = notImplemented()
+        var a1: Expect<AbstractList<Int>> = notImplemented()
+        var a1b: Expect<MutableList<Int?>> = notImplemented()
 
         var star: Expect<List<*>> = notImplemented()
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/MapAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/MapAssertionsSpec.kt
@@ -9,8 +9,9 @@ import kotlin.jvm.JvmName
 class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
     mfun2<String, Int, Int>(Expect<Map<out String, Int>>::contains),
     mfun2<String?, Int?, Int?>(Expect<Map<out String?, Int?>>::contains).withNullableSuffix(),
-    mfun2<String, Int, Expect<Int>.() -> Unit>(::contains).adjustName { "$it ${KeyValue::class.simpleName}" },
-    mfun2<String?, Int?, (Expect<Int>.() -> Unit)?>(::contains).adjustName { "$it ${KeyValue::class.simpleName}" }.withNullableSuffix(),
+    mfun2<String, Int, Expect<Int>.() -> Unit>(Companion::contains).adjustName { "$it ${KeyValue::class.simpleName}" },
+    mfun2<String?, Int?, (Expect<Int>.() -> Unit)?>(Companion::contains).adjustName { "$it ${KeyValue::class.simpleName}" }
+        .withNullableSuffix(),
     fun1(Expect<Map<out String, *>>::containsKey),
     fun1(Expect<Map<out String?, *>>::containsKey).withNullableSuffix(),
     fun1(Expect<Map<out String, *>>::containsNotKey),
@@ -18,6 +19,26 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
     fun0(Expect<Map<*, *>>::isEmpty),
     fun0(Expect<Map<*, *>>::isNotEmpty)
 ) {
+
+    companion object {
+        private fun contains(
+            expect: Expect<Map<out String, Int>>,
+            keyValue: Pair<String, Expect<Int>.() -> Unit>,
+            otherKeyValues: Array<out Pair<String, Expect<Int>.() -> Unit>>
+        ) = mapArguments(keyValue, otherKeyValues).to { KeyValue(it.first, it.second) }.let { (first, others) ->
+            expect.contains(first, *others)
+        }
+
+        @JvmName("containsNullable")
+        private fun contains(
+            expect: Expect<Map<out String?, Int?>>,
+            keyValue: Pair<String?, (Expect<Int>.() -> Unit)?>,
+            otherKeyValues: Array<out Pair<String?, (Expect<Int>.() -> Unit)?>>
+        ) = mapArguments(keyValue, otherKeyValues).to { KeyValue(it.first, it.second) }.let { (first, others) ->
+            expect.contains(first, *others)
+        }
+
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -183,21 +204,4 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
         starMap = starMap.isNotEmpty()
 
     }
-}
-
-private fun contains(
-    expect: Expect<Map<out String, Int>>,
-    keyValue: Pair<String, Expect<Int>.() -> Unit>,
-    otherKeyValues: Array<out Pair<String, Expect<Int>.() -> Unit>>
-) = mapArguments(keyValue, otherKeyValues).to { KeyValue(it.first, it.second) }.let { (first, others) ->
-    expect.contains(first, *others)
-}
-
-@JvmName("containsNullable")
-private fun contains(
-    expect: Expect<Map<out String?, Int?>>,
-    keyValue: Pair<String?, (Expect<Int>.() -> Unit)?>,
-    otherKeyValues: Array<out Pair<String?, (Expect<Int>.() -> Unit)?>>
-) = mapArguments(keyValue, otherKeyValues).to { KeyValue(it.first, it.second) }.let { (first, others) ->
-    expect.contains(first, *others)
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ThrowableAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ThrowableAssertionsSpec.kt
@@ -1,19 +1,29 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.fun2
-import ch.tutteli.atrium.specs.notImplemented
-import ch.tutteli.atrium.specs.property
-import ch.tutteli.atrium.specs.withFeatureSuffix
+import ch.tutteli.atrium.specs.*
 
 class ThrowableAssertionsSpec : ch.tutteli.atrium.specs.integration.ThrowableAssertionsSpec(
     property<Throwable, String>(Expect<Throwable>::message),
     fun1<Throwable, Expect<String>.() -> Unit>(Expect<Throwable>::message),
     fun2(Expect<Throwable>::messageContains),
-    ("cause" to ::causeFeature).withFeatureSuffix(),
-    "cause" to ::cause
+    ("cause" to Companion::causeFeature).withFeatureSuffix(),
+    "cause" to Companion::cause
 ) {
+
+    companion object {
+
+        @Suppress("RemoveExplicitTypeArguments")
+        private fun causeFeature(expect: Expect<out Throwable>): Expect<IllegalArgumentException> =
+            expect.cause<IllegalArgumentException>()
+
+        @Suppress("RemoveExplicitTypeArguments")
+        private fun cause(
+            expect: Expect<out Throwable>,
+            assertionCreator: Expect<IllegalArgumentException>.() -> Unit
+        ) = expect.cause<IllegalArgumentException>(assertionCreator)
+
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -27,10 +37,3 @@ class ThrowableAssertionsSpec : ch.tutteli.atrium.specs.integration.ThrowableAss
         a1.cause<ClassCastException> { }
     }
 }
-
-@Suppress("RemoveExplicitTypeArguments")
-private fun causeFeature(expect: Expect<out Throwable>): Expect<IllegalArgumentException> = expect.cause<IllegalArgumentException>()
-
-@Suppress("RemoveExplicitTypeArguments")
-private fun cause(expect: Expect<out Throwable>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
-    expect.cause<IllegalArgumentException>(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceAssertionsSpec.kt
@@ -6,9 +6,9 @@ import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
 class CharSequenceAssertionsSpec : ch.tutteli.atrium.specs.integration.CharSequenceAssertionsSpec(
-    "toBe ${Empty::class.simpleName}" to ::toBeEmpty,
-    "notToBe ${Empty::class.simpleName}" to ::notToBeEmpty,
-    "notToBe ${Blank::class.simpleName}" to ::notToBeBlank,
+    "toBe ${Empty::class.simpleName}" to Companion::toBeEmpty,
+    "notToBe ${Empty::class.simpleName}" to Companion::notToBeEmpty,
+    "notToBe ${Blank::class.simpleName}" to Companion::notToBeBlank,
     fun1<CharSequence, CharSequence>(Expect<CharSequence>::startsWith),
     fun1<CharSequence, Char>(Expect<CharSequence>::startsWith),
     fun1<CharSequence, CharSequence>(Expect<CharSequence>::startsNotWith),
@@ -20,7 +20,11 @@ class CharSequenceAssertionsSpec : ch.tutteli.atrium.specs.integration.CharSeque
     fun1<CharSequence, Regex>(Expect<CharSequence>::matches),
     fun1<CharSequence, Regex>(Expect<CharSequence>::mismatches)
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter(){
+        private fun toBeEmpty(expect: Expect<CharSequence>) = expect toBe Empty
+        private fun notToBeEmpty(expect: Expect<CharSequence>) = expect notToBe Empty
+        private fun notToBeBlank(expect: Expect<CharSequence>) = expect notToBe Blank
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -44,7 +48,3 @@ class CharSequenceAssertionsSpec : ch.tutteli.atrium.specs.integration.CharSeque
         a1 mismatches Regex("a")
     }
 }
-
-private fun toBeEmpty(expect: Expect<CharSequence>) = expect toBe Empty
-private fun notToBeEmpty(expect: Expect<CharSequence>) = expect notToBe Empty
-private fun notToBeBlank(expect: Expect<CharSequence>) = expect notToBe Blank

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
@@ -7,11 +7,21 @@ import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
 class CharSequenceContainsContainsNotAssertionsSpec :
     ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
-        fun2<CharSequence, String, Array<out String>>(::contains),
-        fun2<CharSequence, String, Array<out String>>(::containsNot),
+        fun2<CharSequence, String, Array<out String>>(Companion::contains),
+        fun2<CharSequence, String, Array<out String>>(Companion::containsNot),
         "* ", "- ", ">> "
     ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+
+        private fun contains(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
+            if (aX.isEmpty()) expect contains a
+            else expect contains Values(a, *aX)
+
+        private fun containsNot(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
+            if (aX.isEmpty()) expect containsNot a
+            else expect containsNot Values(a, *aX)
+
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -21,11 +31,3 @@ class CharSequenceContainsContainsNotAssertionsSpec :
         a1 containsNot Values(1, "a", 'c')
     }
 }
-
-private fun contains(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
-    if (aX.isEmpty()) expect contains a
-    else expect contains Values(a, *aX)
-
-private fun containsNot(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
-    if (aX.isEmpty()) expect containsNot a
-    else expect containsNot Values(a, *aX)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
@@ -33,7 +33,7 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        val a1: Expect<CharSequence> = notImplemented()
+        val a1: Expect<String> = notImplemented()
 
         a1 contains o atLeast 1 value 1
         a1 contains o atMost 2 the Values("a", 1)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CollectionAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CollectionAssertionsSpec.kt
@@ -5,15 +5,19 @@ import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
 class CollectionAssertionsSpec : ch.tutteli.atrium.specs.integration.CollectionAssertionsSpec(
-    "toBe ${Empty::class.simpleName}" to ::isEmpty,
-    "notToBe ${Empty::class.simpleName}" to ::isNotEmpty
+    "toBe ${Empty::class.simpleName}" to Companion::isEmpty,
+    "notToBe ${Empty::class.simpleName}" to Companion::isNotEmpty
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+        private fun isEmpty(expect: Expect<Collection<Int>>) = expect toBe Empty
+        private fun isNotEmpty(expect: Expect<Collection<Int>>) = expect notToBe Empty
+
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        val a1: Expect<Collection<Int>> = notImplemented()
-        val a1b: Expect<Collection<Int?>> = notImplemented()
+        val a1: Expect<List<Int>> = notImplemented()
+        val a1b: Expect<Set<Int?>> = notImplemented()
 
         val star: Expect<Collection<*>> = notImplemented()
 
@@ -28,5 +32,3 @@ class CollectionAssertionsSpec : ch.tutteli.atrium.specs.integration.CollectionA
     }
 }
 
-private fun isEmpty(expect: Expect<Collection<Int>>) = expect toBe Empty
-private fun isNotEmpty(expect: Expect<Collection<Int>>) = expect notToBe Empty

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CollectionFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CollectionFeatureAssertionsSpec.kt
@@ -14,10 +14,10 @@ class CollectionFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Coll
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        var a1: Expect<Collection<Int>> = notImplemented()
-        var a1b: Expect<Collection<Int?>> = notImplemented()
+        var a1: Expect<AbstractList<Int>> = notImplemented()
+        var a1b: Expect<AbstractSet<Int?>> = notImplemented()
 
-        var star: Expect<out Collection<*>> = notImplemented()
+        var star: Expect<AbstractCollection<*>> = notImplemented()
 
         a1.size
         a1 = a1 size { }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/Fun0AssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/Fun0AssertionsSpec.kt
@@ -8,13 +8,21 @@ import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import ch.tutteli.atrium.specs.withFeatureSuffix
 
 class Fun0AssertionsSpec : ch.tutteli.atrium.specs.integration.Fun0AssertionsSpec(
-    ("toThrow" to ::toThrowFeature).withFeatureSuffix(),
-    "toThrow" to ::toThrow,
+    ("toThrow" to Companion::toThrowFeature).withFeatureSuffix(),
+    "toThrow" to Companion::toThrow,
     feature0<() -> Int, Int>(Expect<() -> Int>::notToThrow),
     feature1<() -> Int, Expect<Int>.() -> Unit, Int>(Expect<() -> Int>::notToThrow),
     "- ", "» "
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+        private fun toThrowFeature(expect: Expect<out () -> Any?>) =
+            expect.toThrow<IllegalArgumentException>()
+
+        private fun toThrow(
+            expect: Expect<out () -> Any?>,
+            assertionCreator: Expect<IllegalArgumentException>.() -> Unit
+        ) = expect.toThrow<IllegalArgumentException> { assertionCreator() }
+    }
 
     @Suppress("unused", "UNUSED_VALUE", "UNUSED_VARIABLE")
     private fun ambiguityTest() {
@@ -35,8 +43,3 @@ class Fun0AssertionsSpec : ch.tutteli.atrium.specs.integration.Fun0AssertionsSpe
     }
 }
 
-private fun toThrowFeature(expect: Expect<out () -> Any?>) =
-    expect.toThrow<IllegalArgumentException>()
-
-private fun toThrow(expect: Expect<out () -> Any?>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
-    expect.toThrow<IllegalArgumentException> { assertionCreator() }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableAllAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableAllAssertionsSpec.kt
@@ -15,8 +15,8 @@ class IterableAllAssertionsSpec : ch.tutteli.atrium.specs.integration.IterableAl
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        var a1: Expect<Iterable<Double>> = notImplemented()
-        var a1b: Expect<Iterable<Double?>> = notImplemented()
+        var a1: Expect<List<Double>> = notImplemented()
+        var a1b: Expect<Set<Double?>> = notImplemented()
 
         var star: Expect<Iterable<*>> = notImplemented()
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ListFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ListFeatureAssertionsSpec.kt
@@ -10,18 +10,30 @@ import kotlin.jvm.JvmName
 
 class ListFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ListFeatureAssertionsSpec(
     feature1<List<Int>, Int, Int>(Expect<List<Int>>::get),
-    fun2<List<Int>, Int, Expect<Int>.() -> Unit>(::get),
+    fun2<List<Int>, Int, Expect<Int>.() -> Unit>(Companion::get),
     feature1<List<Int?>, Int, Int?>(Expect<List<Int?>>::get).withNullableSuffix(),
-    fun2<List<Int?>, Int, Expect<Int?>.() -> Unit>(::get).withNullableSuffix()
+    fun2<List<Int?>, Int, Expect<Int?>.() -> Unit>(Companion::get).withNullableSuffix()
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+
+        private fun get(expect: Expect<List<Int>>, index: Int, assertionCreator: Expect<Int>.() -> Unit) =
+            expect get index(index) { assertionCreator() }
+
+        @JvmName("getNullable")
+        private fun get(
+            expect: Expect<List<Int?>>,
+            index: Int,
+            assertionCreator: Expect<Int?>.() -> Unit
+        ) = expect get index(index) { assertionCreator() }
+
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
-        var a1: Expect<List<Int>> = notImplemented()
-        var a1b: Expect<List<Int?>> = notImplemented()
+        var a1: Expect<AbstractList<Int>> = notImplemented()
+        var a1b: Expect<MutableList<Int?>> = notImplemented()
 
-        var star: Expect<out List<*>> = notImplemented()
+        var star: Expect<List<*>> = notImplemented()
 
         a1 get 1
         a1 = a1 get index(1) { }
@@ -33,13 +45,3 @@ class ListFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ListFeatur
         star = star get index(1) { }
     }
 }
-
-private fun get(expect: Expect<List<Int>>, index: Int, assertionCreator: Expect<Int>.() -> Unit) =
-    expect get index(index) { assertionCreator() }
-
-@JvmName("getNullable")
-private fun get(
-    expect: Expect<List<Int?>>,
-    index: Int,
-    assertionCreator: Expect<Int?>.() -> Unit
-) = expect get index(index) { assertionCreator() }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryAssertionsSpec.kt
@@ -8,10 +8,17 @@ import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import ch.tutteli.atrium.specs.withNullableSuffix
 
 class MapEntryAssertionsSpec : ch.tutteli.atrium.specs.integration.MapEntryAssertionsSpec(
-    fun1(Expect<Map.Entry<String, Int>>::isKeyValue).name to ::isKeyValue,
-    (fun1(Expect<Map.Entry<String?, Int?>>::isKeyValue).name to ::isKeyValueNullable).withNullableSuffix()
+    fun1(Expect<Map.Entry<String, Int>>::isKeyValue).name to Companion::isKeyValue,
+    (fun1(Expect<Map.Entry<String?, Int?>>::isKeyValue).name to Companion::isKeyValueNullable).withNullableSuffix()
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+
+        private fun isKeyValue(expect: Expect<Map.Entry<String, Int>>, key: String, value: Int) =
+            expect isKeyValue (key to value)
+
+        private fun isKeyValueNullable(expect: Expect<Map.Entry<String?, Int?>>, key: String?, value: Int?) =
+            expect isKeyValue (key to value)
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -34,9 +41,3 @@ class MapEntryAssertionsSpec : ch.tutteli.atrium.specs.integration.MapEntryAsser
         star isKeyValue (null to null)
     }
 }
-
-private fun isKeyValue(expect: Expect<Map.Entry<String, Int>>, key: String, value: Int) =
-    expect isKeyValue (key to value)
-
-private fun isKeyValueNullable(expect: Expect<Map.Entry<String?, Int?>>, key: String?, value: Int?) =
-    expect isKeyValue (key to value)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapFeatureAssertionsSpec.kt
@@ -11,11 +11,26 @@ class MapFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.MapFeatureA
     property<Map<String, Int>, Collection<Int>>(Expect<Map<String, Int>>::values),
     fun1<Map<String, Int>, Expect<Collection<Int>>.() -> Unit>(Expect<Map<String, Int>>::values),
     feature1<Map<String, Int>, String, Int>(Expect<Map<String, Int>>::getExisting),
-    fun2<Map<String, Int>, String, Expect<Int>.() -> Unit>(::getExisting),
+    fun2<Map<String, Int>, String, Expect<Int>.() -> Unit>(Companion::getExisting),
     feature1<Map<String?, Int?>, String?, Int?>(Expect<Map<String?, Int?>>::getExisting).withNullableSuffix(),
-    fun2<Map<String?, Int?>, String?, Expect<Int?>.() -> Unit>(::getExisting).withNullableSuffix()
+    fun2<Map<String?, Int?>, String?, Expect<Int?>.() -> Unit>(Companion::getExisting).withNullableSuffix()
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+
+        private fun getExisting(
+            expect: Expect<Map<String, Int>>,
+            key: String,
+            assertionCreator: Expect<Int>.() -> Unit
+        ): Expect<Map<String, Int>> = expect getExisting key(key) { assertionCreator() }
+
+        @JvmName("getExistingNullable")
+        private fun getExisting(
+            expect: Expect<Map<String?, Int?>>,
+            key: String?,
+            assertionCreator: Expect<Int?>.() -> Unit
+        ): Expect<Map<String?, Int?>> = expect getExisting key(key) { assertionCreator() }
+
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -36,16 +51,3 @@ class MapFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.MapFeatureA
         star = star getExisting key("a") { }
     }
 }
-
-private fun getExisting(
-    expect: Expect<Map<String, Int>>,
-    key: String,
-    assertionCreator: Expect<Int>.() -> Unit
-): Expect<Map<String, Int>> = expect getExisting key(key) { assertionCreator() }
-
-@JvmName("getExistingNullable")
-private fun getExisting(
-    expect: Expect<Map<String?, Int?>>,
-    key: String?,
-    assertionCreator: Expect<Int?>.() -> Unit
-): Expect<Map<String?, Int?>> = expect getExisting key(key) { assertionCreator() }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ThrowableAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ThrowableAssertionsSpec.kt
@@ -3,17 +3,35 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
-import ch.tutteli.atrium.specs.withFeatureSuffix
 
 class ThrowableAssertionsSpec : ch.tutteli.atrium.specs.integration.ThrowableAssertionsSpec(
     property<Throwable, String>(Expect<Throwable>::message),
     fun1<Throwable, Expect<String>.() -> Unit>(Expect<Throwable>::message),
-    fun2(::messageContains),
-    ("cause" to ::causeFeature).withFeatureSuffix(),
-    "cause" to ::cause
+    fun2(Companion::messageContains),
+    ("cause" to Companion::causeFeature).withFeatureSuffix(),
+    "cause" to Companion::cause
 ) {
 
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+
+        private fun messageContains(
+            expect: Expect<Throwable>,
+            expected: Any,
+            vararg otherExpected: Any
+        ): Expect<Throwable> =
+            if (otherExpected.isEmpty()) expect messageContains expected
+            else expect messageContains Values(expected, *otherExpected)
+
+        @Suppress("RemoveExplicitTypeArguments")
+        private fun causeFeature(expect: Expect<out Throwable>): Expect<IllegalArgumentException> =
+            expect.cause<IllegalArgumentException>()
+
+        @Suppress("RemoveExplicitTypeArguments")
+        private fun cause(
+            expect: Expect<out Throwable>,
+            assertionCreator: Expect<IllegalArgumentException>.() -> Unit
+        ) = expect.cause<IllegalArgumentException>(assertionCreator)
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -29,15 +47,3 @@ class ThrowableAssertionsSpec : ch.tutteli.atrium.specs.integration.ThrowableAss
         a1.cause<ClassCastException> { message { } }
     }
 }
-
-private fun messageContains(expect: Expect<Throwable>, expected: Any, vararg otherExpected: Any): Expect<Throwable> =
-    if (otherExpected.isEmpty()) expect messageContains expected
-    else expect messageContains Values(expected, *otherExpected)
-
-@Suppress("RemoveExplicitTypeArguments")
-private fun causeFeature(expect: Expect<out Throwable>): Expect<IllegalArgumentException> =
-    expect.cause<IllegalArgumentException>()
-
-@Suppress("RemoveExplicitTypeArguments")
-private fun cause(expect: Expect<out Throwable>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
-    expect.cause<IllegalArgumentException>(assertionCreator)

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/PathAssertionsSpec.kt
@@ -9,18 +9,26 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpec(
-    fun1<Path, exist>(Expect<Path>::to).name to ::exists,
-    fun1<Path, exist>(Expect<Path>::notTo).name to ::existsNot,
+    fun1<Path, exist>(Expect<Path>::to).name to Companion::exists,
+    fun1<Path, exist>(Expect<Path>::notTo).name to Companion::existsNot,
     fun1(Expect<Path>::startsWith),
     fun1(Expect<Path>::startsNotWith),
     fun1(Expect<Path>::endsWith),
     fun1(Expect<Path>::endsNotWith),
-    fun1<Path, readable>(Expect<Path>::toBe).name to ::isReadable,
-    fun1<Path, writable>(Expect<Path>::toBe).name to ::isWritable,
-    fun1<Path, aRegularFile>(Expect<Path>::toBe).name to ::isRegularFile,
-    fun1<Path, aDirectory>(Expect<Path>::toBe).name to ::isDirectory
+    fun1<Path, readable>(Expect<Path>::toBe).name to Companion::isReadable,
+    fun1<Path, writable>(Expect<Path>::toBe).name to Companion::isWritable,
+    fun1<Path, aRegularFile>(Expect<Path>::toBe).name to Companion::isRegularFile,
+    fun1<Path, aDirectory>(Expect<Path>::toBe).name to Companion::isDirectory
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter(){
+
+        private fun exists(expect: Expect<Path>) = expect to exist
+        private fun existsNot(expect: Expect<Path>) = expect notTo exist
+        private fun isReadable(expect: Expect<Path>) = expect toBe readable
+        private fun isWritable(expect: Expect<Path>) = expect toBe writable
+        private fun isRegularFile(expect: Expect<Path>) = expect toBe aRegularFile
+        private fun isDirectory(expect: Expect<Path>) = expect toBe aDirectory
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -38,12 +46,5 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
         a1 toBe aDirectory
     }
 }
-
-private fun exists(expect: Expect<Path>) = expect to exist
-private fun existsNot(expect: Expect<Path>) = expect notTo exist
-private fun isReadable(expect: Expect<Path>) = expect toBe readable
-private fun isWritable(expect: Expect<Path>) = expect toBe writable
-private fun isRegularFile(expect: Expect<Path>) = expect toBe aRegularFile
-private fun isDirectory(expect: Expect<Path>) = expect toBe aDirectory
 
 class DummyPath(path: Path) : Path by path

--- a/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/PathFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/extensions/jdk8/atrium-api-infix-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/jdk8/PathFeatureAssertionsSpec.kt
@@ -1,7 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB.jdk8
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.specs.feature1
+import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.property
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.nio.file.Path
 
@@ -9,7 +12,7 @@ class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatur
     property<Path, Path>(Expect<Path>::parent),
     fun1<Path, Expect<Path>.() -> Unit>(Expect<Path>::parent),
     feature1<Path, String, Path>(Expect<Path>::resolve),
-    "resolve with assertionCreator not implemented in this API" to ::resolve,
+    "resolve with assertionCreator not implemented in this API" to Companion::resolve,
     property<Path, String>(Expect<Path>::fileName),
     fun1<Path, Expect<String>.() -> Unit>(Expect<Path>::fileName),
     property<Path, String>(Expect<Path>::fileNameWithoutExtension),
@@ -17,7 +20,14 @@ class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatur
     property<Path, String>(Expect<Path>::extension),
     fun1<Path, Expect<String>.() -> Unit>(Expect<Path>::extension)
 ) {
-    companion object : WithAsciiReporter()
+    companion object : WithAsciiReporter() {
+
+        private fun resolve(
+            expect: Expect<Path>,
+            other: String,
+            assertionCreator: Expect<Path>.() -> Unit
+        ): Expect<Path> = (expect resolve other).addAssertionsCreatedBy(assertionCreator)
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -39,5 +49,3 @@ class PathFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PathFeatur
     }
 }
 
-private fun resolve(expect: Expect<Path>, other: String, assertionCreator: Expect<Path>.() -> Unit): Expect<Path> =
-    (expect resolve other).addAssertionsCreatedBy(assertionCreator)


### PR DESCRIPTION
I started to move them out but realised that it makes more sense to
keep them there as we can define BaseSpecs this way providing some
utility functionality. This could be moved out as well of course but
this is really not worth the effort.



----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
