### PR TITLE
use class.fullName instead of class.java.name

### DIFF
--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/TextFallbackAssertionFormatterSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/TextFallbackAssertionFormatterSpec.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.assertions.*
 import ch.tutteli.atrium.core.coreFactory
+import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.domain.builders.ExpectImpl
 import ch.tutteli.atrium.reporting.AssertionFormatter
 import ch.tutteli.atrium.reporting.AssertionFormatterController
@@ -59,7 +60,7 @@ abstract class TextFallbackAssertionFormatterSpec(
                 testee.formatNonGroup(unsupportedAssertion, parameterObject)
                 expect(sb) {
                     contains("false")
-                    contains("Unsupported type ${unsupportedAssertion::class.java.name}")
+                    contains("Unsupported type ${unsupportedAssertion::class.fullName}")
                 }
             }
         }
@@ -150,7 +151,7 @@ abstract class TextFallbackAssertionFormatterSpec(
                             "$bulletPoint inner group: subject of inner group$separator" +
                             "$indentBulletPoint$bulletPoint ${IS_SAME.getDefault()}: b$separator" +
                             "$indentBulletPoint$bulletPoint ${TO_BE.getDefault()}: d",
-                        "$bulletPoint Unsupported type ${unsupportedAssertion::class.java.name}"
+                        "$bulletPoint Unsupported type ${unsupportedAssertion::class.fullName}"
                     )
                 }
             }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslationSupplierBasedTranslatorSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslationSupplierBasedTranslatorSpec.kt
@@ -8,7 +8,6 @@ import ch.tutteli.atrium.specs.describeFunTemplate
 import io.mockk.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
-import org.spekframework.spek2.style.specification.describe
 
 abstract class TranslationSupplierBasedTranslatorSpec(
     testeeFactory: (translationSupplier: TranslationSupplier, localeOrderDecider: LocaleOrderDecider, locale: Locale, fallbackLocals: List<Locale>) -> Translator,


### PR DESCRIPTION
This way it is not platform specific and can be moved to common



----
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
