### PR TITLE
Limit the text to represent calling DetailedObjectFormatter#format

### DIFF
--- a/core/robstoll-lib/atrium-core-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatter.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatter.kt
@@ -41,24 +41,24 @@ abstract class DetailedObjectFormatterCommon(
      * @return The formatted [value].
      */
     @Suppress( /* TODO remove with 1.0.0 */ "DEPRECATION")
-    override fun format(value: Any?): String = limitRepresentation(when (value) {
+    override fun format(value: Any?): String = when (value) {
         null -> Text.NULL.string
         is LazyRepresentation -> format(safeEval(value))
         is Char -> "'$value'"
         is Boolean -> value.toString()
         is String -> format(value)
         is CharSequence -> format(value)
-        is Text -> value.string
-        is Translatable -> translator.translate(value)
+        is Text -> limitRepresentation(value.string)
+        is Translatable -> limitRepresentation(translator.translate(value))
         is KClass<*> -> format(value)
         is Enum<*> -> format(value)
         is Throwable -> format(value)
         //TODO remove with 1.0.0
-        is StringBasedRawString -> value.string
-        is ch.tutteli.atrium.reporting.translating.TranslatableBasedRawString -> translator.translate(value.translatable)
+        is StringBasedRawString -> limitRepresentation(value.string)
+        is ch.tutteli.atrium.reporting.translating.TranslatableBasedRawString -> limitRepresentation(translator.translate(value.translatable))
 
-        else -> value.toString() + classNameAndIdentity(value)
-    })
+        else -> limitRepresentation(value.toString()) + classNameAndIdentity(value)
+    }
 
     private fun safeEval(lazyRepresentation: LazyRepresentation) =
         //TODO remove try-catch with 1.0.0 should no longer be necessary
@@ -68,15 +68,17 @@ abstract class DetailedObjectFormatterCommon(
             ErrorMessages.REPRESENTATION_BASED_ON_SUBJECT_NOT_DEFINED
         }
 
-    private fun format(string: String) = "\"$string\"" + identityHash(INDENT, string)
-    private fun format(charSequence: CharSequence) = "\"$charSequence\"" + classNameAndIdentity(charSequence)
+    private fun format(string: String) = "\"${limitRepresentation(string)}\"" + identityHash(INDENT, string)
+    private fun format(charSequence: CharSequence) = "\"${limitRepresentation(charSequence.toString())}\"" + classNameAndIdentity(charSequence)
     private fun format(enum: Enum<*>) =
-        enum.toString() + INDENT + "(" + (enum::class.fullName) + ")"
+        limitRepresentation(enum.toString()) + INDENT + "(" + (enum::class.fullName) + ")"
 
     private fun format(throwable: Throwable) = throwable::class.fullName
 
     private fun classNameAndIdentity(any: Any): String = INDENT + "(${any::class.fullName}${identityHash(" ", any)})"
-    private fun limitRepresentation(value: String) = if (value.length > 10000) value.substring(0, 10000) else value
+    private fun limitRepresentation(value: String): String {
+        return if (value.length > 10000) "${value.substring(0, 10000)}..." else value
+    }
 
     protected abstract fun format(kClass: KClass<*>): String
     protected abstract fun identityHash(indent: String, any: Any): String

--- a/core/robstoll-lib/atrium-core-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatter.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatter.kt
@@ -76,7 +76,7 @@ abstract class DetailedObjectFormatterCommon(
     private fun format(throwable: Throwable) = throwable::class.fullName
 
     private fun classNameAndIdentity(any: Any): String = INDENT + "(${any::class.fullName}${identityHash(" ", any)})"
-    private fun limitRepresentation(value: String, limit: Int = 10000) = if (value.length > limit) value.substring(0, limit) else value
+    private fun limitRepresentation(value: String) = if (value.length > 10000) value.substring(0, 10000) else value
 
     protected abstract fun format(kClass: KClass<*>): String
     protected abstract fun identityHash(indent: String, any: Any): String

--- a/core/robstoll-lib/atrium-core-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatter.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatter.kt
@@ -41,7 +41,7 @@ abstract class DetailedObjectFormatterCommon(
      * @return The formatted [value].
      */
     @Suppress( /* TODO remove with 1.0.0 */ "DEPRECATION")
-    override fun format(value: Any?): String = when (value) {
+    override fun format(value: Any?): String = limitRepresentation(when (value) {
         null -> Text.NULL.string
         is LazyRepresentation -> format(safeEval(value))
         is Char -> "'$value'"
@@ -58,7 +58,7 @@ abstract class DetailedObjectFormatterCommon(
         is ch.tutteli.atrium.reporting.translating.TranslatableBasedRawString -> translator.translate(value.translatable)
 
         else -> value.toString() + classNameAndIdentity(value)
-    }
+    })
 
     private fun safeEval(lazyRepresentation: LazyRepresentation) =
         //TODO remove try-catch with 1.0.0 should no longer be necessary
@@ -76,6 +76,7 @@ abstract class DetailedObjectFormatterCommon(
     private fun format(throwable: Throwable) = throwable::class.fullName
 
     private fun classNameAndIdentity(any: Any): String = INDENT + "(${any::class.fullName}${identityHash(" ", any)})"
+    private fun limitRepresentation(value: String, limit: Int = 10000) = if (value.length > limit) value.substring(0, limit) else value
 
     protected abstract fun format(kClass: KClass<*>): String
     protected abstract fun identityHash(indent: String, any: Any): String

--- a/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
+++ b/core/robstoll-lib/atrium-core-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/core/robstoll/lib/reporting/DetailedObjectFormatterSpec.kt
@@ -118,6 +118,28 @@ object DetailedObjectFormatterSpec : Spek({
                     expect(result).toBe("${clazz.simpleName} (${clazz.qualifiedName}) -- Class: ${clazz.java.name}")
                 }
             }
+
+        }
+
+        context("output type information") {
+            it("type information is still given in the output if no textual limiting occurs") {
+                val numbers = mutableListOf<Int>()
+                repeat(10) { numbers += it }
+                val result = testee.format(numbers)
+                val expected = "[${numbers.joinToString(", ")}]$INDENT(${numbers::class.qualifiedName} <${System.identityHashCode(numbers)}>)"
+                expect(result).toBe(expected)
+            }
+
+            it("type information is still given in the output if the textual representation is too long") {
+                val numbers = mutableListOf<Int>()
+                repeat(5000) { numbers += it }
+                val result = testee.format(numbers)
+                val expected =
+                    "${numbers
+                        .joinToString(prefix = "[", separator = ", ")
+                        .substring(0, 10000)}...$INDENT(${numbers::class.qualifiedName} <${System.identityHashCode(numbers)}>)"
+                expect(result).toBe(expected)
+            }
         }
 
         mapOf(


### PR DESCRIPTION
The specific implementation of the jvm and js version seem only to be formatting classes, so I left them out.
I can change it though, just lest me know.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
