### PR TITLE
return empty message in case callee is org.spekframework.ide

### DIFF
--- a/core/api/atrium-core-api-jvm/src/main/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
+++ b/core/api/atrium-core-api-jvm/src/main/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
@@ -27,6 +27,7 @@ actual class AtriumError internal actual constructor(message: String) : Assertio
         get() {
             val isDoublePrintingTestRunner = Thread.currentThread().stackTrace[2].let {
                 it.className.startsWith("org.jetbrains.spek.tooling.adapter.sm") ||
+                    it.className.startsWith("org.spekframework.ide") ||
                     it.className == "org.gradle.internal.serialize.ExceptionPlaceholder"
             }
             return if (isDoublePrintingTestRunner) {
@@ -44,8 +45,8 @@ actual class AtriumError internal actual constructor(message: String) : Assertio
     /**
      * Returns first [getLocalizedMessage] and then the qualified name of this exception.
      *
-     * Which has the effect that printStackTrace will show first the error message and then stacktrace including
-     * qualified name - resulting in a tidier report 😊
+     * Which has the effect that printStackTrace will show first the error message and then qualified name including
+     * stacktrace - resulting in a tidier report 😊
      *
      * One unwanted effect, we show the qualified name even if someone has chosen the following for the gradle runner
      * showExceptions=true, showStacktrace=false => however, I think that's fine.


### PR DESCRIPTION
- fixes #485 

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
