### PR TITLE
#430 add deprecation for charsequence files

### DIFF
--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -111,10 +111,11 @@ infix fun <T : CharSequence> Assert<T>.contains(expected: Any): AssertionPlant<T
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().contains(values).asAssert()",
+        "this.asExpect().contains(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.contains"
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
     )
 )
 infix fun <T : CharSequence> Assert<T>.contains(values: Values<Any>): AssertionPlant<T>
@@ -213,10 +214,11 @@ infix fun <T : CharSequence> Assert<T>.containsNot(expected: Any)
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().containsNot(values).asAssert()",
+        "this.asExpect().containsNot(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.containsNot"
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
     )
 )
 infix fun <T : CharSequence> Assert<T>.containsNot(values: Values<Any>)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -24,6 +24,16 @@ import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.
  *
  * @return The newly created builder.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(ch.tutteli.atrium.api.infix.en_GB.o)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.to(@Suppress("UNUSED_PARAMETER") contain: contain): CharSequenceContains.Builder<T, NoOpSearchBehaviour>
     = AssertImpl.charSequence.containsBuilder(this)
 
@@ -33,6 +43,16 @@ infix fun <T : CharSequence> Assert<T>.to(@Suppress("UNUSED_PARAMETER") contain:
  *
  * @return The newly created builder.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsNot(ch.tutteli.atrium.api.infix.en_GB.o)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.notTo(@Suppress("UNUSED_PARAMETER") contain: contain): NotCheckerOption<T, NotSearchBehaviour>
     = NotCheckerOptionImpl(AssertImpl.charSequence.containsNotBuilder(this))
 
@@ -51,6 +71,15 @@ infix fun <T : CharSequence> Assert<T>.notTo(@Suppress("UNUSED_PARAMETER") conta
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.contains"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.contains(expected: Any): AssertionPlant<T>
     = this contains Values(expected)
 
@@ -79,6 +108,15 @@ infix fun <T : CharSequence> Assert<T>.contains(expected: Any): AssertionPlant<T
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(values).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.contains"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.contains(values: Values<Any>): AssertionPlant<T>
     = this to contain atLeast 1 the values
 
@@ -91,6 +129,15 @@ infix fun <T : CharSequence> Assert<T>.contains(values: Values<Any>): AssertionP
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsRegex(pattern).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.containsRegex"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.containsRegex(pattern: String): AssertionPlant<T>
     = this contains RegexPatterns(pattern)
 
@@ -116,6 +163,15 @@ infix fun <T : CharSequence> Assert<T>.containsRegex(pattern: String): Assertion
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(patterns).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.contains"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.contains(patterns: RegexPatterns): AssertionPlant<T>
     = this to contain atLeast 1 the patterns
 
@@ -130,6 +186,15 @@ infix fun <T : CharSequence> Assert<T>.contains(patterns: RegexPatterns): Assert
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsNot(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.containsNot(expected: Any)
     = this containsNot Values(expected)
 
@@ -145,6 +210,15 @@ infix fun <T : CharSequence> Assert<T>.containsNot(expected: Any)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsNot(values).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.containsNot(values: Values<Any>)
     = this notTo contain the values
 
@@ -154,6 +228,15 @@ infix fun <T : CharSequence> Assert<T>.containsNot(values: Values<Any>)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().startsWith(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.startsWith"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.startsWith(expected: CharSequence)
     = addAssertion(AssertImpl.charSequence.startsWith(this, expected))
 
@@ -163,6 +246,15 @@ infix fun <T : CharSequence> Assert<T>.startsWith(expected: CharSequence)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().startsNotWith(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.startsNotWith"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.startsNotWith(expected: CharSequence)
     = addAssertion(AssertImpl.charSequence.startsNotWith(this, expected))
 
@@ -173,6 +265,15 @@ infix fun <T : CharSequence> Assert<T>.startsNotWith(expected: CharSequence)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().endsWith(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.endsWith"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.endsWith(expected: CharSequence)
     = addAssertion(AssertImpl.charSequence.endsWith(this, expected))
 
@@ -182,6 +283,15 @@ infix fun <T : CharSequence> Assert<T>.endsWith(expected: CharSequence)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().endsNotWith(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.endsNotWith"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.endsNotWith(expected: CharSequence)
     = addAssertion(AssertImpl.charSequence.endsNotWith(this, expected))
 
@@ -194,6 +304,15 @@ infix fun <T : CharSequence> Assert<T>.endsNotWith(expected: CharSequence)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().toBe(empty).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.toBe"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty: Empty)
     = addAssertion(AssertImpl.charSequence.isEmpty(this))
 
@@ -205,6 +324,15 @@ infix fun <T : CharSequence> Assert<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty:
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().notToBe(empty).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.notToBe"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty: Empty)
     = addAssertion(AssertImpl.charSequence.isNotEmpty(this))
 
@@ -216,5 +344,14 @@ infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Emp
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().notToBe(blank).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.notToBe"
+    )
+)
 infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Blank: Blank)
     = addAssertion(AssertImpl.charSequence.isNotBlank(this))

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -214,7 +214,7 @@ infix fun <T : CharSequence> Assert<T>.containsNot(expected: Any)
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().containsNot(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected).asAssert()",
+        "this.asExpect().containsNot(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.containsNot",

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -335,7 +335,7 @@ infix fun <T : CharSequence> Assert<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty:
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.notToBe",
-        "ch.tutteli.atrium.api.infix.en_GB.toBe"
+        "ch.tutteli.atrium.api.infix.en_GB.empty"
     )
 )
 infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty: Empty)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -167,10 +167,11 @@ infix fun <T : CharSequence> Assert<T>.containsRegex(pattern: String): Assertion
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().contains(patterns).asAssert()",
+        "this.asExpect().contains(regexPatterns(patterns.pattern, *patterns.otherPatterns)).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.contains"
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.api.infix.en_GB.regexPatterns"
     )
 )
 infix fun <T : CharSequence> Assert<T>.contains(patterns: RegexPatterns): AssertionPlant<T>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -167,7 +167,7 @@ infix fun <T : CharSequence> Assert<T>.containsRegex(pattern: String): Assertion
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().contains(regexPatterns(patterns.pattern, *patterns.otherPatterns)).asAssert()",
+        "this.asExpect().contains(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
         "ch.tutteli.atrium.api.infix.en_GB.contains",

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceAssertions.kt
@@ -312,7 +312,8 @@ infix fun <T : CharSequence> Assert<T>.endsNotWith(expected: CharSequence)
         "this.asExpect().toBe(empty).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.toBe"
