### PR TITLE
setup codecov upload for windows workflow #235

### DIFF
--- a/.github/workflows/java-windows.yml
+++ b/.github/workflows/java-windows.yml
@@ -24,7 +24,7 @@ jobs:
                 uses: codecov/codecov-action@v1
                 with:
                     token: ${{ secrets.CODECOV_TOKEN }}
-                    flags: current-windows
+                    flags: current_windows
                     fail_ci_if_error: true
 
             -   name: build sample atrium+spek project

--- a/.github/workflows/java-windows.yml
+++ b/.github/workflows/java-windows.yml
@@ -20,6 +20,12 @@ jobs:
                 run: ./gradlew buildNonDeprecatedJvm
                 env:
                   CI: true
+            -   name: Upload windows build code coverage
+                uses: codecov/codecov-action@v1
+                with:
+                    token: ${{ secrets.CODECOV_TOKEN }}
+                    flags: current-windows
+                    fail_ci_if_error: true
 
             -   name: build sample atrium+spek project
                 run: samples\jvm\spek\gradlew -p samples\jvm\spek build


### PR DESCRIPTION
Hey, I think this should do for windows code coverage #235 . I didn't specify file but apparently codecov github actions only support .xml and not .codecov type of file, so if its the latter one it shouldn't work, but let's see.

Also added `fail_ci_if_error: true` so the whole CI fails if codecov upload fails, rather than blocking PR because coverage dropped, if you think that is not needed I will remove it :).

EDIT: just checked, looks like jacoco reports are .xml
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
