### PR TITLE
#430 [WIP] deprecate iterableassertions file

### DIFF
--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/AtLeastCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/AtLeastCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.atLeast

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/AtMostCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/AtMostCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.atLeast

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/ButAtMostCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/ButAtMostCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.atLeast

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/ExactlyCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/ExactlyCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.ExactlyCheckerOption

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/NotOrAtMostCheckerOptionImpl.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/creating/iterable/contains/builders/impl/NotOrAtMostCheckerOptionImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION" /* will be removed with 1.0.0 */)
 package ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.impl
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.creating.iterable.contains.builders.NotOrAtMostCheckerOption

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableAssertions.kt
@@ -26,6 +26,16 @@ import kotlin.jvm.JvmName
  *
  * @return The newly created builder.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(ch.tutteli.atrium.api.infix.en_GB.o)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.to(@Suppress("UNUSED_PARAMETER") contain: contain): IterableContains.Builder<E, T, NoOpSearchBehaviour>
     = AssertImpl.iterable.containsBuilder(this)
 
@@ -35,6 +45,16 @@ infix fun <E, T : Iterable<E>> Assert<T>.to(@Suppress("UNUSED_PARAMETER") contai
  *
  * @return The newly created builder.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsNot(ch.tutteli.atrium.api.infix.en_GB.o)",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot",
+        "ch.tutteli.atrium.api.infix.en_GB.o"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.notTo(@Suppress("UNUSED_PARAMETER") contain: contain): NotCheckerOption<E, T, NotSearchBehaviour>
     = NotCheckerOptionImpl(AssertImpl.iterable.containsNotBuilder(this))
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableAssertions.kt
@@ -46,6 +46,15 @@ infix fun <E, T : Iterable<E>> Assert<T>.notTo(@Suppress("UNUSED_PARAMETER") con
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.contains(expected: E)
     = o to contain inAny order atLeast 1 value expected
 
@@ -68,6 +77,16 @@ infix fun <E, T : Iterable<E>> Assert<T>.contains(expected: E)
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.contains(values: Values<E>): AssertionPlant<T>
     = o to contain inAny order atLeast 1 the values
 
@@ -85,6 +104,15 @@ infix fun <E, T : Iterable<E>> Assert<T>.contains(values: Values<E>): AssertionP
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(assertionCreatorOrNull).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.contains(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
     = o to contain inAny order atLeast 1 entry assertionCreatorOrNull
 
@@ -100,6 +128,15 @@ infix fun <E : Any, T : Iterable<E?>> Assert<T>.contains(assertionCreatorOrNull:
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().contains(entries).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.contains",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.contains(entries: Entries<E>): AssertionPlant<T>
     = o to contain inAny order atLeast 1 the entries
 
@@ -113,6 +150,15 @@ infix fun <E : Any, T : Iterable<E?>> Assert<T>.contains(entries: Entries<E>): A
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsExactly(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.containsExactly",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.containsExactly(expected: E): AssertionPlant<T>
     = o to contain inGiven order and only value expected
 
@@ -125,6 +171,16 @@ infix fun <E, T : Iterable<E>> Assert<T>.containsExactly(expected: E): Assertion
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsExactly(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.containsExactly",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.containsExactly(values: Values<E>): AssertionPlant<T>
     = o to contain inGiven order and only the values
 
@@ -142,6 +198,15 @@ infix fun <E, T : Iterable<E>> Assert<T>.containsExactly(values: Values<E>): Ass
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsExactly(assertionCreatorOrNull).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.containsExactly",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.containsExactly(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
     = o to contain inGiven order and only entry assertionCreatorOrNull
 
@@ -158,6 +223,15 @@ infix fun <E : Any, T : Iterable<E?>> Assert<T>.containsExactly(assertionCreator
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsExactly(entries).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.containsExactly",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.containsExactly(entries: Entries<E>): AssertionPlant<T>
     = o to contain inGiven order and only the entries
 
@@ -170,6 +244,15 @@ infix fun <E : Any, T : Iterable<E?>> Assert<T>.containsExactly(entries: Entries
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsNot(expected).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.containsNot(expected: E): AssertionPlant<T>
     = o notTo contain value expected
 
@@ -181,6 +264,16 @@ infix fun <E, T : Iterable<E>> Assert<T>.containsNot(expected: E): AssertionPlan
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().containsNot(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.containsNot",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.api.infix.en_GB.values"
+    )
+)
 infix fun <E, T : Iterable<E>> Assert<T>.containsNot(values: Values<E>): AssertionPlant<T>
     = o notTo contain the values
 
@@ -195,6 +288,16 @@ infix fun <E, T : Iterable<E>> Assert<T>.containsNot(values: Values<E>): Asserti
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().any(asSubExpect(assertionCreatorOrNull)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.any"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.any(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
     = o to contain inAny order atLeast 1 entry assertionCreatorOrNull
 
@@ -209,6 +312,16 @@ infix fun <E : Any, T : Iterable<E?>> Assert<T>.any(assertionCreatorOrNull: (Ass
  * @return This plant to support a fluent API.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().none(asSubExpect(assertionCreatorOrNull)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.none"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.none(assertionCreatorOrNull: (Assert<E>.() -> Unit)?)
     = o notTo contain entry assertionCreatorOrNull
 
@@ -222,5 +335,15 @@ infix fun <E : Any, T : Iterable<E?>> Assert<T>.none(assertionCreatorOrNull: (As
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress("DEPRECATION")
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.asExpect().all(asSubExpect(assertionCreatorOrNull)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.all"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.all(assertionCreatorOrNull: (Assert<E>.() -> Unit)?)
     = addAssertion(AssertImpl.iterable.all(this, assertionCreatorOrNull))

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableAssertions.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableAssertions.kt
@@ -107,10 +107,11 @@ infix fun <E, T : Iterable<E>> Assert<T>.contains(values: Values<E>): AssertionP
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().contains(assertionCreatorOrNull).asAssert()",
+        "this.asExpect().contains(asSubExpect(assertionCreatorOrNull)).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
-        "ch.tutteli.atrium.api.infix.en_GB.contains",
-        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.contains"
     )
 )
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.contains(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
@@ -201,10 +202,11 @@ infix fun <E, T : Iterable<E>> Assert<T>.containsExactly(values: Values<E>): Ass
 @Deprecated(
     "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
     ReplaceWith(
-        "this.asExpect().containsExactly(assertionCreatorOrNull).asAssert()",
+        "this.asExpect().containsExactly(asSubExpect(assertionCreatorOrNull)).asAssert()",
         "ch.tutteli.atrium.domain.builders.migration.asExpect",
-        "ch.tutteli.atrium.api.infix.en_GB.containsExactly",
-        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.fluent.en_GB.containsExactly"
     )
 )
 infix fun <E : Any, T : Iterable<E?>> Assert<T>.containsExactly(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsCheckers.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsCheckers.kt
@@ -17,6 +17,13 @@ import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAn
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] equals to zero; use [containsNot] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.atLeast(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.atLeast"
+    )
+)
 infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Builder<E, T, S>.atLeast(times: Int): AtLeastCheckerOption<E, T, S>
     = AtLeastCheckerOptionImpl(times, this)
 
@@ -35,6 +42,13 @@ infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Bu
  * @throws IllegalArgumentException In case [times] of this `at most` restriction equals to the number of the
  *   `at least` restriction; use the [exactly] restriction instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.butAtMost(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.butAtMost"
+    )
+)
 infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> AtLeastCheckerOption<E, T, S>.butAtMost(times: Int): ButAtMostCheckerOption<E, T, S>
     = ButAtMostCheckerOptionImpl(times, this, containsBuilder)
 
@@ -49,6 +63,13 @@ infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> AtLeastCheckerOptio
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] equals to zero; use [containsNot] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.exactly(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.exactly"
+    )
+)
 infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Builder<E, T, S>.exactly(times: Int): ExactlyCheckerOption<E, T, S>
     = ExactlyCheckerOptionImpl(times, this)
 
@@ -68,6 +89,13 @@ infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Bu
  * @throws IllegalArgumentException In case [times] equals to zero; use [containsNot] instead.
  * @throws IllegalArgumentException In case [times] equals to one; use [exactly] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.atMost(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.atMost"
+    )
+)
 infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Builder<E, T, S>.atMost(times: Int): AtMostCheckerOption<E, T, S>
     = AtMostCheckerOptionImpl(times, this)
 
@@ -82,5 +110,12 @@ infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Bu
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] equals to zero; use [containsNot] instead.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.notOrAtMost(times)",
+        "ch.tutteli.atrium.api.infix.en_GB.notOrAtMost"
+    )
+)
 infix fun <E, T : Iterable<E>, S: InAnyOrderSearchBehaviour> IterableContains.Builder<E, T, S>.notOrAtMost(times: Int): NotOrAtMostCheckerOption<E, T, S>
     = NotOrAtMostCheckerOptionImpl(times, this)

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsInAnyOrderCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsInAnyOrderCreators.kt
@@ -27,6 +27,14 @@ import kotlin.jvm.JvmName
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.value(expected).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.value",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> IterableContains.CheckerOption<E, T, InAnyOrderSearchBehaviour>.value(expected: E): AssertionPlant<T>
     = this the Values(expected)
 
@@ -50,6 +58,15 @@ infix fun <E, T : Iterable<E>> IterableContains.CheckerOption<E, T, InAnyOrderSe
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> IterableContains.CheckerOption<E, T, InAnyOrderSearchBehaviour>.the(values: Values<E>): AssertionPlant<T>
     = addAssertion(AssertImpl.iterable.contains.valuesInAnyOrder(this, values.toList()))
 
@@ -67,6 +84,16 @@ infix fun <E, T : Iterable<E>> IterableContains.CheckerOption<E, T, InAnyOrderSe
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.entry(asSubExpect(assertionCreatorOrNull)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.entry"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> IterableContains.CheckerOption<E?, T, InAnyOrderSearchBehaviour>.entry(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
     = this the Entries(assertionCreatorOrNull)
 
@@ -83,6 +110,14 @@ infix fun <E : Any, T : Iterable<E?>> IterableContains.CheckerOption<E?, T, InAn
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress("DEPRECATION")
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(entries)",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> IterableContains.CheckerOption<E?, T, InAnyOrderSearchBehaviour>.the(entries: Entries<E>): AssertionPlant<T>
     = addAssertion(AssertImpl.iterable.contains.entriesInAnyOrderWithAssert(this, entries.toList()))
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsInAnyOrderOnlyCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsInAnyOrderOnlyCreators.kt
@@ -26,6 +26,14 @@ import kotlin.jvm.JvmName
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.value(expected).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.value",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): AssertionPlant<T>
     = this the Values(expected)
 
@@ -38,6 +46,15 @@ infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InAnyOrderOnlySear
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InAnyOrderOnlySearchBehaviour>.the(values: Values<E>): AssertionPlant<T>
     = addAssertion(AssertImpl.iterable.contains.valuesInAnyOrderOnly(this, values.toList()))
 
@@ -53,6 +70,16 @@ infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InAnyOrderOnlySear
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.entry(asSubExpect(assertionCreatorOrNull)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.entry"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> IterableContains.Builder<E?, T, InAnyOrderOnlySearchBehaviour>.entry(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
     = this the Entries(assertionCreatorOrNull)
 
@@ -78,6 +105,14 @@ infix fun <E : Any, T : Iterable<E?>> IterableContains.Builder<E?, T, InAnyOrder
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress("DEPRECATION")
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(entries)",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> IterableContains.Builder<E?, T, InAnyOrderOnlySearchBehaviour>.the(entries: Entries<E>): AssertionPlant<T>
     = addAssertion(AssertImpl.iterable.contains.entriesInAnyOrderOnlyWithAssert(this, entries.toList()))
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsInOrderOnlyCreators.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/iterableContainsInOrderOnlyCreators.kt
@@ -23,6 +23,14 @@ import kotlin.jvm.JvmName
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.value(expected).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.value",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InOrderOnlySearchBehaviour>.value(expected: E): AssertionPlant<T>
     = this the Values(expected)
 
@@ -35,6 +43,15 @@ infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InOrderOnlySearchB
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected)).asAssert()",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.api.infix.en_GB.values",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InOrderOnlySearchBehaviour>.the(values: Values<E>): AssertionPlant<T>
     = addAssertion(AssertImpl.iterable.contains.valuesInOrderOnly(this, values.toList()))
 
@@ -50,6 +67,16 @@ infix fun <E, T : Iterable<E>> IterableContains.Builder<E, T, InOrderOnlySearchB
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
+@Deprecated(
+    "Switch from Assert to Expect; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.entry(asSubExpect(assertionCreatorOrNull)).asAssert()",
+        "ch.tutteli.atrium.domain.builders.migration.asExpect",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert",
+        "ch.tutteli.atrium.domain.builders.migration.asSubExpect",
+        "ch.tutteli.atrium.api.infix.en_GB.entry"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> IterableContains.Builder<E?, T, InOrderOnlySearchBehaviour>.entry(assertionCreatorOrNull: (Assert<E>.() -> Unit)?): AssertionPlant<T>
     = this the Entries(assertionCreatorOrNull)
 
@@ -69,5 +96,13 @@ infix fun <E : Any, T : Iterable<E?>> IterableContains.Builder<E?, T, InOrderOnl
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 @Suppress("DEPRECATION")
+@Deprecated(
+    "Switch from api-cc-infix-en_GB to api-infix-en_GB; will be removed with 1.0.0 -- see https://github.com/robstoll/atrium/releases/tag/v0.9.0#migration for migration hints and scripts.",
+    ReplaceWith(
+        "this.the(entries)",
+        "ch.tutteli.atrium.api.infix.en_GB.the",
+        "ch.tutteli.atrium.domain.builders.migration.asAssert"
+    )
+)
 infix fun <E : Any, T : Iterable<E?>> IterableContains.Builder<E?, T, InOrderOnlySearchBehaviour>.the(entries: Entries<E>): AssertionPlant<T>
     = addAssertion(AssertImpl.iterable.contains.entriesInOrderOnlyWithAssert(this, entries.toList()))

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAllAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAllAssertionsSpec.kt
@@ -3,8 +3,12 @@
 
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
+import ch.tutteli.atrium.api.infix.en_GB.all
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -34,6 +38,6 @@ class IterableAllAssertionsSpec: Spek({
         fun getAnyNullablePair() = anyNullableFun.name to Companion::allNullable
 
         private fun allNullable(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?) =
-            plant all a
+            plant.asExpect().all(asSubExpect(a)).asAssert()
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
@@ -5,8 +5,13 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.any
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
@@ -57,13 +62,13 @@ class IterableAnyAssertionsSpec : Spek({
         fun getAnyPair() = anyFun.name to Companion::any
 
         private fun any(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit)
-            = plant any a
+            = plant.asExpect().any(asSubExpect(a)).asAssert()
 
         private val anyNullableFun: KFunction2<Assert<Iterable<Double?>>, (Assert<Double>.() -> Unit)?, Assert<Iterable<Double?>>> = Assert<Iterable<Double?>>::any
         fun getAnyNullablePair() = anyNullableFun.name to Companion::anyNullable
 
         private fun anyNullable(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?)
-            = plant any a
+            = plant.asExpect().any(asSubExpect(a)).asAssert()
 
 
         fun getContainsPair()
@@ -83,13 +88,13 @@ class IterableAnyAssertionsSpec : Spek({
         fun getContainsShortcutPair() = containsShortcutFun.name to Companion::containsInAnyOrderEntriesShortcut
 
         private fun containsInAnyOrderEntriesShortcut(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit)
-            = plant contains a
+            = plant.asExpect().contains<Any?, Iterable<Double>>(a).asAssert()
 
         private val containsShortcutNullableFun: KFunction2<Assert<Iterable<Double?>>, (Assert<Double>.() -> Unit)?, Assert<Iterable<Double?>>> = Assert<Iterable<Double?>>::contains
         fun getContainsNullableShortcutPair() = containsShortcutNullableFun.name to Companion::containsNullableEntriesShortcut
 
         private fun containsNullableEntriesShortcut(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?)
-            = plant contains a
+            = plant.asExpect().contains(a).asAssert()
 
 
         private fun getContainsSequencePair()

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
@@ -94,7 +94,7 @@ class IterableAnyAssertionsSpec : Spek({
         fun getContainsNullableShortcutPair() = containsShortcutNullableFun.name to Companion::containsNullableEntriesShortcut
 
         private fun containsNullableEntriesShortcut(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?)
-            = plant.asExpect().contains(a).asAssert()
+            = plant.asExpect().contains(asSubExpect(a)).asAssert()
 
 
         private fun getContainsSequencePair()

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
@@ -16,6 +16,7 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableAnyAssertionsSpec : Spek({
@@ -75,13 +76,13 @@ class IterableAnyAssertionsSpec : Spek({
             = "$toContain $inAnyOrder $atLeast 1 $inAnyOrderEntries" to Companion::containsInAnyOrderEntries
 
         private fun containsInAnyOrderEntries(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit)
-            = plant to contain inAny order atLeast 1 entry a
+            = plant.asExpect().contains(o) inAny order atLeast 1 entry a
 
         fun getContainsNullablePair()
             = "$toContain $inAnyOrder $atLeast 1 $inAnyOrderEntries" to Companion::containsNullableEntries
 
         private fun containsNullableEntries(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?)
-            = plant to contain inAny order atLeast 1 entry a
+            = plant.asExpect().contains(o) inAny order atLeast 1 entry a
 
 
         private val containsShortcutFun : KFunction2<Assert<Iterable<Double>>, Assert<Double>.() -> Unit, Assert<Iterable<Double>>> = Assert<Iterable<Double>>::contains

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableAnyAssertionsSpec.kt
@@ -6,6 +6,7 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.api.infix.en_GB.any
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.ExpectImpl
@@ -76,7 +77,7 @@ class IterableAnyAssertionsSpec : Spek({
             = "$toContain $inAnyOrder $atLeast 1 $inAnyOrderEntries" to Companion::containsInAnyOrderEntries
 
         private fun containsInAnyOrderEntries(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit)
-            = plant.asExpect().contains(o) inAny order atLeast 1 entry a
+            = (plant.asExpect().contains(o) inAny order).atLeast(1) entry a
 
         fun getContainsNullablePair()
             = "$toContain $inAnyOrder $atLeast 1 $inAnyOrderEntries" to Companion::containsNullableEntries

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
@@ -5,6 +5,7 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
@@ -42,7 +43,7 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsInAnyOrderEntries(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order atLeast 1 entry a
+                (plant.asExpect().contains(o) inAny order).atLeast(1) entry a
             } else {
                 plant.asExpect().contains(o) inAny order atLeast 1 the Entries(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
@@ -5,7 +5,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -60,9 +63,9 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsInAnyOrderEntriesShortcut(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant contains a
+                plant.asExpect().contains<Any?, Iterable<Double>>(a).asAssert()
             } else {
-                plant contains Entries(a, *aX)
+                plant.asExpect().contains<Any?, Iterable<Double>>(Entries(a, *aX)).asAssert()
             }
         }
 
@@ -71,9 +74,9 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsNullableEntriesShortcut(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant contains a
+                plant.asExpect().contains(a).asAssert()
             } else {
-                plant contains Entries(a, *aX)
+                plant.asExpect().contains(Entries(a, *aX)).asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
@@ -13,6 +13,7 @@ import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
@@ -41,9 +42,9 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsInAnyOrderEntries(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order atLeast 1 entry a
+                plant.asExpect().contains(o) inAny order atLeast 1 entry a
             } else {
-                plant to contain inAny order atLeast 1 the Entries(a, *aX)
+                plant.asExpect().contains(o) inAny order atLeast 1 the Entries(a, *aX)
             }
         }
 
@@ -52,9 +53,9 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsNullableEntries(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order atLeast 1 entry a
+                plant.asExpect().contains(o) inAny order atLeast 1 entry a
             } else {
-                plant to contain inAny order atLeast 1 the Entries(a, *aX)
+                plant.asExpect().contains(o) inAny order atLeast 1 the Entries(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec.kt
@@ -9,6 +9,7 @@ import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -63,7 +64,7 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsInAnyOrderEntriesShortcut(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains<Any?, Iterable<Double>>(a).asAssert()
+                plant.asExpect().contains(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().contains<Any?, Iterable<Double>>(Entries(a, *aX)).asAssert()
             }
@@ -74,7 +75,7 @@ class IterableContainsInAnyOrderAtLeast1EntriesAssertionsSpec : Spek({
 
         private fun containsNullableEntriesShortcut(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(a).asAssert()
+                plant.asExpect().contains(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().contains(Entries(a, *aX)).asAssert()
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
@@ -5,8 +5,12 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
+import ch.tutteli.atrium.api.infix.en_GB.values
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
 
@@ -60,9 +64,12 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
 
         private fun contains(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant contains a
+                plant.asExpect().contains(a).asAssert()
             } else {
-                plant contains Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect()
+                    .contains(values(values.expected, *values.otherExpected))
+                    .asAssert()
             }
         }
 
@@ -71,9 +78,10 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
 
         private fun containsNullableValuesShortcut(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant contains a
+                plant.asExpect().contains(a).asAssert()
             } else {
-                plant contains Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect().contains(values(values.expected, *values.otherExpected)).asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
@@ -5,6 +5,7 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
@@ -42,7 +43,7 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
 
         private fun containsValues(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order atLeast 1 value a
+                (plant.asExpect().contains(o) inAny order).atLeast(1) value a
             } else {
                 plant.asExpect().contains(o) inAny order atLeast 1 the Values(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
@@ -13,6 +13,7 @@ import org.jetbrains.spek.api.Spek
 import ch.tutteli.atrium.api.infix.en_GB.values
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
@@ -41,9 +42,9 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
 
         private fun containsValues(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order atLeast 1 value a
+                plant.asExpect().contains(o) inAny order atLeast 1 value a
             } else {
-                plant to contain inAny order atLeast 1 the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order atLeast 1 the Values(a, *aX)
             }
         }
 
@@ -52,9 +53,9 @@ class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec : Spek({
 
         private fun containsNullableValues(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order atLeast 1 value a
+                plant.asExpect().contains(o) inAny order atLeast 1 value a
             } else {
-                plant to contain inAny order atLeast 1 the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order atLeast 1 the Values(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
@@ -5,8 +5,11 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.butAtMost
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -44,7 +47,7 @@ class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec : ch.tutteli.atrium.
 
         private fun containsAtLeastButAtMost(plant: Assert<Iterable<Double>>, atLeast: Int, butAtMost: Int, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order atLeast atLeast butAtMost butAtMost value a
+                (plant.asExpect().contains(o) inAny order).atLeast(atLeast) butAtMost butAtMost value a
             } else {
                 plant.asExpect().contains(o) inAny order atLeast atLeast butAtMost butAtMost the Values(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
@@ -6,6 +6,8 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
@@ -28,9 +30,9 @@ class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec : ch.tutteli.atrium.
 
         private fun containsAtLeast(plant: Assert<Iterable<Double>>, atLeast: Int, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order atLeast atLeast value a
+                plant.asExpect().contains(o) inAny order atLeast atLeast value a
             } else {
-                plant to contain inAny order atLeast atLeast the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order atLeast atLeast the Values(a, *aX)
             }
         }
 
@@ -42,9 +44,9 @@ class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec : ch.tutteli.atrium.
 
         private fun containsAtLeastButAtMost(plant: Assert<Iterable<Double>>, atLeast: Int, butAtMost: Int, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order atLeast atLeast butAtMost butAtMost value a
+                plant.asExpect().contains(o) inAny order atLeast atLeast butAtMost butAtMost value a
             } else {
-                plant to contain inAny order atLeast atLeast butAtMost butAtMost the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order atLeast atLeast butAtMost butAtMost the Values(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtLeastValuesAssertionsSpec.kt
@@ -51,7 +51,7 @@ class IterableContainsInAnyOrderAtLeastValuesAssertionsSpec : ch.tutteli.atrium.
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$atLeast $times`"
+            = "use `$containsNotValues` instead of `$atLeast $times`"
 
         private fun getExactlyPair() = exactly to Companion::getErrorMsgExactly
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
@@ -31,7 +31,7 @@ class IterableContainsInAnyOrderAtMostValuesAssertionsSpec : ch.tutteli.atrium.s
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$atMost $times`"
+            = "use `$containsNotValues` instead of `$atMost $times`"
 
         private fun getExactlyPair() = exactly to Companion::getErrorMsgExactly
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
@@ -5,6 +5,7 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.atMost
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.api.infix.en_GB.o
@@ -28,7 +29,7 @@ class IterableContainsInAnyOrderAtMostValuesAssertionsSpec : ch.tutteli.atrium.s
         )
 
         private fun containsAtMost(plant: Assert<Iterable<Double>>, atMost: Int, a: Double, aX: Array<out Double>)
-            = plant.asExpect().contains(o) inAny order atMost atMost the Values(a, *aX)
+            = (plant.asExpect().contains(o) inAny order).atMost(atMost) the Values(a, *aX)
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderAtMostValuesAssertionsSpec.kt
@@ -5,7 +5,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderAtMostValuesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderAtMostValuesAssertionSpec(
@@ -25,7 +28,7 @@ class IterableContainsInAnyOrderAtMostValuesAssertionsSpec : ch.tutteli.atrium.s
         )
 
         private fun containsAtMost(plant: Assert<Iterable<Double>>, atMost: Int, a: Double, aX: Array<out Double>)
-            = plant to contain inAny order atMost atMost the Values(a, *aX)
+            = plant.asExpect().contains(o) inAny order atMost atMost the Values(a, *aX)
 
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
@@ -34,7 +34,7 @@ class IterableContainsInAnyOrderExactlyValuesAssertionsSpec : ch.tutteli.atrium.
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$exactly $times`"
+            = "use `$containsNotValues` instead of `$exactly $times`"
 
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.exactly
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.api.infix.en_GB.o
 import ch.tutteli.atrium.domain.builders.migration.asExpect
@@ -28,7 +29,7 @@ class IterableContainsInAnyOrderExactlyValuesAssertionsSpec : ch.tutteli.atrium.
 
         private fun containsExactly(plant: Assert<Iterable<Double>>, exactly: Int, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order exactly exactly value a
+                (plant.asExpect().contains(o) inAny order).exactly(exactly) value a
             } else {
                 plant.asExpect().contains(o) inAny order exactly exactly the Values(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
@@ -5,7 +5,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderExactlyValuesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
@@ -25,9 +28,9 @@ class IterableContainsInAnyOrderExactlyValuesAssertionsSpec : ch.tutteli.atrium.
 
         private fun containsExactly(plant: Assert<Iterable<Double>>, exactly: Int, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order exactly exactly value a
+                plant.asExpect().contains(o) inAny order exactly exactly value a
             } else {
-                plant to contain inAny order exactly exactly the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order exactly exactly the Values(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.notOrAtMost
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.api.infix.en_GB.o
@@ -27,7 +28,7 @@ class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec : ch.tutteli.atr
         )
 
         private fun containsNotOrAtMost(plant: Assert<Iterable<Double>>, atMost: Int, a: Double, aX: Array<out Double>)
-            = plant.asExpect().contains(o) inAny order notOrAtMost atMost the Values(a, *aX)
+            = (plant.asExpect().contains(o) inAny order).notOrAtMost(atMost) the Values(a, *aX)
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
@@ -5,7 +5,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec(
@@ -24,7 +27,7 @@ class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec : ch.tutteli.atr
         )
 
         private fun containsNotOrAtMost(plant: Assert<Iterable<Double>>, atMost: Int, a: Double, aX: Array<out Double>)
-            = plant to contain inAny order notOrAtMost atMost the Values(a, *aX)
+            = plant.asExpect().contains(o) inAny order notOrAtMost atMost the Values(a, *aX)
 
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
@@ -29,7 +29,7 @@ class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec : ch.tutteli.atr
         private fun getContainsNotPair() = containsNotValues to Companion::getErrorMsgContainsNot
 
         private fun getErrorMsgContainsNot(times: Int)
-            = "use $containsNotValues instead of `$notOrAtMost $times`"
+            = "use `$containsNotValues` instead of `$notOrAtMost $times`"
 
     }
 }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
@@ -7,9 +7,12 @@ import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.entry
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
@@ -24,7 +27,7 @@ class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec : ch.tutteli.atrium.sp
 
         private fun containsInAnyOrderOnlyEntries(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order but only entry a
+                (plant.asExpect().contains(o) inAny order but only).entry(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().contains(o) inAny order but only the Entries(a, *aX)
             }
@@ -35,7 +38,7 @@ class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec : ch.tutteli.atrium.sp
 
         private fun containsInAnyOrderOnlyNullableEntries(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order but only entry a
+                (plant.asExpect().contains(o) inAny order but only).entry(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().contains(o) inAny order but only the Entries(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
@@ -6,7 +6,10 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
@@ -21,9 +24,9 @@ class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec : ch.tutteli.atrium.sp
 
         private fun containsInAnyOrderOnlyEntries(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order but only entry a
+                plant.asExpect().contains(o) inAny order but only entry a
             } else {
-                plant to contain inAny order but only the Entries(a, *aX)
+                plant.asExpect().contains(o) inAny order but only the Entries(a, *aX)
             }
         }
 
@@ -32,9 +35,9 @@ class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec : ch.tutteli.atrium.sp
 
         private fun containsInAnyOrderOnlyNullableEntries(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order but only entry a
+                plant.asExpect().contains(o) inAny order but only entry a
             } else {
-                plant to contain inAny order but only the Entries(a, *aX)
+                plant.asExpect().contains(o) inAny order but only the Entries(a, *aX)
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
@@ -6,7 +6,10 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInAnyOrderOnlyValuesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
@@ -21,9 +24,9 @@ class IterableContainsInAnyOrderOnlyValuesAssertionsSpec : ch.tutteli.atrium.spe
 
         private fun containsInAnyOrderOnlyValues(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order but only value a
+                plant.asExpect().contains(o) inAny order but only value a
             } else {
-                plant to contain inAny order but only the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order but only the Values(a, *aX)
             }
         }
 
@@ -32,9 +35,9 @@ class IterableContainsInAnyOrderOnlyValuesAssertionsSpec : ch.tutteli.atrium.spe
 
         private fun containsInAnyOrderOnlyNullableValues(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant to contain inAny order but only value(a)
+                plant.asExpect().contains(o) inAny order but only value(a)
             } else {
-                plant to contain inAny order but only the Values(a, *aX)
+                plant.asExpect().contains(o) inAny order but only the Values(a, *aX)
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
@@ -9,6 +9,8 @@ import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.api.infix.en_GB.value
+import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
@@ -24,7 +26,7 @@ class IterableContainsInAnyOrderOnlyValuesAssertionsSpec : ch.tutteli.atrium.spe
 
         private fun containsInAnyOrderOnlyValues(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order but only value a
+                (plant.asExpect().contains(o) inAny order but only).value(a).asAssert()
             } else {
                 plant.asExpect().contains(o) inAny order but only the Values(a, *aX)
             }
@@ -35,7 +37,7 @@ class IterableContainsInAnyOrderOnlyValuesAssertionsSpec : ch.tutteli.atrium.spe
 
         private fun containsInAnyOrderOnlyNullableValues(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inAny order but only value(a)
+                (plant.asExpect().contains(o) inAny order but only).value((a)).asAssert()
             } else {
                 plant.asExpect().contains(o) inAny order but only the Values(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.api.infix.en_GB.containsExactly
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
@@ -13,6 +14,7 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
@@ -43,9 +45,9 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
 
         private fun containsInOrderOnly(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inGiven order and only entry a
+                plant.asExpect().contains(o) inGiven order and only entry a
             } else {
-                plant to contain inGiven order and only the Entries(a, *aX)
+                plant.asExpect().contains(o) inGiven order and only the Entries(a, *aX)
             }
         }
 
@@ -54,9 +56,9 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyNullableEntriesPair(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant to contain inGiven order and only entry a
+                plant.asExpect().contains(o) inGiven order and only entry a
             } else {
-                plant to contain inGiven order and only the Entries(a, *aX)
+                plant.asExpect().contains(o) inGiven order and only the Entries(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
@@ -6,7 +6,10 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.containsExactly
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -62,9 +65,9 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyEntriesShortcut(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant containsExactly a
+                plant.asExpect().containsExactly<Any?, Iterable<Double>>(a).asAssert()
             } else {
-                plant containsExactly Entries(a, *aX)
+                plant.asExpect().containsExactly<Any?, Iterable<Double>>(Entries(a, *aX)).asAssert()
             }
         }
 
@@ -73,9 +76,9 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
 
         private fun containsStrictlyEntries(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant containsExactly a
+                plant.asExpect().containsExactly(a).asAssert()
             } else {
-                plant containsExactly Entries(a, *aX)
+                plant.asExpect().containsExactly(Entries(a, *aX)).asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
@@ -8,6 +8,7 @@ import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
 import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.api.infix.en_GB.containsExactly
+import ch.tutteli.atrium.api.infix.en_GB.entry
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
@@ -15,6 +16,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
 import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
@@ -45,7 +47,7 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
 
         private fun containsInOrderOnly(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inGiven order and only entry a
+                (plant.asExpect().contains(o) inGiven order and only).entry(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().contains(o) inGiven order and only the Entries(a, *aX)
             }
@@ -56,7 +58,7 @@ class IterableContainsInOrderOnlyEntriesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyNullableEntriesPair(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inGiven order and only entry a
+                (plant.asExpect().contains(o) inGiven order and only).entry(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().contains(o) inGiven order and only the Entries(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec.kt
@@ -3,9 +3,12 @@
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.*
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.utils.Group
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec(
@@ -25,7 +28,7 @@ class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec : ch.tutteli.atriu
             a2: Group<(Assert<Double>.() -> Unit)?>,
             aX: Array<out Group<(Assert<Double>.() -> Unit)?>>
         ): Assert<Iterable<Double?>> {
-            return plant to contain inGiven order and only grouped entries within group inAny Order(a1, a2, *aX)
+            return plant.asExpect().contains(o) inGiven order and only grouped entries within group inAny Order(a1, a2, *aX)
         }
 
         private fun groupFactory(groups: Array<out (Assert<Double>.() -> Unit)?>): Group<(Assert<Double>.() -> Unit)?> {

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
@@ -3,9 +3,12 @@
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.*
+import ch.tutteli.atrium.api.infix.en_GB.contains
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.domain.builders.utils.Group
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsInOrderOnlyGroupedValuesAssertionsSpec(
@@ -27,7 +30,7 @@ class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec : ch.tutteli.atrium
             a2: Group<Double>,
             aX: Array<out Group<Double>>
         ): Assert<Iterable<Double>> {
-            return plant to contain inGiven order and only grouped entries within group inAny Order(a1, a2, *aX)
+            return plant.asExpect().contains(o) inGiven order and only grouped entries within group inAny Order(a1, a2, *aX)
         }
 
         private fun groupFactory(groups: Array<out Double>): Group<Double> {
@@ -47,7 +50,7 @@ class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec : ch.tutteli.atrium
             a2: Group<Double?>,
             aX: Array<out Group<Double?>>
         ): Assert<Iterable<Double?>> {
-            return plant to contain inGiven order and only grouped entries within group inAny Order(a1, a2, *aX)
+            return plant.asExpect().contains(o) inGiven order and only grouped entries within group inAny Order(a1, a2, *aX)
         }
 
         private fun nullableGroupFactory(groups: Array<out Double?>): Group<Double?> {

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
@@ -10,6 +10,7 @@ import ch.tutteli.atrium.api.infix.en_GB.containsExactly
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.api.infix.en_GB.o
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -43,9 +44,9 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyValues(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant to contain inGiven order and only value a
+                plant.asExpect().contains(o) inGiven order and only value a
             } else {
-                plant to contain inGiven order and only the Values(a, *aX)
+                plant.asExpect().contains(o) inGiven order and only the Values(a, *aX)
             }
         }
 
@@ -54,9 +55,9 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyNullableValues(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant to contain inGiven order and only value a
+                plant.asExpect().contains(o) inGiven order and only value a
             } else {
-                plant to contain inGiven order and only the Values(a, *aX)
+                plant.asExpect().contains(o) inGiven order and only the Values(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
@@ -14,6 +14,7 @@ import ch.tutteli.atrium.api.infix.en_GB.o
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.contains
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
@@ -6,7 +6,10 @@ import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.only
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.order
+import ch.tutteli.atrium.api.infix.en_GB.containsExactly
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -62,9 +65,12 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyValuesShortcut(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant containsExactly a
+                plant.asExpect().containsExactly(a).asAssert()
             } else {
-                plant containsExactly Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect()
+                    .containsExactly(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected))
+                    .asAssert()
             }
         }
 
@@ -73,9 +79,12 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyNullableValuesShortcut(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant containsExactly a
+                plant.asExpect().containsExactly(a).asAssert()
             } else {
-                plant containsExactly Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect()
+                    .containsExactly(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected))
+                    .asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
@@ -15,6 +15,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
 import ch.tutteli.atrium.api.infix.en_GB.contains
+import ch.tutteli.atrium.api.infix.en_GB.value
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
@@ -45,7 +46,7 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyValues(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inGiven order and only value a
+                (plant.asExpect().contains(o) inGiven order and only).value(a).asAssert()
             } else {
                 plant.asExpect().contains(o) inGiven order and only the Values(a, *aX)
             }
@@ -56,7 +57,7 @@ class IterableContainsInOrderOnlyValuesAssertionsSpec : Spek({
 
         private fun containsInOrderOnlyNullableValues(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().contains(o) inGiven order and only value a
+                (plant.asExpect().contains(o) inGiven order and only).value(a).asAssert()
             } else {
                 plant.asExpect().contains(o) inGiven order and only the Values(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotEntriesAssertionsSpec.kt
@@ -5,7 +5,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.containsNot
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsNotEntriesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsNotEntriesAssertionsSpec(
@@ -21,9 +24,9 @@ class IterableContainsNotEntriesAssertionsSpec : ch.tutteli.atrium.spec.integrat
 
         private fun containsNotFun(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant notTo contain entry a
+                plant.asExpect().containsNot(o) entry a
             } else {
-                plant notTo contain the Entries(a, *aX)
+                plant.asExpect().containsNot(o) the Entries(a, *aX)
             }
         }
 
@@ -31,9 +34,9 @@ class IterableContainsNotEntriesAssertionsSpec : ch.tutteli.atrium.spec.integrat
 
         private fun containsNotNullableFun(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant notTo contain entry  a
+                plant.asExpect().containsNot(o) entry  a
             } else {
-                plant notTo contain the Entries(a, *aX)
+                plant.asExpect().containsNot(o) the Entries(a, *aX)
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotEntriesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotEntriesAssertionsSpec.kt
@@ -6,9 +6,12 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
 import ch.tutteli.atrium.api.infix.en_GB.containsNot
+import ch.tutteli.atrium.api.infix.en_GB.entry
 import ch.tutteli.atrium.creating.Assert
 import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.domain.builders.migration.asAssert
 import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsNotEntriesAssertionsSpec : ch.tutteli.atrium.spec.integration.IterableContainsNotEntriesAssertionsSpec(
@@ -24,7 +27,7 @@ class IterableContainsNotEntriesAssertionsSpec : ch.tutteli.atrium.spec.integrat
 
         private fun containsNotFun(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit, aX: Array<out Assert<Double>.() -> Unit>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().containsNot(o) entry a
+                plant.asExpect().containsNot(o).entry(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().containsNot(o) the Entries(a, *aX)
             }
@@ -34,7 +37,7 @@ class IterableContainsNotEntriesAssertionsSpec : ch.tutteli.atrium.spec.integrat
 
         private fun containsNotNullableFun(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?, aX: Array<out (Assert<Double>.() -> Unit)?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().containsNot(o) entry  a
+                plant.asExpect().containsNot(o).entry(asSubExpect(a)).asAssert()
             } else {
                 plant.asExpect().containsNot(o) the Entries(a, *aX)
             }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
@@ -11,6 +11,7 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsNotValuesAssertionsSpec : Spek({
@@ -42,9 +43,9 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
 
         private fun containsNotFun(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant notTo contain value a
+                plant.asExpect().containsNot(o) value a
             } else {
-                plant notTo contain the Values(a, *aX)
+                plant.asExpect().containsNot(o) the Values(a, *aX)
             }
         }
 
@@ -52,9 +53,9 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
 
         private fun containsNotNullableFun(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant notTo contain value a
+                plant.asExpect().containsNot(o) value a
             } else {
-                plant notTo contain the Values(a, *aX)
+                plant.asExpect().containsNot(o) the Values(a, *aX)
             }
         }
 

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
@@ -4,7 +4,10 @@ package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.containsNot
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -60,9 +63,12 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
 
         private fun containsNotShortcut(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant containsNot a
+                plant.asExpect().containsNot(a).asAssert()
             } else {
-                plant containsNot Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect()
+                    .containsNot(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected))
+                    .asAssert()
             }
         }
     }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsNotValuesAssertionsSpec.kt
@@ -12,6 +12,9 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
 import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.api.infix.en_GB.the
+import ch.tutteli.atrium.api.infix.en_GB.value
+import ch.tutteli.atrium.api.infix.en_GB.values
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableContainsNotValuesAssertionsSpec : Spek({
@@ -43,9 +46,10 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
 
         private fun containsNotFun(plant: Assert<Iterable<Double>>, a: Double, aX: Array<out Double>): Assert<Iterable<Double>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().containsNot(o) value a
+                plant.asExpect().containsNot(o).value(a).asAssert()
             } else {
-                plant.asExpect().containsNot(o) the Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect().containsNot(o).the(values(values.expected, *values.otherExpected)).asAssert()
             }
         }
 
@@ -53,9 +57,10 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
 
         private fun containsNotNullableFun(plant: Assert<Iterable<Double?>>, a: Double?, aX: Array<out Double?>): Assert<Iterable<Double?>> {
             return if (aX.isEmpty()) {
-                plant.asExpect().containsNot(o) value a
+                plant.asExpect().containsNot(o).value(a).asAssert()
             } else {
-                plant.asExpect().containsNot(o) the Values(a, *aX)
+                val values = Values(a, *aX)
+                plant.asExpect().containsNot(o).the(values(values.expected, *values.otherExpected)).asAssert()
             }
         }
 
@@ -68,7 +73,7 @@ class IterableContainsNotValuesAssertionsSpec : Spek({
             } else {
                 val values = Values(a, *aX)
                 plant.asExpect()
-                    .containsNot(ch.tutteli.atrium.api.infix.en_GB.values(values.expected, *values.otherExpected))
+                    .containsNot(values(values.expected, *values.otherExpected))
                     .asAssert()
             }
         }

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsSpecBase.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableContainsSpecBase.kt
@@ -25,7 +25,7 @@ abstract class IterableContainsSpecBase {
     private val containsNotFun: KFunction2<Assert<Iterable<Int>>, Int, Assert<Iterable<Int>>> = Assert<Iterable<Int>>::containsNot
     protected val toContain = "${Assert<Iterable<*>>::to.name} ${contain::class.simpleName}"
     protected val containsNot = "${Assert<Iterable<*>>::notTo.name} ${contain::class.simpleName}"
-    protected val containsNotValues = "${containsNotFun.name} $Values"
+    protected val containsNotValues = "${containsNotFun.name} values"
     protected val atLeast = IterableContains.Builder<*, Iterable<*>, InAnyOrderSearchBehaviour>::atLeast.name
     protected val butAtMost = AtLeastCheckerOption<*, Iterable<*>, InAnyOrderSearchBehaviour>::butAtMost.name
     protected val exactly = IterableContains.Builder<*, Iterable<*>, InAnyOrderSearchBehaviour>::exactly.name

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableNoneAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableNoneAssertionsSpec.kt
@@ -3,8 +3,12 @@
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.none
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.migration.asAssert
+import ch.tutteli.atrium.domain.builders.migration.asExpect
+import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
@@ -37,13 +41,13 @@ class IterableNoneAssertionsSpec : Spek({
         fun getNonePair() = noneFun.name to Companion::none
 
         private fun none(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit)
-            = plant none a
+            = plant.asExpect().none(asSubExpect(a)).asAssert()
 
         private val noneNullableFun: KFunction2<Assert<Iterable<Double?>>, (Assert<Double>.() -> Unit)?, Assert<Iterable<Double?>>> = Assert<Iterable<Double?>>::none
         fun getNoneNullablePair() = noneNullableFun.name to Companion::noneNullable
 
         private fun noneNullable(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?)
-            = plant none a
+            = plant.asExpect().none(asSubExpect(a)).asAssert()
 
 
         private fun getContainsNotPair()

--- a/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableNoneAssertionsSpec.kt
+++ b/apis/cc-infix-en_GB/atrium-api-cc-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/cc/infix/en_GB/IterableNoneAssertionsSpec.kt
@@ -3,6 +3,7 @@
 package ch.tutteli.atrium.api.cc.infix.en_GB
 
 import ch.tutteli.atrium.api.cc.infix.en_GB.keywords.contain
+import ch.tutteli.atrium.api.infix.en_GB.containsNot
 import ch.tutteli.atrium.api.infix.en_GB.none
 import ch.tutteli.atrium.verbs.internal.AssertionVerbFactory
 import ch.tutteli.atrium.creating.Assert
@@ -12,6 +13,7 @@ import ch.tutteli.atrium.domain.builders.migration.asSubExpect
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.include
 import kotlin.reflect.KFunction2
+import ch.tutteli.atrium.api.infix.en_GB.o
 
 //TODO remove with 1.0.0, no need to migrate to Spek 2
 class IterableNoneAssertionsSpec : Spek({
@@ -54,11 +56,11 @@ class IterableNoneAssertionsSpec : Spek({
             = containsNot to Companion::containsNotFun
 
         private fun containsNotFun(plant: Assert<Iterable<Double>>, a: Assert<Double>.() -> Unit)
-            = plant notTo contain entry a
+            = plant.asExpect().containsNot(o) entry a
 
         private fun getContainsNotNullablePair() = containsNot to Companion::containsNotNullableFun
 
         private fun containsNotNullableFun(plant: Assert<Iterable<Double?>>, a: (Assert<Double>.() -> Unit)?)
-            = plant notTo contain entry a
+            = plant.asExpect().containsNot(o) entry a
     }
 }


### PR DESCRIPTION
This PR add Deprecate api-cc-infix and add Replacewith for the expect for these files:
- [x] iterableAssertions.kt
- [x] iterableContainsCheckers.kt
- [x] iterableContainsInAnyOrderCreators.kt
- [x] iterableContainsInOrderOnlyCreators.kt
- [x] iterableContainsInAnyOrderOnlyCreators.kt
- [ ] iterableContainsInOrderOnlyGroupedCreators.kt
- [ ] iterableContainsSearchBehaviours.kt
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