+        "ch.tutteli.atrium.api.infix.en_GB.toBe",
+        "ch.tutteli.atrium.api.infix.en_GB.empty"
     )
 )
 infix fun <T : CharSequence> Assert<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty: Empty)
@@ -332,7 +333,8 @@ infix fun <T : CharSequence> Assert<T>.toBe(@Suppress("UNUSED_PARAMETER") Empty:
         "this.asExpect().notToBe(empty).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.notToBe"
+        "ch.tutteli.atrium.api.infix.en_GB.notToBe",
+        "ch.tutteli.atrium.api.infix.en_GB.toBe"
     )
 )
 infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Empty: Empty)
@@ -352,7 +354,8 @@ infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Emp
         "this.asExpect().notToBe(blank).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
         "ch.tutteli.atrium.domain.builders.migration.asAssert",
-        "ch.tutteli.atrium.api.infix.en_GB.notToBe"
+        "ch.tutteli.atrium.api.infix.en_GB.notToBe",
+        "ch.tutteli.atrium.api.infix.en_GB.blank"
     )
 )
 infix fun <T : CharSequence> Assert<T>.notToBe(@Suppress("UNUSED_PARAMETER") Blank: Blank)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCheckers.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCheckers.kt
@@ -17,6 +17,13 @@ import ch.tutteli.atrium.domain.creating.charsequence.contains.CharSequenceConta
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] equals to zero; use [enthaeltNicht] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.atLeast(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.atLeast"
+    )
+)
 infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T, S>.atLeast(times: Int): AtLeastCheckerOption<T, S>
     = AtLeastCheckerOptionImpl(times, this)
 
@@ -35,6 +42,13 @@ infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T
  * @throws IllegalArgumentException In case [times] of this `at most` restriction equals to the number of the
  *   `at least` restriction; use the [genau] restriction instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.butAtMost(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.butAtMost"
+    )
+)
 infix fun <T : CharSequence, S : SearchBehaviour> AtLeastCheckerOption<T, S>.butAtMost(times: Int): ButAtMostCheckerOption<T, S>
     = ButAtMostCheckerOptionImpl(times, this, containsBuilder)
 
@@ -49,6 +63,13 @@ infix fun <T : CharSequence, S : SearchBehaviour> AtLeastCheckerOption<T, S>.but
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] equals to zero; use [enthaeltNicht] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.exactly(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.exactly"
+    )
+)
 infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T, S>.exactly(times: Int): ExactlyCheckerOption<T, S>
     = ExactlyCheckerOptionImpl(times, this)
 
@@ -68,6 +89,13 @@ infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T
  * @throws IllegalArgumentException In case [times] equals to zero; use [containsNot] instead.
  * @throws IllegalArgumentException In case [times] equals to one; use [exactly] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.atMost(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.atMost"
+    )
+)
 infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T, S>.atMost(times: Int): AtMostCheckerOption<T, S>
     = AtMostCheckerOptionImpl(times, this)
 
@@ -82,5 +110,12 @@ infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] equals to zero; use [enthaeltNicht] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.notOrAtMost(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.notOrAtMost"
+    )
+)
 infix fun <T : CharSequence, S : SearchBehaviour> CharSequenceContains.Builder<T, S>.notOrAtMost(times: Int): NotOrAtMostCheckerOption<T, S>
     = NotOrAtMostCheckerOptionImpl(times, this)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
@@ -64,8 +64,9 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(values)",
-        "ch.tutteli.atrium.api.infix.en_GB.the"
+        "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
     )
 )
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>
@@ -127,8 +128,9 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(values)",
-        "ch.tutteli.atrium.api.infix.en_GB.the"
+        "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
     )
 )
 @JvmName("valuesIgnoringCase")
@@ -189,8 +191,9 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(values)",
-        "ch.tutteli.atrium.api.infix.en_GB.the"
+        "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
     )
 )
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
@@ -247,8 +247,10 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(patterns)",
-        "ch.tutteli.atrium.api.infix.en_GB.the"
+        "this.the(regexPatterns(patterns.pattern, *patterns.otherPatterns))",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.regexPatterns",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
     )
 )
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.the(patterns: RegexPatterns): AssertionPlant<T>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
@@ -27,6 +27,13 @@ import kotlin.jvm.JvmName
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.value(expected)",
+        "ch.tutteli.atrium.api.infix.en_GB.value"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.value(expected: Any): AssertionPlant<T>
     = this the Values(expected)
 
