### PR TITLE
507 add Path.hasSameTextualContentAs/hasSameBinaryContent to infix API 

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.specs.fun0
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.fun3
 import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -20,8 +21,15 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isRegularFile),
     fun0(Expect<Path>::isDirectory),
     fun1(Expect<Path>::hasSameBinaryContentAs),
-    fun3(Expect<Path>::hasSameTextualContentAs)
+    fun3(Expect<Path>::hasSameTextualContentAs),
+    fun1(Companion::hasSameTextualContentAsDefaultArgs)
 ) {
+
+    companion object : WithAsciiReporter() {
+        private fun hasSameTextualContentAsDefaultArgs(expect: Expect<Path>, targetPath: Path): Expect<Path> =
+            expect.hasSameTextualContentAs(targetPath)
+    }
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         val a1: Expect<DummyPath> = notImplemented()

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
@@ -25,7 +25,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun1(Companion::hasSameTextualContentAsDefaultArgs)
 ) {
 
-    companion object : WithAsciiReporter() {
+    companion object {
         private fun hasSameTextualContentAsDefaultArgs(expect: Expect<Path>, targetPath: Path): Expect<Path> =
             expect.hasSameTextualContentAs(targetPath)
     }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/encoding/EncodingWithCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/encoding/EncodingWithCreator.kt
@@ -1,0 +1,16 @@
+package ch.tutteli.atrium.api.infix.en_GB.creating.encoding
+
+import ch.tutteli.atrium.creating.Expect
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+/**
+ *  Parameter object which combines [path] (as [Path]), [sourceCharset] (as [Charset]), [targetCharset] (as [Charset])
+ *  with an [assertionCreator] which defines assertions for a resulting feature of type [E].
+ *
+ *  Use the function `withEncoding(Path, Charset, Charset) { ... }` to create this representation.
+ *
+ *  @since 0.13.0
+ */
+data class EncodingWithCreator<E> internal constructor(val path: Path, val sourceCharset: Charset, val targetCharset: Charset,
+                                                       val assertionCreator: Expect<E>)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/encoding/EncodingWithCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/encoding/EncodingWithCreator.kt
@@ -12,5 +12,4 @@ import java.nio.file.Path
  *
  *  @since 0.13.0
  */
-data class EncodingWithCreator<E> internal constructor(val path: Path, val sourceCharset: Charset, val targetCharset: Charset,
-                                                       val assertionCreator: Expect<E>)
+data class EncodingWithCreator<E> internal constructor(val path: Path, val sourceCharset: Charset, val targetCharset: Charset)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -325,8 +325,8 @@ infix fun <T : Path> Expect<T>.hasSameTextualContentAs(
  *
  * @since 0.13.0
  */
-infix fun <T : Path> Expect<T>.hasSameTextualContentAs(encodingWithCreator: EncodingWithCreator<T>):
-    Expect<T> = _logicAppend {
+infix fun <T : Path> Expect<T>.hasSameTextualContentAs(encodingWithCreator: EncodingWithCreator<T>): Expect<T> =
+    _logicAppend {
         hasSameTextualContentAs(
             encodingWithCreator.path, encodingWithCreator.sourceCharset, encodingWithCreator.targetCharset
         )

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -349,6 +349,6 @@ infix fun <T : Path> Expect<T>.hasSameBinaryContentAs(targetPath: Path):
 /**
  * Helper function to create an [EncodingWithCreator] based on the given [path] and [assertionCreator].
  */
-fun <T : Path> withEncoding(path: Path, assertionCreator: Expect<T>,
+fun <T : Path> withEncoding(path: Path
                             sourceCharset: Charset = Charsets.UTF_8, targetCharset: Charset = Charsets.UTF_8):
-    EncodingWithCreator<T> = EncodingWithCreator(path, sourceCharset, targetCharset, assertionCreator)
+    EncodingWithCreator<T> = EncodingWithCreator(path, sourceCharset, targetCharset)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -340,10 +340,8 @@ infix fun <T : Path> Expect<T>.hasSameTextualContentAs(encodingWithCreator: Enco
  *
  * @since 0.13.0
  */
-infix fun <T : Path> Expect<T>.hasSameBinaryContentAs(targetPath: Path):
-    Expect<T> = _logicAppend {
-    hasSameBinaryContentAs(targetPath)
-}
+infix fun <T : Path> Expect<T>.hasSameBinaryContentAs(targetPath: Path): Expect<T> = 
+    _logicAppend { hasSameBinaryContentAs(targetPath) }
 
 
 /**

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -312,7 +312,7 @@ infix fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> 
  */
 infix fun <T : Path> Expect<T>.hasSameTextualContentAs(
     targetPath: Path
-): Expect<T> = hasSameTextualContentAs(withEncoding(targetPath, this))
+): Expect<T> = hasSameTextualContentAs(withEncoding(targetPath))
 
 /**
  * Expects that the subject of the assertion (a [Path]) has the same textual content

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -8,6 +8,7 @@ import ch.tutteli.atrium.specs.fun0
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.fun3
 import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -23,8 +24,15 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isRegularFile),
     fun0(Expect<Path>::isDirectory),
     fun1(Expect<Path>::hasSameBinaryContentAs),
-    fun3(Expect<Path>::hasSameTextualContentAs)
+    fun3(Expect<Path>::hasSameTextualContentAs),
+    fun1(Companion::hasSameTextualContentAsDefaultArgs)
 ) {
+
+    companion object : WithAsciiReporter() {
+        private fun hasSameTextualContentAsDefaultArgs(expect: Expect<Path>, targetPath: Path): Expect<Path> =
+            expect.hasSameTextualContentAs(targetPath)
+    }
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         val a1: Expect<DummyPath> = notImplemented()

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -28,7 +28,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun1(Companion::hasSameTextualContentAsDefaultArgs)
 ) {
 
-    companion object : WithAsciiReporter() {
+    companion object {
         private fun hasSameTextualContentAsDefaultArgs(expect: Expect<Path>, targetPath: Path): Expect<Path> =
             expect.hasSameTextualContentAs(targetPath)
     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -59,6 +59,7 @@ abstract class PathAssertionsSpec(
     isDirectory: Fun0<Path>,
     hasSameBinaryContentAs: Fun1<Path, Path>,
     hasSameTextualContentAs: Fun3<Path, Path, Charset, Charset>,
+    hasSameTextualContentAsDefaultArgs: Fun1<Path, Path>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
@@ -75,7 +76,8 @@ abstract class PathAssertionsSpec(
         isRegularFile.forSubjectLess(),
         isDirectory.forSubjectLess(),
         hasSameBinaryContentAs.forSubjectLess(Paths.get("a")),
-        hasSameTextualContentAs.forSubjectLess(Paths.get("a"), Charsets.ISO_8859_1, Charsets.ISO_8859_1)
+        hasSameTextualContentAs.forSubjectLess(Paths.get("a"), Charsets.ISO_8859_1, Charsets.ISO_8859_1) ,
+        hasSameTextualContentAsDefaultArgs.forSubjectLess(Paths.get("a"))
     ) {})
 
     val tempFolder by memoizedTempFolder()
@@ -748,9 +750,10 @@ abstract class PathAssertionsSpec(
         }
     }
 
-    describeFun(hasSameBinaryContentAs, hasSameTextualContentAs) {
+    describeFun(hasSameBinaryContentAs, hasSameTextualContentAs, hasSameTextualContentAsDefaultArgs) {
         val hasSameBinaryContentAsFun = hasSameBinaryContentAs.lambda
         val hasSameTextualContentAsFun = hasSameTextualContentAs.lambda
+        val hasSameTextualContentAsDefaultArgsAsFun = hasSameTextualContentAsDefaultArgs.lambda
 
         fun errorHasSameTextualContentAs(sourceEncoding: Charset, targetEncoding: Charset) =
             TranslatableWithArgs(HAS_SAME_TEXTUAL_CONTENT, sourceEncoding, targetEncoding).getDefault()
@@ -781,9 +784,15 @@ abstract class PathAssertionsSpec(
                 val (sourcePath, targetPath) = createFiles(maybeLink)
                 expect(sourcePath).hasSameTextualContentAsFun(targetPath, Charsets.UTF_8, Charsets.UTF_16)
             }
+
             it("${hasSameTextualContentAs.name} - does not throw if UTF-16, ISO_8859_1 is used") withAndWithoutSymlink { maybeLink ->
                 val (sourcePath, targetPath) = createFiles(maybeLink)
                 expect(sourcePath).hasSameTextualContentAsFun(targetPath, Charsets.UTF_16, Charsets.ISO_8859_1)
+            }
+
+            it("${hasSameTextualContentAsDefaultArgs.name} - does not throw") withAndWithoutSymlink { maybeLink ->
+                val (sourcePath, targetPath) = createFiles(maybeLink)
+                expect(sourcePath).hasSameTextualContentAsDefaultArgsAsFun(targetPath)
             }
         }
 
@@ -828,6 +837,11 @@ abstract class PathAssertionsSpec(
                     contains(errorHasSameTextualContentAs(Charsets.UTF_16, Charsets.ISO_8859_1))
                 }
             }
+
+            it("${hasSameTextualContentAsDefaultArgs.name} - does not throw if UTF-8, UTF-8 is used") withAndWithoutSymlink { maybeLink ->
+                val (sourcePath, targetPath) = createFiles(maybeLink)
+                expect(sourcePath).hasSameTextualContentAsDefaultArgsAsFun(targetPath)
+            }
         }
 
         context("has same textual content in UTF-8 and UTF-16") {
@@ -870,6 +884,15 @@ abstract class PathAssertionsSpec(
                     contains(errorHasSameTextualContentAs(Charsets.UTF_16, Charsets.UTF_8))
                 }
             }
+
+            it("${hasSameTextualContentAsDefaultArgs.name} - throws AssertionError if UTF-8, UTF-8 is used") withAndWithoutSymlink { maybeLink ->
+                val (sourcePath, targetPath) = createFiles(maybeLink)
+                expect {
+                    expect(sourcePath).hasSameTextualContentAsDefaultArgsAsFun(targetPath)
+                }.toThrow<AssertionError>().message {
+                    contains(errorHasSameTextualContentAs(Charsets.UTF_8, Charsets.UTF_8))
+                }
+            }
         }
 
         context("has different textual content") {
@@ -905,6 +928,15 @@ abstract class PathAssertionsSpec(
                     expect(sourcePath).hasSameTextualContentAsFun(targetPath, Charsets.UTF_16, Charsets.UTF_16)
                 }.toThrow<AssertionError>().message {
                     contains(errorHasSameTextualContentAs(Charsets.UTF_16, Charsets.UTF_16))
+                }
+            }
+
+            it("${hasSameTextualContentAsDefaultArgs.name} - throws AssertionError if UTF-8, UTF-8 is used") withAndWithoutSymlink { maybeLink ->
+                val (sourcePath, targetPath) = createFiles(maybeLink)
+                expect {
+                    expect(sourcePath).hasSameTextualContentAsDefaultArgsAsFun(targetPath)
+                }.toThrow<AssertionError>().message {
+                    contains(errorHasSameTextualContentAs(Charsets.UTF_8, Charsets.UTF_8))
                 }
             }
         }


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
