### PR TITLE
API #483 #comment replaced usages IS_LESS_OR_EQUALS and IS_GREATER_OR…

### DIFF
--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultComparableAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultComparableAssertions.kt
@@ -16,7 +16,7 @@ class DefaultComparableAssertions : ComparableAssertions {
     override fun <T1 : Comparable<T2>, T2 : Any?> isLessThanOrEqual(
         container: AssertionContainer<T1>,
         expected: T2
-    ): Assertion = container.createDescriptiveAssertion(IS_LESS_OR_EQUALS, expected) { it <= expected }
+    ): Assertion = container.createDescriptiveAssertion(IS_LESS_THAN_OR_EQUAL, expected) { it <= expected }
 
     override fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThan(
         container: AssertionContainer<T1>,
@@ -26,7 +26,7 @@ class DefaultComparableAssertions : ComparableAssertions {
     override fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThanOrEqual(
         container: AssertionContainer<T1>,
         expected: T2
-    ): Assertion = container.createDescriptiveAssertion(IS_GREATER_OR_EQUALS, expected) { it >= expected }
+    ): Assertion = container.createDescriptiveAssertion(IS_GREATER_THAN_OR_EQUAL, expected) { it >= expected }
 
     override fun <T1 : Comparable<T2>, T2 : Any?> isEqualComparingTo(
         container: AssertionContainer<T1>,

--- a/misc/deprecated/atrium-spec/src/main/kotlin/ch/tutteli/atrium/spec/integration/ComparableAssertionsSpec.kt
+++ b/misc/deprecated/atrium-spec/src/main/kotlin/ch/tutteli/atrium/spec/integration/ComparableAssertionsSpec.kt
@@ -42,9 +42,9 @@ abstract class ComparableAssertionsSpec(
     val (isGreaterOrEquals, isGreaterOrEqualsFun) = isGreaterOrEqualsPair
 
     val isLessThanDescr = DescriptionComparableAssertion.IS_LESS_THAN.getDefault()
-    val isLessOrEqualsDescr = DescriptionComparableAssertion.IS_LESS_OR_EQUALS.getDefault()
+    val isLessOrEqualsDescr = DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL.getDefault()
     val isGreaterThanDescr = DescriptionComparableAssertion.IS_GREATER_THAN.getDefault()
-    val isGreaterOrEqualsDescr = DescriptionComparableAssertion.IS_GREATER_OR_EQUALS.getDefault()
+    val isGreaterOrEqualsDescr = DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL.getDefault()
 
     val fluent = verbs.checkImmediately(10)
     group("$describePrefix context subject is 10") {
@@ -71,7 +71,7 @@ abstract class ComparableAssertionsSpec(
             test("... 10 does not throw") {
                 fluent.isLessOrEqualsFun(10)
             }
-            test("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.${DescriptionComparableAssertion.IS_LESS_OR_EQUALS} and `: 10`") {
+            test("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.${DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL} and `: 10`") {
                 expect {
                     fluent.isLessOrEqualsFun(9)
                 }.toThrow<AssertionError> { messageContains("$isLessOrEqualsDescr: 9") }
@@ -95,7 +95,7 @@ abstract class ComparableAssertionsSpec(
         }
 
         describe("$isGreaterOrEquals ...") {
-            test("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.${DescriptionComparableAssertion.IS_GREATER_OR_EQUALS} and `: 11`") {
+            test("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.${DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL} and `: 11`") {
                 expect {
                     fluent.isGreaterOrEqualsFun(11)
                 }.toThrow<AssertionError> { messageContains("$isGreaterOrEqualsDescr: 11") }

--- a/misc/deprecated/atrium-spec/src/main/kotlin/ch/tutteli/atrium/spec/verbs/VerbSpec.kt
+++ b/misc/deprecated/atrium-spec/src/main/kotlin/ch/tutteli/atrium/spec/verbs/VerbSpec.kt
@@ -82,8 +82,8 @@ abstract class VerbSpec(
             }.toThrow<AssertionError> {
                 message {
                     contains(": 1")
-                    contains("${IS_LESS_OR_EQUALS.getDefault()}: 0")
-                    containsNot("${IS_GREATER_OR_EQUALS.getDefault()}: 2")
+                    contains("${IS_LESS_THAN_OR_EQUAL.getDefault()}: 0")
+                    containsNot("${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 2")
                 }
             }
         }

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/comparableAssertions.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/comparableAssertions.kt
@@ -13,7 +13,7 @@ fun <T1 : Comparable<T2>, T2 : Any?> _isLessThan(subjectProvider: SubjectProvide
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated("use the function from atrium-logic instead, will be removed with 1.0.0")
 fun <T1 : Comparable<T2>, T2 : Any?> _isLessThanOrEqual(subjectProvider: SubjectProvider<T1>, expected: T2) =
-    assertionBuilder.createDescriptive(subjectProvider, IS_LESS_OR_EQUALS, expected) { it <= expected }
+    assertionBuilder.createDescriptive(subjectProvider, IS_LESS_THAN_OR_EQUAL, expected) { it <= expected }
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated("use the function from atrium-logic instead, will be removed with 1.0.0")
@@ -23,7 +23,7 @@ fun <T1 : Comparable<T2>, T2 : Any?> _isGreaterThan(subjectProvider: SubjectProv
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated("use the function from atrium-logic instead, will be removed with 1.0.0")
 fun <T1 : Comparable<T2>, T2 : Any?> _isGreaterThanOrEqual(subjectProvider: SubjectProvider<T1>, expected: T2) =
-    assertionBuilder.createDescriptive(subjectProvider, IS_GREATER_OR_EQUALS, expected) { it >= expected }
+    assertionBuilder.createDescriptive(subjectProvider, IS_GREATER_THAN_OR_EQUAL, expected) { it >= expected }
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated("use the function from atrium-logic instead, will be removed with 1.0.0")

--- a/misc/deprecated/translations/atrium-translations-de_CH-deprecated/src/main/kotlin/ch/tutteli/atrium/assertions/DescriptionComparableAssertion.kt
+++ b/misc/deprecated/translations/atrium-translations-de_CH-deprecated/src/main/kotlin/ch/tutteli/atrium/assertions/DescriptionComparableAssertion.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
 )
 enum class DescriptionComparableAssertion(override val value: String) : StringBasedTranslatable {
     IS_LESS_THAN(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_LESS_THAN.value),
-    IS_LESS_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_LESS_OR_EQUALS.value),
+    IS_LESS_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL.value),
     IS_GREATER_THAN(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_GREATER_THAN.value),
-    IS_GREATER_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_GREATER_OR_EQUALS.value),
+    IS_GREATER_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL.value),
 }

--- a/misc/deprecated/translations/atrium-translations-en_UK-deprecated/src/main/kotlin/ch/tutteli/atrium/assertions/DescriptionComparableAssertion.kt
+++ b/misc/deprecated/translations/atrium-translations-en_UK-deprecated/src/main/kotlin/ch/tutteli/atrium/assertions/DescriptionComparableAssertion.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
 )
 enum class DescriptionComparableAssertion(override val value: String) : StringBasedTranslatable {
     IS_LESS_THAN(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_LESS_THAN.value),
-    IS_LESS_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_LESS_OR_EQUALS.value),
+    IS_LESS_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL.value),
     IS_GREATER_THAN(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_GREATER_THAN.value),
-    IS_GREATER_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_GREATER_OR_EQUALS.value),
+    IS_GREATER_OR_EQUALS(ch.tutteli.atrium.translations.DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL.value),
 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ComparableAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ComparableAssertionsSpec.kt
@@ -29,9 +29,9 @@ abstract class ComparableAssertionsSpec(
     ) {})
 
     val isLessThanDescr = IS_LESS_THAN.getDefault()
-    val isLessOrEqualsDescr = IS_LESS_OR_EQUALS.getDefault()
+    val isLessOrEqualsDescr = IS_LESS_THAN_OR_EQUAL.getDefault()
     val isGreaterThanDescr = IS_GREATER_THAN.getDefault()
-    val isGreaterOrEqualsDescr = IS_GREATER_OR_EQUALS.getDefault()
+    val isGreaterOrEqualsDescr = IS_GREATER_THAN_OR_EQUAL.getDefault()
     val isEqualComparingToDescr = IS_EQUAL.getDefault()
 
     val fluent = expect(10)
@@ -63,7 +63,7 @@ abstract class ComparableAssertionsSpec(
             it("... 10 does not throw") {
                 fluent.isLessOrEqualsFun(10)
             }
-            it("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_LESS_OR_EQUALS and `: 10`") {
+            it("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_LESS_THAN_OR_EQUAL and `: 10`") {
                 expect {
                     fluent.isLessOrEqualsFun(9)
                 }.toThrow<AssertionError> { messageContains("$isLessOrEqualsDescr: 9") }
@@ -91,7 +91,7 @@ abstract class ComparableAssertionsSpec(
         describe("${isGreaterOrEquals.name} ...") {
             val isGreaterOrEqualsFun = isGreaterOrEquals.lambda
 
-            it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_OR_EQUALS and `: 11`") {
+            it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN_OR_EQUAL and `: 11`") {
                 expect {
                     fluent.isGreaterOrEqualsFun(11)
                 }.toThrow<AssertionError> { messageContains("$isGreaterOrEqualsDescr: 11") }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/reporting/AssertionFormatterControllerSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/reporting/AssertionFormatterControllerSpec.kt
@@ -69,12 +69,12 @@ abstract class AssertionFormatterControllerSpec(
 
     val holdingAssertion = assertionBuilder.descriptive
         .holding
-        .withDescriptionAndRepresentation(IS_GREATER_OR_EQUALS, 1)
+        .withDescriptionAndRepresentation(IS_GREATER_THAN_OR_EQUAL, 1)
         .build()
 
     val failingAssertion = assertionBuilder.descriptive
         .failing
-        .withDescriptionAndRepresentation(IS_LESS_OR_EQUALS, 2)
+        .withDescriptionAndRepresentation(IS_LESS_THAN_OR_EQUAL, 2)
         .build()
 
     describeFun(testee::format.name) {
@@ -149,7 +149,7 @@ abstract class AssertionFormatterControllerSpec(
                             testee.format(holdingGroup, parameterObject)
                             expect(sb.toString()).toBe(
                                 lineSeperator +
-                                    "$prefix ${IS_GREATER_OR_EQUALS.getDefault()}: 1"
+                                    "$prefix ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1"
                             )
                         }
 
@@ -157,7 +157,7 @@ abstract class AssertionFormatterControllerSpec(
                             testee.format(failingGroup, parameterObject)
                             expect(sb.toString()).toBe(
                                 lineSeperator +
-                                    "$prefix ${IS_LESS_OR_EQUALS.getDefault()}: 2"
+                                    "$prefix ${IS_LESS_THAN_OR_EQUAL.getDefault()}: 2"
                             )
                         }
                     }
@@ -187,7 +187,7 @@ abstract class AssertionFormatterControllerSpec(
                     testee.format(rootGroup, parameterObject)
                     expect(sb.toString()).toBe(
                         "${AssertionVerb.ASSERT.getDefault()}: 5$lineSeperator" +
-                            "$indentBulletPoint$arrow ${IS_GREATER_OR_EQUALS.getDefault()}: 1"
+                            "$indentBulletPoint$arrow ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1"
                     )
                 }
             }
@@ -205,7 +205,7 @@ abstract class AssertionFormatterControllerSpec(
                     testee.format(rootGroup, parameterObject)
                     expect(sb.toString()).toBe(
                         "${AssertionVerb.ASSERT.getDefault()}: 5$lineSeperator" +
-                            "$indentBulletPoint$warning ${IS_GREATER_OR_EQUALS.getDefault()}: 1"
+                            "$indentBulletPoint$warning ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1"
                     )
                 }
             }
@@ -229,9 +229,9 @@ abstract class AssertionFormatterControllerSpec(
                     expect(sb.toString()).toBe(
                         "${AssertionVerb.ASSERT.getDefault()}: 5$lineSeperator" +
                             "$indentBulletPoint$arrow ${AssertionVerb.EXPECT_THROWN.getDefault()}: 2$lineSeperator" +
-                            "$indentBulletPoint$indentArrow$listBulletPoint ${IS_GREATER_OR_EQUALS.getDefault()}: 1$lineSeperator" +
-                            "$indentBulletPoint$indentArrow$listBulletPoint ${IS_LESS_OR_EQUALS.getDefault()}: 2$lineSeperator" +
-                            "$indentBulletPoint$arrow ${IS_GREATER_OR_EQUALS.getDefault()}: 1"
+                            "$indentBulletPoint$indentArrow$listBulletPoint ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1$lineSeperator" +
+                            "$indentBulletPoint$indentArrow$listBulletPoint ${IS_LESS_THAN_OR_EQUAL.getDefault()}: 2$lineSeperator" +
+                            "$indentBulletPoint$arrow ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1"
                     )
                 }
 
@@ -249,9 +249,9 @@ abstract class AssertionFormatterControllerSpec(
                         expect(sb.toString()).toBe(
                             "${IS_LESS_THAN.getDefault()}: 10$lineSeperator" +
                                 "$indentBulletPoint$indentArrow$arrow ${AssertionVerb.EXPECT_THROWN.getDefault()}: 2$lineSeperator" +
-                                "$indentBulletPoint$indentArrow$indentArrow$listBulletPoint ${IS_GREATER_OR_EQUALS.getDefault()}: 1$lineSeperator" +
-                                "$indentBulletPoint$indentArrow$indentArrow$listBulletPoint ${IS_LESS_OR_EQUALS.getDefault()}: 2$lineSeperator" +
-                                "$indentBulletPoint$indentArrow$arrow ${IS_GREATER_OR_EQUALS.getDefault()}: 1"
+                                "$indentBulletPoint$indentArrow$indentArrow$listBulletPoint ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1$lineSeperator" +
+                                "$indentBulletPoint$indentArrow$indentArrow$listBulletPoint ${IS_LESS_THAN_OR_EQUAL.getDefault()}: 2$lineSeperator" +
+                                "$indentBulletPoint$indentArrow$arrow ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1"
                         )
                     }
                 }
@@ -289,8 +289,8 @@ abstract class AssertionFormatterControllerSpec(
                         expect(sb.toString()).toBe(
                             lineSeperator +
                                 "${AssertionVerb.ASSERT.getDefault()}: ${Text.EMPTY}$lineSeperator" +
-                                "$successfulBulletPoint ${IS_GREATER_OR_EQUALS.getDefault()}: 1$lineSeperator" +
-                                "$failingBulletPoint ${IS_LESS_OR_EQUALS.getDefault()}: 2"
+                                "$successfulBulletPoint ${IS_GREATER_THAN_OR_EQUAL.getDefault()}: 1$lineSeperator" +
+                                "$failingBulletPoint ${IS_LESS_THAN_OR_EQUAL.getDefault()}: 2"
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/verbs/VerbSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/verbs/VerbSpec.kt
@@ -165,8 +165,8 @@ private fun Suite.testNonNullableSubject(assertionVerb: (Int) -> Expect<Int>) {
         }.toThrow<AssertionError> {
             message {
                 contains(": 1")
-                contains("${DescriptionComparableAssertion.IS_LESS_OR_EQUALS.getDefault()}: 0")
-                containsNot("${DescriptionComparableAssertion.IS_GREATER_OR_EQUALS.getDefault()}: 2")
+                contains("${DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL.getDefault()}: 0")
+                containsNot("${DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL.getDefault()}: 2")
             }
         }
     }

--- a/misc/tools/atrium-bc-test/build.gradle
+++ b/misc/tools/atrium-bc-test/build.gradle
@@ -358,29 +358,31 @@ createBcAndBbcTasksForApis('0.6.0',
     'cc-de_CH', 'cc-en_UK', 'cc-infix-en_UK'
 )
 createBcAndBbcTasksForApis('0.7.0',
-    'forgive=.*ch\\.tutteli\\.atrium\\.api\\.cc\\.(de_CH|en_UK|en_GB|(infix\\.(en_UK|en_GB)))\\.(' +
+    'forgive=(.*ch\\.tutteli\\.atrium\\.api\\.cc\\.(de_CH|en_UK|en_GB|(infix\\.(en_UK|en_GB)))\\.(' +
         '(FloatingPointWithErrorToleranceAssertionsSpec.*throws AssertionError.*)|' +
         '(ThrowableAssertionsSpec.*throws an AssertionError.*shows message and stacktrace.*)|' +
-        '(CharSequenceContainsRegexAssertionsSpec.*16 times throws AssertionError.*)' +
-    ')',
+        '(CharSequenceContainsRegexAssertionsSpec.*16 times throws AssertionError.*)|' +
+        '(ComparableAssertionsSpec.*(isGreaterOrEquals|istGroesserOderGleich|isLessOrEquals|istKleinerOderGleich).*)' +
+    '))|(.*ch\\.tutteli\\.atrium\\.VerbSpec.*which immediately evaluates assertions.*)',
     'cc-de_CH', 'cc-en_GB', 'cc-infix-en_GB'
 )
 createBcAndBbcTasksForApis('0.8.0',
-    'forgive=.*ch\\.tutteli\\.atrium\\.api\\.cc\\.(de_CH|en_GB|(infix\\.en_GB))\\.('+
-        '(CharSequenceContainsRegexAssertionsSpec.*(16 times throws AssertionError|(roberto?.*once throws AssertionError)).*)' +
-    ')',
+    'forgive=(.*ch\\.tutteli\\.atrium\\.api\\.cc\\.(de_CH|en_GB|(infix\\.en_GB))\\.('+
+        '(CharSequenceContainsRegexAssertionsSpec.*(16 times throws AssertionError|(roberto?.*once throws AssertionError)).*)|' +
+        '(ComparableAssertionsSpec.*(isGreaterOrEquals|istGroesserOderGleich|isLessOrEquals|istKleinerOderGleich).*)' +
+    '))|(.*ch\\.tutteli\\.atrium\\.VerbSpec.*which immediately evaluates assertions.*)',
     'cc-de_CH', 'cc-en_GB', 'cc-infix-en_GB'
 )
 createBcAndBbcTasksForApis('0.9.2',
-    'forgive=^$',
+    'forgive=(ch/tutteli/atrium/api/fluent/en_GB/ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual).*)',
     'fluent-en_GB'
 )
 createBcAndBbcTasksForApis('0.10.0',
-    'forgive=^$',
+    'forgive=(ch/tutteli/atrium/api/fluent/en_GB/ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual).*)',
     'fluent-en_GB'
 )
 createBcAndBbcTasksForApis('0.11.1',
-    'forgive=^$',
+    'forgive=(ch/tutteli/atrium/api/fluent/en_GB/ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual).*)',
     'fluent-en_GB'
 )
 createBcAndBbcTasksForApis('0.12.0',
@@ -389,7 +391,7 @@ createBcAndBbcTasksForApis('0.12.0',
     '))|(ch/tutteli/atrium/api/infix/en_GB/(' +
         '(Fun0AssertionsJvmSpec/.*)|' +
         '(PathAssertionsSpec/.*`toBe (readable|writable|aRegularFile|aDirectory)`.*)' +
-    '))',
+    '))|(ch/tutteli/atrium/api/(fluent|infix)/en_GB/ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual).*)',
     'fluent-en_GB','infix-en_GB'
 )
 //@formatter:on

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
@@ -8,8 +8,14 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class DescriptionComparableAssertion(override val value: String) : StringBasedTranslatable {
     IS_LESS_THAN("ist weniger als"),
+    @Deprecated("Use IS_LESS_THAN_OR_EQUAL; will be removed with 1.0.0", ReplaceWith("DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL"))
     IS_LESS_OR_EQUALS("ist weniger oder gleich"),
     IS_GREATER_THAN("ist grösser als"),
+    @Deprecated("Use IS_GREATER_THAN_OR_EQUAL; will be removed with 1.0.0", ReplaceWith("DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL"))
     IS_GREATER_OR_EQUALS("ist grösser oder gleich"),
     IS_EQUAL("ist gleich wie"),
+    /** @since 0.13.0 */
+    IS_LESS_THAN_OR_EQUAL("ist weniger als oder gleich wie"),
+    /** @since 0.13.0 */
+    IS_GREATER_THAN_OR_EQUAL("ist grösser als oder gleich wie"),
 }

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
@@ -8,8 +8,14 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class DescriptionComparableAssertion(override val value: String) : StringBasedTranslatable {
     IS_LESS_THAN("is less than"),
+    @Deprecated("Use IS_LESS_THAN_OR_EQUAL; will be removed with 1.0.0", ReplaceWith("DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL"))
     IS_LESS_OR_EQUALS("is less or equals"),
     IS_GREATER_THAN("is greater than"),
+    @Deprecated("Use IS_GREATER_THAN_OR_EQUAL; will be removed with 1.0.0", ReplaceWith("DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL"))
     IS_GREATER_OR_EQUALS("is greater or equals"),
     IS_EQUAL("is equal comparing to"),
+    /** @since 0.13.0 */
+    IS_LESS_THAN_OR_EQUAL("is less than or equal to"),
+    /** @since 0.13.0 */
+    IS_GREATER_THAN_OR_EQUAL("is greater than or equal to"),
 }


### PR DESCRIPTION
…_EQUALS with IS_LESS_THAN_OR_EQUAL and IS_GREATER_THAN_OR_EQUAL



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
