### PR TITLE
bundles for infix api (#236)

### DIFF
--- a/bundles/infix-en_GB/atrium-infix-en_GB-android/build.gradle
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-android/build.gradle
@@ -1,0 +1,18 @@
+description = 'Represents a convenience module which merely bundles dependencies for Android.'
+
+dependencies {
+    api prefixedProject('verbs-android')
+    api prefixedProject('api-infix-en_GB-android')
+    api prefixedProject('translations-en_GB-android')
+    api prefixedProject('domain-builders-android')
+    api prefixedProject('domain-api-android')
+    api prefixedProject('core-api-android')
+
+    runtimeOnly prefixedProject('domain-robstoll-android')
+    runtimeOnly prefixedProject('core-robstoll-android')
+
+    //TODO remove once all specs are with spek2 where they are set via spek plugin
+    spekDep(delegate)
+}
+
+srcAndResourcesFromJvmProject(project)

--- a/bundles/infix-en_GB/atrium-infix-en_GB-common/build.gradle
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-common/build.gradle
@@ -1,0 +1,13 @@
+description = 'Represents a convenience module which merely bundles dependencies as common module.'
+
+dependencies {
+    api prefixedProject('verbs-common')
+    api prefixedProject('api-infix-en_GB-common')
+    api prefixedProject('translations-en_GB-common')
+    api prefixedProject('domain-builders-common')
+    api prefixedProject('domain-api-common')
+    api prefixedProject('core-api-common')
+
+    runtimeOnly prefixedProject('domain-robstoll-common')
+    runtimeOnly prefixedProject('core-robstoll-common')
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-common/src/test/kotlin/SmokeTest.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-common/src/test/kotlin/SmokeTest.kt
@@ -1,0 +1,71 @@
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.verbs.AssertionVerb
+import ch.tutteli.atrium.api.verbs.assert
+import ch.tutteli.atrium.api.verbs.assertThat
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+import ch.tutteli.atrium.translations.DescriptionBasic.IS
+import ch.tutteli.atrium.translations.DescriptionBasic.TO_BE
+import kotlin.test.Test
+
+class SmokeTest {
+
+    @Test
+    fun toBe_canBeUsed() {
+        assertThat(1) toBe 1
+    }
+
+    @Test
+    fun assertionFunctionWithoutI18nCanBeUsed() {
+        assertThat(2) tobe even
+    }
+
+    @Test
+    fun assertionFunctionWithI18nCanBeUsed() {
+        assertThat(4) isMultipleOf 2
+    }
+
+    @Test
+    fun assertAnExceptionOccurred() {
+        assertThat {
+            throw IllegalArgumentException()
+        }.toThrow<IllegalArgumentException>()
+    }
+
+    @Test
+    fun assertAnExceptionWithAMessageOccurred() {
+        assertThat {
+            throw IllegalArgumentException("oho... hello btw")
+        }.toThrow<IllegalArgumentException> {
+            it messageContains "hello"
+        }
+    }
+
+    @Test
+    fun assertNotToThrow() {
+        assertThat {
+
+        }.notToThrow()
+    }
+}
+
+@Suppress("ClassName")
+object even
+
+infix fun Expect<Int>.tobe(@Suppress("UNUSED_PARAMETER") even: even) =
+    createAndAddAssertion(IS, RawString.create("an even number")) { it % 2 == 0 }
+
+infix fun Expect<Int>.isMultipleOf(base: Int): Expect<Int> = addAssertion(isMultipleOf(this, base))
+
+private fun isMultipleOf(expect: Expect<Int>, base: Int): Assertion =
+    ExpectImpl.builder.createDescriptive(expect, DescriptionIntAssertions.IS_MULTIPLE_OF, base) {
+        it % base == 0
+    }
+
+enum class DescriptionIntAssertions(override val value: String) : StringBasedTranslatable {
+    IS_MULTIPLE_OF("is multiple of")
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-js/build.gradle
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-js/build.gradle
@@ -1,0 +1,13 @@
+description = 'Represents a convenience module which merely bundles dependencies for the JS platform.'
+
+dependencies {
+    api prefixedProject('verbs-js')
+    api prefixedProject('api-infix-en_GB-js')
+    api prefixedProject('translations-en_GB-js')
+    api prefixedProject('domain-builders-js')
+    api prefixedProject('domain-api-js')
+    api prefixedProject('core-api-js')
+
+    implementation prefixedProject('domain-robstoll-js')
+    implementation prefixedProject('core-robstoll-js')
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-js/src/main/kotlin/ch/tutteli/atrium/infix/en_GB/dependOnMe.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-js/src/main/kotlin/ch/tutteli/atrium/infix/en_GB/dependOnMe.kt
@@ -1,0 +1,15 @@
+package ch.tutteli.atrium.infix.en_GB
+
+import ch.tutteli.atrium.core.robstoll.dependOn_atrium_core_robstoll
+import ch.tutteli.atrium.domain.robstoll.dependOn_atrium_domain_robstoll
+
+/**
+ * Dummy function in order that other modules can define a dependency on atrium-infix-en_GB-js
+ *
+ * Moreover it has the side effect that a dependency on core-robstoll and domain-robstoll is established.
+ * This is necessary, as it has only a loosely coupled dependency (via serviceLoader).
+ */
+fun dependOnAtrium() {
+    dependOn_atrium_core_robstoll()
+    dependOn_atrium_domain_robstoll()
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-js/src/test/kotlin/ch/tutteli/atrium/infix/en_GB/JsNameAmbiguityTest.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-js/src/test/kotlin/ch/tutteli/atrium/infix/en_GB/JsNameAmbiguityTest.kt
@@ -1,0 +1,25 @@
+package ch.tutteli.atrium.infix.en_GB
+
+import ch.tutteli.atrium.api.infix.en_GB.asEntries
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+/**
+ * As there are bugs related to JsName in Kotlin we should test each to be sure that it works also during runtime.
+ */
+class JsNameAmbiguityTest {
+
+    @Test
+    fun toBeNullable() {
+        expect(null as Int?) toBe null
+        expect(1 as Int?) toBe 1
+    }
+
+    @Test
+    fun isKeyValueNullable() {
+        expect(mapOf(1 to null as Int?)).asEntries(o).containsExactly {
+            it isKeyValue (1 to null)
+        }
+    }
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-js/src/test/kotlin/testSetup.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-js/src/test/kotlin/testSetup.kt
@@ -1,0 +1,4 @@
+import ch.tutteli.atrium.infix.en_GB.dependOnAtrium
+
+@Suppress("unused")
+private val establishDependencyToAtrium = dependOnAtrium()

--- a/bundles/infix-en_GB/atrium-infix-en_GB-jvm/build.gradle
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-jvm/build.gradle
@@ -1,0 +1,16 @@
+description = 'Represents a convenience module which merely bundles dependencies for the JVM platform.'
+
+dependencies {
+    api prefixedProject('verbs-jvm')
+    api prefixedProject('api-infix-en_GB-jvm')
+    api prefixedProject('translations-en_GB-jvm')
+    api prefixedProject('domain-builders-jvm')
+    api prefixedProject('domain-api-jvm')
+    api prefixedProject('core-api-jvm')
+
+    runtimeOnly prefixedProject('domain-robstoll-jvm')
+    runtimeOnly prefixedProject('core-robstoll-jvm')
+
+    //TODO remove once all specs are with spek2 where they are set via spek plugin
+    spekDep(delegate)
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-jvm/src/module/module-info.java
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-jvm/src/module/module-info.java
@@ -1,0 +1,7 @@
+module ch.tutteli.atrium.infix.en_GB {
+    requires transitive ch.tutteli.atrium.verbs;
+    requires transitive ch.tutteli.atrium.api.infix.en_GB;
+    requires transitive ch.tutteli.atrium.domain.builders;
+    requires transitive ch.tutteli.atrium.translations.en_GB;
+    requires            kotlin.stdlib;
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-jvm/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-jvm/src/test/kotlin/custom/SmokeSpec.kt
@@ -1,0 +1,43 @@
+package custom
+
+import ch.tutteli.atrium.api.infix.en_GB.toBe
+import ch.tutteli.atrium.api.verbs.assertThat
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+import ch.tutteli.atrium.translations.DescriptionBasic
+import org.spekframework.spek2.Spek
+
+object SmokeSpec : Spek({
+    test("see if `toBe` can be used") {
+        assertThat(1) toBe 1
+    }
+
+    test("see if own assertion function without i18n can be used") {
+        assertThat(2) tobe even
+    }
+
+    test("see if own assertion function with i18n can be used") {
+        assertThat(4) isMultipleOf 2
+    }
+})
+
+@Suppress("ClassName")
+object even
+
+infix fun Expect<Int>.tobe(@Suppress("UNUSED_PARAMETER") even: even) =
+    createAndAddAssertion(DescriptionBasic.IS, RawString.create("an even number")) { it % 2 == 0 }
+
+infix fun Expect<Int>.isMultipleOf(base: Int) = addAssertion(isMultipleOf(this, base))
+
+fun isMultipleOf(expect: Expect<Int>, base: Int): Assertion =
+    ExpectImpl.builder.createDescriptive(expect, DescriptionIntAssertions.IS_MULTIPLE_OF, base) {
+        it % base == 0
+    }
+
+enum class DescriptionIntAssertions(override val value: String) : StringBasedTranslatable {
+    IS_MULTIPLE_OF("is multiple of")
+}

--- a/bundles/infix-en_GB/atrium-infix-en_GB-smoke-test/src/test/kotlin/module-info.java
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-smoke-test/src/test/kotlin/module-info.java
@@ -1,0 +1,9 @@
+module ch.tutteli.atrium.infix.en_GB.smoke {
+    // test dependencies are usually defined in build.gradle via --patch-module but that's quite cumbersome and I did
+    // not get it running in 10 minutes so I am using this, the effect should be the same, the kotlin compiler checks if
+    // I am using symbols from packages I do not require etc.
+
+    requires ch.tutteli.atrium.infix.en_GB;
+    requires kotlin.stdlib;
+    requires spek.dsl.jvm;
+}

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-jdk8/build.gradle
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-jdk8/build.gradle
@@ -1,0 +1,10 @@
+description = "Represents a JDK >= 9 smoke test for atrium-infix-en_GB with jdk8 extension"
+
+sourceCompatibility = JavaVersion.current()
+targetCompatibility = JavaVersion.current()
+
+dependencies {
+    //I don't see how to set up compileTestKotlin with --patch-module, so we have put the module-info.java directly in src/test/kotlin instead
+    testImplementation prefixedProject('infix-en_GB-jvm')
+    testImplementation prefixedProject('api-infix-en_GB-jdk8-jvm')
+}

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-jdk8/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-jdk8/src/test/kotlin/custom/SmokeSpec.kt
@@ -1,0 +1,50 @@
+package custom
+
+import ch.tutteli.atrium.api.infix.en_GB.jdk8.notTo
+import ch.tutteli.atrium.api.infix.en_GB.exist
+import ch.tutteli.atrium.api.infix.en_GB.toBe
+import ch.tutteli.atrium.api.verbs.assert
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+import ch.tutteli.atrium.translations.DescriptionBasic
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
+
+object SmokeSpec : Spek({
+    test("see if `toBe` can be used") {
+        assert(1) toBe 1
+    }
+
+    test("see if `Path.existsNot` can be used") {
+        assert(Paths.get("nonExisting")) notTo exist
+    }
+
+    test("see if own assertion function without i18n can be used") {
+        assert(2) tobe even
+    }
+
+    test("see if own assertion function with i18n can be used") {
+        assert(4) isMultipleOf 2
+    }
+})
+
+@Suppress("ClassName")
+object even
+
+infix fun Expect<Int>.tobe(@Suppress("UNUSED_PARAMETER") even: even) =
+    createAndAddAssertion(DescriptionBasic.IS, RawString.create("an even number")) { it % 2 == 0 }
+
+infix fun Expect<Int>.isMultipleOf(base: Int): Expect<Int> = addAssertion(_isMultipleOf(this, base))
+
+fun _isMultipleOf(expect: Expect<Int>, base: Int): Assertion =
+    ExpectImpl.builder.createDescriptive(expect, DescriptionIntAssertions.IS_MULTIPLE_OF, base) {
+        it % base == 0
+    }
+
+enum class DescriptionIntAssertions(override val value: String) : StringBasedTranslatable {
+    IS_MULTIPLE_OF("is multiple of")
+}

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-jdk8/src/test/kotlin/module-info.java
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-jdk8/src/test/kotlin/module-info.java
@@ -1,0 +1,10 @@
+module ch.tutteli.atrium.infix.en_GB.jdk8.smoke {
+    // test dependencies are usually defined in build.gradle via --patch-module but that's quite cumbersome and I did
+    // not get it running in 10 minutes so I am using this, the effect should be the same, the kotlin compiler checks if
+    // I am using symbols from packages I do not require etc.
+
+    requires ch.tutteli.atrium.infix.en_GB;
+    requires ch.tutteli.atrium.api.infix.en_GB.jdk8;
+    requires kotlin.stdlib;
+    requires spek.dsl.jvm;
+}

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/build.gradle
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/build.gradle
@@ -1,0 +1,11 @@
+description = "Represents a JDK >= 9 smoke test for atrium-infix-en_GB with kotlin_1_3 extension"
+
+sourceCompatibility = JavaVersion.current()
+targetCompatibility = JavaVersion.current()
+
+dependencies {
+    //I don't see how to set up compileTestKotlin with --patch-module, so we have put the module-info.java directly in src/test/kotlin instead
+    testImplementation prefixedProject('infix-en_GB-jvm')
+    testImplementation prefixedProject('api-infix-en_GB-kotlin_1_3-jvm')
+    testRuntimeOnly prefixedProject('domain-robstoll-kotlin_1_3-jvm')
+}

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
@@ -1,0 +1,50 @@
+@file:Suppress("JAVA_MODULE_DOES_NOT_READ_UNNAMED_MODULE" /* TODO remove once https://youtrack.jetbrains.com/issue/KT-35343 is fixed */)
+
+package custom
+
+import ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3.toBe
+import ch.tutteli.atrium.api.infix.en_GB.toBe
+import ch.tutteli.atrium.api.infix.en_GB.success
+import ch.tutteli.atrium.api.verbs.expect
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
+import ch.tutteli.atrium.translations.DescriptionBasic
+import org.spekframework.spek2.Spek
+
+object SmokeSpec : Spek({
+    test("see if `toBe` can be used") {
+        expect(1) toBe 1
+    }
+
+    test("see if `Result.isSuccess` can be used") {
+        expect(Result.success(1)) toBe success
+    }
+
+    test("see if own assertion function without i18n can be used") {
+        expect(2) tobe even
+    }
+
+    test("see if own assertion function with i18n can be used") {
+        expect(4) isMultipleOf 2
+    }
+})
+
+@Suppress("ClassName")
+object even
+
+infix fun Expect<Int>.tobe(@Suppress("UNUSED_PARAMETER") even: even) =
+    createAndAddAssertion(DescriptionBasic.IS, RawString.create("an even number")) { it % 2 == 0 }
+
+infix fun Expect<Int>.isMultipleOf(base: Int): Expect<Int> = addAssertion(_isMultipleOf(this, base))
+
+fun _isMultipleOf(expect: Expect<Int>, base: Int): Assertion =
+    ExpectImpl.builder.createDescriptive(expect, DescriptionIntAssertions.IS_MULTIPLE_OF, base) {
+        it % base == 0
+    }
+
+enum class DescriptionIntAssertions(override val value: String) : StringBasedTranslatable {
+    IS_MULTIPLE_OF("is multiple of")
+}

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/module-info.java
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/module-info.java
@@ -1,0 +1,10 @@
+module ch.tutteli.atrium.infix.en_GB.kotlin_1_3.smoke {
+    // test dependencies are usually defined in build.gradle via --patch-module but that's quite cumbersome and I did
+    // not get it running in 10 minutes so I am using this, the effect should be the same, the kotlin compiler checks if
+    // I am using symbols from packages I do not require etc.
+
+    requires ch.tutteli.atrium.infix.en_GB;
+    requires ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3;
+    requires kotlin.stdlib;
+    requires spek.dsl.jvm;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,7 @@ include {
 
     bundles {
         bundleWithExtensionsAndSmokeTest(delegate, 'fluent-en_GB')
+        bundleWithExtensionsAndSmokeTest(delegate, 'infix-en_GB')
     }
 
     apis('api-') {


### PR DESCRIPTION
@robstoll This PR addresses issue #236 but I'm not sure that I've done all required steps.
I've next questions:
1)I'm not sure about places where assert should be changed to expect (if should be at all in this case)
2)I'm not sure about infix functions in SmokeSpec in extensions 
3)During the push I've got several errors that `module` isn't supported in language level '8' and seems it's related to 
```
sourceCompatibility = 8
targetCompatibility = 8
```
Is it possible to set language level to 11 via gradle for such modules to get rid of such errors?
Could you please carefully take a look at this PR and comment what should be fixed and updated?
Thank you!
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
