### PR TITLE
change Charsequence `contains not` to `containsNot o`

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
@@ -3,13 +3,44 @@ package ch.tutteli.atrium.api.fluent.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.notImplemented
+import org.spekframework.spek2.Spek
 
-class CharSequenceContainsContainsNotAssertionsSpec :
-    ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
-        fun2<CharSequence, String, Array<out String>>(Expect<CharSequence>::contains),
-        fun2<CharSequence, String, Array<out String>>(Expect<CharSequence>::containsNot),
-        "◆ ", "⚬ ", "▶ "
-    ) {
+class CharSequenceContainsContainsNotAssertionsSpec : Spek({
+
+    include(object : ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
+        getContainsPair(),
+        getContainsNotPair(),
+        "◆ ", "⚬ ", "▶ ",
+        "[Atrium][Builder]"
+    ) {})
+
+    include(object : ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
+        getContainsShortcutPair(),
+        getContainsNotShortcutPair(),
+        "◆ ", "⚬ ", "▶ ",
+        "[Atrium][Shortcut]"
+    ) {})
+}) {
+    companion object : CharSequenceContainsSpecBase() {
+        private fun getContainsPair() = "$contains.$atLeast(1).values" to Companion::containsValues
+
+        private fun containsValues(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
+            if (aX.isEmpty()) expect.contains.atLeast(1).value(a)
+            else expect.contains.atLeast(1).values(a, *aX)
+
+        private fun getContainsNotPair() =
+            "${super.containsNot} o $atLeast 1 value/the Values" to Companion::containsNotValues
+
+        private fun containsNotValues(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
+            if (aX.isEmpty()) expect.containsNot.value(a)
+            else expect.containsNot.values(a, *aX)
+
+        private fun getContainsShortcutPair() =
+            fun2<CharSequence, Any, Array<out Any>>(Expect<CharSequence>::contains)
+
+        private fun getContainsNotShortcutPair() =
+            fun2<CharSequence, Any, Array<out Any>>(Expect<CharSequence>::containsNot)
+    }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
@@ -28,8 +28,8 @@ infix fun <T : CharSequence> Expect<T>.contains(
  *
  * @return The newly created builder.
  */
-infix fun <T : CharSequence> Expect<T>.contains(
-    @Suppress("UNUSED_PARAMETER") not: not
+infix fun <T : CharSequence> Expect<T>.containsNot(
+    @Suppress("UNUSED_PARAMETER") o: o
 ): NotCheckerOption<T, NotSearchBehaviour> = NotCheckerOptionImpl(ExpectImpl.charSequence.containsNotBuilder(this))
 
 
@@ -90,7 +90,7 @@ infix fun <T : CharSequence> Expect<T>.contains(values: Values<Any>): Expect<T> 
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : CharSequence> Expect<T>.containsNot(expected: Any) =
-    this contains not value expected
+    this containsNot O value expected
 
 /**
  * Expects that the subject of the assertion (a [CharSequence]) does not contain the [toString] representation
@@ -105,7 +105,7 @@ infix fun <T : CharSequence> Expect<T>.containsNot(expected: Any) =
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : CharSequence> Expect<T>.containsNot(values: Values<Any>) =
-    this contains not the values
+    this containsNot O the values
 
 /**
  * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
@@ -3,15 +3,39 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.notImplemented
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
+import org.spekframework.spek2.Spek
 
-class CharSequenceContainsContainsNotAssertionsSpec :
-    ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
-        fun2<CharSequence, String, Array<out String>>(Companion::contains),
-        fun2<CharSequence, String, Array<out String>>(Companion::containsNot),
-        "* ", "- ", ">> "
-    ) {
-    companion object : WithAsciiReporter() {
+class CharSequenceContainsContainsNotAssertionsSpec : Spek({
+
+    include(object : ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
+        getContainsPair(),
+        getContainsNotPair(),
+        "* ", "- ", ">> ",
+        "[Atrium][Builder]"
+    ) {})
+
+    include(object : ch.tutteli.atrium.specs.integration.CharSequenceContainsContainsNotAssertionsSpec(
+        getContainsShortcutPair(),
+        getContainsNotShortcutPair(),
+        "* ", "- ", ">> ",
+        "[Atrium][Shortcut]"
+    ) {})
+}) {
+    companion object : CharSequenceContainsSpecBase() {
+
+        private fun getContainsPair() = "$contains o $atLeast 1 value/the Values" to Companion::containsBuilder
+
+        private fun containsBuilder(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
+            if (aX.isEmpty()) expect contains o atLeast 1 value a
+            else expect contains o atLeast 1 the Values(a, *aX)
+
+        private fun getContainsNotPair() = "$containsNot o $atLeast 1 value/the Values" to Companion::containsNotBuilder
+        private fun containsNotBuilder(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
+            if (aX.isEmpty()) expect containsNot o value a
+            else expect containsNot o the Values(a, *aX)
+
+        private fun getContainsShortcutPair() = fun2<CharSequence, Any, Array<out Any>>(Companion::contains)
+        private fun getContainsNotShortcutPair() = fun2<CharSequence, Any, Array<out Any>>(Companion::containsNot)
 
         private fun contains(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains a
@@ -20,7 +44,6 @@ class CharSequenceContainsContainsNotAssertionsSpec :
         private fun containsNot(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect containsNot a
             else expect containsNot Values(a, *aX)
-
     }
 
     @Suppress("unused", "UNUSED_VALUE")

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
@@ -15,15 +15,15 @@ class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.specs.integratio
                 (containsNotValues to Companion::containsNotFun)
 
         private fun containsNotFun(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
-            if (aX.isEmpty()) expect contains not value a
-            else expect contains not the Values(a, *aX)
+            if (aX.isEmpty()) expect containsNot o value a
+            else expect containsNot o the Values(a, *aX)
 
         private fun getContainsNotIgnoringCaseTriple() =
             { what: String -> "$containsNotValues $ignoringCase $what" } to
                 ("$containsNotValues o $ignoringCase" to Companion::containsNotIgnoringCase)
 
         private fun containsNotIgnoringCase(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
-            if (aX.isEmpty()) expect contains not ignoring case value a
-            else expect contains not ignoring case the Values(a, *aX)
+            if (aX.isEmpty()) expect containsNot o ignoring case value a
+            else expect containsNot o ignoring case the Values(a, *aX)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
@@ -1,9 +1,11 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.contains.builders.AtLeastCheckerOption
+import ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.contains.builders.NotCheckerOption
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
+import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.name
 import ch.tutteli.atrium.specs.notImplemented
@@ -14,6 +16,10 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
     private val containsProp: KFunction2<Expect<String>, o, CharSequenceContains.Builder<String, NoOpSearchBehaviour>> =
         Expect<String>::contains
     protected val contains = containsProp.name
+    private val containsNotProp: KFunction2<Expect<String>, o, NotCheckerOption<String, NotSearchBehaviour>> =
+        Expect<String>::containsNot
+    protected val containsNot = containsNotProp.name
+
     private val containsNotFun: KFunction2<Expect<String>, Any, Expect<String>> = Expect<String>::containsNot
     protected val containsNotValues = "${containsNotFun.name} ${Values::class.simpleName}"
     protected val containsRegex = fun1<String, String>(Expect<String>::containsRegex).name
@@ -42,6 +48,7 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
         a1 contains o atLeast 2 matchFor Regex("bla")
         a1 contains o atLeast 2 matchFor All(Regex("bla"), Regex("b"))
         a1 contains o atLeast 2 elementsOf listOf(1, 2)
+        a1 containsNot o
 
         a1 contains o ignoring case atLeast 1 value "a"
         a1 contains o ignoring case atLeast 1 the Values("a", 'b')
@@ -56,5 +63,15 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
         a1 contains o ignoring case the RegexPatterns("a", "bl")
         //TODO add to infix as well as fluent
         //a1 contains o ignoring case elementsOf listOf(1, 2)
+
+
+
+        a1 and { o contains O atLeast 1 value 1 }
+        a1 and { o contains O atMost 2 the Values("a", 1) }
+        a1 and { o contains O notOrAtMost 2 regex "h|b" }
+        a1 and { o contains O exactly 2 the RegexPatterns("h|b", "b") }
+        a1 and { o contains O atLeast 2 matchFor Regex("bla") }
+        a1 and { o contains O atLeast 2 matchFor All(Regex("bla"), Regex("b")) }
+        a1 and { o contains O atLeast 2 elementsOf listOf(1, 2) }
     }
 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceContainsContainsNotAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceContainsContainsNotAssertionsSpec.kt
@@ -8,8 +8,8 @@ import ch.tutteli.atrium.translations.DescriptionCharSequenceAssertion.CONTAINS_
 import org.spekframework.spek2.style.specification.Suite
 
 abstract class CharSequenceContainsContainsNotAssertionsSpec(
-    contains: Fun2<CharSequence, String, Array<out String>>,
-    containsNot: Fun2<CharSequence, String, Array<out String>>,
+    contains: Fun2<CharSequence, Any, Array<out Any>>,
+    containsNot: Fun2<CharSequence, Any, Array<out Any>>,
     rootBulletPoint: String,
     listBulletPoint: String,
     featureArrow: String,


### PR DESCRIPTION
Even though `contains not` looks nicer it is better to have
`containsNot o` as it fits into the other `containsNot` functions.



----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