@@ -54,6 +61,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(values)",
+        "ch.tutteli.atrium.api.infix.en_GB.the"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>
     = addAssertion(AssertImpl.charSequence.contains.values(this, values.toList()))
 
@@ -75,6 +89,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.value(expected)",
+        "ch.tutteli.atrium.api.infix.en_GB.value"
+    )
+)
 @JvmName("valueIgnoringCase")
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseSearchBehaviour>.value(expected: Any): AssertionPlant<T>
     = this the Values(expected)
@@ -103,6 +124,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(values)",
+        "ch.tutteli.atrium.api.infix.en_GB.the"
+    )
+)
 @JvmName("valuesIgnoringCase")
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>
     = addAssertion(AssertImpl.charSequence.contains.valuesIgnoringCase(this, values.toList()))
@@ -124,6 +152,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.value(expected)",
+        "ch.tutteli.atrium.api.infix.en_GB.value"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.value(expected: Any): AssertionPlant<T>
     = this atLeast 1 value expected
 
@@ -151,6 +186,13 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(values)",
+        "ch.tutteli.atrium.api.infix.en_GB.the"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>
     = this atLeast 1 the values
 
@@ -165,6 +207,13 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.regex(pattern)",
+        "ch.tutteli.atrium.api.infix.en_GB.regex"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.regex(pattern: String): AssertionPlant<T>
     = this the RegexPatterns(pattern)
 
@@ -189,6 +238,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(patterns)",
+        "ch.tutteli.atrium.api.infix.en_GB.the"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.the(patterns: RegexPatterns): AssertionPlant<T>
     = addAssertion(AssertImpl.charSequence.contains.regex(this, patterns.toList()))
 
@@ -204,6 +260,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.regex(pattern)",
+        "ch.tutteli.atrium.api.infix.en_GB.regex"
+    )
+)
 @JvmName("regexIgnoringCase")
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseSearchBehaviour>.regex(pattern: String): AssertionPlant<T>
     = this the RegexPatterns(pattern)
@@ -229,6 +292,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(patterns)",
+        "ch.tutteli.atrium.api.infix.en_GB.the"
+    )
+)
 @JvmName("regexIgnoringCase")
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseSearchBehaviour>.the(patterns: RegexPatterns): AssertionPlant<T>
     = addAssertion(AssertImpl.charSequence.contains.regexIgnoringCase(this, patterns.toList()))
@@ -244,6 +314,13 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.regex(pattern)",
+        "ch.tutteli.atrium.api.infix.en_GB.regex"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.regex(pattern: String): AssertionPlant<T>
     = this atLeast 1 regex pattern
 
@@ -268,6 +345,13 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(patterns)",
+        "ch.tutteli.atrium.api.infix.en_GB.the"
+    )
+)
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.the(patterns: RegexPatterns): AssertionPlant<T>
     = this atLeast 1 the patterns
 
@@ -277,5 +361,12 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
  *
  * @return The plant to support a fluent API.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.addAssertion(assertion)",
+        "ch.tutteli.atrium.api.infix.en_GB.addAssertion"
+    )
+)
 private fun <T : CharSequence, S : CharSequenceContains.SearchBehaviour> CharSequenceContains.CheckerOption<T, S>.addAssertion(assertion: Assertion): AssertionPlant<T>
     = addAssertionForAssert(assertion)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
@@ -247,7 +247,7 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(regexPatterns(patterns.pattern, *patterns.otherPatterns))",
+        "this.the(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()",
         "ch.tutteli.atrium.api.infix.en_GB.the",
         "ch.tutteli.atrium.api.infix.en_GB.regexPatterns",
         "ch.tutteli.atrium.domain.builders.migration.asAssert"
@@ -303,8 +303,10 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(patterns)",
-        "ch.tutteli.atrium.api.infix.en_GB.the"
+        "this.the(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.regexPatterns",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
     )
 )
 @JvmName("regexIgnoringCase")
@@ -356,8 +358,10 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
 @Deprecated(
     "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.the(patterns)",
-        "ch.tutteli.atrium.api.infix.en_GB.the"
+        "this.the(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.regexPatterns",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
     )
 )
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.the(patterns: RegexPatterns): AssertionPlant<T>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsCreators.kt
@@ -66,7 +66,8 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBeh
     ReplaceWith(
         "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
         "ch.tutteli.atrium.api.infix.en_GB.the",
-        "ch.tutteli.atrium.api.infix.en_GB.values"
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
     )
 )
 infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>
@@ -130,7 +131,8 @@ infix fun <T : CharSequence> CharSequenceContains.CheckerOption<T, IgnoringCaseS
     ReplaceWith(
         "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
         "ch.tutteli.atrium.api.infix.en_GB.the",
-        "ch.tutteli.atrium.api.infix.en_GB.values"
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
     )
 )
 @JvmName("valuesIgnoringCase")
@@ -193,7 +195,8 @@ infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchB
     ReplaceWith(
         "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
         "ch.tutteli.atrium.api.infix.en_GB.the",
-        "ch.tutteli.atrium.api.infix.en_GB.values"
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
     )
 )
 infix fun <T : CharSequence> CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>.the(values: Values<Any>): AssertionPlant<T>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsSearchBehaviours.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/charSequenceContainsSearchBehaviours.kt
@@ -17,8 +17,7 @@ import ch.tutteli.atrium.domain.creating.charsequence.contains.searchbehaviours.
  *
  * @return The newly created builder.
  */
