### PR TITLE
shortcut Iterable.containsExactlyElementsOf implemented

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
@@ -198,6 +198,20 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
     vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?
 ): Expect<T> = contains.inOrder.only.entries(assertionCreatorOrNull, *otherAssertionCreatorsOrNulls)
 
+/**
+ * Expects that the subject of the assertion (an [Iterable]) contains only elements of [expectedIterable]
+ * in same order
+ *
+ * It is a shortcut for 'contains.inOrder.only.elementsOf(anotherList)'
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ *  @since 0.11.0
+ */
+inline fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsOf(
+    expectedIterable: Iterable<E>
+): Expect<T> = contains.inOrder.only.elementsOf(expectedIterable)
 
 /**
  * Expects that the subject of the assertion (an [Iterable]) does not contain the [expected] value

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyElementsOfAssertionSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyElementsOfAssertionSpec.kt
@@ -2,16 +2,27 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.kbox.glue
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import kotlin.reflect.KFunction2
 
 class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
     include(BuilderSpec)
+    include(ShortcutSpec)
 
     describe("contains.inOrder.only.elementsOf") {
         it("passing an empty iterable throws an IllegalArgumentException") {
             expect {
                 expect(listOf(1, 2)).contains.inOrder.only.elementsOf(listOf())
+            }.toThrow<IllegalArgumentException>()
+        }
+    }
+
+    describe("containsExactlyElementsOf") {
+        it("passing an empty iterable throws an IllegalArgumentException") {
+            expect {
+                expect(listOf(1, 2)).containsExactlyElementsOf(listOf())
             }.toThrow<IllegalArgumentException>()
         }
     }
@@ -21,6 +32,13 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
         getContainsNullablePair(),
         "◆ ", "✔ ", "✘ ", "❗❗ ", "⚬ ", "▶ ", "◾ ",
         "[Atrium][Builder] "
+    )
+
+    object ShortcutSpec : ch.tutteli.atrium.specs.integration.IterableContainsInOrderOnlyValuesAssertionsSpec(
+        getContainsShortcutPair(),
+        getContainsNullableShortcutPair(),
+        "◆ ", "✔ ", "✘ ", "❗❗ ", "⚬ ", "▶ ", "◾ ",
+        "[Atrium][Shortcut] "
     )
 
     companion object : IterableContainsSpecBase() {
@@ -40,6 +58,29 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
             a: Double?,
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> = expect.contains.inOrder.only.elementsOf(listOf(a, *aX))
+
+        private val containsExactlyElementsOfShortcutFun: KFunction2<Expect<Iterable<Double>>, Iterable<Double>, Expect<Iterable<Double>>> =
+            Expect<Iterable<Double>>::containsExactlyElementsOf
+
+        private fun getContainsShortcutPair() = Pair(containsExactlyElementsOfShortcutFun.name, Companion::containsExactlyElementsOfShortcut)
+
+        private fun containsExactlyElementsOfShortcut(
+            expect: Expect<Iterable<Double>>,
+            a: Double,
+            aX: Array<out Double>
+        ): Expect<Iterable<Double>> = expect.containsExactlyElementsOf(a.glue(aX))
+
+        private val containsExactlyElementsOfNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Iterable<Double?>, Expect<Iterable<Double?>>> =
+            Expect<Iterable<Double?>>::containsExactlyElementsOf
+
+        private fun getContainsNullableShortcutPair() = Pair(containsExactlyElementsOfNullableShortcutFun.name, Companion::containsExactlyElementsOfNullableShortcut)
+
+        private fun containsExactlyElementsOfNullableShortcut(
+            expect: Expect<Iterable<Double?>>,
+            a: Double?,
+            aX: Array<out Double?>
+        ): Expect<Iterable<Double?>> = expect.containsExactlyElementsOf(a.glue(aX))
+
     }
 }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
@@ -234,6 +234,21 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(entries: Entries
     it contains o inGiven order and only the entries
 
 /**
+ * Expects that the subject of the assertion (an [Iterable]) contains only elements of [expectedIterable]
+ * in same order
+ *
+ * It is a shortcut for 'contains.inOrder.only.elementsOf(anotherList)'
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.11.0
+ */
+inline infix fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsOf(
+    expectedIterable: Iterable<E>
+): Expect<T> = it contains o inGiven order and only elementsOf (expectedIterable)
+
+/**
  * Expects that the subject of the assertion (an [Iterable]) does not contain the [expected] value.
  *
  *  It is a shortcut for `containsNot o value expected`

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyElementsOfAssertionSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyElementsOfAssertionSpec.kt
@@ -2,16 +2,27 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.kbox.glue
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import kotlin.reflect.KFunction2
 
 class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
     include(BuilderSpec)
+    include(ShortcutSpec)
 
     describe("contains o inGiven order and only elementsOf") {
         it("passing an empty iterable throws an IllegalArgumentException") {
             expect {
                 expect(listOf(1, 2)) contains o inGiven order and only elementsOf listOf()
+            }.toThrow<IllegalArgumentException>()
+        }
+    }
+
+    describe("contains o inGiven order and only elementsOf") {
+        it("passing an empty iterable throws an IllegalArgumentException") {
+            expect {
+                expect(listOf(1, 2)) containsExactlyElementsOf (listOf())
             }.toThrow<IllegalArgumentException>()
         }
     }
@@ -21,6 +32,13 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
         getContainsNullablePair(),
         "* ", "(/) ", "(x) ", "(!) ", "- ", ">> ", "=> ",
         "[Atrium][Builder] "
+    )
+
+    object ShortcutSpec : ch.tutteli.atrium.specs.integration.IterableContainsInOrderOnlyValuesAssertionsSpec(
+        getContainsShortcutPair(),
+        getContainsNullableShortcutPair(),
+        "* ", "(/) ", "(x) ", "(!) ", "- ", ">> ", "=> ",
+        "[Atrium][Shortcut] "
     )
 
     companion object : IterableContainsSpecBase() {
@@ -41,6 +59,29 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
             a: Double?,
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> = expect contains o inGiven order and only elementsOf listOf(a, *aX)
+
+        private val containsExactlyElementsOfShortcutFun: KFunction2<Expect<Iterable<Double>>, Iterable<Double>, Expect<Iterable<Double>>> =
+            Expect<Iterable<Double>>::containsExactlyElementsOf
+
+        private fun getContainsShortcutPair() = containsExactlyElementsOfShortcutFun.name to Companion::containsExactlyElementsOfShortcut
+
+        private fun containsExactlyElementsOfShortcut(
+            expect: Expect<Iterable<Double>>,
+            a: Double,
+            aX: Array<out Double>
+        ): Expect<Iterable<Double>> = expect containsExactlyElementsOf(a glue aX)
+
+        private val containsExactlyElementsOfNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Iterable<Double?>, Expect<Iterable<Double?>>> =
+            Expect<Iterable<Double?>>::containsExactlyElementsOf
+
+        private fun getContainsNullableShortcutPair() = containsExactlyElementsOfNullableShortcutFun.name to Companion::containsExactlyElementsOfNullableShortcut;
+
+        private fun containsExactlyElementsOfNullableShortcut(
+            expect: Expect<Iterable<Double?>>,
+            a: Double?,
+            aX: Array<out Double?>
+        ): Expect<Iterable<Double?>> = expect containsExactlyElementsOf(a glue aX)
+
     }
 }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyElementsOfAssertionSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyElementsOfAssertionSpec.kt
@@ -2,7 +2,6 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.kbox.glue
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import kotlin.reflect.KFunction2
@@ -19,10 +18,10 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
         }
     }
 
-    describe("contains o inGiven order and only elementsOf") {
+    describe("containsExactlyElementsOf") {
         it("passing an empty iterable throws an IllegalArgumentException") {
             expect {
-                expect(listOf(1, 2)) containsExactlyElementsOf (listOf())
+                expect(listOf(1, 2)) containsExactlyElementsOf listOf()
             }.toThrow<IllegalArgumentException>()
         }
     }
@@ -69,7 +68,7 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
             expect: Expect<Iterable<Double>>,
             a: Double,
             aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect containsExactlyElementsOf(a glue aX)
+        ): Expect<Iterable<Double>> = expect containsExactlyElementsOf listOf(a, *aX)
 
         private val containsExactlyElementsOfNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Iterable<Double?>, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::containsExactlyElementsOf
@@ -80,7 +79,7 @@ class IterableContainsInOrderOnlyElementsOfAssertionSpec : Spek({
             expect: Expect<Iterable<Double?>>,
             a: Double?,
             aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect containsExactlyElementsOf(a glue aX)
+        ): Expect<Iterable<Double?>> = expect containsExactlyElementsOf listOf(a, *aX)
 
     }
 }


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
