### PR TITLE
fix #422 add elementsOf to contains.ignoreCase infix-api

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
@@ -7,6 +7,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.ExpectImpl
 import ch.tutteli.atrium.domain.builders.creating.basic.contains.addAssertion
 import ch.tutteli.atrium.domain.builders.utils.toVarArg
+import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains.Builder
 import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceContains.CheckerOption
 import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
@@ -375,6 +376,14 @@ infix fun <T : CharSequence> CheckerOption<T, NoOpSearchBehaviour>.elementsOf(
  */
 @JvmName("elementsOfIgnoringCase")
 infix fun <T : CharSequence> CheckerOption<T, IgnoringCaseSearchBehaviour>.elementsOf(
+    expectedIterable: Iterable<Any>
+): Expect<T> {
+    val (first, rest) = toVarArg(expectedIterable)
+    return this the Values(first, rest)
+}
+
+@JvmName("elementsOfIgnoringCase")
+infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.elementsOf(
     expectedIterable: Iterable<Any>
 ): Expect<T> {
     val (first, rest) = toVarArg(expectedIterable)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -36,6 +36,13 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
                 }.toThrow<IllegalArgumentException> { it messageContains "Iterable without elements are not allowed" }
             }
         }
+        describe("ignoring case elementsOf") {
+            it("passing an empty iterable throws an IllegalArgumentException") {
+                expect {
+                    expect("test") contains o ignoring case elementsOf emptyList()
+                }.toThrow<IllegalArgumentException> { it messageContains "Iterable without elements are not allowed" }
+            }
+        }
         describe("ignoring case atLeast 1 elementsOf") {
             it("passing an empty iterable throws an IllegalArgumentException") {
                 expect {
@@ -101,7 +108,12 @@ class CharSequenceContainsAtLeastAssertionsSpec : Spek({
             a: Any,
             aX: Array<out Any>
         ): Expect<CharSequence> =
-            expect contains o ignoring case atLeast atLeast elementsOf listOf(a, *aX)
+            if (aX.isEmpty()) {
+                if (atLeast == 1) expect contains o ignoring case elementsOf listOf(a)
+                else expect contains o ignoring case atLeast atLeast elementsOf listOf(a)
+            } else {
+                if (atLeast == 1) expect contains o ignoring case elementsOf listOf(a, *aX)
+                else expect contains o ignoring case atLeast atLeast elementsOf listOf(a, *aX)            }
 
         private val atLeastButAtMostDescr = { what: String, timesAtLeast: String, timesAtMost: String ->
             "$contains o $what $atLeast $timesAtLeast $butAtMost $timesAtMost"

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceContainsSpecBase.kt
@@ -87,8 +87,7 @@ abstract class CharSequenceContainsSpecBase : WithAsciiReporter() {
         // and hence these would be a second way to do the same thing
         //a1 contains o ignoring case matchFor Regex("a")
         //a1 contains o ignoring case matchFor all(Regex("a"), Regex("bl"))
-        //TODO #422 uncomment
-        //a1 contains o ignoring case elementsOf listOf("a", 2)
+        a1 contains o ignoring case elementsOf listOf("a", 2)
 
         a1 and { it contains o atLeast 1 value 1 }
         a1 and { it contains o atMost 2 the values("a", 1) }


### PR DESCRIPTION
Following the things that I have done:

infix-api
- [x] add elementsOf to charSequenceContainsCreators for CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour> (copy the existing elementsOf and adjust)
- [x] search for TODO #422 in specs and fix
- [x] add test-case to CharSequenceContainsAtLeastAssertionsSpec covering the case that an empty iterable is passed

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
