### PR TITLE
add arrayAssertions for the new infix API

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arrayAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arrayAssertions.kt
@@ -11,6 +11,8 @@ import kotlin.jvm.JvmName
  * Use `feature(Array<out E>::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 fun <E> Expect<out Array<out E>>.asList(): Expect<List<E>> =
     ExpectImpl.changeSubject(this).unreported { it.asList() }
@@ -23,6 +25,8 @@ fun <E> Expect<out Array<out E>>.asList(): Expect<List<E>> =
  * Use `feature(Array<out E>::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<E>> =
     apply { asList().addAssertionsCreatedBy(assertionCreator) }
@@ -35,6 +39,8 @@ fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): E
  * Use `feature(Array<out E>::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("asListEOut")
 fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<out E>> =
@@ -47,6 +53,8 @@ fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit
  * Use `feature(ByteArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("byteArrAsList")
 fun Expect<ByteArray>.asList(): Expect<List<Byte>> =
@@ -60,6 +68,8 @@ fun Expect<ByteArray>.asList(): Expect<List<Byte>> =
  * Use `feature(ByteArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("byteArrAsList")
 fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Unit): Expect<ByteArray> =
@@ -73,6 +83,8 @@ fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Unit): E
  * Use `feature(CharArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("charArrAsList")
 fun Expect<CharArray>.asList(): Expect<List<Char>> =
@@ -86,6 +98,8 @@ fun Expect<CharArray>.asList(): Expect<List<Char>> =
  * Use `feature(CharArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("charArrAsList")
 fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Unit): Expect<CharArray> =
@@ -99,6 +113,8 @@ fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Unit): E
  * Use `feature(ShortArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("shortArrAsList")
 fun Expect<ShortArray>.asList(): Expect<List<Short>> =
@@ -112,6 +128,8 @@ fun Expect<ShortArray>.asList(): Expect<List<Short>> =
  * Use `feature(ShortArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("shortArrAsList")
 fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> Unit): Expect<ShortArray> =
@@ -125,6 +143,8 @@ fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> Unit):
  * Use `feature(IntArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("intArrAsList")
 fun Expect<IntArray>.asList(): Expect<List<Int>> = ExpectImpl.changeSubject(this).unreported { it.asList() }
@@ -137,6 +157,8 @@ fun Expect<IntArray>.asList(): Expect<List<Int>> = ExpectImpl.changeSubject(this
  * Use `feature(IntArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("intArrAsList")
 fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit): Expect<IntArray> =
@@ -150,6 +172,8 @@ fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit): Exp
  * Use `feature(LongArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("longArrAsList")
 fun Expect<LongArray>.asList(): Expect<List<Long>> =
@@ -163,6 +187,8 @@ fun Expect<LongArray>.asList(): Expect<List<Long>> =
  * Use `feature(LongArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("longArrAsList")
 fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Unit): Expect<LongArray> =
@@ -176,6 +202,8 @@ fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Unit): E
  * Use `feature(FloatArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("floatArrAsList")
 fun Expect<FloatArray>.asList(): Expect<List<Float>> =
@@ -189,6 +217,8 @@ fun Expect<FloatArray>.asList(): Expect<List<Float>> =
  * Use `feature(FloatArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("floatArrAsList")
 fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> Unit): Expect<FloatArray> =
@@ -202,6 +232,8 @@ fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> Unit):
  * Use `feature(DoubleArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("doubleArrAsList")
 fun Expect<DoubleArray>.asList(): Expect<List<Double>> =
@@ -215,6 +247,8 @@ fun Expect<DoubleArray>.asList(): Expect<List<Double>> =
  * Use `feature(DoubleArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("doubleArrAsList")
 fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -> Unit): Expect<DoubleArray> =
@@ -228,6 +262,8 @@ fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -> Unit
  * Use `feature(BooleanArray::asList)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("boolArrAsList")
 fun Expect<BooleanArray>.asList(): Expect<List<Boolean>> =
@@ -241,6 +277,8 @@ fun Expect<BooleanArray>.asList(): Expect<List<Boolean>> =
  * Use `feature(BooleanArray::asList, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.9.0
  */
 @JvmName("boolArrAsList")
 fun Expect<BooleanArray>.asList(assertionCreator: Expect<List<Boolean>>.() -> Unit): Expect<BooleanArray> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
@@ -1,0 +1,247 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import kotlin.jvm.JvmName
+
+/**
+ * Turns `Expect<Array<E>>` into `Expect<List<E>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(Array<out E>::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<E>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(Array<out E>::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<E>> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(Array<out E>::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("asListEOut")
+infix fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<out E>> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+/**
+ * Turns `Expect<CharArray>` into `Expect<List<Byte>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(ByteArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("byteArrAsList")
+infix fun Expect<ByteArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Byte>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(ByteArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("byteArrAsList")
+infix fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Unit): Expect<ByteArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<CharArray>` into `Expect<List<Char>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(CharArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("charArrAsList")
+infix fun Expect<CharArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Char>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(CharArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("charArrAsList")
+infix fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Unit): Expect<CharArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<ShortArray>` into `Expect<List<Short>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(ShortArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("shortArrAsList")
+infix fun Expect<ShortArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Short>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(ShortArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("shortArrAsList")
+infix fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> Unit): Expect<ShortArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<IntArray>` into `Expect<List<Int>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(IntArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("intArrAsList")
+infix fun Expect<IntArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Int>> = ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(IntArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("intArrAsList")
+infix fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit): Expect<IntArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<LongArray>` into `Expect<List<Double>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(LongArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("longArrAsList")
+infix fun Expect<LongArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Long>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(LongArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("longArrAsList")
+infix fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Unit): Expect<LongArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<FloatArray>` into `Expect<List<Float>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(FloatArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("floatArrAsList")
+infix fun Expect<FloatArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Float>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(FloatArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("floatArrAsList")
+infix fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> Unit): Expect<FloatArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<DoubleArray>` into `Expect<List<Double>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(DoubleArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("doubleArrAsList")
+infix fun Expect<DoubleArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Double>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(DoubleArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("doubleArrAsList")
+infix fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -> Unit): Expect<DoubleArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
+
+
+/**
+ * Turns `Expect<BooleanArray>` into `Expect<List<Boolean>>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(BooleanArray::asList)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("boolArrAsList")
+infix fun Expect<BooleanArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Boolean>> =
+    ExpectImpl.changeSubject(this).unreported { it.asList() }
+
+/**
+ * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * the subject as [List].
+ *
+ * The transformation as such is not reflected in reporting.
+ * Use `feature(BooleanArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ */
+@JvmName("boolArrAsList")
+infix fun Expect<BooleanArray>.asList(assertionCreator: Expect<List<Boolean>>.() -> Unit): Expect<BooleanArray> =
+    apply { asList(o).addAssertionsCreatedBy(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
@@ -8,9 +8,11 @@ import kotlin.jvm.JvmName
  * Turns `Expect<Array<E>>` into `Expect<List<E>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(Array<out E>::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<E>> =
     ExpectImpl.changeSubject(this).unreported { it.asList() }
@@ -20,9 +22,11 @@ infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(Array<out E>::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<E>> =
     apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
@@ -32,9 +36,11 @@ infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Un
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(Array<out E>::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("asListEOut")
 infix fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<out E>> =
@@ -44,9 +50,11 @@ infix fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -
  * Turns `Expect<CharArray>` into `Expect<List<Byte>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(ByteArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("byteArrAsList")
 infix fun Expect<ByteArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Byte>> =
@@ -57,9 +65,11 @@ infix fun Expect<ByteArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(ByteArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("byteArrAsList")
 infix fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Unit): Expect<ByteArray> =
@@ -70,9 +80,11 @@ infix fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Un
  * Turns `Expect<CharArray>` into `Expect<List<Char>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(CharArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("charArrAsList")
 infix fun Expect<CharArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Char>> =
@@ -83,9 +95,11 @@ infix fun Expect<CharArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(CharArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("charArrAsList")
 infix fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Unit): Expect<CharArray> =
@@ -96,9 +110,11 @@ infix fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Un
  * Turns `Expect<ShortArray>` into `Expect<List<Short>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(ShortArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("shortArrAsList")
 infix fun Expect<ShortArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Short>> =
@@ -109,9 +125,11 @@ infix fun Expect<ShortArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(ShortArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("shortArrAsList")
 infix fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> Unit): Expect<ShortArray> =
@@ -122,9 +140,11 @@ infix fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> 
  * Turns `Expect<IntArray>` into `Expect<List<Int>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(IntArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("intArrAsList")
 infix fun Expect<IntArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Int>> = ExpectImpl.changeSubject(this).unreported { it.asList() }
@@ -134,9 +154,11 @@ infix fun Expect<IntArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<Li
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(IntArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("intArrAsList")
 infix fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit): Expect<IntArray> =
@@ -147,9 +169,11 @@ infix fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit
  * Turns `Expect<LongArray>` into `Expect<List<Double>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(LongArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("longArrAsList")
 infix fun Expect<LongArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Long>> =
@@ -160,9 +184,11 @@ infix fun Expect<LongArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(LongArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("longArrAsList")
 infix fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Unit): Expect<LongArray> =
@@ -173,9 +199,11 @@ infix fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Un
  * Turns `Expect<FloatArray>` into `Expect<List<Float>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(FloatArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("floatArrAsList")
 infix fun Expect<FloatArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Float>> =
@@ -186,9 +214,11 @@ infix fun Expect<FloatArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(FloatArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("floatArrAsList")
 infix fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> Unit): Expect<FloatArray> =
@@ -199,9 +229,11 @@ infix fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> 
  * Turns `Expect<DoubleArray>` into `Expect<List<Double>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(DoubleArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("doubleArrAsList")
 infix fun Expect<DoubleArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Double>> =
@@ -212,9 +244,11 @@ infix fun Expect<DoubleArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(DoubleArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("doubleArrAsList")
 infix fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -> Unit): Expect<DoubleArray> =
@@ -225,9 +259,11 @@ infix fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -
  * Turns `Expect<BooleanArray>` into `Expect<List<Boolean>>`.
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(BooleanArray::asList)` if you want to show the transformation in reporting.
+ * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("boolArrAsList")
 infix fun Expect<BooleanArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<Boolean>> =
@@ -238,9 +274,11 @@ infix fun Expect<BooleanArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expec
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
- * Use `feature(BooleanArray::asList, assertionCreator)` if you want to show the transformation in reporting.
+ * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.11.0
  */
 @JvmName("boolArrAsList")
 infix fun Expect<BooleanArray>.asList(assertionCreator: Expect<List<Boolean>>.() -> Unit): Expect<BooleanArray> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ArrayAsListAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ArrayAsListAssertionsSpec.kt
@@ -27,34 +27,34 @@ class ArrayAsListAssertionsSpec : ch.tutteli.atrium.specs.integration.ArrayAsLis
 ) {
 
     companion object {
-        fun arrayInt(plant: Expect<Array<Int>>) = plant asList o
-        fun byteArray(plant: Expect<ByteArray>) = plant asList o
-        fun charArray(plant: Expect<CharArray>) = plant asList o
-        fun shortArray(plant: Expect<ShortArray>) = plant asList o
-        fun intArray(plant: Expect<IntArray>) = plant asList o
-        fun longArray(plant: Expect<LongArray>) = plant asList o
-        fun floatArray(plant: Expect<FloatArray>) = plant asList o
-        fun doubleArray(plant: Expect<DoubleArray>) = plant asList o
-        fun booleanArray(plant: Expect<BooleanArray>) = plant asList o
+        fun arrayInt(expect: Expect<Array<Int>>) = expect asList o
+        fun byteArray(expect: Expect<ByteArray>) = expect asList o
+        fun charArray(expect: Expect<CharArray>) = expect asList o
+        fun shortArray(expect: Expect<ShortArray>) = expect asList o
+        fun intArray(expect: Expect<IntArray>) = expect asList o
+        fun longArray(expect: Expect<LongArray>) = expect asList o
+        fun floatArray(expect: Expect<FloatArray>) = expect asList o
+        fun doubleArray(expect: Expect<DoubleArray>) = expect asList o
+        fun booleanArray(expect: Expect<BooleanArray>) = expect asList o
 
-        fun arrayIntWithCreator(plant: Expect<Array<Int>>, assertionCreator: Expect<List<Int>>.() -> Unit) =
-            plant asList assertionCreator
-        fun byteArrayWithCreator(plant: Expect<ByteArray>, assertionCreator: Expect<List<Byte>>.() -> Unit) =
-            plant asList assertionCreator
-        fun charArrayWithCreator(plant: Expect<CharArray>, assertionCreator: Expect<List<Char>>.() -> Unit) =
-            plant asList assertionCreator
-        fun shortArrayWithCreator(plant: Expect<ShortArray>, assertionCreator: Expect<List<Short>>.() -> Unit) =
-            plant asList assertionCreator
-        fun intArrayWithCreator(plant: Expect<IntArray>, assertionCreator: Expect<List<Int>>.() -> Unit) =
-            plant asList assertionCreator
-        fun longArrayWithCreator(plant: Expect<LongArray>, assertionCreator: Expect<List<Long>>.() -> Unit) =
-            plant asList assertionCreator
-        fun floatArrayWithCreator(plant: Expect<FloatArray>, assertionCreator: Expect<List<Float>>.() -> Unit) =
-            plant asList  assertionCreator
-        fun doubleArrayWithCreator(plant: Expect<DoubleArray>, assertionCreator: Expect<List<Double>>.() -> Unit) =
-            plant asList  assertionCreator
-        fun booleanArrayWithCreator(plant: Expect<BooleanArray>, assertionCreator: Expect<List<Boolean>>.() -> Unit) =
-            plant asList  assertionCreator
+        fun arrayIntWithCreator(expect: Expect<Array<Int>>, assertionCreator: Expect<List<Int>>.() -> Unit) =
+            expect asList { assertionCreator() }
+        fun byteArrayWithCreator(expect: Expect<ByteArray>, assertionCreator: Expect<List<Byte>>.() -> Unit) =
+            expect asList { assertionCreator() }
+        fun charArrayWithCreator(expect: Expect<CharArray>, assertionCreator: Expect<List<Char>>.() -> Unit) =
+            expect asList { assertionCreator() }
+        fun shortArrayWithCreator(expect: Expect<ShortArray>, assertionCreator: Expect<List<Short>>.() -> Unit) =
+            expect asList { assertionCreator() }
+        fun intArrayWithCreator(expect: Expect<IntArray>, assertionCreator: Expect<List<Int>>.() -> Unit) =
+            expect asList { assertionCreator() }
+        fun longArrayWithCreator(expect: Expect<LongArray>, assertionCreator: Expect<List<Long>>.() -> Unit) =
+            expect asList { assertionCreator() }
+        fun floatArrayWithCreator(expect: Expect<FloatArray>, assertionCreator: Expect<List<Float>>.() -> Unit) =
+            expect asList  { assertionCreator() }
+        fun doubleArrayWithCreator(expect: Expect<DoubleArray>, assertionCreator: Expect<List<Double>>.() -> Unit) =
+            expect asList  { assertionCreator() }
+        fun booleanArrayWithCreator(expect: Expect<BooleanArray>, assertionCreator: Expect<List<Boolean>>.() -> Unit) =
+            expect asList  { assertionCreator() }
     }
 
     @Suppress("unused", "UNUSED_VALUE")

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ArrayAsListAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ArrayAsListAssertionsSpec.kt
@@ -1,0 +1,84 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
+
+class ArrayAsListAssertionsSpec : ch.tutteli.atrium.specs.integration.ArrayAsListAssertionsSpec(
+    "asList",
+    Companion::arrayInt,
+    Companion::byteArray,
+    Companion::charArray,
+    Companion::shortArray,
+    Companion::intArray,
+    Companion::longArray,
+    Companion::floatArray,
+    Companion::doubleArray,
+    Companion::booleanArray,
+
+    Companion::arrayIntWithCreator,
+    Companion::byteArrayWithCreator,
+    Companion::charArrayWithCreator,
+    Companion::shortArrayWithCreator,
+    Companion::intArrayWithCreator,
+    Companion::longArrayWithCreator,
+    Companion::floatArrayWithCreator,
+    Companion::doubleArrayWithCreator,
+    Companion::booleanArrayWithCreator
+) {
+
+    companion object {
+        fun arrayInt(plant: Expect<Array<Int>>) = plant asList o
+        fun byteArray(plant: Expect<ByteArray>) = plant asList o
+        fun charArray(plant: Expect<CharArray>) = plant asList o
+        fun shortArray(plant: Expect<ShortArray>) = plant asList o
+        fun intArray(plant: Expect<IntArray>) = plant asList o
+        fun longArray(plant: Expect<LongArray>) = plant asList o
+        fun floatArray(plant: Expect<FloatArray>) = plant asList o
+        fun doubleArray(plant: Expect<DoubleArray>) = plant asList o
+        fun booleanArray(plant: Expect<BooleanArray>) = plant asList o
+
+        fun arrayIntWithCreator(plant: Expect<Array<Int>>, assertionCreator: Expect<List<Int>>.() -> Unit) =
+            plant asList assertionCreator
+        fun byteArrayWithCreator(plant: Expect<ByteArray>, assertionCreator: Expect<List<Byte>>.() -> Unit) =
+            plant asList assertionCreator
+        fun charArrayWithCreator(plant: Expect<CharArray>, assertionCreator: Expect<List<Char>>.() -> Unit) =
+            plant asList assertionCreator
+        fun shortArrayWithCreator(plant: Expect<ShortArray>, assertionCreator: Expect<List<Short>>.() -> Unit) =
+            plant asList assertionCreator
+        fun intArrayWithCreator(plant: Expect<IntArray>, assertionCreator: Expect<List<Int>>.() -> Unit) =
+            plant asList assertionCreator
+        fun longArrayWithCreator(plant: Expect<LongArray>, assertionCreator: Expect<List<Long>>.() -> Unit) =
+            plant asList assertionCreator
+        fun floatArrayWithCreator(plant: Expect<FloatArray>, assertionCreator: Expect<List<Float>>.() -> Unit) =
+            plant asList  assertionCreator
+        fun doubleArrayWithCreator(plant: Expect<DoubleArray>, assertionCreator: Expect<List<Double>>.() -> Unit) =
+            plant asList  assertionCreator
+        fun booleanArrayWithCreator(plant: Expect<BooleanArray>, assertionCreator: Expect<List<Boolean>>.() -> Unit) =
+            plant asList  assertionCreator
+    }
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var a1: Expect<Array<Int>> = notImplemented()
+        var a2: Expect<Array<out Int>> = notImplemented()
+        var a1b: Expect<Array<Int?>> = notImplemented()
+        var a2b: Expect<Array<out Int?>> = notImplemented()
+
+        var star: Expect<Array<*>> = notImplemented()
+
+        a1 asList o
+        a2 asList o
+
+        a1 = a1 asList { }
+        a2 = a2 asList { }
+
+        a1b asList o
+        a2b asList o
+
+        a1b = a1b asList { }
+        a2b = a2b asList { }
+
+        star asList o
+        star = star asList { }
+    }
+}


### PR DESCRIPTION
This PR addresses issue #226. @robstoll I have a couple of questions: 1) `change since 0.9.0 to 0.11.0` but currently there is no any `since` version. Should I just add `since 0.11.0` to every function added to `arrayAssertions`? 2) I'm not sure that I've properly updated infix methods to use filler object `o`.  Could you please check it? Also I've left description as is from fluent arrayAssertions. Please notify me if descriptions should be updated.
_______________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
