### PR TITLE
introduce helper functions for the parameter objects

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
@@ -35,17 +35,17 @@ val <T : CharSequence> Expect<T>.containsNot: NotCheckerOption<T, NotSearchBehav
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and [expected]
- * is defined as `'a'` and one [otherExpected] is defined as `'a'` as well, then both match, even though they match the
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and [expected]
+ * is defined as `"a"` and one [otherExpected] is defined as `"a"` as well, then both match, even though they match the
  * same sequence in the input of the search. Use the property `contains` to create a more sophisticated `contains`
  * assertion where you can use options such as [atLeast], [atMost] and [exactly] to control the number of occurrences
  * you expect.
  *
  * Meaning you might want to use:
- *   `contains.exactly(2).value('a')`
+ *   `contains.exactly(2).value("a")`
  * instead of:
- *   `contains('a', 'a')`
+ *   `contains("a", "a")`
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -76,9 +76,9 @@ fun <T : CharSequence> Expect<T>.containsNot(expected: Any, vararg otherExpected
  *
  * It is a shortcut for `contains.atLeast(1).regex(pattern, *otherPatterns)`.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and [pattern]
- * is defined as `'a(b)?'` and one of the [otherPatterns] is defined as `'a(b)?'` as well, then both match, even though
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and [pattern]
+ * is defined as `"a(b)?"` and one of the [otherPatterns] is defined as `"a(b)?"` as well, then both match, even though
  * they match the same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to
  * control the number of occurrences you expect.
  *
@@ -102,9 +102,9 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatt
  *
  * It is a shortcut for `contains.atLeast(1).regex(pattern, *otherPatterns)`.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and [pattern]
- * is defined as `'a(b)?'` and one of the [otherPatterns] is defined as `'a(b)?'` as well, then both match, even though
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and [pattern]
+ * is defined as `"a(b)?"` and one of the [otherPatterns] is defined as `"a(b)?"` as well, then both match, even though
  * they match the same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to
  * control the number of occurrences you expect.
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
@@ -19,7 +19,7 @@ import kotlin.jvm.JvmName
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
@@ -37,16 +37,16 @@ fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.value(expected: Any
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and [expected]
- * is defined as `'a'` and one [otherExpected] is defined as `'a'` as well, then both match, even though they match the
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and [expected]
+ * is defined as `"a"` and one [otherExpected] is defined as `"a"` as well, then both match, even though they match the
  * same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to control
  * the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `contains.exactly(2).value('a')`
+ *   `contains.exactly(2).value("a")`
  * instead of:
- *   `contains.atLeast(1).values('a', 'a')`
+ *   `contains.atLeast(1).values("a", "a")`
  *
  * @param expected The value which is expected to be contained within the input of the search.
  * @param otherExpected Additional values which are expected to be contained within the input of the search.
@@ -71,7 +71,7 @@ fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.values(
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
@@ -91,16 +91,16 @@ fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.value(
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and [expected]
- * is defined as `'a'` and one [otherExpected] is defined as `'a'` as well, then both match, even though they match the
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and [expected]
+ * is defined as `"a"` and one [otherExpected] is defined as `"a"` as well, then both match, even though they match the
  * same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to control
  * the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `contains.ignoringCase.exactly(2).value('a')`
+ *   `contains.ignoringCase.exactly(2).value("a")`
  * instead of:
- *   `contains.ignoringCase.atLeast(1).values('a', 'a')`
+ *   `contains.ignoringCase.atLeast(1).values("a", "a")`
  *
  * @param expected The value which is expected to be contained within the input of the search.
  * @param otherExpected Additional values which are expected to be contained within the input of the search.
@@ -126,7 +126,7 @@ fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.values(
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
@@ -147,9 +147,9 @@ fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.value(expected: A
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and [expected]
- * is defined as `'a'` and one [otherExpected] is defined as `'a'` as well, then both match, even though they match the
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and [expected]
+ * is defined as `"a"` and one [otherExpected] is defined as `"a"` as well, then both match, even though they match the
  * same sequence in the input of the search.
  *
  * @param expected The value which is expected to be contained within the input of the search.
@@ -169,9 +169,9 @@ fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.values(
  * Finishes the specification of the sophisticated `contains` assertion where the given regular expression [pattern]
  * as well as the [otherPatterns] are expected to have a match, using a non disjoint search.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and [pattern]
- * is defined as `'a(b)?'` and one of the [otherPatterns] is defined as `'a(b)?'` as well, then both match, even though
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and [pattern]
+ * is defined as `"a(b)?"` and one of the [otherPatterns] is defined as `"a(b)?"` as well, then both match, even though
  * they match the same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to
  * control the number of occurrences you expect.
  *
@@ -195,9 +195,9 @@ fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.regex(
  * Finishes the specification of the sophisticated `contains` assertion where the given [Regex] [pattern]
  * as well as the [otherPatterns] are expected to have a match, using a non disjoint search.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and [pattern]
- * is defined as `'a(b)?'` and one of the [otherPatterns] is defined as `'a(b)?'` as well, then both match, even though
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and [pattern]
+ * is defined as `"a(b)?"` and one of the [otherPatterns] is defined as `"a(b)?"` as well, then both match, even though
  * they match the same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to
  * control the number of occurrences you expect.
  *
@@ -224,16 +224,16 @@ fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.regex(
  * Finishes the specification of the sophisticated `contains` assertion where the given regular expression [pattern]
  * as well as the [otherPatterns] are expected to have a match (ignoring case), using a non disjoint search.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and [pattern]
- * is defined as `'a(b)?'` and one of the [otherPatterns] is defined as `'a(b)?'` as well, then both match, even though
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and [pattern]
+ * is defined as `"a(b)?"` and one of the [otherPatterns] is defined as `"a(b)?"` as well, then both match, even though
  * they match the same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly] to
  * control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `contains.ignoringCase.exactly(2).regex('a(b)?')`
+ *   `contains.ignoringCase.exactly(2).regex("a(b)?")`
  * instead of:
- *   `contains.ignoringCase.atLeast(1).regex('a(b)?', 'a(b)?')`
+ *   `contains.ignoringCase.atLeast(1).regex("a(b)?", "a(b)?")`
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
@@ -254,16 +254,16 @@ fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.regex(
  *
  * Delegates to `atLeast(1).regex(pattern, otherPatterns)`
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and [pattern]
- * is defined as `'a(b)?'` and one of the [otherPatterns] is defined as `'a(b)?'` as well, then both match, even though
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and [pattern]
+ * is defined as `"a(b)?"` and one of the [otherPatterns] is defined as `"a(b)?"` as well, then both match, even though
  * they match the same sequence in the input of the search. Use an option such as [atLeast], [atMost] and [exactly]
  * to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `contains.ignoringCase.exactly(2).regex('a(b)?')`
+ *   `contains.ignoringCase.exactly(2).regex("a(b)?")`
  * instead of:
- *   `contains.ignoringCase.atLeast(1).regex('a(b)?', 'a(b)?')`
+ *   `contains.ignoringCase.atLeast(1).regex("a(b)?", "a(b)?")`
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
@@ -286,7 +286,7 @@ fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.regex(
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expectedIterable The [Iterable] whose elements are expected to be contained within the input of the search.
  *
@@ -314,7 +314,7 @@ fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.elementsOf(
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expectedIterable The [Iterable] whose elements are expected to be contained within the input of the search.
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -29,14 +29,14 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
     ) {})
 
     include(object : Spek({
-        describe("elementsOf") {
+        describe("atLeast(1).elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {
                     expect("test").contains.atLeast(1).elementsOf(emptyList())
                 }.toThrow<IllegalArgumentException> { messageContains("Iterable without elements are not allowed") }
             }
         }
-        describe("elementsOf ignoring case") {
+        describe("ignoringCase.atLeast(1).elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {
                     expect("test").contains.ignoringCase.atLeast(1).elementsOf(emptyList())

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsSpecBase.kt
@@ -42,17 +42,42 @@ abstract class CharSequenceContainsSpecBase {
         a1.contains.atLeast(2).regex(Regex("bla"), Regex("b"))
         a1.contains.atLeast(2).elementsOf(listOf("a", 2))
 
+        a1.containsNot.value(1)
+        a1.containsNot.values("a", 1)
+        a1.containsNot.regex("h|b", "b")
+        a1.containsNot.regex(Regex("bla"))
+        a1.containsNot.regex(Regex("bla"), Regex("b"))
+        a1.containsNot.elementsOf(listOf("a", 2))
+
         a1.contains.ignoringCase.atLeast(1).value("a")
         a1.contains.ignoringCase.atLeast(1).values("a", 'b')
         a1.contains.ignoringCase.atLeast(1).regex("a")
         a1.contains.ignoringCase.atLeast(1).regex("a", "bl")
+        // not supported on purpose as one can specify an ignore case flag for Regex
+        // and hence these would be a second way to do the same thing
+        //a1.contains.ignoringCase.atLeast(1).regex(Regex("a"))
+        //a1.contains.ignoringCase.atLeast(1).regex(Regex("a"), Regex("bl"))
         a1.contains.ignoringCase.atLeast(1).elementsOf(listOf(1, 2))
+
+        a1.containsNot.ignoringCase.value("a")
+        a1.containsNot.ignoringCase.values("a", 'b')
+        a1.containsNot.ignoringCase.regex("a")
+        a1.containsNot.ignoringCase.regex("a", "bl")
+        // not supported on purpose as one can specify an ignore case flag for Regex
+        // and hence these would be a second way to do the same thing
+        //a1.containsNot.ignoringCase.regex(Regex("a"))
+        //a1.containsNot.ignoringCase.regex(Regex("a"), Regex("bl"))
+        a1.containsNot.ignoringCase.elementsOf(listOf(1, 2))
 
         // skip atLeast
         a1.contains.ignoringCase.value("a")
         a1.contains.ignoringCase.values("a", 'b')
         a1.contains.ignoringCase.regex("a")
         a1.contains.ignoringCase.regex("a", "bl")
+        // not supported on purpose as one can specify an ignore case flag for Regex
+        // and hence these would be a second way to do the same thing
+        //a1.contains.ignoringCase.regex(Regex("a"))
+        //a1.contains.ignoringCase.regex(Regex("a"), Regex("bl"))
         //TODO #422 uncomment
         //a1.contains.ignoringCase.elementsOf(listOf("a", 2))
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
@@ -21,9 +21,7 @@ class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec :
             a1: Group<Double>,
             a2: Group<Double>,
             aX: Array<out Group<Double>>
-        ): Expect<Iterable<Double>> {
-            return expect.contains.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
-        }
+        ): Expect<Iterable<Double>> = expect.contains.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
 
         private fun groupFactory(groups: Array<out Double>): Group<Double> =
             when (groups.size) {
@@ -43,9 +41,7 @@ class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec :
             a1: Group<Double?>,
             a2: Group<Double?>,
             aX: Array<out Group<Double?>>
-        ): Expect<Iterable<Double?>> {
-            return expect.contains.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
-        }
+        ): Expect<Iterable<Double?>> = expect.contains.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
 
         private fun nullableGroupFactory(groups: Array<out Double?>): Group<Double?> =
             when (groups.size) {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
@@ -57,22 +57,24 @@ infix fun <T : CharSequence> Expect<T>.contains(expected: Any): Expect<T> =
  * Expects that the subject of the assertion (a [CharSequence]) contains the [toString] representation of the
  * given [values] using a non disjoint search.
  *
- * It is a shortcut for `contains o atLeast 1 the Values(expected, *otherExpected)`.
+ * It is a shortcut for `contains o atLeast 1 the values(expected, *otherExpected)`.
  *
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and
- * [Values.expected] is defined as `'a'` and one [Values.otherExpected] is defined as `'a'` as well, then both match,
- * even though they match the same sequence in the input of the search. Use the property `contains` to create
- * a more sophisticated `contains` assertion where you can use options such as [atLeast], [atMost] and [exactly]
- * to control the number of occurrences you expect.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and
+ * [Values] is defined as `values("a", "a")`, then both match,
+ * even though they match the same sequence in the input of the search.
+ * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `contains o exactly 2 value 'a'`
+ *   `contains o exactly 2 value "a"`
  * instead of:
- *   `contains Values('a', 'a')`
+ *   `contains values("a", "a")`
+ *
+ * @param values The values which are expected to be contained within the input of the search
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -100,10 +102,12 @@ infix fun <T : CharSequence> Expect<T>.containsNot(expected: Any) =
  * Expects that the subject of the assertion (a [CharSequence]) does not contain the [toString] representation
  * of the given [values].
  *
- * It is a shortcut for `contains not the Values(expected, *otherExpected)`.
+ * It is a shortcut for `contains not the values(expected, *otherExpected)`.
  *
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
+ *
+ * @param values The values which should not be found -- use the function `values(t, ...)` to create a [Values].
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -129,7 +133,7 @@ infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: String): Expect<T>
  * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
  * regular expression [pattern].
  *
- * It is a shortcut for `contains o atLeast 1 regex pattern`.
+ * It is a shortcut for `contains o atLeast 1 matchFor pattern`.
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  *
@@ -143,20 +147,21 @@ infix fun <T : CharSequence> Expect<T>.contains(pattern: Regex): Expect<T> =
  * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
  * regular expression [patterns], using a non disjoint search.
  *
- * It is a shortcut for `contains o atLeast 1 the RegexPatterns(pattern, *otherPatterns)`.
+ * It is a shortcut for `contains o atLeast 1 the regexPatterns(pattern, *otherPatterns)`.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and
- * [RegexPatterns.expected] is defined as `'a(b)?'` and one of the [RegexPatterns.otherExpected] is defined
- * as `'a(b)?'` as well, then both match, even though they match the same sequence in the input of the search.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [RegexPatterns] is defined as `regexPatterns("a(b)?", "a(b)?")` as well, then both match,
+ * even though they match the same sequence in the input of the search.
  * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
  *   `contains o exactly 2 regex "a(b)?"`
  * instead of:
- *   `contains o atLeast 1 the RegexPatterns("a(b)?", "a(b)?")`
+ *   `contains o atLeast 1 the regexPatterns("a(b)?", "a(b)?")`
  *
- * @param patterns The patterns which are expected to have a match against the input of the search.
+ * @param patterns The patterns which are expected to have a match against the input of the search --
+ *   use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -165,23 +170,30 @@ infix fun <T : CharSequence> Expect<T>.containsRegex(patterns: RegexPatterns): E
     this contains o atLeast 1 the patterns
 
 /**
+ * Helper function to create a [RegexPatterns] based on the given [pattern] and [otherPatterns]
+ * -- allows to express `String, vararg String`.
+ */
+fun regexPatterns(pattern: String, vararg otherPatterns: String): RegexPatterns = RegexPatterns(pattern, otherPatterns)
+
+/**
  * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
  * regular expression [patterns], using a non disjoint search.
  *
  * It is a shortcut for `contains o atLeast 1 regex All(pattern, *otherPatterns)`.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and
- * [RegexPatterns.expected] is defined as `'a(b)?'` and one of the [RegexPatterns.otherExpected] is defined
- * as `'a(b)?'` as well, then both match, even though they match the same sequence in the input of the search.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [All] is defined as `all(Regex("a(b)?"), Regex("a(b)?"))` as well, then both match,
+ * even though they match the same sequence in the input of the search.
  * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
  *   `contains o exactly 2 regex "a(b)?"`
  * instead of:
- *   `contains o atLeast 1 the RegexPatterns("a(b)?", "a(b)?")`
+ *   `contains o atLeast 1 the all(Regex("a(b)?"), Regex("a(b)?"))`
  *
- * @param patterns The patterns which are expected to have a match against the input of the search.
+ * @param patterns The patterns which are expected to have a match against the input of the search --
+ *   use the function `all(Regex(...), ...)` to create a [All].
  *
  * @return This assertion container to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
@@ -17,12 +17,12 @@ import kotlin.jvm.JvmName
  * Finishes the specification of the sophisticated `contains` assertion where the [expected] object shall be searched,
  * using a non disjoint search.
  *
- * Delegates to `the Values(expected)`.
+ * Delegates to `the values(expected)`.
  *
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
@@ -31,7 +31,7 @@ import kotlin.jvm.JvmName
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.value(expected: Any): Expect<T> =
-    this the Values(expected)
+    this the values(expected)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the given [values]
@@ -40,18 +40,19 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.value(expecte
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and
- * [Values.expected] is defined as `'a'` and one [Values.otherExpected] is defined as `'a'` as well, then both match,
- * even though they match the same sequence in the input of the search. Use an option such as
- * [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and
+ * [Values] is defined as `values("a", "a")`, then both match,
+ * even though they match the same sequence in the input of the search.
+ * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `to contain exactly 2 the value 'a'`
+ *   `contains o exactly 2 the value "a"`
  * instead of:
- *   `to contain atLeast 1 the Values('a', 'a')`
+ *   `contains o atLeast 1 the values("a", "a")`
  *
- * @param values The values which are expected to be contained within the input of the search.
+ * @param values The values which should not be found within the input of the search
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -65,12 +66,12 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.the(values: V
  * Finishes the specification of the sophisticated `contains` assertion where the [expected] value shall be searched
  * (ignoring case), using a non disjoint search.
  *
- * Delegates to `the Values(expected)`.
+ * Delegates to `the values(expected)`.
  *
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
@@ -80,7 +81,7 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.the(values: V
  */
 @JvmName("valueIgnoringCase")
 infix fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.value(expected: Any): Expect<T> =
-    this the Values(expected)
+    this the values(expected)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the [values]
@@ -89,18 +90,19 @@ infix fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.value
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and
- * [Values.expected] is defined as `'a'` and one [Values.otherExpected] is defined as `'a'` as well, then both match,
- * even though they match the same sequence in the input of the search. Use an option such as
- * [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and
+ * [Values] is defined as `values("a", "a")`, then both match,
+ * even though they match the same sequence in the input of the search.
+ * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `to contain ignoring case exactly 2 the value 'a'`
+ *   `contains o ignoring case exactly 2 the value "a"`
  * instead of:
- *   `to contain ignoring case atLeast 1 the Values('a', 'a')`
+ *   `contains o ignoring case atLeast 1 the values("a", "a")`
  *
- * @param values The values which are expected to be contained within the input of the search.
+ * @param values The values which are expected to be contained within the input of the search
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -119,7 +121,7 @@ infix fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.the(v
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
@@ -137,18 +139,19 @@ infix fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.value(expec
  *
  * Delegates to `atLeast 1 the value`
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'a'` and
- * [Values.expected] is defined as `'a'` and one [Values.otherExpected] is defined as `'a'` as well, then both match,
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"a"` and
+ * [Values] is defined as `values("a", "a")`, then both match,
  * even though they match the same sequence in the input of the search.
  * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `to contain ignoring case exactly 2 the value 'a'`
+ *   `contains o ignoring case exactly 2 the value "a"`
  * instead of:
- *   `to contain ignoring case atLeast 1 the Values('a', 'a')`
+ *   `contains o ignoring case atLeast 1 the values("a", "a")`
  *
- * @param values The values which are expected to be contained within the input of the search.
+ * @param values The values which are expected to be contained within the input of the search
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -161,7 +164,7 @@ infix fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.the(values:
  * Finishes the specification of the sophisticated `contains` assertion where the given regular expression [pattern]
  * is expected to have a match, using a non disjoint search.
  *
- * Delegates to `the RegexPatterns(pattern)`.
+ * Delegates to `the regexPatterns(pattern)`.
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  *
@@ -169,13 +172,13 @@ infix fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.the(values:
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.regex(pattern: String): Expect<T> =
-    this the RegexPatterns(pattern)
+    this the regexPatterns(pattern)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the given [Regex] [pattern]
  * is expected to have a match.
  *
- * Delegates to `All(pattern)`
+ * Delegates to `matchFor all(pattern)`
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  *
@@ -186,25 +189,25 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.regex(pattern
  */
 infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.matchFor(
     pattern: Regex
-): Expect<T> = this matchFor All(pattern)
+): Expect<T> = this matchFor all(pattern)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the given regular expression [patterns]
  * are expected to have a match, using a non disjoint search.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and
- * [patterns].[pattern][RegexPatterns.expected] is defined as `'a(b)?'` and one of the
- * [patterns].[otherPatterns][RegexPatterns.otherExpected] is defined as `'a(b)?'` as well, then both match, even though
- * they match the same sequence in the input of the search.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [RegexPatterns] is defined as `regexPatterns("a(b)?", "a(b)?")` as well, then both match,
+ * even though they match the same sequence in the input of the search.
  * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `to contain exactly 2 the regex 'a(b)?'`
+ *   `contains o exactly 2 regex "a(b)?"`
  * instead of:
- *   `to contain atLeast 1 the RegexPatterns('a(b)?', 'a(b)?')`
+ *   `contains o atLeast 1 the regexPatterns("a(b)?", "a(b)?")`
  *
- * @param patterns The patterns which are expected to have a match against the input of the search.
+ * @param patterns The patterns which are expected to have a match against the input of the search
+ *   -- use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -216,19 +219,19 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.the(patterns:
  * Finishes the specification of the sophisticated `contains` assertion where the given [Regex] [patterns]
  * are expected to have a match, using a non disjoint search.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and the first
- * pattern in [patterns] is defined as `'a(b)?'` and one of the other patterns is defined as `'a(b)?'` as well,
- * then both match, even though they match the same sequence in the input of the search.
- * Use an option such as [atLeast], [atMost] and [exactly] to
- * control the number of occurrences you expect.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [All] is defined as `all(Regex("a(b)?"), Regex("a(b)?"))` as well, then both match,
+ * even though they match the same sequence in the input of the search.
+ * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `contains o exactly 2 matchFor Regex("a(b)?")`
+ *   `contains o exactly 2 regex "a(b)?"`
  * instead of:
- *   `contains o atLeast 1 matchFor All(Regex("a(b)?"), Regex("a(b)?"))
+ *   `contains o atLeast 1 the all(Regex("a(b)?"), Regex("a(b)?"))`
  *
- * @param patterns The patterns which are expected to have a match against the input of the search.
+ * @param patterns The patterns which are expected to have a match against the input of the search --
+ *   use the function `all(Regex(...), ...)` to create a [All].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -244,7 +247,7 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.matchFor(patt
  * Finishes the specification of the sophisticated `contains` assertion where the given regular expression [pattern]
  * is expected to have a match (ignoring case), using a non disjoint search.
  *
- * Delegates to `the RegexPatterns(pattern)`.
+ * Delegates to `the regexPatterns(pattern)`.
  *
  * @param pattern The patterns which is expected to have a match against the input of the search.
  *
@@ -253,25 +256,25 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.matchFor(patt
  */
 @JvmName("regexIgnoringCase")
 infix fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.regex(pattern: String): Expect<T> =
-    this the RegexPatterns(pattern)
+    this the regexPatterns(pattern)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the given regular expression [patterns]
  * are expected to have a match (ignoring case), using a non disjoint search.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and
- * [patterns].[pattern][RegexPatterns.expected] is defined as `'a(b)?'` and one of the
- * [patterns].[otherPatterns][RegexPatterns.otherExpected] is defined as `'a(b)?'` as well, then both match, even though
- * they match the same sequence in the input of the search.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [RegexPatterns] is defined as `regexPatterns("a(b)?", "a(b)?")` as well, then both match,
+ * even though they match the same sequence in the input of the search.
  * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `to contain ignoring case exactly 2 the regex 'a(b)?'`
+ *   `contains o ignoring case exactly 2 the regex "a(b)?"`
  * instead of:
- *   `to contain ignoring case atLeast 1 the RegexPatterns('a(b)?', 'a(b)?')`
+ *   `contains o ignoring case atLeast 1 the regexPatterns("a(b)?", "a(b)?")`
  *
- * @param patterns The patterns which are expected to have a match against the input of the search.
+ * @param patterns The patterns which are expected to have a match against the input of the search
+ *   -- use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -300,19 +303,19 @@ infix fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.regex(patte
  *
  * Delegates to `atLeast 1 the patterns`.
  *
- * By non disjoint is meant that `'aa'` in `'aaaa'` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `'ab'` and
- * [patterns].[pattern][RegexPatterns.expected] is defined as `'a(b)?'` and one of the
- * [patterns].[otherPatterns][RegexPatterns.otherExpected] is defined as `'a(b)?'` as well, then both match, even though
- * they match the same sequence in the input of the search.
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [RegexPatterns] is defined as `regexPatterns("a(b)?", "a(b)?")` as well, then both match,
+ * even though they match the same sequence in the input of the search.
  * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
- *   `to contain ignoring case exactly 2 the regex 'a(b)?'`
+ *   `contains o ignoring case exactly 2 the regex "a(b)?"`
  * instead of:
- *   `to contain ignoring case atLeast 1 the RegexPatterns('a(b)?', 'a(b)?')`
+ *   `contains o ignoring case atLeast 1 the RegexPatterns("a(b)?", "a(b)?")`
  *
- * @param patterns The patterns which are expected to have a match against the input of the search.
+ * @param patterns The patterns which are expected to have a match against the input of the search --
+ *   use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -324,13 +327,13 @@ infix fun <T : CharSequence> Builder<T, IgnoringCaseSearchBehaviour>.the(pattern
  * Finishes the specification of the sophisticated `contains` assertion where all elements of the [expectedIterable]
  * shall be searched, using a non disjoint search.
  *
- * Delegates to `the Values(expectedIterable.first(), *expectedIterable.drop(1).toTypedArray())`
+ * Delegates to `the values(expectedIterable.first(), *expectedIterable.drop(1).toTypedArray())`
  * (see [the] for more information).
  *
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expectedIterable The [Iterable] whose elements are expected to be contained within the input of the search.
  *
@@ -345,7 +348,7 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.elementsOf(
     expectedIterable: Iterable<Any>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)
-    return this the Values(first, *rest)
+    return this the Values(first, rest)
 }
 
 
@@ -353,13 +356,13 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.elementsOf(
  * Finishes the specification of the sophisticated `contains` assertion where all elements of the [expectedIterable]
  * shall be searched (ignoring case), using a non disjoint search.
  *
- * Delegates to `the Values(expectedIterable.first(), *expectedIterable.drop(1).toTypedArray())`
+ * Delegates to `the values(expectedIterable.first(), *expectedIterable.drop(1).toTypedArray())`
  * (see [the] for more information).
  *
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed (this
  * function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
  *
- * By non disjoint is meant that 'aa' in 'aaaa' is found three times and not only two times.
+ * By non disjoint is meant that "aa" in "aaaa" is found three times and not only two times.
  *
  * @param expectedIterable The [Iterable] whose elements are expected to be contained within the input of the search.
  *
@@ -375,5 +378,5 @@ infix fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.eleme
     expectedIterable: Iterable<Any>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)
-    return this the Values(first, *rest)
+    return this the Values(first, rest)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/All.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/All.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.domain.builders.utils.VarArgHelper
 
 /**
  * Parameter object to express `T, vararg T`.
+ *
+ * Use the function `all(t, ...)` to create this representation.
  */
-class All<out T>(override val expected: T, override vararg val otherExpected: T) :
-    VarArgHelper<T>
+class All<out T>(override val expected: T, override val otherExpected: Array<out T>) : VarArgHelper<T>

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entries.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entries.kt
@@ -17,6 +17,8 @@ import ch.tutteli.kbox.glue
  * In case `null` is used for an identification lambda then it is expected that the corresponding entry
  * is `null` as well.
  *
+ * Use the function `entries({ ... }, ...)` to create this representation.
+ *
  * @param assertionCreatorOrNull The identification lambda identifying the entry where an entry is considered
  *   to be identified if it holds all [Assertion]s the lambda might create.
  *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
@@ -24,7 +26,7 @@ import ch.tutteli.kbox.glue
  */
 class Entries<T>(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
-    vararg val otherAssertionCreatorsOrNulls: (Expect<T>.() -> Unit)?
+    val otherAssertionCreatorsOrNulls: Array<out (Expect<T>.() -> Unit)?>
 ) : GroupWithoutNullableEntries<(Expect<T>.() -> Unit)?>,
     GroupWithNullableEntries<(Expect<T>.() -> Unit)?>,
     VarArgHelper<(Expect<T>.() -> Unit)?> {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entry.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entry.kt
@@ -13,13 +13,16 @@ import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
  * In case `null` is used for the identification lambda then it is expected that the corresponding entry
  * is `null` as well.
  *
+ * Use the function `entry { ... }` to create this representation.
+ *
  * @param assertionCreatorOrNull The identification lambda identifying the entry where an entry is considered
  *   to be identified if it holds all [Assertion]s the lambda creates.
  *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
  */
-class Entry<T : Any>(
+data class Entry<T : Any>(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?
 ) : GroupWithoutNullableEntries<(Expect<T>.() -> Unit)?>,
     GroupWithNullableEntries<(Expect<T>.() -> Unit)?> {
+
     override fun toList(): List<(Expect<T>.() -> Unit)?> = listOf(assertionCreatorOrNull)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Pairs.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Pairs.kt
@@ -4,8 +4,10 @@ import ch.tutteli.atrium.domain.builders.utils.VarArgHelper
 
 /**
  * Parameter object to express `Pair<K, V>, vararg Pair<K, V>`.
+ *
+ * Use the function `pairs(x to y, ...)` to create this representation.
  */
 class Pairs<out K, out V>(
     override val expected: Pair<K, V>,
-    override vararg val otherExpected: Pair<K, V>
+    override val otherExpected: Array<out Pair<K, V>>
 ) : VarArgHelper<Pair<K, V>>

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
@@ -7,6 +7,8 @@ import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
 
 /**
  * Represents a [Group] with a single value.
+ *
+ * Use the function `value(t)` to create this representation.
  */
 data class Value<T>(val expected: T) : GroupWithNullableEntries<T>,
     GroupWithoutNullableEntries<T> {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Values.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Values.kt
@@ -10,12 +10,14 @@ import ch.tutteli.atrium.domain.builders.utils.VarArgHelper
 /**
  * Represents a [Group] of multiple values.
  *
+ * Use the function `values(t, ...)` to create this representation.
+ *
  * Note, [Values] will be made invariant once Kotlin 1.4 is out and Atrium depends on it (most likely with 1.0.0)
  */
 //TODO remove `out` with Kotlin 1.4 (most likely with Atrium 1.0.0)
 class Values<out T>(
     override val expected: T,
-    override vararg val otherExpected: T
+    override val otherExpected: Array<out T>
 ) : GroupWithoutNullableEntries<T>, GroupWithNullableEntries<T>, VarArgHelper<T> {
-    override fun toList() = listOf(expected, *otherExpected)
+    override fun toList(): List<T> = super.toList()
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/charsequence/RegexPatterns.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/charsequence/RegexPatterns.kt
@@ -4,8 +4,10 @@ import ch.tutteli.atrium.domain.builders.utils.VarArgHelper
 
 /**
  * Parameter object to express `String, vararg String` in the infix-api.
+ *
+ * Use the function `regexPatterns("pattern", ...)` to create this representation.
  */
-class RegexPatterns(pattern: String, vararg otherPatterns: String) :
+class RegexPatterns(pattern: String, otherPatterns: Array<out String>) :
     VarArgHelper<String> {
     override val expected = pattern
     override val otherExpected = otherPatterns

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/charsequence/contains.builders/impl/nameContainsNotFun.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/charsequence/contains.builders/impl/nameContainsNotFun.kt
@@ -8,5 +8,5 @@ import kotlin.reflect.KFunction2
 internal object StaticName {
     private val f: KFunction2<Expect<CharSequence>, Values<Any>, Expect<CharSequence>> =
         Expect<CharSequence>::containsNot
-    val nameContainsNotValuesFun = "`${f.name} ${Values::class.simpleName}`"
+    val nameContainsNotValuesFun = "`${f.name} values`"
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order.kt
@@ -2,14 +2,15 @@ package ch.tutteli.atrium.api.infix.en_GB.creating.iterable
 
 import ch.tutteli.atrium.domain.builders.utils.Group
 
-//TODO #63 introduce function in addition
 /**
  * Parameter object to express `Group<T>, Group<T>, vararg Group<T>` in the infix-api.
+ *
+ * Use the function `order(group, group, ...)` to create this representation.
  *
  * Notice, most probably the type parameter G will be removed in the future, will be fixed to [Group].
  */
 class Order<out T, out G : Group<T>>(
     val firstGroup: G,
     val secondGroup: G,
-    vararg val otherExpectedGroups: G
+    val otherExpectedGroups: Array<out G>
 )

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
@@ -19,5 +19,5 @@ internal object StaticName {
         Values<Double>,
         Expect<Iterable<Double>>
         > = IterableContains.CheckerOption<Double, Iterable<Double>, InAnyOrderSearchBehaviour>::the
-    val nameContainsNotValuesFun = "`${f.name} ${o::class.simpleName} ${fThe.name} ${Values::class.simpleName}`"
+    val nameContainsNotValuesFun = "`${f.name} ${o::class.simpleName} ${fThe.name} values`"
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator.kt
@@ -5,8 +5,10 @@ import ch.tutteli.atrium.creating.Expect
 /**
  * Parameter object to express a key/value [Pair] whose value type is a nullable lambda with an
  * [Expect] receiver, which means one can either pass a lambda or `null`.
+ *
+ * Use the function `keyValue(x) { ... }` to create this representation.
  */
-data class KeyValue<out K, V : Any>(val key: K, val valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?) {
+data class KeyWithValueCreator<out K, V : Any>(val key: K, val valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?) {
     fun toPair(): Pair<K, (Expect<V>.() -> Unit)?> = key to valueAssertionCreatorOrNull
     override fun toString(): String =
         "KeyValue(key=$key, value=${if (valueAssertionCreatorOrNull == null) "null" else "lambda"})"

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/genericHelperFunctions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/genericHelperFunctions.kt
@@ -1,0 +1,51 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.api.infix.en_GB.creating.*
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.Expect
+
+/**
+ * Helper function to create an [All] based on the given [t] and [ts]
+ * -- allows to express `T, vararg T`.
+ */
+fun <T> all(t: T, vararg ts: T) = All(t, ts)
+
+/**
+ * Helper function to create an [Entry] based on the given [assertionCreatorOrNull].
+ */
+fun <T : Any> entry(assertionCreatorOrNull: (Expect<T>.() -> Unit)?): Entry<T> = Entry(assertionCreatorOrNull)
+
+/**
+ * Helper function to create an [Entries] based on the given [assertionCreatorOrNull]
+ * and [otherAssertionCreatorsOrNulls] -- allows to express `{ }, vararg { }`.
+ *
+ * In case `null` is used for an identification lambda then it is expected that the corresponding entry
+ * is `null` as well.
+ *
+ * @param assertionCreatorOrNull The identification lambda identifying the entry where an entry is considered
+ *   to be identified if it holds all [Assertion]s the lambda might create.
+ *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
+ * @param otherAssertionCreatorsOrNulls A variable amount of additional identification lambdas or `null`s.
+ */
+fun <T : Any> entries(
+    assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
+    vararg otherAssertionCreatorsOrNulls: (Expect<T>.() -> Unit)?
+): Entries<T> = Entries(assertionCreatorOrNull, otherAssertionCreatorsOrNulls)
+
+
+/**
+ * Helper function to create a [Pairs] based on the given [pair] and [otherPairs]
+ * -- allows to express `Pair<K, V>, vararg Pair<K, V>`.
+ */
+fun <K, V> pairs(pair: Pair<K, V>, vararg otherPairs: Pair<K, V>): Pairs<K, V> = Pairs(pair, otherPairs)
+
+/**
+ * Helper function to create a [Value] based on the given [value].
+ */
+fun <T> value(value: T): Value<T> = Value(value)
+
+/**
+ * Helper function to create a [Values] based on the given [value] and [otherValues]
+ * -- allows to express `T, vararg T`.
+ */
+fun <T> values(value: T, vararg otherValues: T): Values<T> = Values(value, otherValues)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
@@ -1,11 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.api.infix.en_GB.creating.Entries
+import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.contains.builders.NotCheckerOption
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.contains.builders.impl.NotCheckerOptionImpl
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.creating.SubjectProvider
 import ch.tutteli.atrium.domain.builders.ExpectImpl
 import ch.tutteli.atrium.domain.creating.iterable.contains.IterableContains
 import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
@@ -102,18 +101,20 @@ infix fun <E, T : Iterable<E>> Expect<T>.contains(expected: E) =
 /**
  * Expects that the subject of the assertion (an [Iterable]) contains the expected [values].
  *
- * It is a shortcut for `contains o inAny order atLeast 1 the Values(...)`
+ * It is a shortcut for `contains o inAny order atLeast 1 the values(...)`
  *
  * Notice, that it does not search for unique matches. Meaning, if the iterable is `setOf('a', 'b')` and
- * [values].[expected][Values.expected] is defined as `'a'` and
- * one [values].[otherExpected][Values.otherExpected] is defined as `'a'` as well, then both match,
- * even though they match the same entry. Use an option such as [atLeast], [atMost] and [exactly] to control the
- * number of occurrences you expect.
+ * [Values] is defined as `values("a", "a")`, then both match,
+ * even though they match the same sequence in the input of the search.
+ * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
  *    contains o inAny order exactly 2 value 'a'`
  * instead of:
- *   `contains Values('a', 'a')`
+ *   `contains values('a', 'a')`
+ *
+ * @param values The values which are expected to be contained within the [Iterable]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -139,20 +140,22 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull:
     it contains o inAny order atLeast 1 entry assertionCreatorOrNull
 
 /**
- * Makes the assertion that the [Assert.subject][SubjectProvider.subject] contains an entry holding the
+ *  Expects that the subject of the assertion (an [Iterable]) contains an entry holding the
  * assertions created by [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] or an entry
  * which is `null` in case [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull]
  * is defined as `null` -- likewise an entry (can be the same) is searched for each of the
  * [entries].[otherAssertionCreatorsOrNulls][Entries.otherAssertionCreatorsOrNulls].
  *
- * It is a shortcut for `contains o inAny order atLeast 1 the Entries(...)`
+ * It is a shortcut for `contains o inAny order atLeast 1 the entries({ ... }, ...)`
+ *
+ * @param entries The entries which are expected to be contained within the [Iterable]
+ *   -- use the function `entries(t, ...)` to create an [Entries].
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-infix fun <E : Any, T : Iterable<E?>> Expect<T>.contains(
-    entries: Entries<E>
-): Expect<T> = it contains o inAny order atLeast 1 the entries
+infix fun <E : Any, T : Iterable<E?>> Expect<T>.contains(entries: Entries<E>): Expect<T> =
+    it contains o inAny order atLeast 1 the entries
 
 /**
  * Expects that the subject of the assertion (an [Iterable]) contains only
@@ -175,6 +178,9 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E): Expect<T>
  * Note that we might change the signature of this function with the next version
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
+ *
+ * @param values The values which are expected to be contained within the [Iterable]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -200,8 +206,9 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsExactly(values: Values<E>): Exp
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
-    it contains o inGiven order and only entry assertionCreatorOrNull
+infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
+    assertionCreatorOrNull: (Expect<E>.() -> Unit)?
+): Expect<T> = it contains o inGiven order and only entry assertionCreatorOrNull
 
 /**
  * Expects that the subject of the assertion (an [Iterable]) contains only an entry holding
@@ -216,6 +223,9 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(assertionCreator
  * Note that we might change the signature of this function with the next version
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
+ *
+ * @param entries The entries which are expected to be contained within the [Iterable]
+ *   -- use the function `entries(t, ...)` to create an [Entries].
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -237,7 +247,10 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E): Expect<T> =
 /**
  * Expects that the subject of the assertion (an [Iterable]) does not contain the expected [values].
  *
- *  It is a shortcut for `containsNot o the Values(...)`
+ *  It is a shortcut for `containsNot o the values(...)`
+ *
+ * @param values The values which should not be contained within the [Iterable]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInAnyOrderCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInAnyOrderCreators.kt
@@ -14,7 +14,7 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAn
  * Finishes the specification of the sophisticated `contains` assertion where the [expected]
  * value shall be searched within the [Iterable].
  *
- * Delegates to [values].
+ * Delegates to `the values(expected)`.
  *
  * @param expected The value which is expected to be contained within this [Iterable].
  *
@@ -22,24 +22,24 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAn
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <E, T : Iterable<E>> CheckerOption<E, T, InAnyOrderSearchBehaviour>.value(expected: E): Expect<T> =
-    this the Values(expected)
+    this the values(expected)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the expected [values]
  * shall be searched within the [Iterable].
  *
  * Notice, that it does not search for unique matches. Meaning, if the iterable is `setOf('a', 'b')` and
- * [values].[expected][Values.expected] is defined as `'a'` and one
- * [values].[otherExpected][Values.otherExpected] is defined as `'a'` as well, then both match,
- * even though they match the same entry. Use an option such as [atLeast], [atMost] and [exactly] to control the
- * number of occurrences you expect.
+ * [Values] is defined as `values("a", "a")`, then both match,
+ * even though they match the same sequence in the input of the search.
+ * Use an option such as [atLeast], [atMost] and [exactly] to control the number of occurrences you expect.
  *
  * Meaning you might want to use:
  *   `to contain inAny order exactly 2 value 'a'`
  * instead of:
- *   `to contain inAny order exactly 1 the Values('a', 'a')`
+ *   `to contain inAny order exactly 1 the values('a', 'a')`
  *
- * @param values The values which are expected to be contained within the [Iterable].
+ * @param values The values which are expected to be contained within the [Iterable]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return The [AssertionPlant] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -52,7 +52,7 @@ infix fun <E, T : Iterable<E>> CheckerOption<E, T, InAnyOrderSearchBehaviour>.th
  * holds all assertions [assertionCreatorOrNull] creates or needs to be `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
- * Delegates to [entries].
+ * Delegates to `the entries(assertionCreatorOrNull)`
  *
  * @param assertionCreatorOrNull The identification lambda which creates the assertions which the entry we are looking
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
@@ -63,9 +63,7 @@ infix fun <E, T : Iterable<E>> CheckerOption<E, T, InAnyOrderSearchBehaviour>.th
  */
 infix fun <E : Any, T : Iterable<E?>> CheckerOption<E?, T, InAnyOrderSearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
-): Expect<T> = this the Entries(
-    assertionCreatorOrNull
-)
+): Expect<T> = this the entries(assertionCreatorOrNull)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where an entry shall be searched which either
@@ -74,7 +72,8 @@ infix fun <E : Any, T : Iterable<E?>> CheckerOption<E?, T, InAnyOrderSearchBehav
  * is defined as `null` -- likewise an entry (can be the same) is searched for each of
  * the [entries].[otherAssertionCreatorsOrNulls][Entries.otherAssertionCreatorsOrNulls].
  *
- * @param entries The parameter object which contains the identification lambdas.
+ * @param entries The entries which are expected to be contained within the [Iterable]
+ *   -- use the function `entries(t, ...)` to create an [Entries].
  *
  * @return The [AssertionPlant] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -102,5 +101,5 @@ inline infix fun <reified E, T : Iterable<E>> CheckerOption<E, T, InAnyOrderSear
     expectedIterable: Iterable<E>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)
-    return this the Values(first, *rest)
+    return this the Values(first, rest)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInAnyOrderOnlyCreators.kt
@@ -13,7 +13,7 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAn
  * Finishes the specification of the sophisticated `contains` assertion where the [Iterable] needs to contain only the
  * [expected] value.
  *
- * Delegates to [values].
+ * Delegates to `the values(expected)`.
  *
  * Note that we might change the signature of this function with the next version
  * which will cause a binary backward compatibility break (see
@@ -25,7 +25,7 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAn
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <E, T : Iterable<E>> Builder<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
-    this the Values(expected)
+    this the values(expected)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the expected [values]
@@ -35,21 +35,21 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InAnyOrderOnlySearchBehaviour>.valu
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
  *
- * @param values The values which are expected to be contained within the [Iterable].
+ * @param values The values which are expected to be contained within the [Iterable]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-infix fun <E, T : Iterable<E>> Builder<E, T, InAnyOrderOnlySearchBehaviour>.the(
-    values: Values<E>
-): Expect<T> = addAssertion(ExpectImpl.iterable.contains.valuesInAnyOrderOnly(this, values.toList()))
+infix fun <E, T : Iterable<E>> Builder<E, T, InAnyOrderOnlySearchBehaviour>.the(values: Values<E>): Expect<T> =
+    addAssertion(ExpectImpl.iterable.contains.valuesInAnyOrderOnly(this, values.toList()))
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the [Iterable] needs to contain only one
  * entry which holds all assertions created by the given [assertionCreatorOrNull] or is `null` in case
  * [assertionCreatorOrNull] is defined as `null`.
  *
- * Delegates to [entries].
+ * Delegates to `the entries(assertionCreatorOrNull)`
  *
  * Note that we might change the signature of this function with the next version
  * which will cause a binary backward compatibility break (see
@@ -64,9 +64,7 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InAnyOrderOnlySearchBehaviour>.the(
  */
 infix fun <E : Any, T : Iterable<E?>> Builder<E?, T, InAnyOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
-): Expect<T> = this the Entries(
-    assertionCreatorOrNull
-)
+): Expect<T> = this the entries(assertionCreatorOrNull)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where an entry needs to be contained in the
@@ -80,7 +78,7 @@ infix fun <E : Any, T : Iterable<E?>> Builder<E?, T, InAnyOrderOnlySearchBehavio
  * Notice, that a first-wins strategy applies which means your assertion creator lambdas -- which kind of serve as
  * identification lambdas -- should be ordered in such a way that the most specific identification lambda appears
  * first, not that a less specific lambda wins. For instance, given a `setOf(1, 2)` you should not search for
- * `Entries({ isGreaterThan(0) }, { toBe(1) })` but for `Entries({ toBe(1) }, { isGreaterThan(0) })`
+ * `entries({ isGreaterThan(0) }, { toBe(1) })` but for `entries({ toBe(1) }, { isGreaterThan(0) })`
  * otherwise `isGreaterThan(0)` matches `1` before `toBe(1)` would match it. As a consequence `toBe(1)` could
  * only match the entry which is left -- in this case `2` -- and of course this would fail.
  *
@@ -88,7 +86,8 @@ infix fun <E : Any, T : Iterable<E?>> Builder<E?, T, InAnyOrderOnlySearchBehavio
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
  *
- * @param entries The parameter object containing the identification lambdas.
+ * @param entries The entries which are expected to be contained within the [Iterable]
+ *   -- use the function `entries(t, ...)` to create an [Entries].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -121,5 +120,5 @@ inline infix fun <reified E, T : Iterable<E>> Builder<E, T, InAnyOrderOnlySearch
     expectedIterable: Iterable<E>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)
-    return this the Values(first, *rest)
+    return this the Values(first, rest)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInOrderOnlyCreators.kt
@@ -14,7 +14,7 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InOr
  * Finishes the specification of the sophisticated `contains` assertion where the [Iterable] needs to contain only the
  * [expected] value.
  *
- * Delegates to [values].
+ * Delegates to `the values(expected)`.
  *
  * Note that we might change the signature of this function with the next version
  * which will cause a binary backward compatibility break (see
@@ -26,7 +26,7 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InOr
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <E, T : Iterable<E>> Builder<E, T, InOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
-    this the Values(expected)
+    this the values(expected)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the [Iterable] needs to contain only the
@@ -36,7 +36,8 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InOrderOnlySearchBehaviour>.value(e
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
  *
- * @param values The nullable values which are expected to be contained within the [Iterable].
+ * @param values The values which are expected to be contained within the [Iterable]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return The [AssertionPlant] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -49,7 +50,7 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InOrderOnlySearchBehaviour>.the(val
  * single entry which holds all assertions created by the given [assertionCreatorOrNull] or needs to be `null`
  * in case [assertionCreatorOrNull] is defined as `null`.
  *
- * Delegates to `entries(assertionCreatorOrNull)`.
+ * Delegates to `the entries(assertionCreatorOrNull)`.
  *
  * Note that we might change the signature of this function with the next version
  * which will cause a binary backward compatibility break (see
@@ -64,9 +65,7 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InOrderOnlySearchBehaviour>.the(val
  */
 infix fun <E : Any, T : Iterable<E?>> Builder<E?, T, InOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
-): Expect<T> = this the Entries(
-    assertionCreatorOrNull
-)
+): Expect<T> = this the entries(assertionCreatorOrNull)
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the [Iterable] needs to contain only an
@@ -80,7 +79,8 @@ infix fun <E : Any, T : Iterable<E?>> Builder<E?, T, InOrderOnlySearchBehaviour>
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
  *
- * @param entries The parameter object containing the identification lambdas.
+ * @param entries The entries which are expected to be contained within the [Iterable]
+ *   -- use the function `entries(t, ...)` to create an [Entries].
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -112,5 +112,5 @@ inline infix fun <reified E, T : Iterable<E>> Builder<E, T, InOrderOnlySearchBeh
     expectedIterable: Iterable<E>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)
-    return this the Values(first, *rest)
+    return this the Values(first, rest)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableContainsInOrderOnlyGroupedCreators.kt
@@ -15,7 +15,9 @@ import kotlin.jvm.JvmName
  * the [Order.secondGroup] and optionally [Order.otherExpectedGroups] of values need to be
  * contained in [Iterable] in the specified order whereas the values within the groups can occur in any order.
  *
- * @param order A parameter object containing the different groups which have to appear in order in the [Iterable].
+ * @param order A parameter object containing the different groups which have to appear in order in the [Iterable]
+ *   -- use `order(group, group, ...)` to create an [Order] where group is either `value(e)` or `values(e, ...)`;
+ *   so a call could look as follows: `inAny order(values(1, 2), value(2), values(3, 2))
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -30,6 +32,15 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InOrderOnlyGroupedWithinSearchBehav
 )
 
 /**
+ * Helper function to create an [Order] based on the given [firstGroup], [secondGroup] and [otherExpectedGroups].
+ */
+fun <E> order(
+    firstGroup: Group<E>,
+    secondGroup: Group<E>,
+    vararg otherExpectedGroups: Group<E>
+): Order<E, Group<E>> = Order(firstGroup, secondGroup, otherExpectedGroups)
+
+/**
  * Finishes the specification of the sophisticated `contains` assertion where the expected [Order.firstGroup] as well as
  * the [Order.secondGroup] and optionally [Order.otherExpectedGroups] of identification lambdas, identifying an entry,
  * need to be contained in [Iterable] in the specified order whereas the identification lambdas within the groups
@@ -37,7 +48,15 @@ infix fun <E, T : Iterable<E>> Builder<E, T, InOrderOnlyGroupedWithinSearchBehav
  *
  * An identification lambda can also be defined as `null` in which case it matches an entry which is `null` as well.
  *
- * @param order A parameter object containing the different groups which have to appear in order in the [Iterable].
+ * @param order A parameter object containing the different groups which have to appear in order in the [Iterable]
+ *   -- use `order(group, group, ...)` to create an [Order] where group is either `entry { ... }` or
+ *   `entries({ ... }, ...)`; so a call could look as follows:
+ *   ```
+ *   inAny order(
+ *     entry { it toBe 1 },
+ *     entries({ it lessThan 2 }, {it toBe 3 })
+ *   )
+ *   ```
  *
  * @return The [Expect] for which the assertion was built to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableAssertions.kt
@@ -36,7 +36,7 @@ infix fun <T : Throwable> Expect<T>.message(assertionCreator: Expect<String>.() 
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <T : Throwable> Expect<T>.messageContains(expected: Any): Expect<T> =
-    this messageContains Values(expected)
+    this messageContains values(expected)
 
 /**
  * Expects that the property [Throwable.message] of the subject of the assertion is not null and contains
@@ -44,6 +44,9 @@ infix fun <T : Throwable> Expect<T>.messageContains(expected: Any): Expect<T> =
  **
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed
  * (this function expects `Any` for your convenience, so that you can mix [String] and [Int] for instance).
+ *
+ * @param values The values which are expected to be contained within [Throwable.message]
+ *   -- use the function `values(t, ...)` to create a [Values].
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -60,7 +63,6 @@ infix fun <T : Throwable> Expect<T>.messageContains(values: Values<Any>): Expect
  *
  * @since 0.11.0
  */
-@Suppress("RemoveExplicitTypeArguments")
 inline fun <reified TExpected : Throwable> Expect<out Throwable>.cause(): Expect<TExpected> =
     ExpectImpl.throwable.cause(this, TExpected::class).getExpectOfFeature()
 
@@ -77,7 +79,6 @@ inline fun <reified TExpected : Throwable> Expect<out Throwable>.cause(): Expect
  *
  * @since 0.11.0
  */
-@Suppress("RemoveExplicitTypeArguments")
 inline infix fun <reified TExpected : Throwable> Expect<out Throwable>.cause(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import org.spekframework.spek2.Spek
@@ -30,14 +29,14 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
     ) {})
 
     include(object : Spek({
-        describe("elementsOf") {
+        describe("atLeast 1 elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {
                     expect("test") contains o atLeast 1 elementsOf emptyList()
                 }.toThrow<IllegalArgumentException> { it messageContains "Iterable without elements are not allowed" }
             }
         }
-        describe("elementsOf ignoring case") {
+        describe("ignoring case atLeast 1 elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {
                     expect("test") contains o ignoring case atLeast 1 elementsOf emptyList()
@@ -60,10 +59,7 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
             aX: Array<out Any>
         ): Expect<CharSequence> =
             if (aX.isEmpty()) expect contains o atLeast atLeast value a
-            else expect contains o atLeast atLeast the Values(
-                a,
-                *aX
-            )
+            else expect contains o atLeast atLeast the values(a, *aX)
 
         internal fun getAtLeastElementsOfTriple() =
             atLeastDescr to ("$contains o $atLeast" to Companion::containsAtLeastElementsOf)
@@ -92,14 +88,8 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
                 if (atLeast == 1) expect contains o ignoring case value a
                 else expect contains o ignoring case atLeast atLeast value a
             } else {
-                if (atLeast == 1) expect contains o ignoring case the Values(
-                    a,
-                    *aX
-                )
-                else expect contains o ignoring case atLeast atLeast the Values(
-                    a,
-                    *aX
-                )
+                if (atLeast == 1) expect contains o ignoring case the values(a, *aX)
+                else expect contains o ignoring case atLeast atLeast the values(a, *aX)
             }
 
         private fun getAtLeastIgnoringCaseElementsOfTriple() =
@@ -139,10 +129,7 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
             aX: Array<out Any>
         ) =
             if (aX.isEmpty()) expect contains o atLeast atLeast butAtMost butAtMost value a
-            else expect contains o atLeast atLeast butAtMost butAtMost the Values(
-                a,
-                *aX
-            )
+            else expect contains o atLeast atLeast butAtMost butAtMost the values(a, *aX)
 
         private val atLeastButAtMostIgnoringCaseDescr = { what: String, timesAtLeast: String, timesAtMost: String ->
             "$contains $ignoringCase $what $atLeast $timesAtLeast $butAtMost $timesAtMost"
@@ -159,10 +146,7 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
             aX: Array<out Any>
         ) =
             if (aX.isEmpty()) expect contains o ignoring case atLeast atLeast butAtMost butAtMost value a
-            else expect contains o ignoring case atLeast atLeast butAtMost butAtMost the Values(
-                a,
-                *aX
-            )
+            else expect contains o ignoring case atLeast atLeast butAtMost butAtMost the values(a, *aX)
 
         private fun getAtLeastButAtMostIgnoringCaseElementsOfTriple() =
             atLeastButAtMostIgnoringCaseDescr to ("$contains o $ignoringCase $atLeast $butAtMost" to Companion::containsAtLeastButAtMostIgnoringCaseElementsOf)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 
 
@@ -21,10 +20,7 @@ class CharSequenceContainsAtMostAssertionsSpec :
 
         private fun containsAtMost(expect: Expect<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains o atMost atMost value a
-            else expect contains o atMost atMost the Values(
-                a,
-                *aX
-            )
+            else expect contains o atMost atMost the values(a, *aX)
 
         private fun getAtMostIgnoringCaseTriple() =
             { what: String, times: String -> "$contains $ignoringCase $what $atMost $times" } to
@@ -32,10 +28,7 @@ class CharSequenceContainsAtMostAssertionsSpec :
 
         private fun containsAtMostIgnoringCase(expect: Expect<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains o ignoring case atMost atMost value a
-            else expect contains o ignoring case atMost atMost the Values(
-                a,
-                *aX
-            )
+            else expect contains o ignoring case atMost atMost the values(a, *aX)
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.notImplemented
@@ -28,42 +27,30 @@ class CharSequenceContainsContainsNotAssertionsSpec : Spek({
 
         private fun containsBuilder(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains o atLeast 1 value a
-            else expect contains o atLeast 1 the Values(
-                a,
-                *aX
-            )
+            else expect contains o atLeast 1 the values(a, *aX)
 
         private fun getContainsNotPair() = "$containsNot o $atLeast 1 value/the Values" to Companion::containsNotBuilder
         private fun containsNotBuilder(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect containsNot o value a
-            else expect containsNot o the Values(
-                a,
-                *aX
-            )
+            else expect containsNot o the values(a, *aX)
 
         private fun getContainsShortcutPair() = fun2<CharSequence, Any, Array<out Any>>(Companion::contains)
         private fun getContainsNotShortcutPair() = fun2<CharSequence, Any, Array<out Any>>(Companion::containsNot)
 
         private fun contains(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains a
-            else expect contains Values(
-                a,
-                *aX
-            )
+            else expect contains values(a, *aX)
 
         private fun containsNot(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect containsNot a
-            else expect containsNot Values(
-                a,
-                *aX
-            )
+            else expect containsNot values(a, *aX)
     }
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         val a1: Expect<String> = notImplemented()
 
-        a1 contains Values(1, "a", 'c')
-        a1 containsNot Values(1, "a", 'c')
+        a1 contains values(1, "a", 'c')
+        a1 containsNot values(1, "a", 'c')
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 
 class CharSequenceContainsExactlyAssertionsSpec :
@@ -19,10 +18,7 @@ class CharSequenceContainsExactlyAssertionsSpec :
 
         private fun containsExactly(expect: Expect<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains o exactly exactly value a
-            else expect contains o exactly exactly the Values(
-                a,
-                *aX
-            )
+            else expect contains o exactly exactly the values(a, *aX)
 
         private fun getExactlyIgnoringCaseTriple() =
             { what: String, times: String -> "$contains $ignoringCase $what $exactly $times" } to
@@ -36,10 +32,7 @@ class CharSequenceContainsExactlyAssertionsSpec :
             aX: Array<out Any>
         ) =
             if (aX.isEmpty()) expect contains o ignoring case exactly exactly value a
-            else expect contains o ignoring case exactly exactly the Values(
-                a,
-                *aX
-            )
+            else expect contains o ignoring case exactly exactly the values(a, *aX)
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
         private fun getErrorMsgContainsNot(times: Int) = "use `$containsNotValues` instead of `$exactly $times`"

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 
 class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.specs.integration.CharSequenceContainsNotAssertionsSpec(
@@ -17,10 +16,7 @@ class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.specs.integratio
 
         private fun containsNotFun(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect containsNot o value a
-            else expect containsNot o the Values(
-                a,
-                *aX
-            )
+            else expect containsNot o the values(a, *aX)
 
         private fun getContainsNotIgnoringCaseTriple() =
             { what: String -> "$containsNotValues $ignoringCase $what" } to
@@ -28,9 +24,6 @@ class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.specs.integratio
 
         private fun containsNotIgnoringCase(expect: Expect<CharSequence>, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect containsNot o ignoring case value a
-            else expect containsNot o ignoring case the Values(
-                a,
-                *aX
-            )
+            else expect containsNot o ignoring case the values(a, *aX)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsNotOrAtMostAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsNotOrAtMostAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 
 class CharSequenceContainsNotOrAtMostAssertionsSpec :
@@ -19,10 +18,7 @@ class CharSequenceContainsNotOrAtMostAssertionsSpec :
 
         private fun containsNotOrAtMost(expect: Expect<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>) =
             if (aX.isEmpty()) expect contains o notOrAtMost atMost value a
-            else expect contains o notOrAtMost atMost the Values(
-                a,
-                *aX
-            )
+            else expect contains o notOrAtMost atMost the values(a, *aX)
 
         private fun getNotOrAtMostIgnoringCaseTriple() =
             { what: String, times: String -> "$contains $ignoringCase $what $notOrAtMost $times" } to
@@ -35,10 +31,7 @@ class CharSequenceContainsNotOrAtMostAssertionsSpec :
             aX: Array<out Any>
         ) =
             if (aX.isEmpty()) expect contains o ignoring case notOrAtMost atMost value a
-            else expect contains o ignoring case notOrAtMost atMost the Values(
-                a,
-                *aX
-            )
+            else expect contains o ignoring case notOrAtMost atMost the values(a, *aX)
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -1,7 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.All
-import ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.RegexPatterns
 import ch.tutteli.atrium.creating.Expect
 import org.spekframework.spek2.Spek
 
@@ -50,17 +48,11 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
             aX: Array<out String>
         ) =
             if (aX.isEmpty()) expect contains o atLeast atLeast regex a
-            else expect contains o atLeast atLeast the RegexPatterns(
-                a,
-                *aX
-            )
+            else expect contains o atLeast atLeast the regexPatterns(a, *aX)
 
         private fun containsAtLeastRegex(expect: Expect<CharSequence>, atLeast: Int, a: String, aX: Array<out String>) =
             if (aX.isEmpty()) expect contains o atLeast atLeast matchFor Regex(a)
-            else expect contains o atLeast atLeast matchFor All(
-                Regex(a),
-                *aX.map { it.toRegex() }.toTypedArray()
-            )
+            else expect contains o atLeast atLeast matchFor all(Regex(a), *aX.map { it.toRegex() }.toTypedArray())
 
         private fun getAtLeastIgnoringCaseTripleString() =
             { what: String, times: String -> "$contains $ignoringCase $what $atLeast $times" } to
@@ -76,14 +68,8 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
                 if (atLeast == 1) expect contains o ignoring case regex a
                 else expect contains o ignoring case atLeast atLeast regex a
             } else {
-                if (atLeast == 1) expect contains o ignoring case the RegexPatterns(
-                    a,
-                    *aX
-                )
-                else expect contains o ignoring case atLeast atLeast the RegexPatterns(
-                    a,
-                    *aX
-                )
+                if (atLeast == 1) expect contains o ignoring case the regexPatterns(a, *aX)
+                else expect contains o ignoring case atLeast atLeast the regexPatterns(a, *aX)
             }
 
         private fun getShortcutTripleString() =
@@ -100,10 +86,7 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
             aX: Array<out String>
         ) =
             if (aX.isEmpty()) expect containsRegex a
-            else expect containsRegex RegexPatterns(
-                a,
-                *aX
-            )
+            else expect containsRegex regexPatterns(a, *aX)
 
         private fun containsShortcutRegex(
             expect: Expect<CharSequence>,
@@ -111,10 +94,7 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
             aX: Array<out String>
         ) =
             if (aX.isEmpty()) expect contains Regex(a)
-            else expect contains All(
-                Regex(a),
-                *aX.map { it.toRegex() }.toTypedArray()
-            )
+            else expect contains all(Regex(a), *aX.map { it.toRegex() }.toTypedArray())
 
 
         private fun getAtMostTripleString() =
@@ -132,10 +112,7 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
             aX: Array<out String>
         ) =
             if (aX.isEmpty()) expect contains o atMost atMost regex a
-            else expect contains o atMost atMost the RegexPatterns(
-                a,
-                *aX
-            )
+            else expect contains o atMost atMost the regexPatterns(a, *aX)
 
         private fun getAtMostIgnoringCaseTripleString() =
             { what: String, times: String -> "$contains $ignoringCase $what $atMost $times" } to
@@ -148,10 +125,7 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
             aX: Array<out String>
         ) =
             if (aX.isEmpty()) expect contains o atMost atMost matchFor Regex(a)
-            else expect contains o atMost atMost matchFor All(
-                Regex(a),
-                *aX.map { it.toRegex() }.toTypedArray()
-            )
+            else expect contains o atMost atMost matchFor all(Regex(a), *aX.map { it.toRegex() }.toTypedArray())
 
         private fun containsAtMostIgnoringCase(
             expect: Expect<CharSequence>,
@@ -160,9 +134,6 @@ class CharSequenceContainsRegexAssertionsSpec : Spek({
             aX: Array<out String>
         ) =
             if (aX.isEmpty()) expect contains o ignoring case atMost atMost regex a
-            else expect contains o ignoring case atMost atMost the RegexPatterns(
-                a,
-                *aX
-            )
+            else expect contains o ignoring case atMost atMost the regexPatterns(a, *aX)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
@@ -1,10 +1,8 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
+import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.contains.builders.AtLeastCheckerOption
 import ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.contains.builders.NotCheckerOption
-import ch.tutteli.atrium.api.infix.en_GB.creating.All
-import ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.RegexPatterns
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
@@ -24,7 +22,7 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
     protected val containsNot = containsNotProp.name
 
     private val containsNotFun: KFunction2<Expect<String>, Any, Expect<String>> = Expect<String>::containsNot
-    protected val containsNotValues = "${containsNotFun.name} ${Values::class.simpleName}"
+    protected val containsNotValues = "${containsNotFun.name} values"
     protected val containsRegex = fun1<String, String>(Expect<String>::containsRegex).name
     protected val atLeast = CharSequenceContains.Builder<*, *>::atLeast.name
     protected val butAtMost = AtLeastCheckerOption<*, *>::butAtMost.name
@@ -45,87 +43,59 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
         val a1: Expect<String> = notImplemented()
 
         a1 contains o atLeast 1 value 1
-        a1 contains o atMost 2 the Values(
-            "a",
-            1
-        )
+        a1 contains o atMost 2 the values("a", 1)
         a1 contains o notOrAtMost 2 regex "h|b"
-        a1 contains o exactly 2 the RegexPatterns(
-            "h|b",
-            "b"
-        )
+        a1 contains o exactly 2 the regexPatterns("h|b", "b")
         a1 contains o atLeast 2 matchFor Regex("bla")
-        a1 contains o atLeast 2 matchFor All(
-            Regex("bla"),
-            Regex("b")
-        )
+        a1 contains o atLeast 2 matchFor all(Regex("bla"), Regex("b"))
         a1 contains o atLeast 2 elementsOf listOf(1, 2)
 
         a1 containsNot o value "a"
-        a1 containsNot o the Values("a", 'b')
+        a1 containsNot o the values("a", 'b')
         a1 containsNot o regex "a"
-        a1 containsNot o the RegexPatterns(
-            "a",
-            "bl"
-        )
+        a1 containsNot o the regexPatterns("a", "bl")
+        a1 containsNot o matchFor Regex("a")
+        a1 containsNot o matchFor all(Regex("a"), Regex("bl"))
         a1 containsNot o elementsOf listOf(1, 2)
 
         a1 contains o ignoring case atLeast 1 value "a"
-        a1 contains o ignoring case atLeast 1 the Values(
-            "a",
-            'b'
-        )
+        a1 contains o ignoring case atLeast 1 the values("a", 'b')
         a1 contains o ignoring case atLeast 1 regex "a"
-        a1 contains o ignoring case atLeast 1 the RegexPatterns(
-            "a",
-            "bl"
-        )
+        a1 contains o ignoring case atLeast 1 the regexPatterns("a", "bl")
+        // not supported on purpose as one can specify an ignore case flag for Regex
+        // and hence these would be a second way to do the same thing
+        //a1 contains o ignoring case atLeast 1 matchFor Regex("a")
+        //a1 contains o ignoring case atLeast 1 matchFor all(Regex("a"), Regex("bl"))
         a1 contains o ignoring case atLeast 1 elementsOf listOf(1, 2)
 
         a1 containsNot o ignoring case value "a"
-        a1 containsNot o ignoring case the Values(
-            "a",
-            'b'
-        )
+        a1 containsNot o ignoring case the values("a", 'b')
         a1 containsNot o ignoring case regex "a"
-        a1 containsNot o ignoring case the RegexPatterns(
-            "a",
-            "bl"
-        )
+        a1 containsNot o ignoring case the regexPatterns("a", "bl")
+        // not supported on purpose as one can specify an ignore case flag for Regex
+        // and hence these would be a second way to do the same thing
+        //a1 containsNot o ignoring case matchFor Regex("a")
+        //a1 containsNot o ignoring case matchFor all(Regex("a"), Regex("bl"))
         a1 containsNot o ignoring case elementsOf listOf(1, 2)
 
         // skip atLeast
         a1 contains o ignoring case value "a"
-        a1 contains o ignoring case the Values(
-            "a",
-            'b'
-        )
+        a1 contains o ignoring case the values("a", 'b')
         a1 contains o ignoring case regex "a"
-        a1 contains o ignoring case the RegexPatterns(
-            "a",
-            "bl"
-        )
+        a1 contains o ignoring case the regexPatterns("a", "bl")
+        // not supported on purpose as one can specify an ignore case flag for Regex
+        // and hence these would be a second way to do the same thing
+        //a1 contains o ignoring case matchFor Regex("a")
+        //a1 contains o ignoring case matchFor all(Regex("a"), Regex("bl"))
         //TODO #422 uncomment
         //a1 contains o ignoring case elementsOf listOf("a", 2)
 
         a1 and { it contains o atLeast 1 value 1 }
-        a1 and { it contains o atMost 2 the Values(
-            "a",
-            1
-        )
-        }
+        a1 and { it contains o atMost 2 the values("a", 1) }
         a1 and { it contains o notOrAtMost 2 regex "h|b" }
-        a1 and { it contains o exactly 2 the RegexPatterns(
-            "h|b",
-            "b"
-        )
-        }
+        a1 and { it contains o exactly 2 the regexPatterns("h|b", "b") }
         a1 and { it contains o atLeast 2 matchFor Regex("bla") }
-        a1 and { it contains o atLeast 2 matchFor All(
-            Regex("bla"),
-            Regex("b")
-        )
-        }
+        a1 and { it contains o atLeast 2 matchFor all(Regex("bla"), Regex("b")) }
         a1 and { it contains o atLeast 2 elementsOf listOf(1, 2) }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CollectionFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CollectionFeatureAssertionsSpec.kt
@@ -1,10 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
 class CollectionFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.CollectionFeatureAssertionsSpec(
     property<Collection<String>, Int>(Expect<Collection<String>>::size),

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
@@ -32,10 +32,7 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
             aX: Array<out Expect<Double>.() -> Unit>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inAny order atLeast 1 entry a
-            else expect contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect contains o inAny order atLeast 1 the entries(a, *aX)
 
         fun getContainsNullablePair() =
             "$contains $filler $inAnyOrder $atLeast 1 $inAnyOrderEntries" to Companion::containsNullableEntries
@@ -46,10 +43,7 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
             aX: Array<out (Expect<Double>.() -> Unit)?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains o inAny order atLeast 1 entry a
-            else expect contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect contains o inAny order atLeast 1 the entries(a, *aX)
 
 
         private val containsShortcutFun: KFunction2<Expect<Iterable<Double>>, Expect<Double>.() -> Unit, Expect<Iterable<Double>>> =
@@ -63,7 +57,7 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
             aX: Array<out Expect<Double>.() -> Unit>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains a
-            else expect contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries(a, *aX)
+            else expect contains entries(a, *aX)
 
         private val containsEntriesFun: KFunction2<Expect<Iterable<Double?>>, (Expect<Double>.() -> Unit)?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::contains
@@ -76,6 +70,6 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
             aX: Array<out (Expect<Double>.() -> Unit)?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains a
-            else expect contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries(a, *aX)
+            else expect contains entries(a, *aX)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
@@ -32,10 +32,7 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inAny order atLeast 1 value a
-            else expect contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order atLeast 1 the values(a, *aX)
 
         fun getContainsNullablePair() =
             "$contains $filler $inAnyOrder $atLeast 1 $inAnyOrderValues" to Companion::containsNullableValues
@@ -46,10 +43,7 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains o inAny order atLeast 1 value a
-            else expect contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order atLeast 1 the values(a, *aX)
 
 
         private val containsFun: KFunction2<Expect<Iterable<Double>>, Double, Expect<Iterable<Double>>> =
@@ -63,10 +57,7 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains a
-            else expect contains ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains values(a, *aX)
 
 
         private val containsNullableFun: KFunction2<Expect<Iterable<Double?>>, Double?, Expect<Iterable<Double?>>> =
@@ -80,10 +71,7 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains a
-            else expect contains ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains values(a, *aX)
 
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
@@ -25,10 +25,7 @@ class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec :
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inAny order atLeast atLeast value a
-            else expect contains o inAny order atLeast atLeast the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order atLeast atLeast the values(a, *aX)
 
 
         private fun getAtLeastButAtMostTriple() =
@@ -41,10 +38,7 @@ class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec :
             butAtMost: Int,
             a: Double,
             aX: Array<out Double>
-        ) = expect contains o inAny order atLeast atLeast butAtMost butAtMost the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-            a,
-            *aX
-        )
+        ) = expect contains o inAny order atLeast atLeast butAtMost butAtMost the values(a, *aX)
 
         private fun getContainsNotPair() = containsNot to Companion::getErrorMsgContainsNot
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
@@ -18,10 +18,7 @@ class IterableContainsInAnyOrderAtMostValuesAssertionsSpec :
 
         private fun containsAtMost(expect: Expect<Iterable<Double>>, atMost: Int, a: Double, aX: Array<out Double>) =
             if(aX.isEmpty()) expect contains o inAny order atMost atMost value a
-            else expect contains o inAny order atMost atMost the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order atMost atMost the values(a, *aX)
 
 
         private fun getContainsNotPair() = containsNot to Companion::getErrorMsgContainsNot

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
@@ -22,10 +22,7 @@ class IterableContainsInAnyOrderExactlyValuesAssertionsSpec :
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inAny order exactly exactly value a
-            else expect contains o inAny order exactly exactly the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order exactly exactly the values(a, *aX)
 
         private fun getContainsNotPair() = containsNot to Companion::getErrorMsgContainsNot
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
@@ -22,10 +22,7 @@ class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec :
             aX: Array<out Double>
         ) =
             if (aX.isEmpty()) expect contains o inAny order notOrAtMost atMost value a
-            else expect contains o inAny order notOrAtMost atMost the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order notOrAtMost atMost the values(a, *aX)
 
         private fun getContainsNotPair() = containsNot to Companion::getErrorMsgContainsNot
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
@@ -18,10 +18,7 @@ class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec :
             aX: Array<out Expect<Double>.() -> Unit>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inAny order but only entry a
-            else expect contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect contains o inAny order but only the entries(a, *aX)
 
 
         fun getContainsNullablePair() =
@@ -33,10 +30,7 @@ class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec :
             aX: Array<out (Expect<Double>.() -> Unit)?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains o inAny order but only entry a
-            else expect contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect contains o inAny order but only the entries(a, *aX)
 
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
@@ -18,10 +18,7 @@ class IterableContainsInAnyOrderOnlyValuesAssertionsSpec :
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inAny order but only value a
-            else expect contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order but only the values(a, *aX)
 
 
         fun getContainsNullablePair() =
@@ -33,10 +30,7 @@ class IterableContainsInAnyOrderOnlyValuesAssertionsSpec :
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains o inAny order but only value a
-            else expect contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inAny order but only the values(a, *aX)
 
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
@@ -34,10 +34,7 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
             aX: Array<out Expect<Double>.() -> Unit>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inGiven order and only entry a
-            else expect contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect contains o inGiven order and only the entries(a, *aX)
 
         fun getContainsNullablePair() =
             "$contains $filler $inOrder $andOnly $inOrderOnlyEntries" to Companion::containsInOrderOnlyNullableEntriesPair
@@ -48,10 +45,7 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
             aX: Array<out (Expect<Double>.() -> Unit)?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains o inGiven order and only entry a
-            else expect contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect contains o inGiven order and only the entries(a, *aX)
 
         private val containsShortcutFun: KFunction2<Expect<Iterable<Double>>, Expect<Double>.() -> Unit, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::containsExactly
@@ -64,10 +58,7 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
             aX: Array<out Expect<Double>.() -> Unit>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect containsExactly { a() }
-            else expect containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect containsExactly entries(a, *aX)
 
         private val containsNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, (Expect<Double>.() -> Unit)?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::containsExactly
@@ -85,10 +76,7 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
                 if (a == null) expect containsExactly a as Double?
                 else expect containsExactly { a() }
             } else {
-                expect containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                    a,
-                    *aX
-                )
+                expect containsExactly entries(a, *aX)
             }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec.kt
@@ -1,7 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Entry
-import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.Order
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.utils.Group
 
@@ -22,22 +20,15 @@ class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec :
             a2: Group<(Expect<Double>.() -> Unit)?>,
             aX: Array<out Group<(Expect<Double>.() -> Unit)?>>
         ): Expect<Iterable<Double?>> =
-            expect contains o inGiven order and only grouped entries within group inAny Order(
-                a1,
-                a2,
-                *aX
-            )
+            expect contains o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
 
         private fun groupFactory(groups: Array<out (Expect<Double>.() -> Unit)?>) =
             when (groups.size) {
                 0 -> object : Group<(Expect<Double>.() -> Unit)?> {
                     override fun toList() = listOf<Expect<Double>.() -> Unit>()
                 }
-                1 -> Entry(groups[0])
-                else -> ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                    groups[0],
-                    *groups.drop(1).toTypedArray()
-                )
+                1 -> entry(groups[0])
+                else -> entries(groups[0], *groups.drop(1).toTypedArray())
             }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
@@ -1,7 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.Order
-import ch.tutteli.atrium.api.infix.en_GB.creating.Value
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.utils.Group
 
@@ -23,24 +21,16 @@ class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec :
             a1: Group<Double>,
             a2: Group<Double>,
             aX: Array<out Group<Double>>
-        ): Expect<Iterable<Double>> {
-            return expect contains o inGiven order and only grouped entries within group inAny Order(
-                a1,
-                a2,
-                *aX
-            )
-        }
+        ): Expect<Iterable<Double>> =
+            expect contains o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
 
         private fun groupFactory(groups: Array<out Double>): Group<Double> =
             when (groups.size) {
                 0 -> object : Group<Double> {
                     override fun toList() = listOf<Double>()
                 }
-                1 -> Value(groups[0])
-                else -> ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                    groups[0],
-                    *groups.drop(1).toTypedArray()
-                )
+                1 -> value(groups[0])
+                else -> values(groups[0], *groups.drop(1).toTypedArray())
             }
 
 
@@ -52,24 +42,16 @@ class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec :
             a1: Group<Double?>,
             a2: Group<Double?>,
             aX: Array<out Group<Double?>>
-        ): Expect<Iterable<Double?>> {
-            return expect contains o inGiven order and only grouped entries within group inAny Order(
-                a1,
-                a2,
-                *aX
-            )
-        }
+        ): Expect<Iterable<Double?>> =
+            expect contains o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
 
         private fun nullableGroupFactory(groups: Array<out Double?>): Group<Double?> =
             when (groups.size) {
                 0 -> object : Group<Double?> {
                     override fun toList() = listOf<Double>()
                 }
-                1 -> Value(groups[0])
-                else -> ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                    groups[0],
-                    *groups.drop(1).toTypedArray()
-                )
+                1 -> value(groups[0])
+                else -> values(groups[0], *groups.drop(1).toTypedArray())
             }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
@@ -25,7 +25,8 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
     )
 
     companion object : IterableContainsSpecBase() {
-        fun getContainsPair() = "$contains $filler $inOrder $andOnly $inOrderOnlyValues" to Companion::containsInOrderOnlyValues
+        fun getContainsPair() =
+            "$contains $filler $inOrder $andOnly $inOrderOnlyValues" to Companion::containsInOrderOnlyValues
 
         private fun containsInOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
@@ -33,10 +34,7 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect contains o inGiven order and only value a
-            else expect contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inGiven order and only the values(a, *aX)
 
         fun getContainsNullablePair() =
             "$contains $filler $inOrder $andOnly $inOrderOnlyValues" to Companion::containsInOrderOnlyNullableValues
@@ -47,10 +45,7 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect contains o inGiven order and only value a
-            else expect contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect contains o inGiven order and only the values(a, *aX)
 
         private val containsShortcutFun: KFunction2<Expect<Iterable<Double>>, Double, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::containsExactly
@@ -63,10 +58,7 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect containsExactly a
-            else expect containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect containsExactly values(a, *aX)
 
         private val containsNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Double?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::containsExactly
@@ -80,10 +72,7 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect containsExactly a
-            else expect containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect containsExactly values(a, *aX)
     }
 }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsNotEntriesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsNotEntriesAssertionsSpec.kt
@@ -20,10 +20,7 @@ class IterableContainsNotEntriesAssertionsSpec :
             aX: Array<out Expect<Double>.() -> Unit>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect containsNot o entry a
-            else expect containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect containsNot o the entries(a, *aX)
 
         private fun getContainsNotNullablePair() = containsNot to Companion::containsNotNullableFun
 
@@ -33,9 +30,6 @@ class IterableContainsNotEntriesAssertionsSpec :
             aX: Array<out (Expect<Double>.() -> Unit)?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect containsNot o entry a
-            else expect containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-                a,
-                *aX
-            )
+            else expect containsNot o the entries(a, *aX)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
@@ -35,10 +35,7 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
             aX: Array<out Double>
         ): Expect<Iterable<Double>> =
             if (aX.isEmpty()) expect containsNot o value a
-            else expect containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect containsNot o the values(a, *aX)
 
         private fun getContainsNotNullablePair() = containsNot to Companion::containsNotNullableFun
 
@@ -48,10 +45,7 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect containsNot o value a
-            else expect containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect containsNot o the values(a, *aX)
 
         private val containsNotShortcutFun: KFunction2<Expect<Iterable<Double>>, Double, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::containsNot
@@ -60,9 +54,6 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
 
         private fun containsNotShortcut(expect: Expect<Iterable<Double>>, a: Double, aX: Array<out Double>) =
             if (aX.isEmpty()) expect containsNot a
-            else expect containsNot ch.tutteli.atrium.api.infix.en_GB.creating.Values(
-                a,
-                *aX
-            )
+            else expect containsNot values(a, *aX)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsSpecBase.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsSpecBase.kt
@@ -1,9 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.Values
-import ch.tutteli.atrium.api.infix.en_GB.creating.Entry
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.Order
-import ch.tutteli.atrium.api.infix.en_GB.creating.Value
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.contains.builders.AtLeastCheckerOption
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.contains.builders.NotCheckerOption
 import ch.tutteli.atrium.creating.Expect
@@ -15,8 +13,8 @@ import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import kotlin.reflect.KFunction2
 
 abstract class IterableContainsSpecBase : WithAsciiReporter() {
-    protected val Values = ch.tutteli.atrium.api.infix.en_GB.creating.Values::class.simpleName
-    private val Entries = ch.tutteli.atrium.api.infix.en_GB.creating.Entries::class.simpleName
+    private val Values = "values"
+    private val Entries = "entries"
 
     //@formatter:off
     protected val atLeast = IterableContains.Builder<*, *, InAnyOrderSearchBehaviour>::atLeast.name
@@ -72,448 +70,256 @@ abstract class IterableContainsSpecBase : WithAsciiReporter() {
 
         list contains 1
         list contains 1f
-        list contains Values(1, 2f)
+        list contains values(1, 2f)
         list contains {}
-        list contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        list contains entries({}, {})
         list containsNot 1
         list containsNot 1f
-        list containsNot Values(1, 2f)
+        list containsNot values(1, 2f)
         list containsNot o entry {}
-        list containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        list containsNot o the entries({}, {})
 
         subList contains 1
-        subList contains 1f
-        subList contains Values(1, 2f)
+        subList contains 1f; subList contains values(1, 2f)
         subList contains {}
-        subList contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        subList contains entries({}, {})
         subList containsNot 1
         subList containsNot 1f
-        subList containsNot Values(1, 2f)
+        subList containsNot values(1, 2f)
         subList containsNot o entry {}
-        subList containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        subList containsNot o the entries({}, {})
 
         nullableList contains 1
         nullableList contains 1f
-        nullableList contains Values(1, 2f)
+        nullableList contains values(1, 2f)
         nullableList contains {}
-        nullableList contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        nullableList contains entries({}, {})
         nullableList containsNot 1
         nullableList containsNot 1f
-        nullableList containsNot Values(
-            1,
-            2f
-        )
+        nullableList containsNot values(1, 2f)
         nullableList containsNot o entry {}
-        nullableList containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        nullableList containsNot o the entries({}, {})
         //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
         nullableList contains null as Number?
-        nullableList contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, {})
-        nullableList contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, null)
-        nullableList contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, null)
+        nullableList contains entries(null, {})
+        nullableList contains entries({}, null)
+        nullableList contains entries(null, null)
         //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
         nullableList containsNot null as Number?
-        nullableList containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        nullableList containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        nullableList containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        nullableList containsNot o the entries(null, {})
+        nullableList containsNot o the entries({}, null)
+        nullableList containsNot o the entries(null, null)
 
         star contains 1
         star contains 1f
-        star contains Values(1, 2f)
+        star contains values(1, 2f)
         star contains {}
-        star contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        star contains entries({}, {})
         star containsNot 1
         star containsNot 1f
-        star containsNot Values(1, 2f)
+        star containsNot values(1, 2f)
         star containsNot o entry {}
-        star containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        star containsNot o the entries({}, {})
         //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
         star contains (null as Number?)
-        star contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, {})
-        star contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, null)
-        star contains ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, null)
+        star contains entries(null, {})
+        star contains entries({}, null)
+        star contains entries(null, null)
         //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
         star containsNot (null as Number?)
-        star containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, {})
-        star containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, null)
-        star containsNot o the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        star containsNot o the entries(null, {})
+        star containsNot o the entries({}, null)
+        star containsNot o the entries(null, null)
 
         list containsExactly 1
-        list containsExactly Values(1, 2f)
+        list containsExactly values(1, 2f)
         list containsExactly {}
-        list containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        list containsExactly entries({}, {})
 
         subList containsExactly 1
-        subList containsExactly Values(1, 2f)
+        subList containsExactly values(1, 2f)
         subList containsExactly {}
-        subList containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        subList containsExactly entries({}, {})
 
         nullableList containsExactly 1
-        nullableList containsExactly Values(
-            1,
-            2f
-        )
+        nullableList containsExactly values(1, 2f)
         nullableList containsExactly {}
-        nullableList containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        nullableList containsExactly entries({}, {})
         //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
         nullableList containsExactly (null as (Expect<Number>.() -> Unit)?)
-        nullableList containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        nullableList containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        nullableList containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        nullableList containsExactly entries({}, null)
+        nullableList containsExactly entries(null, {})
+        nullableList containsExactly entries(null, null)
 
         star containsExactly 1
-        star containsExactly Values(1, 2f)
+        star containsExactly values(1, 2f)
         star containsExactly {}
-        star containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
+        star containsExactly entries({}, {})
         //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
         star containsExactly (null as (Expect<Number>.() -> Unit)?)
-        star containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, null)
-        star containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, {})
-        star containsExactly ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, null)
+        star containsExactly entries({}, null)
+        star containsExactly entries(null, {})
+        star containsExactly entries(null, null)
 
         list contains o inAny order atLeast 1 value 1
-        list contains o inAny order atLeast 1 the Values(
-            2,
-            1
-        )
+        list contains o inAny order atLeast 1 the values(2, 1)
         list contains o inAny order atLeast 1 entry {}
-        list contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        list contains o inAny order atLeast 1 the entries({}, {})
         list contains o inAny order atLeast 1 elementsOf listOf(1, 2)
         subList contains o inAny order atLeast 1 value 1
-        subList contains o inAny order atLeast 1 the Values(
-            2,
-            1
-        )
+        subList contains o inAny order atLeast 1 the values(2, 1)
         subList contains o inAny order atLeast 1 entry {}
-        subList contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        subList contains o inAny order atLeast 1 the entries({}, {})
         subList contains o inAny order atLeast 1 elementsOf listOf(1, 2)
         nullableList contains o inAny order atLeast 1 value 1
-        nullableList contains o inAny order atLeast 1 the Values(
-            2,
-            1
-        )
+        nullableList contains o inAny order atLeast 1 the values(2, 1)
         nullableList contains o inAny order atLeast 1 entry {}
-        nullableList contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        nullableList contains o inAny order atLeast 1 the entries({}, {})
         nullableList contains o inAny order atLeast 1 elementsOf listOf(1, 2)
         nullableList contains o inAny order atLeast 1 value null
-        nullableList contains o inAny order atLeast 1 the Values(
-            null,
-            1
-        )
-        nullableList contains o inAny order atLeast 1 the Values(
-            2,
-            null
-        )
-        nullableList contains o inAny order atLeast 1 the Values(
-            null,
-            null
-        )
+        nullableList contains o inAny order atLeast 1 the values(null, 1)
+        nullableList contains o inAny order atLeast 1 the values(2, null)
+        nullableList contains o inAny order atLeast 1 the values(null, null)
         nullableList contains o inAny order atLeast 1 entry null
-        nullableList contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        nullableList contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        nullableList contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        nullableList contains o inAny order atLeast 1 the entries(null, {})
+        nullableList contains o inAny order atLeast 1 the entries({}, null)
+        nullableList contains o inAny order atLeast 1 the entries(null, null)
         star contains o inAny order atLeast 1 value 1
-        star contains o inAny order atLeast 1 the Values(
-            2,
-            1
-        )
+        star contains o inAny order atLeast 1 the values(2, 1)
         star contains o inAny order atLeast 1 entry {}
-        star contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        star contains o inAny order atLeast 1 the entries({}, {})
         star contains o inAny order atLeast 1 elementsOf listOf(1, 2)
         star contains o inAny order atLeast 1 value null
-        star contains o inAny order atLeast 1 the Values(
-            null,
-            1
-        )
-        star contains o inAny order atLeast 1 the Values(
-            2,
-            null
-        )
-        star contains o inAny order atLeast 1 the Values(
-            null,
-            null
-        )
+        star contains o inAny order atLeast 1 the values(null, 1)
+        star contains o inAny order atLeast 1 the values(2, null)
+        star contains o inAny order atLeast 1 the values(null, null)
         star contains o inAny order atLeast 1 entry null
-        star contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        star contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        star contains o inAny order atLeast 1 the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        star contains o inAny order atLeast 1 the entries(null, {})
+        star contains o inAny order atLeast 1 the entries({}, null)
+        star contains o inAny order atLeast 1 the entries(null, null)
 
         list contains o inAny order but only value 1
-        list contains o inAny order but only the Values(
-            2,
-            1
-        )
+        list contains o inAny order but only the values(2, 1)
         list contains o inAny order but only entry {}
-        list contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        list contains o inAny order but only the entries({}, {})
         list contains o inAny order but only elementsOf listOf(1, 2)
         subList contains o inAny order but only value 1
-        subList contains o inAny order but only the Values(
-            2,
-            1
-        )
+        subList contains o inAny order but only the values(2, 1)
         subList contains o inAny order but only entry {}
-        subList contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        subList contains o inAny order but only the entries({}, {})
         subList contains o inAny order but only elementsOf listOf(1, 2)
         nullableList contains o inAny order but only value 1
-        nullableList contains o inAny order but only the Values(
-            2,
-            1
-        )
+        nullableList contains o inAny order but only the values(2, 1)
         nullableList contains o inAny order but only entry {}
-        nullableList contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        nullableList contains o inAny order but only the entries({}, {})
         nullableList contains o inAny order but only elementsOf listOf(1, 2)
         nullableList contains o inAny order but only value null
-        nullableList contains o inAny order but only the Values(
-            null,
-            1
-        )
-        nullableList contains o inAny order but only the Values(
-            2,
-            null
-        )
-        nullableList contains o inAny order but only the Values(
-            null,
-            null
-        )
+        nullableList contains o inAny order but only the values(null, 1)
+        nullableList contains o inAny order but only the values(2, null)
+        nullableList contains o inAny order but only the values(null, null)
         nullableList contains o inAny order but only entry null
-        nullableList contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        nullableList contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        nullableList contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        nullableList contains o inAny order but only the entries(null, {})
+        nullableList contains o inAny order but only the entries({}, null)
+        nullableList contains o inAny order but only the entries(null, null)
         star contains o inAny order but only value 1
-        star contains o inAny order but only the Values(
-            2,
-            1
-        )
+        star contains o inAny order but only the values(2, 1)
         star contains o inAny order but only entry {}
-        star contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        star contains o inAny order but only the entries({}, {})
         star contains o inAny order but only elementsOf listOf(1, 2)
         star contains o inAny order but only value null
-        star contains o inAny order but only the Values(
-            null,
-            1
-        )
-        star contains o inAny order but only the Values(
-            2,
-            null
-        )
-        star contains o inAny order but only the Values(
-            null,
-            null
-        )
+        star contains o inAny order but only the values(null, 1)
+        star contains o inAny order but only the values(2, null)
+        star contains o inAny order but only the values(null, null)
         star contains o inAny order but only entry null
-        star contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        star contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        star contains o inAny order but only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        star contains o inAny order but only the entries(null, {})
+        star contains o inAny order but only the entries({}, null)
+        star contains o inAny order but only the entries(null, null)
 
         list contains o inGiven order and only value 1
-        list contains o inGiven order and only the Values(
-            2,
-            1
-        )
+        list contains o inGiven order and only the values(2, 1)
         list contains o inGiven order and only entry {}
-        list contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        list contains o inGiven order and only the entries({}, {})
         list contains o inGiven order and only elementsOf listOf(1, 2)
         subList contains o inGiven order and only value 1
-        subList contains o inGiven order and only the Values(
-            2,
-            1
-        )
+        subList contains o inGiven order and only the values(2, 1)
         subList contains o inGiven order and only entry {}
-        subList contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        subList contains o inGiven order and only the entries({}, {})
         subList contains o inGiven order and only elementsOf listOf(1, 2)
         nullableList contains o inGiven order and only value 1
-        nullableList contains o inGiven order and only the Values(
-            2,
-            1
-        )
+        nullableList contains o inGiven order and only the values(2, 1)
         nullableList contains o inGiven order and only entry {}
-        nullableList contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        nullableList contains o inGiven order and only the entries({}, {})
         nullableList contains o inGiven order and only elementsOf listOf(1, 2)
         nullableList contains o inGiven order and only value null
-        nullableList contains o inGiven order and only the Values(
-            null,
-            1
-        )
-        nullableList contains o inGiven order and only the Values(
-            2,
-            null
-        )
-        nullableList contains o inGiven order and only the Values(
-            null,
-            null
-        )
+        nullableList contains o inGiven order and only the values(null, 1)
+        nullableList contains o inGiven order and only the values(2, null)
+        nullableList contains o inGiven order and only the values(null, null)
         nullableList contains o inGiven order and only entry null
-        nullableList contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        nullableList contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
-        )
-        nullableList contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
-        )
+        nullableList contains o inGiven order and only the entries(null, {})
+        nullableList contains o inGiven order and only the entries({}, null)
+        nullableList contains o inGiven order and only the entries(null, null)
         star contains o inGiven order and only value 1
-        star contains o inGiven order and only the Values(
-            2,
-            1
-        )
+        star contains o inGiven order and only the values(2, 1)
         star contains o inGiven order and only entry {}
-        star contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            {})
+        star contains o inGiven order and only the entries({}, {})
         star contains o inGiven order and only elementsOf listOf(1, 2)
         star contains o inGiven order and only value null
-        star contains o inGiven order and only the Values(
-            null,
-            1
-        )
-        star contains o inGiven order and only the Values(
-            2,
-            null
-        )
-        star contains o inGiven order and only the Values(
-            null,
-            null
-        )
+        star contains o inGiven order and only the values(null, 1)
+        star contains o inGiven order and only the values(2, null)
+        star contains o inGiven order and only the values(null, null)
         star contains o inGiven order and only entry null
-        star contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            {})
-        star contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            {},
-            null
+        star contains o inGiven order and only the entries(null, {})
+        star contains o inGiven order and only the entries({}, null)
+        star contains o inGiven order and only the entries(null, null)
+
+        list contains o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1f),
+            values(1f, 1)
         )
-        star contains o inGiven order and only the ch.tutteli.atrium.api.infix.en_GB.creating.Entries(
-            null,
-            null
+        subList contains o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1f),
+            values(1f, 1)
+        )
+        nullableList contains o inGiven order and only grouped entries within group inAny order(
+            value(null),
+            values(null),
+            values(null, 2),
+            values(1, null),
+            values(null, null)
+        )
+        star contains o inGiven order and only grouped entries within group inAny order(
+            value(null),
+            values(null),
+            values(null, 2),
+            values(1, null),
+            values(null, null)
         )
 
-        list contains o inGiven order and only grouped entries within group inAny Order(
-            Value(1),
-            Values(1f),
-            Values(1f, 1)
+        list contains o inGiven order and only grouped entries within group inAny order(
+            entry {},
+            entries({}),
+            entries({}, {})
         )
-        subList contains o inGiven order and only grouped entries within group inAny Order(
-            Value(1),
-            Values(1f),
-            Values(1f, 1)
+        subList contains o inGiven order and only grouped entries within group inAny order(
+            entry {},
+            entries({}),
+            entries({}, {})
         )
-        nullableList contains o inGiven order and only grouped entries within group inAny Order(
-            Value(null),
-            Values(null),
-            Values(null, 2),
-            Values(1, null),
-            Values(null, null)
+        nullableList contains o inGiven order and only grouped entries within group inAny order(
+            entry(null),
+            entries(null),
+            entries(null, {}),
+            entries({}, null),
+            entries(null, null)
         )
-        star contains o inGiven order and only grouped entries within group inAny Order(
-            Value(null),
-            Values(null),
-            Values(null, 2),
-            Values(1, null),
-            Values(null, null)
-        )
-
-        list contains o inGiven order and only grouped entries within group inAny Order(
-            Entry {},
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
-        )
-        subList contains o inGiven order and only grouped entries within group inAny Order(
-            Entry {},
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, {})
-        )
-        nullableList contains o inGiven order and only grouped entries within group inAny Order(
-            Entry(null),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, {}),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, null),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, null)
-        )
-        star contains o inGiven order and only grouped entries within group inAny Order(
-            Entry(null),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, {}),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries({}, null),
-            ch.tutteli.atrium.api.infix.en_GB.creating.Entries(null, null)
+        star contains o inGiven order and only grouped entries within group inAny order(
+            entry(null),
+            entries(null),
+            entries(null, {}),
+            entries({}, null),
+            entries(null, null)
         )
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapAssertionsSpec.kt
@@ -1,20 +1,19 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.All
-import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyValue
-import ch.tutteli.atrium.api.infix.en_GB.creating.Pairs
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.utils.mapArguments
-import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.integration.mfun2
+import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
+import ch.tutteli.atrium.specs.withNullableSuffix
 import kotlin.jvm.JvmName
 
 class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
     mfun2<String, Int, Int>(Companion::contains),
     mfun2<String?, Int?, Int?>(Companion::contains).withNullableSuffix(),
-    mfun2<String, Int, Expect<Int>.() -> Unit>(Companion::contains).adjustName { "$it ${KeyValue::class.simpleName}" },
-    mfun2<String?, Int?, (Expect<Int>.() -> Unit)?>(Companion::contains).adjustName { "$it ${KeyValue::class.simpleName}" }.withNullableSuffix(),
+    mfun2<String, Int, Expect<Int>.() -> Unit>(Companion::contains),
+    mfun2<String?, Int?, (Expect<Int>.() -> Unit)?>(Companion::contains).withNullableSuffix(),
     fun1<Map<out String, *>, String>(Companion::containsKey),
     fun1<Map<out String?, *>, String?>(Companion::containsKey).withNullableSuffix(),
     fun1<Map<out String, *>, String>(Companion::containsNotKey),
@@ -22,90 +21,46 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
     "toBe ${Empty::class.simpleName}" to Companion::isEmpty,
     "notToBe ${Empty::class.simpleName}" to Companion::isNotEmpty
 ) {
-    companion object : WithAsciiReporter(){
+    companion object : WithAsciiReporter() {
 
         private fun contains(
             expect: Expect<Map<out String, Int>>,
             pair: Pair<String, Int>,
             otherPairs: Array<out Pair<String, Int>>
-        ): Expect<Map<out String, Int>> {
-            return if (otherPairs.isEmpty()) {
-                expect contains (pair.first to pair.second)
-            } else {
-                expect contains Pairs(
-                    pair,
-                    *otherPairs
-                )
-            }
-        }
+        ): Expect<Map<out String, Int>> =
+            if (otherPairs.isEmpty()) expect contains (pair.first to pair.second)
+            else expect contains pairs(pair, *otherPairs)
 
         @JvmName("containsNullable")
         private fun contains(
             expect: Expect<Map<out String?, Int?>>,
             pair: Pair<String?, Int?>,
             otherPairs: Array<out Pair<String?, Int?>>
-        ): Expect<Map<out String?, Int?>> {
-            return if (otherPairs.isEmpty()) {
-                expect contains (pair.first to pair.second)
-            } else {
-                expect contains Pairs(
-                    pair,
-                    *otherPairs
-                )
-            }
-        }
+        ): Expect<Map<out String?, Int?>> =
+            if (otherPairs.isEmpty()) expect contains (pair.first to pair.second)
+            else expect contains pairs(pair, *otherPairs)
 
         @JvmName("containsKeyWithValueAssertions")
         private fun contains(
             expect: Expect<Map<out String, Int>>,
             keyValue: Pair<String, Expect<Int>.() -> Unit>,
             otherKeyValues: Array<out Pair<String, Expect<Int>.() -> Unit>>
-        ): Expect<Map<out String, Int>> {
-            return if (otherKeyValues.isEmpty()) {
-                expect contains KeyValue(
-                    keyValue.first,
-                    keyValue.second
-                )
-            } else {
-                mapArguments(keyValue, otherKeyValues).to {
-                    KeyValue(
-                        it.first,
-                        it.second
-                    )
-                }.let { (first, others) ->
-                    expect contains All(
-                        first,
-                        *others
-                    )
-                }
-            }
-        }
+        ): Expect<Map<out String, Int>> =
+            if (otherKeyValues.isEmpty()) expect contains keyValue(keyValue.first, keyValue.second)
+            else mapArguments(keyValue, otherKeyValues)
+                .to { keyValue(it.first, it.second) }
+                .let { (first, others) -> expect contains all(first, *others) }
 
         @JvmName("containsKeyWithNullableValueAssertions")
         private fun contains(
             expect: Expect<Map<out String?, Int?>>,
             keyValue: Pair<String?, (Expect<Int>.() -> Unit)?>,
             otherKeyValues: Array<out Pair<String?, (Expect<Int>.() -> Unit)?>>
-        ): Expect<Map<out String?, Int?>> {
-            return if (otherKeyValues.isEmpty()) {
-                expect contains KeyValue(
-                    keyValue.first,
-                    keyValue.second
-                )
-            } else {
-                mapArguments(keyValue, otherKeyValues).to {
-                    KeyValue(
-                        it.first,
-                        it.second
-                    )
-                }.let { (first, others) ->
-                    expect contains All(
-                        first,
-                        *others
-                    )
-                }
-            }
-        }
+        ): Expect<Map<out String?, Int?>> =
+            if (otherKeyValues.isEmpty()) expect contains keyValue(keyValue.first, keyValue.second)
+            else mapArguments(keyValue, otherKeyValues)
+                .to { keyValue(it.first, it.second) }
+                .let { (first, others) -> expect contains all(first, *others) }
 
         private fun containsKey(expect: Expect<Map<out String, *>>, key: String) =
             expect containsKey key
@@ -138,301 +93,120 @@ class MapAssertionsSpec : ch.tutteli.atrium.specs.integration.MapAssertionsSpec(
         var starMap: Expect<Map<*, *>> = notImplemented()
 
         map contains (1 to "a")
-        map contains Pairs(1 to "a", 2 to "b")
-        map contains KeyValue(1) {}
-        map contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
-        map contains Pairs(1.0 to StringBuilder("a"))
-        map contains Pairs(
-            12f to "a",
-            2L to StringBuilder("b")
-        )
-        map contains KeyValue(1) {}
-        map contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
-
+        map contains pairs(1 to "a", 2 to "b")
+        map contains keyValue(1) {}
+        map contains all(keyValue(1) {}, keyValue(2) {})
+        map contains pairs(1.0 to StringBuilder("a"))
+        map contains pairs(12f to "a", 2L to StringBuilder("b"))
+        map contains keyValue(1) {}
+        map contains all(keyValue(1) {}, keyValue(2) {})
         subMap contains (1 to "a")
-        subMap contains Pairs(1 to "a", 2 to "b")
-        subMap contains KeyValue(1) {}
-        subMap contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
+        subMap contains pairs(1 to "a", 2 to "b")
+        subMap contains keyValue(1) {}
+        subMap contains all(keyValue(1) {}, keyValue(2) {})
         subMap contains (1.0 to StringBuilder("a"))
-        subMap contains Pairs(
-            12f to "a",
-            2L to StringBuilder("b")
-        )
-        subMap contains KeyValue(1) {}
-        subMap contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
+        subMap contains pairs(12f to "a", 2L to StringBuilder("b"))
+        subMap contains keyValue(1) {}
+        subMap contains all(keyValue(1) {}, keyValue(2) {})
 
         nullableKeyMap contains (1 to "a")
-        nullableKeyMap contains Pairs(
-            1 to "a",
-            2 to "b"
-        )
-        nullableKeyMap contains KeyValue(1) {}
-        nullableKeyMap contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
+        nullableKeyMap contains pairs(1 to "a", 2 to "b")
+        nullableKeyMap contains keyValue(1) {}
+        nullableKeyMap contains all(keyValue(1) {}, keyValue(2) {})
         nullableKeyMap contains (null to "a")
-        nullableKeyMap contains Pairs(
-            null to "a",
-            null to "b"
-        )
-        nullableKeyMap contains Pairs(
-            null to "a",
-            2 to "b"
-        )
-        nullableKeyMap contains (KeyValue(null) {})
-        nullableKeyMap contains All(
-            KeyValue(null) {},
-            KeyValue(null) {})
-        nullableKeyMap contains All(
-            KeyValue(null) {},
-            KeyValue(2) {})
+        nullableKeyMap contains pairs(null to "a", null to "b")
+        nullableKeyMap contains pairs(null to "a", 2 to "b")
+        nullableKeyMap contains (keyValue(null) {})
+        nullableKeyMap contains all(keyValue(null) {}, keyValue(null) {})
+        nullableKeyMap contains all(keyValue(null) {}, keyValue(2) {})
 
         nullableValueMap contains (1 to "a")
-        nullableValueMap contains Pairs(
-            1 to "a",
-            2 to "b"
-        )
-        nullableValueMap contains KeyValue(1) {}
-        nullableValueMap contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
+        nullableValueMap contains pairs(1 to "a", 2 to "b")
+        nullableValueMap contains keyValue(1) {}
+        nullableValueMap contains all(keyValue(1) {}, keyValue(2) {})
         nullableValueMap contains (1 to null)
-        nullableValueMap contains Pairs(
-            1 to null,
-            2 to null
-        )
-        nullableValueMap contains Pairs(
-            1 to null,
-            2 to "a"
-        )
-        nullableValueMap contains (KeyValue(1, null))
-        nullableValueMap contains All(
-            KeyValue(
-                1,
-                null
-            ), KeyValue(2, null)
-        )
-        nullableValueMap contains All(
-            KeyValue(
-                1,
-                null
-            ), KeyValue(2) {})
-
+        nullableValueMap contains pairs(1 to null, 2 to null)
+        nullableValueMap contains pairs(1 to null, 2 to "a")
+        nullableValueMap contains (keyValue(1, null))
+        nullableValueMap contains all(keyValue(1, null), keyValue(2, null))
+        nullableValueMap contains all(keyValue(1, null), keyValue(2) {})
         nullableKeyValueMap contains (1 to "a")
-        nullableKeyValueMap contains Pairs(
-            1 to "a",
-            2 to "b"
-        )
-        nullableKeyValueMap contains KeyValue(1) {}
-        nullableKeyValueMap contains All(
-            KeyValue(
-                1
-            ) {}, KeyValue(2) {})
+        nullableKeyValueMap contains pairs(1 to "a", 2 to "b")
+        nullableKeyValueMap contains keyValue(1) {}
+        nullableKeyValueMap contains all(keyValue(1) {}, keyValue(2) {})
 
         nullableKeyValueMap contains (null to "a")
-        nullableKeyValueMap contains Pairs(
-            null to "a",
-            null to "b"
-        )
-        nullableKeyValueMap contains Pairs(
-            null to "a",
-            2 to "b"
-        )
-        nullableKeyValueMap contains (KeyValue(null) {})
-        nullableKeyValueMap contains All(
-            KeyValue(
-                null
-            ) {}, KeyValue(null) {})
-        nullableKeyValueMap contains All(
-            KeyValue(
-                null
-            ) {}, KeyValue(2) {})
+        nullableKeyValueMap contains pairs(null to "a", null to "b")
+        nullableKeyValueMap contains pairs(null to "a", 2 to "b")
+        nullableKeyValueMap contains (keyValue(null) {})
+        nullableKeyValueMap contains all(keyValue(null) {}, keyValue(null) {})
+        nullableKeyValueMap contains all(keyValue(null) {}, keyValue(2) {})
 
         nullableKeyValueMap contains (1 to null)
-        nullableKeyValueMap contains Pairs(
-            1 to null,
-            2 to null
-        )
-        nullableKeyValueMap contains Pairs(
-            1 to null,
-            2 to "a"
-        )
-        nullableKeyValueMap contains (KeyValue(
-            1,
-            null
-        ))
-        nullableKeyValueMap contains All(
-            KeyValue(
-                1,
-                null
-            ), KeyValue(2, null)
-        )
-        nullableKeyValueMap contains All(
-            KeyValue(
-                1,
-                null
-            ), KeyValue(2) {})
+        nullableKeyValueMap contains pairs(1 to null, 2 to null)
+        nullableKeyValueMap contains pairs(1 to null, 2 to "a")
+        nullableKeyValueMap contains (keyValue(1, null))
+        nullableKeyValueMap contains all(keyValue(1, null), keyValue(2, null))
+        nullableKeyValueMap contains all(keyValue(1, null), keyValue(2) {})
 
         nullableKeyValueMap contains (null to null)
-        nullableKeyValueMap contains Pairs(
-            null to null,
-            null to null
-        )
-        nullableKeyValueMap contains Pairs(
-            1 to null,
-            null to "a"
-        )
-        nullableKeyValueMap contains (KeyValue(
-            null,
-            null
-        ))
-        nullableKeyValueMap contains All(
-            KeyValue(
-                null,
-                null
-            ), KeyValue(null, null)
-        )
-        nullableKeyValueMap contains All(
-            KeyValue(
-                1,
-                null
-            ), KeyValue(null) {})
+        nullableKeyValueMap contains pairs(null to null, null to null)
+        nullableKeyValueMap contains pairs(1 to null, null to "a")
+        nullableKeyValueMap contains (keyValue(null, null))
+        nullableKeyValueMap contains all(keyValue(null, null), keyValue(null, null))
+        nullableKeyValueMap contains all(keyValue(1, null), keyValue(null) {})
 
         readOnlyNullableKeyValueMap contains (1 to "a")
-        readOnlyNullableKeyValueMap contains Pairs(
-            1 to "a",
-            2 to "b"
-        )
-        readOnlyNullableKeyValueMap contains KeyValue(
-            1
-        ) {}
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
+        readOnlyNullableKeyValueMap contains pairs(1 to "a", 2 to "b")
+        readOnlyNullableKeyValueMap contains keyValue(1) {}
+        readOnlyNullableKeyValueMap contains all(keyValue(1) {}, keyValue(2) {})
 
         readOnlyNullableKeyValueMap contains (null to "a")
-        readOnlyNullableKeyValueMap contains Pairs(
-            null to "a",
-            null to "b"
-        )
-        readOnlyNullableKeyValueMap contains Pairs(
-            null to "a",
-            2 to "b"
-        )
-        readOnlyNullableKeyValueMap contains (KeyValue(
-            null
-        ) {})
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(null) {},
-            KeyValue(null) {})
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(null) {},
-            KeyValue(2) {})
+        readOnlyNullableKeyValueMap contains pairs(null to "a", null to "b")
+        readOnlyNullableKeyValueMap contains pairs(null to "a", 2 to "b")
+        readOnlyNullableKeyValueMap contains (keyValue(null) {})
+        readOnlyNullableKeyValueMap contains all(keyValue(null) {}, keyValue(null) {})
+        readOnlyNullableKeyValueMap contains all(keyValue(null) {}, keyValue(2) {})
 
         readOnlyNullableKeyValueMap contains (1 to null)
-        readOnlyNullableKeyValueMap contains Pairs(
-            1 to null,
-            2 to null
-        )
-        readOnlyNullableKeyValueMap contains Pairs(
-            1 to null,
-            2 to "a"
-        )
-        readOnlyNullableKeyValueMap contains (KeyValue(
-            1,
-            null
-        ))
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(1, null),
-            KeyValue(2, null)
-        )
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(1, null),
-            KeyValue(2) {})
+        readOnlyNullableKeyValueMap contains pairs(1 to null, 2 to null)
+        readOnlyNullableKeyValueMap contains pairs(1 to null, 2 to "a")
+        readOnlyNullableKeyValueMap contains (keyValue(1, null))
+        readOnlyNullableKeyValueMap contains all(keyValue(1, null), keyValue(2, null))
+        readOnlyNullableKeyValueMap contains all(keyValue(1, null), keyValue(2) {})
 
         readOnlyNullableKeyValueMap contains (null to null)
-        readOnlyNullableKeyValueMap contains Pairs(
-            null to null,
-            null to null
-        )
-        readOnlyNullableKeyValueMap contains Pairs(
-            1 to null,
-            null to "a"
-        )
-        readOnlyNullableKeyValueMap contains (KeyValue(
-            null,
-            null
-        ))
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(null, null),
-            KeyValue(null, null)
-        )
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(1, null),
-            KeyValue(null) {})
+        readOnlyNullableKeyValueMap contains pairs(null to null, null to null)
+        readOnlyNullableKeyValueMap contains pairs(1 to null, null to "a")
+        readOnlyNullableKeyValueMap contains (keyValue(null, null))
+        readOnlyNullableKeyValueMap contains all(keyValue(null, null), keyValue(null, null))
+        readOnlyNullableKeyValueMap contains all(keyValue(1, null), keyValue(null) {})
 
         readOnlyNullableKeyValueMap contains (1 to "a")
-        readOnlyNullableKeyValueMap contains Pairs(
-            1 to "a",
-            2 to "b"
-        )
-        readOnlyNullableKeyValueMap contains KeyValue(
-            1
-        ) {}
-        readOnlyNullableKeyValueMap contains All(
-            KeyValue(1) {},
-            KeyValue(2) {})
+        readOnlyNullableKeyValueMap contains pairs(1 to "a", 2 to "b")
+        readOnlyNullableKeyValueMap contains keyValue(1) {}
+        readOnlyNullableKeyValueMap contains all(keyValue(1) {}, keyValue(2) {})
 
         starMap contains (null to "a")
-        starMap contains Pairs(
-            null to "a",
-            null to "b"
-        )
-        starMap contains Pairs(null to "a", 2 to "b")
-        starMap contains (KeyValue(null) {})
-        starMap contains All(
-            KeyValue(null) {},
-            KeyValue(null) {})
-        starMap contains All(
-            KeyValue(null) {},
-            KeyValue(2) {})
+        starMap contains pairs(null to "a", null to "b")
+        starMap contains pairs(null to "a", 2 to "b")
+        starMap contains (keyValue(null) {})
+        starMap contains all(keyValue(null) {}, keyValue(null) {})
+        starMap contains all(keyValue(null) {}, keyValue(2) {})
 
         starMap contains (1 to null)
-        starMap contains Pairs(1 to null, 2 to null)
-        starMap contains Pairs(1 to null, 2 to "a")
-        starMap contains (KeyValue(1, null))
-        starMap contains All(
-            KeyValue(1, null),
-            KeyValue(2, null)
-        )
-        starMap contains All(
-            KeyValue(1, null),
-            KeyValue(2) {})
+        starMap contains pairs(1 to null, 2 to null)
+        starMap contains pairs(1 to null, 2 to "a")
+        starMap contains (keyValue(1, null))
+        starMap contains all(keyValue(1, null), keyValue(2, null))
+        starMap contains all(keyValue(1, null), keyValue(2) {})
 
         starMap contains (null to null)
-        starMap contains Pairs(
-            null to null,
-            null to null
-        )
-        starMap contains Pairs(1 to null, null to "a")
-        starMap contains (KeyValue(null, null))
-        starMap contains All(
-            KeyValue(
-                null,
-                null
-            ), KeyValue(null, null)
-        )
-        starMap contains All(
-            KeyValue(1, null),
-            KeyValue(null) {})
+        starMap contains pairs(null to null, null to null)
+        starMap contains pairs(1 to null, null to "a")
+        starMap contains (keyValue(null, null))
+        starMap contains all(keyValue(null, null), keyValue(null, null))
+        starMap contains all(keyValue(1, null), keyValue(null) {})
 
         map containsKey 1
         map containsKey 1f

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryFeatureAssertionsSpec.kt
@@ -1,10 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
 class MapEntryFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.MapEntryFeatureAssertionsSpec(
     property<Map.Entry<String, Int>, String>(Expect<Map.Entry<String, Int>>::key),

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ThrowableAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ThrowableAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
@@ -21,7 +20,7 @@ class ThrowableAssertionsSpec : ch.tutteli.atrium.specs.integration.ThrowableAss
             vararg otherExpected: Any
         ): Expect<Throwable> =
             if (otherExpected.isEmpty()) expect messageContains expected
-            else expect messageContains Values(
+            else expect messageContains values(
                 expected,
                 *otherExpected
             )
@@ -45,7 +44,7 @@ class ThrowableAssertionsSpec : ch.tutteli.atrium.specs.integration.ThrowableAss
         a1 = a1 message {}
         a1 = a1 messageContains "a"
         a1 = a1 messageContains 'a'
-        a1 = a1 messageContains Values(
+        a1 = a1 messageContains values(
             "a",
             1,
             'b'


### PR DESCRIPTION
moreover:
- improve KDoc use " instead of ' where we refer to a String
- improve ambiguityTest in CharSequenceContainsSpecBase of fluent API
- fix line-break issues (introduce by IntelliJ, refactoring code without
  asking)

part 1 of 2 for #342 

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
