### PR TITLE
#116 migrate spek

### DIFF
--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/LazyThreadUnsafeBasicAssertionSpec.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/LazyThreadUnsafeBasicAssertionSpec.kt
@@ -4,10 +4,8 @@ import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.domain.builders.AssertImpl
 import ch.tutteli.atrium.domain.robstoll.lib.assertions.LazyThreadUnsafeBasicAssertion
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 object LazyThreadUnsafeBasicAssertionSpec : Spek({
 
@@ -17,15 +15,18 @@ object LazyThreadUnsafeBasicAssertionSpec : Spek({
             ++callingCount
             AssertImpl.builder.descriptive.failing.withDescriptionAndRepresentation("a", 2).build()
         }
-        test("does not evaluate anything") {
+        it("does not evaluate anything") {
             expect(callingCount).toBe(0)
         }
-        test("adding it to a list does not evaluate anything") {
+        it("adding it to a list does not evaluate anything") {
             listOf(testee)
             expect(callingCount).toBe(0)
         }
-        on("invoking ${testee::holds.name}") {
-            val resultHolds = testee.holds()
+        context("invoking ${testee::holds.name}") {
+            var resultHolds = true
+            it("execute it") {
+                resultHolds = testee.holds()
+            }
 
             it("evaluates it") {
                 expect(callingCount).toBe(1)
@@ -36,9 +37,12 @@ object LazyThreadUnsafeBasicAssertionSpec : Spek({
             }
         }
 
-        on("invoking ${testee::holds.name} and then ${testee::representation.name}") {
-            val resultHolds = testee.holds()
-            val resultExpected = testee.representation
+        context("invoking ${testee::holds.name} and then ${testee::representation.name}") {
+            var resultHolds = true
+
+            it("execute it") {
+                resultHolds = testee.holds()
+            }
 
             it("evaluates it only once") {
                 expect(callingCount).toBe(1)
@@ -49,7 +53,7 @@ object LazyThreadUnsafeBasicAssertionSpec : Spek({
             }
 
             it("returns ${DescriptiveAssertion::representation.name} of the underlying ${DescriptiveAssertion::class.simpleName}") {
-                expect(resultExpected).toBe(2)
+                expect(testee.representation).toBe(2)
             }
         }
     }

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/creating/charsequence/contains/searchers/CharSequenceContainsIndexSearcherSpec.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/creating/charsequence/contains/searchers/CharSequenceContainsIndexSearcherSpec.kt
@@ -4,13 +4,13 @@ import ch.tutteli.atrium.api.fluent.en_GB.contains
 import ch.tutteli.atrium.api.fluent.en_GB.exactly
 import ch.tutteli.atrium.api.fluent.en_GB.value
 import ch.tutteli.atrium.api.verbs.internal.expect
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.context
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 object CharSequenceContainsIndexSearcherSpec : Spek({
 
-    context("text 'aaaa'") {
-        test("search for 'aa' finds 3 hits since we want non disjoint matches") {
+    describe("text 'aaaa'") {
+        it("search for 'aa' finds 3 hits since we want non disjoint matches") {
             expect("aaaa").contains.exactly(3).value("aa")
         }
     }

--- a/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/creating/charsequence/contains/searchers/CharSequenceContainsRegexSearcherSpec.kt
+++ b/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/creating/charsequence/contains/searchers/CharSequenceContainsRegexSearcherSpec.kt
@@ -4,16 +4,16 @@ import ch.tutteli.atrium.api.fluent.en_GB.contains
 import ch.tutteli.atrium.api.fluent.en_GB.exactly
 import ch.tutteli.atrium.api.fluent.en_GB.regex
 import ch.tutteli.atrium.api.verbs.internal.expect
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.context
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 object CharSequenceContainsRegexSearcherSpec : Spek({
 
-    context("text 'aaaa'") {
-        test("search for 'aa' finds 3 hits since we want non disjoint matches") {
+    describe("text 'aaaa'") {
+        it("search for 'aa' finds 3 hits since we want non disjoint matches") {
             expect("aaaa").contains.exactly(3).regex("aa")
         }
-        test("search for 'aa?' finds 4 hits since we want non disjoint matches") {
+        it("search for 'aa?' finds 4 hits since we want non disjoint matches") {
             expect("aaaa").contains.exactly(4).regex("aa?")
         }
     }


### PR DESCRIPTION
3 Last classes to migrate

- LazyThreadUnsafeBasicAssertionSpec
- CharSequenceContainsIndexSearcherSpec
- CharSequenceContainsRegexSearcherSpec

----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