-infix fun <T : CharSequence> CharSequenceContains.Builder<T, NoOpSearchBehaviour>.ignoring(@Suppress("UNUSED_PARAMETER") case: case): CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>
-    = AssertImpl.charSequence.contains.searchBehaviours.ignoringCase(this)
+infix fun <T : CharSequence> CharSequenceContains.Builder<T, NoOpSearchBehaviour>.ignoring(@Suppress("UNUSED_PARAMETER") case: case): CharSequenceContains.Builder<T, IgnoringCaseSearchBehaviour>    = AssertImpl.charSequence.contains.searchBehaviours.ignoringCase(this)
 
 /**
  * Defines that the search behaviour `ignore case` shall be applied to this sophisticated `contains not` assertion.

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/AtLeastCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/AtLeastCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.atLeast

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/AtMostCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/AtMostCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.atLeast

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/ButAtMostCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/ButAtMostCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.atLeast

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/ExactlyCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/ExactlyCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.ExactlyCheckerOption

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/NotOrAtMostCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/NotOrAtMostCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.NotOrAtMostCheckerOption

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/nameContainsNotFun.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/charsequence/contains/builders/impl/nameContainsNotFun.kt
@@ -1,6 +1,5 @@
 // TODO remove file with 1.0.0
 @file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
-
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.Values

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
@@ -1,6 +1,5 @@
 // TODO remove file with 1.0.0
 @file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
-
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.Values

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceAssertionsSpec.kt
@@ -5,7 +5,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.Blank
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.Empty
+import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 
@@ -30,9 +33,9 @@ class CharSequenceAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequen
 
         private fun containsDefaultTranslationOf(plant: Assert<CharSequence>, expected: Translatable, otherExpected: Array<out Translatable>): Assert<CharSequence> {
             return if (otherExpected.isEmpty()) {
-                plant contains expected.getDefault()
+                plant.asExpect().contains(expected.getDefault()).asAssert()
             } else {
-                plant contains Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())
+                plant.asExpect().contains(Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())).asAssert()
             }
         }
 
@@ -41,27 +44,27 @@ class CharSequenceAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequen
 
 
         private fun containsNotDefaultTranslationOf(plant: Assert<CharSequence>, expected: Translatable, otherExpected: Array<out Translatable>)
-            = plant containsNot Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())
+            = plant.asExpect().containsNot(Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())).asAssert()
 
         fun toBeEmpty(plant: Assert<CharSequence>)
-            = plant toBe Empty
+            = plant.asExpect().toBe(empty).asAssert()
 
         fun notToBeEmpty(plant: Assert<CharSequence>)
-            = plant notToBe Empty
+            = plant.asExpect().notToBe(empty).asAssert()
 
         fun notToBeBlank(plant: Assert<CharSequence>)
-            = plant notToBe Blank
+            = plant.asExpect().notToBe(blank).asAssert()
 
         fun startsWith(plant: Assert<CharSequence>, expected: CharSequence)
-            = plant startsWith expected
+            = plant.asExpect().startsWith(expected).asAssert()
 
         fun startsNotWith(plant: Assert<CharSequence>, expected: CharSequence)
-            = plant startsNotWith expected
+            = plant.asExpect().startsNotWith(expected).asAssert()
 
         fun endsWith(plant: Assert<CharSequence>, expected: CharSequence)
-            = plant endsWith expected
+            = plant.asExpect().endsWith(expected).asAssert()
 
         fun endsNotWith(plant: Assert<CharSequence>, expected: CharSequence)
-            = plant endsNotWith expected
+            = plant.asExpect().endsNotWith(expected).asAssert()
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceAssertionsSpec.kt
@@ -7,6 +7,7 @@ import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.Blank
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.Empty
 import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.creating.AssertionPlant
 import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -35,7 +36,8 @@ class CharSequenceAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequen
             return if (otherExpected.isEmpty()) {
                 plant.asExpect().contains(expected.getDefault()).asAssert()
             } else {
-                plant.asExpect().contains(Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())).asAssert()
+                val values = Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())
+                plant.asExpect().contains(values(values.expected, *values.otherExpected)).asAssert()
             }
         }
 
@@ -43,8 +45,10 @@ class CharSequenceAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequen
             = "containsNotDefaultTranslationOf no longer in this API" to Companion::containsNotDefaultTranslationOf
 
 
-        private fun containsNotDefaultTranslationOf(plant: Assert<CharSequence>, expected: Translatable, otherExpected: Array<out Translatable>)
-            = plant.asExpect().containsNot(Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())).asAssert()
+        private fun containsNotDefaultTranslationOf(plant: Assert<CharSequence>, expected: Translatable, otherExpected: Array<out Translatable>): AssertionPlant<CharSequence> {
+            val values = Values(expected.getDefault(), *otherExpected.map { it.getDefault() }.toTypedArray())
+            return plant.asExpect().containsNot(values(values.expected, *values.otherExpected)).asAssert()
+        }
 
         fun toBeEmpty(plant: Assert<CharSequence>)
             = plant.asExpect().toBe(empty).asAssert()

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -1,5 +1,5 @@
 // TODO remove file with 1.0.0
-//@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package ch.tutteli.atrium.api.cc.infix.en_GB
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -107,7 +107,7 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$atLeast $times`"
+            = "use `$containsNotValues` instead of `$atLeast $times`"
 
         private fun getExactlyPair() = exactly to Companion::getErrorMsgExactly
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -6,7 +6,11 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
+import ch.tutteli.atrium.api.infix.en_GB.butAtMost
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsAtLeastAssertionsSpec(
@@ -31,9 +35,9 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
 
         private fun containsAtLeast(plant: Assert<CharSequence>, atLeast: Int, a: Any, aX: Array<out Any>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant to contain atLeast atLeast value a
+                (plant.asExpect().contains(o)).atLeast(atLeast) value a
             } else {
-                plant to contain atLeast atLeast the Values(a, *aX)
+                (plant.asExpect().contains(o) atLeast atLeast).the(Values(a, *aX))
             }
         }
 
@@ -45,11 +49,11 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
 
         private fun containsAtLeastIgnoringCase(plant: Assert<CharSequence>, atLeast: Int, a: Any, aX: Array<out Any>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                if(atLeast == 1) plant to contain ignoring case value a
-                else plant to contain ignoring case atLeast atLeast value a
+                if(atLeast == 1) (plant.asExpect().contains(o) ignoring case).value(a)
+                else (plant.asExpect().contains(o) ignoring case atLeast atLeast).value(a)
             } else {
-                if(atLeast == 1) plant to contain ignoring case the Values(a, *aX)
-                else plant to contain ignoring case atLeast atLeast the Values(a, *aX)
+                if(atLeast == 1) (plant.asExpect().contains(o) ignoring case).the(Values(a, *aX))
+                else (plant.asExpect().contains(o) ignoring case atLeast atLeast).the(Values(a, *aX))
             }
         }
 
@@ -69,7 +73,7 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
         )
 
         private fun containsAtLeastButAtMostIgnoringCase(plant: Assert<CharSequence>, atLeast: Int, butAtMost: Int, a: Any, aX: Array<out Any>)
-            = plant to contain ignoring case atLeast atLeast butAtMost butAtMost the Values(a, *aX)
+            = (plant.asExpect().contains(o) ignoring case atLeast atLeast butAtMost butAtMost).the(Values(a, *aX))
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtLeastAssertionsSpec.kt
@@ -1,5 +1,5 @@
 // TODO remove file with 1.0.0
-@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+//@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
@@ -10,6 +10,8 @@ import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.butAtMost
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.creating.AssertionPlant
+import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -37,7 +39,8 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
             return if (aX.isEmpty()) {
                 (plant.asExpect().contains(o)).atLeast(atLeast) value a
             } else {
-                (plant.asExpect().contains(o) atLeast atLeast).the(Values(a, *aX))
+                val values = Values(a, *aX)
+                (plant.asExpect().contains(o) atLeast atLeast).the(values(values.expected, *values.otherExpected)).asAssert()
             }
         }
 
@@ -52,8 +55,20 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
                 if(atLeast == 1) (plant.asExpect().contains(o) ignoring case).value(a)
                 else (plant.asExpect().contains(o) ignoring case atLeast atLeast).value(a)
             } else {
-                if(atLeast == 1) (plant.asExpect().contains(o) ignoring case).the(Values(a, *aX))
-                else (plant.asExpect().contains(o) ignoring case atLeast atLeast).the(Values(a, *aX))
+                if(atLeast == 1) {
+                    val values = Values(a, *aX)
+                    (plant.asExpect().contains(o) ignoring case).the(values(values.expected, *values.otherExpected))
+                        .asAssert()
+                }
+                else {
+                    val values = Values(a, *aX)
+                    (plant.asExpect().contains(o) ignoring case atLeast atLeast).the(
+                        values(
+                            values.expected,
+                            *values.otherExpected
+                        )
+                    ).asAssert()
+                }
             }
         }
 
@@ -63,8 +78,15 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
             Companion::containsAtLeastButAtMost
         )
 
-        private fun containsAtLeastButAtMost(plant: Assert<CharSequence>, atLeast: Int, butAtMost: Int, a: Any, aX: Array<out Any>)
-            = plant to contain atLeast atLeast butAtMost butAtMost the Values(a, *aX)
+        private fun containsAtLeastButAtMost(plant: Assert<CharSequence>, atLeast: Int, butAtMost: Int, a: Any, aX: Array<out Any>): AssertionPlant<CharSequence> {
+            val values = Values(a, *aX)
+            return (plant.asExpect().contains(o) atLeast atLeast butAtMost butAtMost).the(
+                values(
+                    values.expected,
+                    *values.otherExpected
+                )
+            ).asAssert()
+        }
 
         private fun getAtLeastBustAtMostIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $atLeast $butAtMost",
@@ -72,8 +94,15 @@ class CharSequenceContainsAtLeastAssertionsSpec : ch.tutteli.atrium.spec.integra
             Companion::containsAtLeastButAtMostIgnoringCase
         )
 
-        private fun containsAtLeastButAtMostIgnoringCase(plant: Assert<CharSequence>, atLeast: Int, butAtMost: Int, a: Any, aX: Array<out Any>)
-            = (plant.asExpect().contains(o) ignoring case atLeast atLeast butAtMost butAtMost).the(Values(a, *aX))
+        private fun containsAtLeastButAtMostIgnoringCase(plant: Assert<CharSequence>, atLeast: Int, butAtMost: Int, a: Any, aX: Array<out Any>): AssertionPlant<CharSequence> {
+            val values = Values(a, *aX)
+            return (plant.asExpect().contains(o) ignoring case atLeast atLeast butAtMost butAtMost).the(
+                values(
+                    values.expected,
+                    *values.otherExpected
+                )
+            ).asAssert()
+        }
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
@@ -56,7 +56,7 @@ class CharSequenceContainsAtMostAssertionsSpec : ch.tutteli.atrium.spec.integrat
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$atMost $times`"
+            = "use `$containsNotValues` instead of `$atMost $times`"
 
         private fun getExactlyPair() = exactly to Companion::getErrorMsgExactly
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
@@ -1,12 +1,13 @@
 // TODO remove file with 1.0.0
 @file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
-
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsAtMostAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsAtMostAssertionsSpec(
@@ -27,7 +28,7 @@ class CharSequenceContainsAtMostAssertionsSpec : ch.tutteli.atrium.spec.integrat
         )
 
         private fun containsAtMost(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>)
-            = plant to contain atMost atMost the Values(a, *aX)
+            = plant.asExpect().contains(ch.tutteli.atrium.api.infix.en_GB.o) atMost atMost the Values(a, *aX)
 
         private fun getAtMostIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $atMost",

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsAtMostAssertionsSpec.kt
@@ -5,8 +5,11 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.creating.AssertionPlant
+import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -27,8 +30,15 @@ class CharSequenceContainsAtMostAssertionsSpec : ch.tutteli.atrium.spec.integrat
             Companion::containsAtMost
         )
 
-        private fun containsAtMost(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>)
-            = plant.asExpect().contains(ch.tutteli.atrium.api.infix.en_GB.o) atMost atMost the Values(a, *aX)
+        private fun containsAtMost(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>): AssertionPlant<CharSequence> {
+            val values = Values(a, *aX)
+            return (plant.asExpect().contains(o) atMost atMost).the(
+                values(
+                    values.expected,
+                    *values.otherExpected
+                )
+            ).asAssert()
+        }
 
         private fun getAtMostIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $atMost",
@@ -36,8 +46,11 @@ class CharSequenceContainsAtMostAssertionsSpec : ch.tutteli.atrium.spec.integrat
             Companion::containsAtMostIgnoringCase
         )
 
-        private fun containsAtMostIgnoringCase(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>)
-            = plant to contain ignoring case atMost atMost the Values(a, *aX)
+        private fun containsAtMostIgnoringCase(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>): AssertionPlant<CharSequence> {
+            val values = Values(a, *aX)
+            return (plant to contain ignoring case atMost atMost).the(values(values.expected, *values.otherExpected))
+                .asAssert()
+        }
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsContainsNotAssertionsSpec.kt
@@ -3,8 +3,12 @@
 
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
+import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.containsNot
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import kotlin.reflect.KFunction2
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -20,9 +24,9 @@ class CharSequenceContainsContainsNotAssertionsSpec : ch.tutteli.atrium.spec.int
 
         private fun contains(plant: Assert<CharSequence>, a: Any, aX: Array<out Any>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant contains a
+                plant.asExpect().contains(a).asAssert()
             } else {
-                plant contains Values(a, *aX)
+                plant.asExpect().contains(Values(a, *aX)).asAssert()
             }
         }
 
@@ -31,9 +35,9 @@ class CharSequenceContainsContainsNotAssertionsSpec : ch.tutteli.atrium.spec.int
 
         private fun containsNot(plant: Assert<CharSequence>, a: Any, aX: Array<out Any>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant containsNot a
+                plant.asExpect().containsNot(a).asAssert()
             } else {
-                plant containsNot Values(a, *aX)
+                plant.asExpect().containsNot(Values(a, *aX)).asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
@@ -1,12 +1,14 @@
 // TODO remove file with 1.0.0
 @file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
-
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
+import ch.tutteli.atrium.api.infix.en_GB.o
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
-import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.exactly
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsExactlyAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsExactlyAssertionsSpec(
@@ -26,7 +28,7 @@ class CharSequenceContainsExactlyAssertionsSpec : ch.tutteli.atrium.spec.integra
         )
 
         private fun containsExactly(plant: Assert<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>)
-            = plant to contain exactly exactly the Values(a, *aX)
+            = (plant.asExpect().contains(o)).exactly(exactly) the Values(a, *aX)
 
         private fun getExactlyIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $exactly",
@@ -35,7 +37,7 @@ class CharSequenceContainsExactlyAssertionsSpec : ch.tutteli.atrium.spec.integra
         )
 
         private fun containsExactlyIgnoringCase(plant: Assert<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>)
-            = plant to contain ignoring case exactly exactly the Values(a, *aX)
+            = plant.asExpect().contains(o) ignoring case exactly exactly the Values(a, *aX)
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
@@ -1,5 +1,5 @@
 // TODO remove file with 1.0.0
-//@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.o

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
@@ -56,7 +56,7 @@ class CharSequenceContainsExactlyAssertionsSpec : ch.tutteli.atrium.spec.integra
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$exactly $times`"
+            = "use `$containsNotValues` instead of `$exactly $times`"
 
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsExactlyAssertionsSpec.kt
@@ -1,5 +1,5 @@
 // TODO remove file with 1.0.0
-@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+//@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.o
@@ -7,7 +7,10 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.api.infix.en_GB.exactly
+import ch.tutteli.atrium.api.infix.en_GB.the
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.creating.AssertionPlant
+import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -27,8 +30,11 @@ class CharSequenceContainsExactlyAssertionsSpec : ch.tutteli.atrium.spec.integra
             Companion::containsExactly
         )
 
-        private fun containsExactly(plant: Assert<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>)
-            = (plant.asExpect().contains(o)).exactly(exactly) the Values(a, *aX)
+        private fun containsExactly(plant: Assert<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>): AssertionPlant<CharSequence> {
+            val values = Values(a, *aX)
+            return (plant.asExpect().contains(o)).exactly(exactly)
+                .the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()
+        }
 
         private fun getExactlyIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $exactly",
@@ -36,8 +42,15 @@ class CharSequenceContainsExactlyAssertionsSpec : ch.tutteli.atrium.spec.integra
             Companion::containsExactlyIgnoringCase
         )
 
-        private fun containsExactlyIgnoringCase(plant: Assert<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>)
-            = plant.asExpect().contains(o) ignoring case exactly exactly the Values(a, *aX)
+        private fun containsExactlyIgnoringCase(plant: Assert<CharSequence>, exactly: Int, a: Any, aX: Array<out Any>): AssertionPlant<CharSequence> {
+            val values = Values(a, *aX)
+            return (plant.asExpect().contains(o) ignoring case exactly exactly).the(
+                ch.tutteli.atrium.api.infix.en_GB.values(
+                    values.expected,
+                    *values.otherExpected
+                )
+            ).asAssert()
+        }
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
@@ -7,6 +7,7 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -43,7 +44,9 @@ class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.spec.integration
             return if (aX.isEmpty()) {
                 plant.asExpect().containsNot(o) ignoring case value a
             } else {
-                plant.asExpect().containsNot(o) ignoring case the Values(a, *aX)
+                val values = Values(a, *aX)
+                (plant.asExpect().containsNot(o) ignoring case).the(values(values.expected, *values.otherExpected))
+                    .asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotAssertionsSpec.kt
@@ -4,9 +4,10 @@
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
-import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsNotAssertionsSpec(
@@ -26,9 +27,9 @@ class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.spec.integration
 
         private fun containsNotFun(plant: Assert<CharSequence>, a: Any, aX: Array<out Any>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant notTo contain value a
+                plant.asExpect().containsNot(o) value a
             } else {
-                plant notTo contain the Values(a, *aX)
+                plant.asExpect().containsNot(o) the Values(a, *aX)
             }
         }
 
@@ -40,9 +41,9 @@ class CharSequenceContainsNotAssertionsSpec : ch.tutteli.atrium.spec.integration
 
         private fun containsNotIgnoringCase(plant: Assert<CharSequence>, a: Any, aX: Array<out Any>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant notTo contain ignoring case value a
+                plant.asExpect().containsNot(o) ignoring case value a
             } else {
-                plant notTo contain ignoring case the Values(a, *aX)
+                plant.asExpect().containsNot(o) ignoring case the Values(a, *aX)
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotOrAtMostAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotOrAtMostAssertionsSpec.kt
@@ -45,6 +45,6 @@ class CharSequenceContainsNotOrAtMostAssertionsSpec : ch.tutteli.atrium.spec.int
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$notOrAtMost $times`"
+            = "use `$containsNotValues` instead of `$notOrAtMost $times`"
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotOrAtMostAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsNotOrAtMostAssertionsSpec.kt
@@ -6,7 +6,11 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.notOrAtMost
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsNotOrAtMostAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsNotOrAtMostAssertionsSpec(
@@ -26,7 +30,7 @@ class CharSequenceContainsNotOrAtMostAssertionsSpec : ch.tutteli.atrium.spec.int
         )
 
         private fun containsNotOrAtMost(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>)
-            = plant to contain notOrAtMost atMost the Values(a, *aX)
+            = (plant.asExpect().contains(o)).notOrAtMost(atMost) the Values(a, *aX)
 
         private fun getNotOrAtMostIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $notOrAtMost",
@@ -35,7 +39,7 @@ class CharSequenceContainsNotOrAtMostAssertionsSpec : ch.tutteli.atrium.spec.int
         )
 
         private fun containsNotOrAtMostIgnoringCase(plant: Assert<CharSequence>, atMost: Int, a: Any, aX: Array<out Any>)
-            = plant to contain ignoring case notOrAtMost atMost the Values(a, *aX)
+            = (plant.asExpect().contains(o) ignoring case notOrAtMost atMost).the(Values(a, *aX))
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -1,5 +1,5 @@
 // TODO remove file with 1.0.0
-//@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package ch.tutteli.atrium.api.cc.infix.en_GB
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -6,13 +6,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
-import ch.tutteli.atrium.api.infix.en_GB.contains
-import ch.tutteli.atrium.api.infix.en_GB.containsRegex
+import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.atMost
 import ch.tutteli.atrium.creating.Assert
-import ch.tutteli.atrium.domain.builders.migration.asAssert
-import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsRegexAssertionsSpec(
@@ -68,9 +65,9 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
 
         private fun containsShortcut(plant: Assert<CharSequence>, a: String, aX: Array<out String>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant.asExpect().containsRegex(a).asAssert()
+                plant containsRegex a
             } else {
-                plant.asExpect().contains(RegexPatterns(a, *aX)).asAssert()
+                plant contains regexPatterns(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -10,6 +10,8 @@ import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.atMost
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsRegexAssertionsSpec(
@@ -67,7 +69,7 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
             return if (aX.isEmpty()) {
                 plant containsRegex a
             } else {
-                plant contains regexPatterns(a, *aX)
+                plant.asExpect().contains(regexPatterns(a, *aX)).asAssert()
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -10,6 +10,7 @@ import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.atMost
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.creating.AssertionPlant
 import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
@@ -39,7 +40,9 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
             return if (aX.isEmpty()) {
                 (plant to contain) atLeast atLeast regex a
             } else {
-                (plant to contain).atLeast(atLeast) the RegexPatterns(a, *aX)
+                val patterns = RegexPatterns(a, *aX)
+                (plant to contain).atLeast(atLeast).the(regexPatterns(patterns.expected, *patterns.otherExpected))
+                    .asAssert()
             }
         }
 
@@ -54,8 +57,19 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
                 if(atLeast == 1) plant to contain ignoring case regex a
                 else plant to contain ignoring case atLeast atLeast regex a
             } else {
-                if(atLeast == 1) plant to contain ignoring case the RegexPatterns(a, *aX)
-                else plant to contain ignoring case atLeast atLeast the RegexPatterns(a, *aX)
+                if(atLeast == 1) {
+                    val patterns = RegexPatterns(a, *aX)
+                    (plant to contain ignoring case).the(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()
+                }
+                else {
+                    val patterns = RegexPatterns(a, *aX)
+                    (plant to contain ignoring case atLeast atLeast).the(
+                        regexPatterns(
+                            patterns.expected,
+                            *patterns.otherExpected
+                        )
+                    ).asAssert()
+                }
             }
         }
 
@@ -79,8 +93,11 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
             Companion::containsAtMost
         )
 
-        private fun containsAtMost(plant: Assert<CharSequence>, atMost: Int, a: String, aX: Array<out String>)
-            = plant to contain atMost atMost the RegexPatterns(a, *aX)
+        private fun containsAtMost(plant: Assert<CharSequence>, atMost: Int, a: String, aX: Array<out String>): AssertionPlant<CharSequence> {
+            val patterns = RegexPatterns(a, *aX)
+            return (plant to contain atMost atMost).the(regexPatterns(patterns.expected, *patterns.otherExpected))
+                .asAssert()
+        }
 
         private fun getAtMostIgnoringCaseTriple() = Triple(
             "$toContain $ignoringCase $atMost $regex",
@@ -92,7 +109,9 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
             return if (aX.isEmpty()) {
                 plant to contain ignoring case atMost atMost regex a
             } else {
-                (plant to contain ignoring case).atMost(atMost) the RegexPatterns(a, *aX)
+                val patterns = RegexPatterns(a, *aX)
+                (plant to contain ignoring case).atMost(atMost)
+                    .the(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -6,7 +6,13 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.case
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.containsRegex
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
+import ch.tutteli.atrium.api.infix.en_GB.atMost
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integration.CharSequenceContainsRegexAssertionsSpec(
@@ -32,9 +38,9 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
 
         private fun containsAtLeast(plant: Assert<CharSequence>, atLeast: Int, a: String, aX: Array<out String>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant to contain atLeast atLeast regex a
+                (plant to contain) atLeast atLeast regex a
             } else {
-                plant to contain atLeast atLeast the RegexPatterns(a, *aX)
+                (plant to contain).atLeast(atLeast) the RegexPatterns(a, *aX)
             }
         }
 
@@ -62,9 +68,9 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
 
         private fun containsShortcut(plant: Assert<CharSequence>, a: String, aX: Array<out String>): Assert<CharSequence> {
             return if (aX.isEmpty()) {
-                plant containsRegex a
+                plant.asExpect().containsRegex(a).asAssert()
             } else {
-                plant contains RegexPatterns(a, *aX)
+                plant.asExpect().contains(RegexPatterns(a, *aX)).asAssert()
             }
         }
 
@@ -87,7 +93,7 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
             return if (aX.isEmpty()) {
                 plant to contain ignoring case atMost atMost regex a
             } else {
-                plant to contain ignoring case atMost atMost the RegexPatterns(a, *aX)
+                (plant to contain ignoring case).atMost(atMost) the RegexPatterns(a, *aX)
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsRegexAssertionsSpec.kt
@@ -1,5 +1,5 @@
 // TODO remove file with 1.0.0
-@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+//@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
@@ -83,7 +83,9 @@ class CharSequenceContainsRegexAssertionsSpec : ch.tutteli.atrium.spec.integrati
             return if (aX.isEmpty()) {
                 plant containsRegex a
             } else {
-                plant.asExpect().contains(regexPatterns(a, *aX)).asAssert()
+                val patterns = RegexPatterns(a, *aX)
+                plant.asExpect().contains(regexPatterns(patterns.expected, *patterns.otherExpected)).asAssert()
+
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsSpecBase.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/CharSequenceContainsSpecBase.kt
@@ -16,7 +16,7 @@ abstract class CharSequenceContainsSpecBase {
     private val containsNotFun: KFunction2<Assert<String>, Any, Assert<String>> = Assert<String>::containsNot
     protected val toContain = "${Assert<String>::to.name} ${contain::class.simpleName}"
     protected val notToContain = "${Assert<String>::notTo.name} ${contain::class.simpleName}"
-    protected val containsNotValues = "${containsNotFun.name} ${Values::class.simpleName}"
+    protected val containsNotValues = "${containsNotFun.name} values"
     protected val containsRegex = "${Assert<String>::to.name} ${contain::class.simpleName} ${RegexPatterns::class.simpleName}"
     protected val atLeast = CharSequenceContains.Builder<*, *>::atLeast.name
     protected val butAtMost = AtLeastCheckerOption<*, *>::butAtMost.name

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/creating/charsequence/contains/builders/impl/nameContainsNotFun.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/creating/charsequence/contains/builders/impl/nameContainsNotFun.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.fluent.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.fluent.en_GB.containsNot

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.fluent.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.fluent.en_GB.containsNot

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/charsequence/contains.builders/impl/nameContainsNotFun.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/charsequence/contains.builders/impl/nameContainsNotFun.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.infix.en_GB.creating.charsequence.contains.builders.impl
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.Values

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/contains/builders/impl/nameContainsNotFun.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.infix.en_GB.containsNot


### PR DESCRIPTION
This PR add Deprecate api-cc-infix and add Replacewith for the expect for these files:
- [x] charSequenceAssertions.kt
- [x] charSequenceContainsCheckers.kt
- [x] charSequenceContainsCheckers.kt
- [x] charSequenceContainsCheckers.kt
- [x] charSequenceContainsCreators.kt
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
