### PR TITLE
API #477 #comment removed wrong replaceWith from new deprecations

### DIFF
--- a/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/charsequence/contains/creators/CharSequenceContainsAssertions.kt
+++ b/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/charsequence/contains/creators/CharSequenceContainsAssertions.kt
@@ -33,24 +33,14 @@ interface CharSequenceContainsAssertions {
     ): AssertionGroup
 
     //TODO remove with 1.0.0
-    @Deprecated("Use AssertImpl.charSequence.contains.defaultTranslationOf; will be removed with 1.0.0",
-        ReplaceWith(
-            "AssertImpl.charSequence.contains.defaultTranslationOf(checker, expected, *otherExpected)",
-            "ch.tutteli.atrium.creating.AssertImpl"
-        )
-    )
+    @Deprecated("Will be removed with 1.0.0")
     fun <T : CharSequence> defaultTranslationOf(
         checkerOption: CharSequenceContains.CheckerOption<T, NoOpSearchBehaviour>,
         expected: List<Translatable>
     ): AssertionGroup
 
     //TODO remove with 1.0.0
-    @Deprecated("Use AssertImpl.charSequence.contains.defaultTranslationOfIgnoringCase; will be removed with 1.0.0",
-        ReplaceWith(
-            "AssertImpl.charSequence.contains.defaultTranslationOfIgnoringCase(checker, expected, *otherExpected)",
-            "ch.tutteli.atrium.creating.AssertImpl"
-        )
-    )
+    @Deprecated("Will be removed with 1.0.0")
     fun <T : CharSequence> defaultTranslationOfIgnoringCase(
         checkerOption: CharSequenceContains.CheckerOption<T, IgnoringCaseSearchBehaviour>,
         expected: List<Translatable>


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
