### PR TITLE
#430 Deprecate api-cc-infix add replacements for api-infix arrayAssertions

### DIFF
--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/arrayAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/arrayAssertions.kt
@@ -18,10 +18,11 @@ import kotlin.jvm.JvmName
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun <E> Assert<Array<out E>>.asIterable(): Assert<Iterable<E>>
@@ -39,10 +40,11 @@ fun <E> Assert<Array<out E>>.asIterable(): Assert<Iterable<E>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun <E> Assert<Array<out E>>.asIterable(assertionCreator: Assert<Iterable<E>>.() -> Unit): Assert<Iterable<E>>
@@ -62,7 +64,7 @@ infix fun <E> Assert<Array<out E>>.asIterable(assertionCreator: Assert<Iterable<
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -84,7 +86,7 @@ fun Assert<ByteArray>.asIterable(): Assert<Iterable<Byte>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -107,7 +109,7 @@ infix fun Assert<ByteArray>.asIterable(assertionCreator: Assert<Iterable<Byte>>.
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -129,7 +131,7 @@ fun Assert<CharArray>.asIterable(): Assert<Iterable<Char>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -152,7 +154,7 @@ infix fun Assert<CharArray>.asIterable(assertionCreator: Assert<Iterable<Char>>.
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -174,7 +176,7 @@ fun Assert<ShortArray>.asIterable(): Assert<Iterable<Short>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -197,7 +199,7 @@ infix fun Assert<ShortArray>.asIterable(assertionCreator: Assert<Iterable<Short>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -219,7 +221,7 @@ fun Assert<IntArray>.asIterable(): Assert<Iterable<Int>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -242,7 +244,7 @@ infix fun Assert<IntArray>.asIterable(assertionCreator: Assert<Iterable<Int>>.()
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -264,7 +266,7 @@ fun Assert<LongArray>.asIterable(): Assert<Iterable<Long>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -287,7 +289,7 @@ infix fun Assert<LongArray>.asIterable(assertionCreator: Assert<Iterable<Long>>.
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -309,7 +311,7 @@ fun Assert<FloatArray>.asIterable(): Assert<Iterable<Float>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -332,7 +334,7 @@ infix fun Assert<FloatArray>.asIterable(assertionCreator: Assert<Iterable<Float>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -354,7 +356,7 @@ fun Assert<DoubleArray>.asIterable(): Assert<Iterable<Double>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -377,7 +379,7 @@ infix fun Assert<DoubleArray>.asIterable(assertionCreator: Assert<Iterable<Doubl
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert()",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"
@@ -399,7 +401,7 @@ fun Assert<BooleanArray>.asIterable(): Assert<Iterable<Boolean>>
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0",
     ReplaceWith(
-        "this.asExpect().asList().asAssert(assertionCreator)",
+        "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.asList"

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/arrayAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/arrayAssertions.kt
@@ -15,6 +15,15 @@ import kotlin.jvm.JvmName
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @Suppress("DEPRECATION")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun <E> Assert<Array<out E>>.asIterable(): Assert<Iterable<E>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -27,6 +36,15 @@ fun <E> Assert<Array<out E>>.asIterable(): Assert<Iterable<E>>
  *
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun <E> Assert<Array<out E>>.asIterable(assertionCreator: Assert<Iterable<E>>.() -> Unit): Assert<Iterable<E>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -41,6 +59,15 @@ infix fun <E> Assert<Array<out E>>.asIterable(assertionCreator: Assert<Iterable<
  */
 @Suppress("DEPRECATION")
 @JvmName("byteArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<ByteArray>.asIterable(): Assert<Iterable<Byte>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -54,6 +81,15 @@ fun Assert<ByteArray>.asIterable(): Assert<Iterable<Byte>>
  * @return The newly created [Assert] for the transformed subject.
  */
 @JvmName("byteArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<ByteArray>.asIterable(assertionCreator: Assert<Iterable<Byte>>.() -> Unit): Assert<Iterable<Byte>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -68,6 +104,15 @@ infix fun Assert<ByteArray>.asIterable(assertionCreator: Assert<Iterable<Byte>>.
  */
 @Suppress("DEPRECATION")
 @JvmName("charArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<CharArray>.asIterable(): Assert<Iterable<Char>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -81,6 +126,15 @@ fun Assert<CharArray>.asIterable(): Assert<Iterable<Char>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("charArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<CharArray>.asIterable(assertionCreator: Assert<Iterable<Char>>.() -> Unit): Assert<Iterable<Char>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -95,6 +149,15 @@ infix fun Assert<CharArray>.asIterable(assertionCreator: Assert<Iterable<Char>>.
  */
 @Suppress("DEPRECATION")
 @JvmName("shortArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<ShortArray>.asIterable(): Assert<Iterable<Short>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -108,6 +171,15 @@ fun Assert<ShortArray>.asIterable(): Assert<Iterable<Short>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("shortArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<ShortArray>.asIterable(assertionCreator: Assert<Iterable<Short>>.() -> Unit): Assert<Iterable<Short>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -122,6 +194,15 @@ infix fun Assert<ShortArray>.asIterable(assertionCreator: Assert<Iterable<Short>
  */
 @Suppress("DEPRECATION")
 @JvmName("intArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<IntArray>.asIterable(): Assert<Iterable<Int>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -135,6 +216,15 @@ fun Assert<IntArray>.asIterable(): Assert<Iterable<Int>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("intArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<IntArray>.asIterable(assertionCreator: Assert<Iterable<Int>>.() -> Unit): Assert<Iterable<Int>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -149,6 +239,15 @@ infix fun Assert<IntArray>.asIterable(assertionCreator: Assert<Iterable<Int>>.()
  */
 @Suppress("DEPRECATION")
 @JvmName("longArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<LongArray>.asIterable(): Assert<Iterable<Long>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -162,6 +261,15 @@ fun Assert<LongArray>.asIterable(): Assert<Iterable<Long>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("longArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<LongArray>.asIterable(assertionCreator: Assert<Iterable<Long>>.() -> Unit): Assert<Iterable<Long>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -176,6 +284,15 @@ infix fun Assert<LongArray>.asIterable(assertionCreator: Assert<Iterable<Long>>.
  */
 @Suppress("DEPRECATION")
 @JvmName("floatArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<FloatArray>.asIterable(): Assert<Iterable<Float>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -189,6 +306,15 @@ fun Assert<FloatArray>.asIterable(): Assert<Iterable<Float>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("floatArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<FloatArray>.asIterable(assertionCreator: Assert<Iterable<Float>>.() -> Unit): Assert<Iterable<Float>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -203,6 +329,15 @@ infix fun Assert<FloatArray>.asIterable(assertionCreator: Assert<Iterable<Float>
  */
 @Suppress("DEPRECATION")
 @JvmName("doubleArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<DoubleArray>.asIterable(): Assert<Iterable<Double>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -216,6 +351,15 @@ fun Assert<DoubleArray>.asIterable(): Assert<Iterable<Double>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("doubleArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<DoubleArray>.asIterable(assertionCreator: Assert<Iterable<Double>>.() -> Unit): Assert<Iterable<Double>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)
 
@@ -230,6 +374,15 @@ infix fun Assert<DoubleArray>.asIterable(assertionCreator: Assert<Iterable<Doubl
  */
 @Suppress("DEPRECATION")
 @JvmName("boolArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 fun Assert<BooleanArray>.asIterable(): Assert<Iterable<Boolean>>
     = ExpectImpl.changeSubject(this).unreported { it.asIterable() }
 
@@ -243,5 +396,14 @@ fun Assert<BooleanArray>.asIterable(): Assert<Iterable<Boolean>>
  * @return The newly created [AssertionPlant] for the transformed subject.
  */
 @JvmName("boolArrAsIterable")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0",
+    ReplaceWith(
+        "this.asExpect().asList().asAssert(assertionCreator)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.asList"
+    )
+)
 infix fun Assert<BooleanArray>.asIterable(assertionCreator: Assert<Iterable<Boolean>>.() -> Unit): Assert<Iterable<Boolean>>
     = asIterable().addAssertionsCreatedBy(assertionCreator)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/arrayAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/arrayAssertions.kt
@@ -67,7 +67,8 @@ infix fun <E> Assert<Array<out E>>.asIterable(assertionCreator: Assert<Iterable<
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<ByteArray>.asIterable(): Assert<Iterable<Byte>>
@@ -89,7 +90,8 @@ fun Assert<ByteArray>.asIterable(): Assert<Iterable<Byte>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<ByteArray>.asIterable(assertionCreator: Assert<Iterable<Byte>>.() -> Unit): Assert<Iterable<Byte>>
@@ -112,7 +114,8 @@ infix fun Assert<ByteArray>.asIterable(assertionCreator: Assert<Iterable<Byte>>.
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<CharArray>.asIterable(): Assert<Iterable<Char>>
@@ -134,7 +137,8 @@ fun Assert<CharArray>.asIterable(): Assert<Iterable<Char>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<CharArray>.asIterable(assertionCreator: Assert<Iterable<Char>>.() -> Unit): Assert<Iterable<Char>>
@@ -157,7 +161,8 @@ infix fun Assert<CharArray>.asIterable(assertionCreator: Assert<Iterable<Char>>.
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<ShortArray>.asIterable(): Assert<Iterable<Short>>
@@ -179,7 +184,8 @@ fun Assert<ShortArray>.asIterable(): Assert<Iterable<Short>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<ShortArray>.asIterable(assertionCreator: Assert<Iterable<Short>>.() -> Unit): Assert<Iterable<Short>>
@@ -202,7 +208,8 @@ infix fun Assert<ShortArray>.asIterable(assertionCreator: Assert<Iterable<Short>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<IntArray>.asIterable(): Assert<Iterable<Int>>
@@ -224,7 +231,8 @@ fun Assert<IntArray>.asIterable(): Assert<Iterable<Int>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<IntArray>.asIterable(assertionCreator: Assert<Iterable<Int>>.() -> Unit): Assert<Iterable<Int>>
@@ -247,7 +255,8 @@ infix fun Assert<IntArray>.asIterable(assertionCreator: Assert<Iterable<Int>>.()
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<LongArray>.asIterable(): Assert<Iterable<Long>>
@@ -269,7 +278,8 @@ fun Assert<LongArray>.asIterable(): Assert<Iterable<Long>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<LongArray>.asIterable(assertionCreator: Assert<Iterable<Long>>.() -> Unit): Assert<Iterable<Long>>
@@ -292,7 +302,8 @@ infix fun Assert<LongArray>.asIterable(assertionCreator: Assert<Iterable<Long>>.
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<FloatArray>.asIterable(): Assert<Iterable<Float>>
@@ -314,7 +325,8 @@ fun Assert<FloatArray>.asIterable(): Assert<Iterable<Float>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<FloatArray>.asIterable(assertionCreator: Assert<Iterable<Float>>.() -> Unit): Assert<Iterable<Float>>
@@ -337,7 +349,8 @@ infix fun Assert<FloatArray>.asIterable(assertionCreator: Assert<Iterable<Float>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<DoubleArray>.asIterable(): Assert<Iterable<Double>>
@@ -359,7 +372,8 @@ fun Assert<DoubleArray>.asIterable(): Assert<Iterable<Double>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<DoubleArray>.asIterable(assertionCreator: Assert<Iterable<Double>>.() -> Unit): Assert<Iterable<Double>>
@@ -382,7 +396,8 @@ infix fun Assert<DoubleArray>.asIterable(assertionCreator: Assert<Iterable<Doubl
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 fun Assert<BooleanArray>.asIterable(): Assert<Iterable<Boolean>>
@@ -404,7 +419,8 @@ fun Assert<BooleanArray>.asIterable(): Assert<Iterable<Boolean>>
         "this.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.asList"
+        "ch.tutteli.atrium.api.infix.en_GB.asList",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
     )
 )
 infix fun Assert<BooleanArray>.asIterable(assertionCreator: Assert<Iterable<Boolean>>.() -> Unit): Assert<Iterable<Boolean>>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/ArrayAsIterableAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/ArrayAsIterableAssertionsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class ArrayAsIterableAssertionsSpec : ch.tutteli.atrium.spec.integration.ArrayAsIterableAssertionsSpec(
@@ -31,25 +32,25 @@ class ArrayAsIterableAssertionsSpec : ch.tutteli.atrium.spec.integration.ArrayAs
     Companion::booleanArrayWithCreator
 ){
     companion object {
-        fun arrayInt(plant: Assert<Array<Int>>) = plant.asExpect<Array<out Int>, Assert<Array<out Int>>>().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun byteArray(plant: Assert<ByteArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun charArray(plant: Assert<CharArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun shortArray(plant: Assert<ShortArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun intArray(plant: Assert<IntArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun longArray(plant: Assert<LongArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun floatArray(plant: Assert<FloatArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun doubleArray(plant: Assert<DoubleArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
-        fun booleanArray(plant: Assert<BooleanArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun arrayInt(plant: Assert<Array<Int>>) = plant.asExpect<Array<out Int>, Assert<Array<out Int>>>().asList(o).asAssert()
+        fun byteArray(plant: Assert<ByteArray>) = plant.asExpect().asList(o).asAssert()
+        fun charArray(plant: Assert<CharArray>) = plant.asExpect().asList(o).asAssert()
+        fun shortArray(plant: Assert<ShortArray>) = plant.asExpect().asList(o).asAssert()
+        fun intArray(plant: Assert<IntArray>) = plant.asExpect().asList(o).asAssert()
+        fun longArray(plant: Assert<LongArray>) = plant.asExpect().asList(o).asAssert()
+        fun floatArray(plant: Assert<FloatArray>) = plant.asExpect().asList(o).asAssert()
+        fun doubleArray(plant: Assert<DoubleArray>) = plant.asExpect().asList(o).asAssert()
+        fun booleanArray(plant: Assert<BooleanArray>) = plant.asExpect().asList(o).asAssert()
 
 
-        fun arrayIntWithCreator(plant: Assert<Array<Int>>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant.asExpect<Array<out Int>, Assert<Array<out Int>>>().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun byteArrayWithCreator(plant: Assert<ByteArray>, assertionCreator: Assert<Iterable<Byte>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun charArrayWithCreator(plant: Assert<CharArray>, assertionCreator: Assert<Iterable<Char>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun shortArrayWithCreator(plant: Assert<ShortArray>, assertionCreator: Assert<Iterable<Short>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun intArrayWithCreator(plant: Assert<IntArray>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun longArrayWithCreator(plant: Assert<LongArray>, assertionCreator: Assert<Iterable<Long>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun floatArrayWithCreator(plant: Assert<FloatArray>, assertionCreator: Assert<Iterable<Float>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun doubleArrayWithCreator(plant: Assert<DoubleArray>, assertionCreator: Assert<Iterable<Double>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
-        fun booleanArrayWithCreator(plant: Assert<BooleanArray>, assertionCreator: Assert<Iterable<Boolean>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun arrayIntWithCreator(plant: Assert<Array<Int>>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant.asExpect<Array<out Int>, Assert<Array<out Int>>>().asList(o).asAssert(assertionCreator)
+        fun byteArrayWithCreator(plant: Assert<ByteArray>, assertionCreator: Assert<Iterable<Byte>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun charArrayWithCreator(plant: Assert<CharArray>, assertionCreator: Assert<Iterable<Char>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun shortArrayWithCreator(plant: Assert<ShortArray>, assertionCreator: Assert<Iterable<Short>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun intArrayWithCreator(plant: Assert<IntArray>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun longArrayWithCreator(plant: Assert<LongArray>, assertionCreator: Assert<Iterable<Long>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun floatArrayWithCreator(plant: Assert<FloatArray>, assertionCreator: Assert<Iterable<Float>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun doubleArrayWithCreator(plant: Assert<DoubleArray>, assertionCreator: Assert<Iterable<Double>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
+        fun booleanArrayWithCreator(plant: Assert<BooleanArray>, assertionCreator: Assert<Iterable<Boolean>>.() -> Unit) = plant.asExpect().asList(o).asAssert(assertionCreator)
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/ArrayAsIterableAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/ArrayAsIterableAssertionsSpec.kt
@@ -1,7 +1,10 @@
 @file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
+import ch.tutteli.atrium.api.infix.en_GB.asList
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -28,25 +31,25 @@ class ArrayAsIterableAssertionsSpec : ch.tutteli.atrium.spec.integration.ArrayAs
     Companion::booleanArrayWithCreator
 ){
     companion object {
-        fun arrayInt(plant: Assert<Array<Int>>) = plant.asIterable()
-        fun byteArray(plant: Assert<ByteArray>) = plant.asIterable()
-        fun charArray(plant: Assert<CharArray>) = plant.asIterable()
-        fun shortArray(plant: Assert<ShortArray>) = plant.asIterable()
-        fun intArray(plant: Assert<IntArray>) = plant.asIterable()
-        fun longArray(plant: Assert<LongArray>) = plant.asIterable()
-        fun floatArray(plant: Assert<FloatArray>) = plant.asIterable()
-        fun doubleArray(plant: Assert<DoubleArray>) = plant.asIterable()
-        fun booleanArray(plant: Assert<BooleanArray>) = plant.asIterable()
+        fun arrayInt(plant: Assert<Array<Int>>) = plant.asExpect<Array<out Int>, Assert<Array<out Int>>>().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun byteArray(plant: Assert<ByteArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun charArray(plant: Assert<CharArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun shortArray(plant: Assert<ShortArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun intArray(plant: Assert<IntArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun longArray(plant: Assert<LongArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun floatArray(plant: Assert<FloatArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun doubleArray(plant: Assert<DoubleArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
+        fun booleanArray(plant: Assert<BooleanArray>) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert()
 
 
-        fun arrayIntWithCreator(plant: Assert<Array<Int>>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant asIterable assertionCreator
-        fun byteArrayWithCreator(plant: Assert<ByteArray>, assertionCreator: Assert<Iterable<Byte>>.() -> Unit) = plant asIterable assertionCreator
-        fun charArrayWithCreator(plant: Assert<CharArray>, assertionCreator: Assert<Iterable<Char>>.() -> Unit) = plant asIterable assertionCreator
-        fun shortArrayWithCreator(plant: Assert<ShortArray>, assertionCreator: Assert<Iterable<Short>>.() -> Unit) = plant asIterable assertionCreator
-        fun intArrayWithCreator(plant: Assert<IntArray>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant asIterable assertionCreator
-        fun longArrayWithCreator(plant: Assert<LongArray>, assertionCreator: Assert<Iterable<Long>>.() -> Unit) = plant asIterable assertionCreator
-        fun floatArrayWithCreator(plant: Assert<FloatArray>, assertionCreator: Assert<Iterable<Float>>.() -> Unit) = plant asIterable assertionCreator
-        fun doubleArrayWithCreator(plant: Assert<DoubleArray>, assertionCreator: Assert<Iterable<Double>>.() -> Unit) = plant asIterable assertionCreator
-        fun booleanArrayWithCreator(plant: Assert<BooleanArray>, assertionCreator: Assert<Iterable<Boolean>>.() -> Unit) = plant asIterable assertionCreator
+        fun arrayIntWithCreator(plant: Assert<Array<Int>>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant.asExpect<Array<out Int>, Assert<Array<out Int>>>().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun byteArrayWithCreator(plant: Assert<ByteArray>, assertionCreator: Assert<Iterable<Byte>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun charArrayWithCreator(plant: Assert<CharArray>, assertionCreator: Assert<Iterable<Char>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun shortArrayWithCreator(plant: Assert<ShortArray>, assertionCreator: Assert<Iterable<Short>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun intArrayWithCreator(plant: Assert<IntArray>, assertionCreator: Assert<Iterable<Int>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun longArrayWithCreator(plant: Assert<LongArray>, assertionCreator: Assert<Iterable<Long>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun floatArrayWithCreator(plant: Assert<FloatArray>, assertionCreator: Assert<Iterable<Float>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun doubleArrayWithCreator(plant: Assert<DoubleArray>, assertionCreator: Assert<Iterable<Double>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
+        fun booleanArrayWithCreator(plant: Assert<BooleanArray>, assertionCreator: Assert<Iterable<Boolean>>.() -> Unit) = plant.asExpect().asList(ch.tutteli.atrium.api.infix.en_GB.o).asAssert(assertionCreator)
     }
 }


### PR DESCRIPTION
This PR add Deprecate api-cc-infix and add Replacewith for the expect for these files:
- [x] arrayAssertions

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
