### PR TITLE
establish bc-tests for 0.12.0 - fix issue in api-infix

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/BigDecimalAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/BigDecimalAssertionsSpec.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.integration.BigDecimalAssertionsSpec
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import ch.tutteli.atrium.specs.withNullableSuffix
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -29,7 +30,7 @@ class BigDecimalAssertionsSpec : Spek({
         }
     }
 }) {
-    companion object {
+    companion object : WithAsciiReporter() {
         @Suppress("DEPRECATION")
         fun toBeBigDecimal(expect: Expect<BigDecimal>, a: BigDecimal): Nothing = expect toBe a
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateAssertionsSpec.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.LocalDate
 import java.time.chrono.ChronoLocalDate
 import java.time.chrono.JapaneseDate
@@ -14,6 +15,8 @@ class ChronoLocalDateAssertionsSpec : ch.tutteli.atrium.specs.integration.Chrono
     fun1(Expect<ChronoLocalDate>::isAfterOrEqual),
     fun1(Expect<ChronoLocalDate>::isEqual)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         val chronoLocalDate: ChronoLocalDate = notImplemented()

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateTimeAssertionSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateTimeAssertionSpec.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.chrono.ChronoLocalDate
@@ -15,6 +16,7 @@ class ChronoLocalDateTimeAssertionSpec : ch.tutteli.atrium.specs.integration.Chr
     fun1(Expect<ChronoLocalDateTime<*>>::isAfterOrEqual),
     fun1(Expect<ChronoLocalDateTime<*>>::isEqual)
 ) {
+    companion object : WithAsciiReporter()
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ChronoZonedDateTimeAssertionSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ChronoZonedDateTimeAssertionSpec.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.time.chrono.ChronoLocalDate
@@ -15,6 +16,8 @@ class ChronoZonedDateTimeAssertionSpec : ch.tutteli.atrium.specs.integration.Chr
     fun1(Expect<ChronoZonedDateTime<*>>::isAfterOrEqual),
     fun1(Expect<ChronoZonedDateTime<*>>::isEqual)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         val chronoZonedDateTime: ChronoZonedDateTime<*> = notImplemented()

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/FileAsPathAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/FileAsPathAssertionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.infix.en_GB.o
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateFeatureAssertionsSpec.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.LocalDate
 
@@ -17,6 +18,8 @@ class LocalDateFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Local
     property<LocalDate, DayOfWeek>(Expect<LocalDate>::dayOfWeek),
     fun1<LocalDate, Expect<DayOfWeek>.() -> Unit>(Expect<LocalDate>::dayOfWeek)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<LocalDate> = notImplemented()

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateTimeFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateTimeFeatureAssertionsSpec.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 
@@ -17,6 +18,8 @@ class LocalDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.L
     property<LocalDateTime, DayOfWeek>(Expect<LocalDateTime>::dayOfWeek),
     fun1<LocalDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<LocalDateTime>::dayOfWeek)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<LocalDateTime> = notImplemented()

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ZonedDateTimeFeatureAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ZonedDateTimeFeatureAssertionsSpec.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
@@ -17,6 +18,8 @@ class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Z
     property<ZonedDateTime, DayOfWeek>(Expect<ZonedDateTime>::dayOfWeek),
     fun1<ZonedDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<ZonedDateTime>::dayOfWeek)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<ZonedDateTime> = notImplemented()

--- a/misc/tools/atrium-bc-test/build.gradle
+++ b/misc/tools/atrium-bc-test/build.gradle
@@ -44,7 +44,7 @@ def bcTests = task("bcTests", group: 'Verification') {
     dependsOn build
 }
 
-['fluent-en_GB', /* TODO remove with 1.0.0 => */ 'cc-de_CH', 'cc-en_GB', 'cc-infix-en_GB', 'cc-en_UK', 'cc-infix-en_UK'].each { apiName ->
+['fluent-en_GB', 'infix-en_GB', /* TODO remove with 1.0.0 => */ 'cc-de_CH', 'cc-en_GB', 'cc-infix-en_GB', 'cc-en_UK', 'cc-infix-en_UK'].each { apiName ->
     task("bcBbc-$apiName", group: 'Verification') {
         description = "runs all backward compatibility and binary backward compatibility tests for $apiName"
         dependsOn build
@@ -147,6 +147,7 @@ def createBcAndBbcTasks(String apiName, String oldVersion, String forgive) {
             exclude group: '*'
         }
 
+        //TODO remove with 1.0.0, keep only else branch
         if (oldVersion == '0.6.0') {
             add(confCommon, "$groupId:atrium-spec:$oldVersion") {
                 exclude group: '*'
@@ -173,7 +174,7 @@ def createBcAndBbcTasks(String apiName, String oldVersion, String forgive) {
 //                exclude group: '*'
 //            }
             add(confCommon, "$groupId:atrium-specs:$oldVersion") {
-                exclude group: '*'
+                exclude group: 'ch.tutteli.atrium'
             }
             add(confCommon, prefixedProject("api-fluent-en_GB-jvm")) {  //required by atrium-specs
                 exclude group: '*'
@@ -183,6 +184,7 @@ def createBcAndBbcTasks(String apiName, String oldVersion, String forgive) {
             }
         }
 
+        //TODO keep only if branch, remove the rest with 1.0.0
         if (isFluentOrInfix) {
             add(confCommon, prefixedProject("$apiName-jvm"))
         } else if (!apiName.endsWith('en_UK')) {
@@ -377,9 +379,13 @@ createBcAndBbcTasksForApis('0.10.0',
     'forgive=^$',
     'fluent-en_GB'
 )
-createBcAndBbcTasksForApis('0.11.0',
+createBcAndBbcTasksForApis('0.11.1',
     'forgive=^$',
     'fluent-en_GB'
+)
+createBcAndBbcTasksForApis('0.12.0',
+    'forgive=.*ch/tutteli/atrium/api/infix/en_GB/Fun0AssertionsJvmSpec.*',
+    'fluent-en_GB','infix-en_GB'
 )
 //@formatter:on
 


### PR DESCRIPTION
the problem is that not all spec in api-infix have a companion which
extends WithAsciiReporter



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
