### PR TITLE
add elementsOf to contains.ignoreCase fluent-api

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.ExpectImpl
 import ch.tutteli.atrium.domain.builders.creating.basic.contains.addAssertion
 import ch.tutteli.atrium.domain.builders.utils.toVarArg
+import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains.*
 import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
 import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
@@ -327,6 +328,14 @@ fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.elementsOf(
  */
 @JvmName("elementsOfIgnoringCase")
 fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.elementsOf(
+    expectedIterable: Iterable<Any>
+): Expect<T> {
+    val (first, rest) = toVarArg(expectedIterable)
+    return values(first, *rest)
+}
+
+@JvmName("elementsOfIgnoringCase")
+fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.elementsOf(
     expectedIterable: Iterable<Any>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -36,10 +36,10 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
                 }.toThrow<IllegalArgumentException> { messageContains("Iterable without elements are not allowed") }
             }
         }
-        describe("ignoringCase.atLeast(1).elementsOf") {
+        describe("ignoringCase.elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {
-                    expect("test").contains.ignoringCase.atLeast(1).elementsOf(emptyList())
+                    expect("test").contains.ignoringCase.elementsOf(emptyList())
                 }.toThrow<IllegalArgumentException> { messageContains("Iterable without elements are not allowed") }
             }
         }
@@ -102,11 +102,12 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
             aX: Array<out Any>
         ): Expect<CharSequence> =
             if (aX.isEmpty()) {
-                expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a))
+                if (atLeast == 1) expect.contains.ignoringCase.elementsOf(listOf(a))
+                else expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a))
             } else {
-                expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a, *aX))
+                if (atLeast == 1) expect.contains.ignoringCase.elementsOf(listOf(a, *aX))
+                else expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a, *aX))
             }
-
 
         private val atLeastButAtMostDescr = { what: String, timesAtLeast: String, timesAtMost: String ->
             "$contains $what $atLeast $timesAtLeast $butAtMost $timesAtMost"

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -36,6 +36,13 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
                 }.toThrow<IllegalArgumentException> { messageContains("Iterable without elements are not allowed") }
             }
         }
+        describe("ignoringCase.atLeast(1).elementsOf") {
+            it("passing an empty iterable throws an IllegalArgumentException") {
+                expect {
+                    expect("test").contains.ignoringCase.atLeast(1).elementsOf(emptyList())
+                }.toThrow<IllegalArgumentException> { messageContains("Iterable without elements are not allowed") }
+            }
+        }
         describe("ignoringCase.elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -101,7 +101,12 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
             a: Any,
             aX: Array<out Any>
         ): Expect<CharSequence> =
-            expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a, *aX))
+            if (aX.isEmpty()) {
+                expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a))
+            } else {
+                expect.contains.ignoringCase.atLeast(atLeast).elementsOf(listOf(a, *aX))
+            }
+
 
         private val atLeastButAtMostDescr = { what: String, timesAtLeast: String, timesAtMost: String ->
             "$contains $what $atLeast $timesAtLeast $butAtMost $timesAtMost"

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceContainsSpecBase.kt
@@ -78,7 +78,6 @@ abstract class CharSequenceContainsSpecBase {
         // and hence these would be a second way to do the same thing
         //a1.contains.ignoringCase.regex(Regex("a"))
         //a1.contains.ignoringCase.regex(Regex("a"), Regex("bl"))
-        //TODO #422 uncomment
-        //a1.contains.ignoringCase.elementsOf(listOf("a", 2))
+        a1.contains.ignoringCase.elementsOf(listOf("a", 2))
     }
 }


### PR DESCRIPTION
Following the things that I done :

_fluent-api_

- [x] add elementsOf to charSequenceContainsCreators for CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour> (copy the existing elementsOf and adjust)
- [x] search for TODO #422 in specs and fix
- [x] add test-case to CharSequenceContainsAtLeastAssertionsSpec covering the case that an empty iterable is passed

infix-api
- [ ] add elementsOf to charSequenceContainsCreators for CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour> (copy the existing elementsOf and adjust)
- [ ] search for TODO #422 in specs and fix
- [ ] add test-case to CharSequenceContainsAtLeastAssertionsSpec covering the case that an empty iterable is passed
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
