### PR TITLE
#577 move FeatureExtractor to logic

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
@@ -57,7 +57,7 @@ inline fun <reified T : Any> Expect<T?>.toBeNullIfNullGivenElse(
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified T : Any> Expect<T?>.notToBeNull(): Expect<T> =
-    _logic.notToBeNullBut(T::class).transform()
+    _logic.notToBeNullButOfType(T::class).transform()
 
 /**
  * Expects that the subject of the assertion is not null and
@@ -67,7 +67,7 @@ inline fun <reified T : Any> Expect<T?>.notToBeNull(): Expect<T> =
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 inline fun <reified T : Any> Expect<T?>.notToBeNull(noinline assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    _logic.notToBeNullBut(T::class).transformAndAppend(assertionCreator)
+    _logic.notToBeNullButOfType(T::class).transformAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of the assertion *is a* [TSub] (the same type or a sub-type)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
@@ -40,7 +40,7 @@ fun <T : Collection<*>> Expect<T>.hasSize(expected: Int): Expect<T> =
  * @return The newly created [Expect] for the extracted feature.
  */
 val <T : Collection<*>> Expect<T>.size: Expect<Int>
-    get() = _logic.size(::identity).getExpectOfFeature()
+    get() = _logic.size(::identity).transform()
 
 /**
  * Expects that the property [Collection.size] of the subject of the assertion
@@ -51,4 +51,4 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
-    _logic.size(::identity).addToInitial(assertionCreator)
+    _logic.size(::identity).collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/expectExtensions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/expectExtensions.kt
@@ -1,15 +1,8 @@
-@file:Suppress(/* TODO remove with 0.14.0 again */ "DEPRECATION")
-
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.None
-import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.creating.ExperimentalExpectConfig
-import ch.tutteli.atrium.creating.FeatureExpect
-import ch.tutteli.atrium.creating.RootExpect
-import ch.tutteli.atrium.domain.builders.creating.changers.FeatureExtractorBuilder
-import ch.tutteli.atrium.domain.builders.creating.changers.FeatureOptions
+import ch.tutteli.atrium.creating.*
 import ch.tutteli.atrium.domain.builders.reporting.ExpectBuilder
 import ch.tutteli.atrium.domain.builders.reporting.ExpectOptions
 import ch.tutteli.atrium.reporting.Text
@@ -80,6 +73,8 @@ fun <T> RootExpect<T>.withOptions(options: ExpectOptions<T>): Expect<T> =
  * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
 fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: String): Expect<R> =
     withOptions { withRepresentation(textRepresentation) }
 
@@ -98,18 +93,22 @@ fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: String): E
  * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
 fun <T, R> FeatureExpect<T, R>.withRepresentation(representationProvider: (R) -> Any): Expect<R> =
     withOptions { withRepresentation(representationProvider) }
 
 /**
- * Uses the given [configuration]-lambda to create an [ExpectOptions] which in turn is used
+ * Uses the given [configuration]-lambda to create an [FeatureExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
  *
  * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
-fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExtractorBuilder.OptionsChooser<R>.() -> Unit): Expect<R> =
-    withOptions(FeatureExtractorBuilder.OptionsChooser.createAndBuild(configuration))
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
+fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExpectOptionsChooser<R>.() -> Unit): Expect<R> =
+    withOptions(FeatureExpectOptionsChooser(configuration))
 
 /**
  * Uses the given [options] to override (parts) of the existing configuration.
@@ -118,6 +117,6 @@ fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExtractorBuilde
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
-@UseExperimental(ExperimentalExpectConfig::class, ExperimentalNewExpectTypes::class)
-fun <T, R> FeatureExpect<T, R>.withOptions(options: FeatureOptions<R>): Expect<R> =
-    FeatureExpect(this, options.toFeatureExpectOptions())
+@UseExperimental(ExperimentalNewExpectTypes::class)
+fun <T, R> FeatureExpect<T, R>.withOptions(options: FeatureExpectOptions<R>): Expect<R> =
+    FeatureExpect(this, options)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/featureAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/featureAssertions.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.*
  * @since 0.9.0
  */
 fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect<T, R> =
-    _logic.property(property).getExpectOfFeature()
+    _logic.property(property).transform()
 
 /**
  * Extracts the [property] out of the current subject of the assertion,
@@ -34,7 +34,7 @@ fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect<T, R>
 fun <T, R> Expect<T>.feature(
     property: KProperty1<in T, R>,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.property(property).addToInitial(assertionCreator)
+): Expect<T> = _logic.property(property).collectAndAppend(assertionCreator)
 
 
 /**
@@ -48,7 +48,7 @@ fun <T, R> Expect<T>.feature(
  * @since 0.9.0
  */
 fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
-    _logic.f0(f).getExpectOfFeature()
+    _logic.f0(f).transform()
 
 /**
  * Extracts the value which is returned when calling [f] on the current subject of the assertion,
@@ -64,7 +64,7 @@ fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
 fun <T, R> Expect<T>.feature(
     f: KFunction1<T, R>,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.f0(f).addToInitial(assertionCreator)
+): Expect<T> = _logic.f0(f).collectAndAppend(assertionCreator)
 
 
 /**
@@ -81,7 +81,7 @@ fun <T, R> Expect<T>.feature(
 fun <T, A1, R> Expect<T>.feature(
     f: KFunction2<T, A1, R>,
     a1: A1
-): FeatureExpect<T, R> = _logic.f1(f, a1).getExpectOfFeature()
+): FeatureExpect<T, R> = _logic.f1(f, a1).transform()
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1]
@@ -99,7 +99,7 @@ fun <T, A1, R> Expect<T>.feature(
     f: KFunction2<T, A1, R>,
     a1: A1,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.f1(f, a1).addToInitial(assertionCreator)
+): Expect<T> = _logic.f1(f, a1).collectAndAppend(assertionCreator)
 
 
 /**
@@ -116,7 +116,7 @@ fun <T, A1, R> Expect<T>.feature(
 fun <T, A1, A2, R> Expect<T>.feature(
     f: KFunction3<T, A1, A2, R>,
     a1: A1, a2: A2
-): FeatureExpect<T, R> = _logic.f2(f, a1, a2).getExpectOfFeature()
+): FeatureExpect<T, R> = _logic.f2(f, a1, a2).transform()
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2]
@@ -134,7 +134,7 @@ fun <T, A1, A2, R> Expect<T>.feature(
     f: KFunction3<T, A1, A2, R>,
     a1: A1, a2: A2,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.f2(f, a1, a2).addToInitial(assertionCreator)
+): Expect<T> = _logic.f2(f, a1, a2).collectAndAppend(assertionCreator)
 
 
 /**
@@ -151,7 +151,7 @@ fun <T, A1, A2, R> Expect<T>.feature(
 fun <T, A1, A2, A3, R> Expect<T>.feature(
     f: KFunction4<T, A1, A2, A3, R>,
     a1: A1, a2: A2, a3: A3
-): FeatureExpect<T, R> = _logic.f3(f, a1, a2, a3).getExpectOfFeature()
+): FeatureExpect<T, R> = _logic.f3(f, a1, a2, a3).transform()
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2], [a3]
@@ -169,7 +169,7 @@ fun <T, A1, A2, A3, R> Expect<T>.feature(
     f: KFunction4<T, A1, A2, A3, R>,
     a1: A1, a2: A2, a3: A3,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.f3(f, a1, a2, a3).addToInitial(assertionCreator)
+): Expect<T> = _logic.f3(f, a1, a2, a3).collectAndAppend(assertionCreator)
 
 
 /**
@@ -186,7 +186,7 @@ fun <T, A1, A2, A3, R> Expect<T>.feature(
 fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
     f: KFunction5<T, A1, A2, A3, A4, R>,
     a1: A1, a2: A2, a3: A3, a4: A4
-): FeatureExpect<T, R> = _logic.f4(f, a1, a2, a3, a4).getExpectOfFeature()
+): FeatureExpect<T, R> = _logic.f4(f, a1, a2, a3, a4).transform()
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2], [a3], [a4]
@@ -204,7 +204,7 @@ fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
     f: KFunction5<T, A1, A2, A3, A4, R>,
     a1: A1, a2: A2, a3: A3, a4: A4,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.f4(f, a1, a2, a3, a4).addToInitial(assertionCreator)
+): Expect<T> = _logic.f4(f, a1, a2, a3, a4).collectAndAppend(assertionCreator)
 
 
 /**
@@ -220,7 +220,7 @@ fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
 fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
     f: KFunction6<T, A1, A2, A3, A4, A5, R>,
     a1: A1, a2: A2, a3: A3, a4: A4, a5: A5
-): FeatureExpect<T, R> = _logic.f5(f, a1, a2, a3, a4, a5).getExpectOfFeature()
+): FeatureExpect<T, R> = _logic.f5(f, a1, a2, a3, a4, a5).transform()
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2], [a3], [a4], [a5]
@@ -238,7 +238,7 @@ fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
     f: KFunction6<T, A1, A2, A3, A4, A5, R>,
     a1: A1, a2: A2, a3: A3, a4: A4, a5: A5,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.f5(f, a1, a2, a3, a4, a5).addToInitial(assertionCreator)
+): Expect<T> = _logic.f5(f, a1, a2, a3, a4, a5).collectAndAppend(assertionCreator)
 
 
 /**
@@ -255,7 +255,7 @@ fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
  * @since 0.9.0
  */
 fun <T, R> Expect<T>.feature(description: String, provider: T.() -> R): FeatureExpect<T, R> =
-    _logic.manualFeature(description, provider).getExpectOfFeature()
+    _logic.manualFeature(description, provider).transform()
 
 /**
  * Extracts a feature out of the current subject of the assertion
@@ -276,7 +276,7 @@ fun <T, R> Expect<T>.feature(
     description: String,
     provider: T.() -> R,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = _logic.manualFeature(description, provider).addToInitial(assertionCreator)
+): Expect<T> = _logic.manualFeature(description, provider).collectAndAppend(assertionCreator)
 
 
 /**
@@ -294,7 +294,7 @@ fun <T, R> Expect<T>.feature(
  * @since 0.9.0
  */
 fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFeature<R>): FeatureExpect<T, R> =
-    extractFeature(provider).getExpectOfFeature()
+    extractFeature(provider).transform()
 
 /**
  * Extracts a feature out of the current subject of the assertion,
@@ -314,7 +314,7 @@ fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFeature<R
 fun <T, R> Expect<T>.feature(
     provider: MetaFeatureOption<T>.(T) -> MetaFeature<R>,
     assertionCreator: Expect<R>.() -> Unit
-): Expect<T> = extractFeature(provider).addToInitial(assertionCreator)
+): Expect<T> = extractFeature(provider).collectAndAppend(assertionCreator)
 
 private fun <R, T> Expect<T>.extractFeature(provider: MetaFeatureOption<T>.(T) -> MetaFeature<R>) =
     _logic.genericSubjectBasedFeature { MetaFeatureOption(this).provider(it) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
@@ -155,6 +155,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
     vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?
 ): Expect<T> = contains.inOrder.only.entries(assertionCreatorOrNull, *otherAssertionCreatorsOrNulls)
 
+//TODO move to iterableAssertionsDeprecated and use parameter for Expect with 0.14.0 - same same for infix maybe
 /**
  * Expects that the subject of the assertion (an [Iterable]) contains only elements of [expectedIterable]
  * in same order
@@ -171,6 +172,7 @@ inline fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsOf(
     expectedIterable: Iterable<E>
 ): Expect<T> = contains.inOrder.only.elementsOf(expectedIterable)
 
+//TODO move to iterableAssertionsDeprecated and use parameter for Expect with 0.14.0 - same same for infix maybe
 /** Expects that the subject of the assertion (an [Iterable]) contains all elements of [expectedIterable].
  *
  * It is a shortcut for `contains.inAnyOrder.atLeast(1).elementsOf(expectedIterable)`
@@ -251,7 +253,7 @@ fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E, vararg otherExpected
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(): Expect<E> =
-    _logic.min(::identity).getExpectOfFeature()
+    _logic.min(::identity).transform()
 
 /**
  * Expects that the result of calling `min()` on the subject of the assertion
@@ -264,7 +266,7 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(): Expect<E> =
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.min(::identity).addToInitial(assertionCreator)
+    _logic.min(::identity).collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the result of calling `max()` on the subject of the assertion,
@@ -275,7 +277,7 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: Expect<
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> =
-    _logic.max(::identity).getExpectOfFeature()
+    _logic.max(::identity).transform()
 
 /**
  * Expects that the result of calling `max()` on  the subject of the assertion
@@ -288,7 +290,7 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> =
  * @since 0.9.0
  */
 fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.max(::identity).addToInitial(assertionCreator)
+    _logic.max(::identity).collectAndAppend(assertionCreator)
 
 
 /**

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.logic.get
  * @throws AssertionError Might throw an [AssertionError] if the given [index] is out of bound.
  */
 fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
-    _logic.get(index).getExpectOfFeature()
+    _logic.get(index).transform()
 
 /**
  * Expects that the given [index] is within the bounds of the subject of the assertion (a [List]) and that
@@ -22,4 +22,4 @@ fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
  * @throws AssertionError Might throw an [AssertionError] if the given [index] is out of bound.
  */
 fun <E, T : List<E>> Expect<T>.get(index: Int, assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.get(index).addToInitial(assertionCreator)
+    _logic.get(index).collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
@@ -92,7 +92,7 @@ fun <T : Map<*, *>> Expect<T>.isNotEmpty(): Expect<T> =
  * @throws AssertionError Might throw an [AssertionError] if the given [key] does not exist.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
-    _logic.getExisting(key).getExpectOfFeature()
+    _logic.getExisting(key).transform()
 
 /**
  * Expects that the subject of the assertion (a [Map]) contains the given [key] and that
@@ -103,7 +103,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
  *   does not hold.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Expect<V>.() -> Unit): Expect<T> =
-    _logic.getExisting(key).addToInitial(assertionCreator)
+    _logic.getExisting(key).collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Map.keys] of the subject of the assertion,
@@ -112,7 +112,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Ex
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
-    get() = _logic.property(Map<out K, *>::keys).getExpectOfFeature()
+    get() = _logic.property(Map<out K, *>::keys).transform()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
@@ -123,7 +123,7 @@ val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
-    _logic.property(Map<out K, *>::keys).addToInitial(assertionCreator)
+    _logic.property(Map<out K, *>::keys).collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
@@ -132,7 +132,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.()
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
-    get() = _logic.property(Map<out Any?, V>::values).getExpectOfFeature()
+    get() = _logic.property(Map<out Any?, V>::values).transform()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
@@ -143,7 +143,7 @@ val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map<K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
-    _logic.property(Map<out K, V>::values).addToInitial(assertionCreator)
+    _logic.property(Map<out K, V>::values).collectAndAppend(assertionCreator)
 
 /**
  * Turns `Expect<Map<K, V>>` into `Expect<Set<Map.Entry<K, V>>>`.

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -24,7 +24,7 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
-    get() = _logic.key().getExpectOfFeature()
+    get() = _logic.key().transform()
 
 /**
  * Expects that the property [Map.Entry.key] of the subject of the assertion
@@ -35,7 +35,7 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
-    _logic.key().addToInitial(assertionCreator)
+    _logic.key().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
@@ -44,7 +44,7 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> 
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
-    get() = _logic.value().getExpectOfFeature()
+    get() = _logic.value().transform()
 
 /**
  * Expects that the property [Map.Entry.value] of the subject of the assertion
@@ -55,4 +55,4 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
-    _logic.value().addToInitial(assertionCreator)
+    _logic.value().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.logic.second
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
-    get() : Expect<K> = _logic.first().getExpectOfFeature()
+    get() : Expect<K> = _logic.first().transform()
 
 /**
  * Expects that the property [Pair.first] of the subject of the assertion
@@ -23,7 +23,7 @@ val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
-    _logic.first().addToInitial(assertionCreator)
+    _logic.first().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
@@ -32,7 +32,7 @@ fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Uni
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
-    get() : Expect<V> = _logic.second().getExpectOfFeature()
+    get() : Expect<V> = _logic.second().transform()
 
 /**
  * Expects that the property [Pair.second] of the subject of the assertion
@@ -43,4 +43,4 @@ val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 fun <K, V, T : Pair<K, V>> Expect<T>.second(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
-    _logic.second().addToInitial(assertionCreator)
+    _logic.second().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateAssertions.kt
@@ -18,7 +18,7 @@ import java.time.LocalDate
  * @since 0.9.0
  */
 val Expect<LocalDate>.year: Expect<Int>
-    get() = _logic.year().getExpectOfFeature()
+    get() = _logic.year().transform()
 
 /**
  * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
@@ -31,7 +31,7 @@ val Expect<LocalDate>.year: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<LocalDate>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDate> =
-    _logic.year().addToInitial(assertionCreator)
+    _logic.year().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion,
@@ -42,7 +42,7 @@ fun Expect<LocalDate>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<Loc
  * @since 0.9.0
  */
 val Expect<LocalDate>.month: Expect<Int>
-    get() = _logic.month().getExpectOfFeature()
+    get() = _logic.month().transform()
 
 /**
  * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
@@ -55,7 +55,7 @@ val Expect<LocalDate>.month: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<LocalDate>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDate> =
-    _logic.month().addToInitial(assertionCreator)
+    _logic.month().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of the assertion,
@@ -66,7 +66,7 @@ fun Expect<LocalDate>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<Lo
  * @since 0.9.0
  */
 val Expect<LocalDate>.dayOfWeek: Expect<DayOfWeek>
-    get() = _logic.dayOfWeek().getExpectOfFeature()
+    get() = _logic.dayOfWeek().transform()
 
 /**
  * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
@@ -79,7 +79,7 @@ val Expect<LocalDate>.dayOfWeek: Expect<DayOfWeek>
  * @since 0.9.0
  */
 fun Expect<LocalDate>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<LocalDate> =
-    _logic.dayOfWeek().addToInitial(assertionCreator)
+    _logic.dayOfWeek().collectAndAppend(assertionCreator)
 
 
 /**
@@ -91,7 +91,7 @@ fun Expect<LocalDate>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit):
  * @since 0.9.0
  */
 val Expect<LocalDate>.day: Expect<Int>
-    get() = _logic.day().getExpectOfFeature()
+    get() = _logic.day().transform()
 
 /**
  * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
@@ -104,4 +104,4 @@ val Expect<LocalDate>.day: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<LocalDate>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDate> =
-    _logic.day().addToInitial(assertionCreator)
+    _logic.day().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateTimeAssertions.kt
@@ -19,7 +19,7 @@ import java.time.LocalDateTime
  * @since 0.9.0
  */
 val Expect<LocalDateTime>.year: Expect<Int>
-    get() = _logic.year().getExpectOfFeature()
+    get() = _logic.year().transform()
 
 /**
  * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
@@ -32,7 +32,7 @@ val Expect<LocalDateTime>.year: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<LocalDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDateTime> =
-    _logic.year().addToInitial(assertionCreator)
+    _logic.year().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]
@@ -43,7 +43,7 @@ fun Expect<LocalDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect
  * @since 0.9.0
  */
 val Expect<LocalDateTime>.month: Expect<Int>
-    get() = _logic.month().getExpectOfFeature()
+    get() = _logic.month().transform()
 
 /**
  * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
@@ -56,7 +56,7 @@ val Expect<LocalDateTime>.month: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<LocalDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDateTime> =
-    _logic.month().addToInitial(assertionCreator)
+    _logic.month().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]
@@ -67,7 +67,7 @@ fun Expect<LocalDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expec
  * @since 0.9.0
  */
 val Expect<LocalDateTime>.dayOfWeek: Expect<DayOfWeek>
-    get() = _logic.dayOfWeek().getExpectOfFeature()
+    get() = _logic.dayOfWeek().transform()
 
 /**
  * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
@@ -80,7 +80,7 @@ val Expect<LocalDateTime>.dayOfWeek: Expect<DayOfWeek>
  * @since 0.9.0
  */
 fun Expect<LocalDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<LocalDateTime> =
-    _logic.dayOfWeek().addToInitial(assertionCreator)
+    _logic.dayOfWeek().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth]
@@ -91,7 +91,7 @@ fun Expect<LocalDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Un
  * @since 0.9.0
  */
 val Expect<LocalDateTime>.day: Expect<Int>
-    get() = _logic.day().getExpectOfFeature()
+    get() = _logic.day().transform()
 
 /**
  * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
@@ -104,5 +104,5 @@ val Expect<LocalDateTime>.day: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<LocalDateTime>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDateTime> =
-    _logic.day().addToInitial(assertionCreator)
+    _logic.day().collectAndAppend(assertionCreator)
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalAssertions.kt
@@ -39,7 +39,7 @@ fun <T : Optional<*>> Expect<T>.isEmpty(): Expect<T> =
  * @since 0.9.0
  */
 fun <E, T : Optional<E>> Expect<T>.isPresent(): Expect<E> =
-    _logic.isPresent().getExpectOfFeature()
+    _logic.isPresent().transform()
 
 /**
  * Expects that the subject of the assertion (an [Optional]) is present and
@@ -51,4 +51,4 @@ fun <E, T : Optional<E>> Expect<T>.isPresent(): Expect<E> =
  * @since 0.9.0
  */
 fun <E, T : Optional<E>> Expect<T>.isPresent(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.isPresent().addToInitial(assertionCreator)
+    _logic.isPresent().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -95,7 +95,7 @@ fun <T : Path> Expect<T>.existsNot(): Expect<T> =
  * @since 0.9.0
  */
 val <T : Path> Expect<T>.fileName: Expect<String>
-    get() = _logic.fileName().getExpectOfFeature()
+    get() = _logic.fileName().transform()
 
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
@@ -109,7 +109,7 @@ val <T : Path> Expect<T>.fileName: Expect<String>
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.fileName().addToInitial(assertionCreator)
+    _logic.fileName().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
@@ -122,7 +122,7 @@ fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): 
  * @since 0.9.0
  */
 val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
-    get() = _logic.fileNameWithoutExtension().getExpectOfFeature()
+    get() = _logic.fileNameWithoutExtension().transform()
 
 /**
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
@@ -136,7 +136,7 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.fileNameWithoutExtension().addToInitial(assertionCreator)
+    _logic.fileNameWithoutExtension().collectAndAppend(assertionCreator)
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent] and creates an [Expect] for it,
@@ -148,7 +148,7 @@ fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<Strin
  * @since 0.9.0
  */
 val <T : Path> Expect<T>.parent: Expect<Path>
-    get() = _logic.parent().getExpectOfFeature()
+    get() = _logic.parent().transform()
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent], that the parent holds all assertions the
@@ -160,7 +160,7 @@ val <T : Path> Expect<T>.parent: Expect<Path>
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
-    _logic.parent().addToInitial(assertionCreator)
+    _logic.parent().collectAndAppend(assertionCreator)
 
 /**
  * Expects that [other] resolves against this [Path] and creates an [Expect] for the resolved [Path]
@@ -172,7 +172,7 @@ fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expe
  * @since 0.10.0
  */
 fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
-    _logic.resolve(other).getExpectOfFeature()
+    _logic.resolve(other).transform()
 
 /**
  * Expects that [other] resolves against this [Path], that the resolved [Path] holds all assertions the
@@ -184,7 +184,7 @@ fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
  * @since 0.10.0
  */
 fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
-    _logic.resolve(other).addToInitial(assertionCreator)
+    _logic.resolve(other).collectAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Path]) is readable;
@@ -296,7 +296,7 @@ fun <T : Path> Expect<T>.isDirectory(): Expect<T> =
  * @since 0.9.0
  */
 val <T : Path> Expect<T>.extension: Expect<String>
-    get() = _logic.extension().getExpectOfFeature()
+    get() = _logic.extension().transform()
 
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
@@ -310,7 +310,7 @@ val <T : Path> Expect<T>.extension: Expect<String>
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.extension().addToInitial(assertionCreator)
+    _logic.extension().collectAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Path]) has the same textual content

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/zonedDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/zonedDateTimeAssertions.kt
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
  * @since 0.9.0
  */
 val Expect<ZonedDateTime>.year: Expect<Int>
-    get() = _logic.year().getExpectOfFeature()
+    get() = _logic.year().transform()
 
 /**
  * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
@@ -32,7 +32,7 @@ val Expect<ZonedDateTime>.year: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<ZonedDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.year().addToInitial(assertionCreator)
+    _logic.year().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
@@ -43,7 +43,7 @@ fun Expect<ZonedDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect
  * @since 0.9.0
  */
 val Expect<ZonedDateTime>.month: Expect<Int>
-    get() = _logic.month().getExpectOfFeature()
+    get() = _logic.month().transform()
 
 /**
  * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
@@ -56,7 +56,7 @@ val Expect<ZonedDateTime>.month: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<ZonedDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.month().addToInitial(assertionCreator)
+    _logic.month().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
@@ -67,7 +67,7 @@ fun Expect<ZonedDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expec
  * @since 0.9.0
  */
 val Expect<ZonedDateTime>.dayOfWeek: Expect<DayOfWeek>
-    get() = _logic.dayOfWeek().getExpectOfFeature()
+    get() = _logic.dayOfWeek().transform()
 
 /**
  * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
@@ -80,7 +80,7 @@ val Expect<ZonedDateTime>.dayOfWeek: Expect<DayOfWeek>
  * @since 0.9.0
  */
 fun Expect<ZonedDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.dayOfWeek().addToInitial(assertionCreator)
+    _logic.dayOfWeek().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
@@ -91,7 +91,7 @@ fun Expect<ZonedDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Un
  * @since 0.9.0
  */
 val Expect<ZonedDateTime>.day: Expect<Int>
-    get() = _logic.day().getExpectOfFeature()
+    get() = _logic.day().transform()
 
 /**
  * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
@@ -104,4 +104,4 @@ val Expect<ZonedDateTime>.day: Expect<Int>
  * @since 0.9.0
  */
 fun Expect<ZonedDateTime>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.day().addToInitial(assertionCreator)
+    _logic.day().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/resultAssertions.kt
+++ b/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/resultAssertions.kt
@@ -15,7 +15,7 @@ import ch.tutteli.atrium.logic.kotlin_1_3.isSuccess
  * @since 0.9.0
  */
 fun <E, T : Result<E>> Expect<T>.isSuccess(): Expect<E> =
-    _logic.isSuccess().getExpectOfFeature()
+    _logic.isSuccess().transform()
 
 /**
  * Expects that the subject of the assertion (a [Result]) is a Success and
@@ -27,7 +27,7 @@ fun <E, T : Result<E>> Expect<T>.isSuccess(): Expect<E> =
  * @since 0.9.0
  */
 fun <E, T : Result<E>> Expect<T>.isSuccess(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.isSuccess().addToInitial(assertionCreator)
+    _logic.isSuccess().collectAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Result]) is a Failure and

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
@@ -63,7 +63,7 @@ inline infix fun <reified T : Any> Expect<T?>.toBeNullIfNullGivenElse(
  */
 @Suppress(/* less magic */ "RemoveExplicitTypeArguments")
 inline infix fun <reified T : Any> Expect<T?>.notToBeNull(@Suppress("UNUSED_PARAMETER") o: o): Expect<T> =
-    _logic.notToBeNullBut(T::class).transform()
+    _logic.notToBeNullButOfType(T::class).transform()
 
 /**
  * Expects that the subject of the assertion is not null and
@@ -74,7 +74,7 @@ inline infix fun <reified T : Any> Expect<T?>.notToBeNull(@Suppress("UNUSED_PARA
  */
 @Suppress(/* less magic */ "RemoveExplicitTypeArguments")
 inline infix fun <reified T : Any> Expect<T?>.notToBeNull(noinline assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    _logic.notToBeNullBut(T::class).transformAndAppend(assertionCreator)
+    _logic.notToBeNullButOfType(T::class).transformAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of the assertion *is a* [TSub] (the same type or a sub-type)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
@@ -45,7 +45,7 @@ infix fun <T : Collection<*>> Expect<T>.hasSize(expected: Int): Expect<T> =
  * @return The newly created [Expect] for the extracted feature.
  */
 val <T : Collection<*>> Expect<T>.size: Expect<Int>
-    get() = _logic.size(::identity).getExpectOfFeature()
+    get() = _logic.size(::identity).transform()
 
 /**
  * Expects that the property [Collection.size] of the subject of the assertion
@@ -56,4 +56,4 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
-    _logic.size(::identity).addToInitial(assertionCreator)
+    _logic.size(::identity).collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/expectExtensions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/expectExtensions.kt
@@ -3,8 +3,6 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.creating.*
-import ch.tutteli.atrium.domain.builders.creating.changers.FeatureExtractorBuilder
-import ch.tutteli.atrium.domain.builders.creating.changers.FeatureOptions
 import ch.tutteli.atrium.domain.builders.reporting.ExpectBuilder
 import ch.tutteli.atrium.domain.builders.reporting.ExpectOptions
 import ch.tutteli.atrium.reporting.Text
@@ -63,8 +61,12 @@ infix fun <T> RootExpect<T>.withOptions(options: ExpectOptions<T>): Expect<T> =
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
  * In case [Expect.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
 infix fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: String): Expect<R> =
     withOptions { withRepresentation(textRepresentation) }
 
@@ -79,24 +81,34 @@ infix fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: Stri
  * a `String` and does the wrapping for you.
  *
  * In case [Expect.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
 infix fun <T, R> FeatureExpect<T, R>.withRepresentation(representationProvider: (R) -> Any): Expect<R> =
     withOptions { withRepresentation(representationProvider) }
 
 /**
- * Uses the given [configuration]-lambda to create an [ExpectOptions] which in turn is used
+ * Uses the given [configuration]-lambda to create an [FeatureExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
- */
-@ExperimentalWithOptions
-infix fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExtractorBuilder.OptionsChooser<R>.() -> Unit): Expect<R> =
-    withOptions(FeatureExtractorBuilder.OptionsChooser.createAndBuild(configuration))
-
-/**
- * Uses the given [options] to override (parts) of the existing configuration.
+ *
+ * @return An [Expect] for the current subject of the assertion.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
-@UseExperimental(ExperimentalExpectConfig::class, ExperimentalNewExpectTypes::class)
-infix fun <T, R> FeatureExpect<T, R>.withOptions(options: FeatureOptions<R>): Expect<R> =
-    FeatureExpect(this, options.toFeatureExpectOptions())
+@UseExperimental(ExperimentalNewExpectTypes::class)
+infix fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExpectOptionsChooser<R>.() -> Unit): Expect<R> =
+    withOptions(FeatureExpectOptionsChooser(configuration))
+
+/**
+ * Uses the given [options] to override (parts) of the existing configuration.
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ */
+@ExperimentalWithOptions
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
+infix fun <T, R> FeatureExpect<T, R>.withOptions(options: FeatureExpectOptions<R>): Expect<R> =
+    FeatureExpect(this, options)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/featureAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/featureAssertions.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.*
  * @since 0.12.0
  */
 infix fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect<T, R> =
-    _logic.property(property).getExpectOfFeature()
+    _logic.property(property).transform()
 
 /**
  * Extracts the value which is returned when calling the method [f] on the current subject of the assertion,
@@ -38,7 +38,7 @@ infix fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect
  * @since 0.12.0
  */
 infix fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
-    _logic.f0(f).getExpectOfFeature()
+    _logic.f0(f).transform()
 
 /**
  * Extracts a feature out of the current subject of the assertion using the given [Feature.extractor],
@@ -59,7 +59,7 @@ infix fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
  */
 //TODO remove `in` with Kotlin 1.4 (most likely with Atrium 1.0.0)
 infix fun <T, R> Expect<T>.feature(of: Feature<in T, R>): FeatureExpect<T, R> =
-    _logic.manualFeature(of.description, of.extractor).getExpectOfFeature()
+    _logic.manualFeature(of.description, of.extractor).transform()
 
 /**
  * Extracts a feature out of the current subject of the assertion using the given [FeatureWithCreator.extractor],
@@ -84,7 +84,7 @@ infix fun <T, R> Expect<T>.feature(of: Feature<in T, R>): FeatureExpect<T, R> =
  */
 //TODO remove `in` with Kotlin 1.4 (most likely with Atrium 1.0.0)
 infix fun <T, R> Expect<T>.feature(of: FeatureWithCreator<in T, R>): Expect<T> =
-    _logic.manualFeature(of.description, of.extractor).addToInitial(of.assertionCreator)
+    _logic.manualFeature(of.description, of.extractor).collectAndAppend(of.assertionCreator)
 
 
 /**
@@ -102,7 +102,7 @@ infix fun <T, R> Expect<T>.feature(of: FeatureWithCreator<in T, R>): Expect<T> =
  * @since 0.12.0
  */
 infix fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFeature<R>): FeatureExpect<T, R> =
-    _logic.genericSubjectBasedFeature { MetaFeatureOption(this).provider(it) }.getExpectOfFeature()
+    _logic.genericSubjectBasedFeature { MetaFeatureOption(this).provider(it) }.transform()
 
 /**
  * Extracts a feature out of the current subject of the assertion,
@@ -137,7 +137,7 @@ infix fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFea
 infix fun <T, R> Expect<T>.feature(of: MetaFeatureOptionWithCreator<T, R>): Expect<T> =
     _logic.genericSubjectBasedFeature {
         MetaFeatureOption(this).(of.provider)(it)
-    }.addToInitial(of.assertionCreator)
+    }.collectAndAppend(of.assertionCreator)
 
 /**
  * Creates a [MetaFeature] using the given [provider] and [description].

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
@@ -294,7 +294,7 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsNot(values: Values<E>): Expect<
  * @since 0.12.0
  */
 infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(@Suppress("UNUSED_PARAMETER") o: o): Expect<E> =
-    _logic.min(::identity).getExpectOfFeature()
+    _logic.min(::identity).transform()
 
 /**
  * Expects that the result of calling `min()` on the subject of the assertion
@@ -307,7 +307,7 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(@Suppress("UNUSED_P
  * @since 0.12.0
  */
 infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.min(::identity).addToInitial(assertionCreator)
+    _logic.min(::identity).collectAndAppend(assertionCreator)
 
 
 /**
@@ -321,7 +321,7 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: E
  * @since 0.12.0
  */
 infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(@Suppress("UNUSED_PARAMETER") o: o): Expect<E> =
-    _logic.max(::identity).getExpectOfFeature()
+    _logic.max(::identity).transform()
 
 /**
  * Expects that the result of calling `max()` on  the subject of the assertion
@@ -334,7 +334,7 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(@Suppress("UNUSED_P
  * @since 0.12.0
  */
 infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
-    _logic.max(::identity).addToInitial(assertionCreator)
+    _logic.max(::identity).collectAndAppend(assertionCreator)
 
 
 /**

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/listAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/listAssertions.kt
@@ -13,7 +13,7 @@ import ch.tutteli.atrium.logic.get
  * @throws AssertionError Might throw an [AssertionError] if the given [index] is out of bound.
  */
 infix fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
-    _logic.get(index).getExpectOfFeature()
+    _logic.get(index).transform()
 
 /**
  * Expects that the given [index][IndexWithCreator.index] is within the bounds of the subject of the assertion
@@ -27,7 +27,7 @@ infix fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
  *   if the assertion made is not correct.
  */
 infix fun <E, T : List<E>> Expect<T>.get(index: IndexWithCreator<E>): Expect<T> =
-    _logic.get(index.index).addToInitial(index.assertionCreator)
+    _logic.get(index.index).collectAndAppend(index.assertionCreator)
 
 /**
  * Helper function to create an [IndexWithCreator] based on the given [index] and [assertionCreator].

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
@@ -128,7 +128,7 @@ infix fun <T : Map<*, *>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") empty:
  * @throws AssertionError Might throw an [AssertionError] if the given [key] does not exist.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
-    _logic.getExisting(key).getExpectOfFeature()
+    _logic.getExisting(key).transform()
 
 /**
  * Expects that the subject of the assertion (a [Map]) contains the given [key] and that
@@ -142,7 +142,7 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
  *   if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: KeyWithCreator<K, V>): Expect<T> =
-    _logic.getExisting(key.key).addToInitial(key.assertionCreator)
+    _logic.getExisting(key.key).collectAndAppend(key.assertionCreator)
 
 /**
  * Helper function to create an [KeyWithCreator] based on the given [key] and [assertionCreator].
@@ -158,7 +158,7 @@ fun <K, V> key(key: K, assertionCreator: Expect<V>.() -> Unit): KeyWithCreator<K
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
-    get() = _logic.property(Map<out K, *>::keys).getExpectOfFeature()
+    get() = _logic.property(Map<out K, *>::keys).transform()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
@@ -169,7 +169,7 @@ val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
-    _logic.property(Map<out K, *>::keys).addToInitial(assertionCreator)
+    _logic.property(Map<out K, *>::keys).collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
@@ -178,7 +178,7 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
-    get() = _logic.property(Map<out Any?, V>::values).getExpectOfFeature()
+    get() = _logic.property(Map<out Any?, V>::values).transform()
 
 /**
  * Expects that the property [Map.keys] of the subject of the assertion
@@ -189,7 +189,7 @@ val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map<K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
-    _logic.property(Map<out K, V>::values).addToInitial(assertionCreator)
+    _logic.property(Map<out K, V>::values).collectAndAppend(assertionCreator)
 
 /**
  * Turns `Expect<Map<K, V>>` into `Expect<Set<Map.Entry<K, V>>>`.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
@@ -24,7 +24,7 @@ infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K,
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
-    get() = _logic.key().getExpectOfFeature()
+    get() = _logic.key().transform()
 
 /**
  * Expects that the property [Map.Entry.key] of the subject of the assertion
@@ -35,7 +35,7 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
-    _logic.key().addToInitial(assertionCreator)
+    _logic.key().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
@@ -44,7 +44,7 @@ infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
-    get() = _logic.value().getExpectOfFeature()
+    get() = _logic.value().transform()
 
 /**
  * Expects that the property [Map.Entry.value] of the subject of the assertion
@@ -55,4 +55,4 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
-    _logic.value().addToInitial(assertionCreator)
+    _logic.value().collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.logic.second
  * @return The newly created [Expect] for the extracted feature.
  */
 val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
-    get() = _logic.first().getExpectOfFeature()
+    get() = _logic.first().transform()
 
 /**
  * Expects that the property [Pair.first] of the subject of the assertion
@@ -23,7 +23,7 @@ val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
-    _logic.first().addToInitial(assertionCreator)
+    _logic.first().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
@@ -32,7 +32,7 @@ infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() 
  * @return The newly created [Expect] for the extracted feature.
  */
 val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
-    get() = _logic.second().getExpectOfFeature()
+    get() = _logic.second().transform()
 
 /**
  * Expects that the property [Pair.second] of the subject of the assertion
@@ -43,4 +43,4 @@ val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
 infix fun <K, V, T : Pair<K, V>> Expect<T>.second(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
-    _logic.second().addToInitial(assertionCreator)
+    _logic.second().collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateAssertions.kt
@@ -19,7 +19,7 @@ import java.time.LocalDate
  * @since 0.12.0
  */
 val Expect<LocalDate>.year: Expect<Int>
-    get() = _logic.year().getExpectOfFeature()
+    get() = _logic.year().transform()
 
 /**
  * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
@@ -32,7 +32,7 @@ val Expect<LocalDate>.year: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<LocalDate>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDate> =
-    _logic.year().addToInitial(assertionCreator)
+    _logic.year().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion,
@@ -43,7 +43,7 @@ infix fun Expect<LocalDate>.year(assertionCreator: Expect<Int>.() -> Unit): Expe
  * @since 0.12.0
  */
 val Expect<LocalDate>.month: Expect<Int>
-    get() = _logic.month().getExpectOfFeature()
+    get() = _logic.month().transform()
 
 /**
  * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
@@ -56,7 +56,7 @@ val Expect<LocalDate>.month: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<LocalDate>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDate> =
-    _logic.month().addToInitial(assertionCreator)
+    _logic.month().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of the assertion,
@@ -67,7 +67,7 @@ infix fun Expect<LocalDate>.month(assertionCreator: Expect<Int>.() -> Unit): Exp
  * @since 0.12.0
  */
 val Expect<LocalDate>.dayOfWeek: Expect<DayOfWeek>
-    get() = _logic.dayOfWeek().getExpectOfFeature()
+    get() = _logic.dayOfWeek().transform()
 
 /**
  * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
@@ -80,7 +80,7 @@ val Expect<LocalDate>.dayOfWeek: Expect<DayOfWeek>
  * @since 0.12.0
  */
 infix fun Expect<LocalDate>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<LocalDate> =
-    _logic.dayOfWeek().addToInitial(assertionCreator)
+    _logic.dayOfWeek().collectAndAppend(assertionCreator)
 
 
 /**
@@ -92,7 +92,7 @@ infix fun Expect<LocalDate>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> 
  * @since 0.12.0
  */
 val Expect<LocalDate>.day: Expect<Int>
-    get() = _logic.day().getExpectOfFeature()
+    get() = _logic.day().transform()
 
 /**
  * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
@@ -105,4 +105,4 @@ val Expect<LocalDate>.day: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<LocalDate>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDate> =
-    _logic.day().addToInitial(assertionCreator)
+    _logic.day().collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateTimeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateTimeAssertions.kt
@@ -19,7 +19,7 @@ import java.time.LocalDateTime
  * @since 0.12.0
  */
 val Expect<LocalDateTime>.year: Expect<Int>
-    get() = _logic.year().getExpectOfFeature()
+    get() = _logic.year().transform()
 
 /**
  * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
@@ -32,7 +32,7 @@ val Expect<LocalDateTime>.year: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<LocalDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDateTime> =
-    _logic.year().addToInitial(assertionCreator)
+    _logic.year().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]
@@ -43,7 +43,7 @@ infix fun Expect<LocalDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): 
  * @since 0.12.0
  */
 val Expect<LocalDateTime>.month: Expect<Int>
-    get() = _logic.month().getExpectOfFeature()
+    get() = _logic.month().transform()
 
 /**
  * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
@@ -56,7 +56,7 @@ val Expect<LocalDateTime>.month: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<LocalDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDateTime> =
-    _logic.month().addToInitial(assertionCreator)
+    _logic.month().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]
@@ -67,7 +67,7 @@ infix fun Expect<LocalDateTime>.month(assertionCreator: Expect<Int>.() -> Unit):
  * @since 0.12.0
  */
 val Expect<LocalDateTime>.dayOfWeek: Expect<DayOfWeek>
-    get() = _logic.dayOfWeek().getExpectOfFeature()
+    get() = _logic.dayOfWeek().transform()
 
 /**
  * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
@@ -80,7 +80,7 @@ val Expect<LocalDateTime>.dayOfWeek: Expect<DayOfWeek>
  * @since 0.12.0
  */
 infix fun Expect<LocalDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<LocalDateTime> =
-    _logic.dayOfWeek().addToInitial(assertionCreator)
+    _logic.dayOfWeek().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth]
@@ -91,7 +91,7 @@ infix fun Expect<LocalDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.()
  * @since 0.12.0
  */
 val Expect<LocalDateTime>.day: Expect<Int>
-    get() = _logic.day().getExpectOfFeature()
+    get() = _logic.day().transform()
 
 /**
  * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
@@ -104,5 +104,5 @@ val Expect<LocalDateTime>.day: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<LocalDateTime>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<LocalDateTime> =
-    _logic.day().addToInitial(assertionCreator)
+    _logic.day().collectAndAppend(assertionCreator)
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalAssertions.kt
@@ -41,7 +41,7 @@ infix fun <T : Optional<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: 
  * @since 0.12.0
  */
 infix fun <E, T : Optional<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") present: present): FeatureExpect<T, E> =
-    _logic.isPresent().getExpectOfFeature()
+    _logic.isPresent().transform()
 
 /**
  * Expects that the subject of the assertion (an [Optional]) is present and
@@ -53,4 +53,4 @@ infix fun <E, T : Optional<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") pres
  * @since 0.12.0
  */
 infix fun <E, T : Optional<E>> Expect<T>.toBe(present: PresentWithCreator<E>): Expect<T> =
-    _logic.isPresent().addToInitial(present.assertionCreator)
+    _logic.isPresent().collectAndAppend(present.assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -97,7 +97,7 @@ infix fun <T : Path> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") existing: e
  * @since 0.12.0
  */
 val <T : Path> Expect<T>.fileName: Expect<String>
-    get() = _logic.fileName().getExpectOfFeature()
+    get() = _logic.fileName().transform()
 
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
@@ -111,7 +111,7 @@ val <T : Path> Expect<T>.fileName: Expect<String>
  * @since 0.12.0
  */
 infix fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.fileName().addToInitial(assertionCreator)
+    _logic.fileName().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
@@ -124,7 +124,7 @@ infix fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> U
  * @since 0.12.0
  */
 val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
-    get() = _logic.fileNameWithoutExtension().getExpectOfFeature()
+    get() = _logic.fileNameWithoutExtension().transform()
 
 /**
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
@@ -138,7 +138,7 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  * @since 0.12.0
  */
 infix fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.fileNameWithoutExtension().addToInitial(assertionCreator)
+    _logic.fileNameWithoutExtension().collectAndAppend(assertionCreator)
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent] and creates an [Expect] for it,
@@ -150,7 +150,7 @@ infix fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect
  * @since 0.12.0
  */
 val <T : Path> Expect<T>.parent: Expect<Path>
-    get() = _logic.parent().getExpectOfFeature()
+    get() = _logic.parent().transform()
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent], that the parent holds all assertions the
@@ -162,7 +162,7 @@ val <T : Path> Expect<T>.parent: Expect<Path>
  * @since 0.12.0
  */
 infix fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
-    _logic.parent().addToInitial(assertionCreator)
+    _logic.parent().collectAndAppend(assertionCreator)
 
 /**
  * Expects that [other] resolves against this [Path] and creates an [Expect] for the resolved [Path]
@@ -174,7 +174,7 @@ infix fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit)
  * @since 0.12.0
  */
 infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
-    _logic.resolve(other).getExpectOfFeature()
+    _logic.resolve(other).transform()
 
 /**
  * Expects that [PathWithCreator.path] resolves against this [Path], that the resolved [Path] holds all assertions the
@@ -189,7 +189,7 @@ infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
  * @since 0.12.0
  */
 infix fun <T : Path> Expect<T>.resolve(path: PathWithCreator<Path>): Expect<T> =
-    _logic.resolve(path.path).addToInitial(path.assertionCreator)
+    _logic.resolve(path.path).collectAndAppend(path.assertionCreator)
 
 /**
  * Helper function to create a [PathWithCreator] based on the given [path] and [assertionCreator].
@@ -306,7 +306,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aDirectory: aD
  * @since 0.12.0
  */
 val <T : Path> Expect<T>.extension: Expect<String>
-    get() = _logic.extension().getExpectOfFeature()
+    get() = _logic.extension().transform()
 
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
@@ -320,7 +320,7 @@ val <T : Path> Expect<T>.extension: Expect<String>
  * @since 0.12.0
  */
 infix fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.extension().addToInitial(assertionCreator)
+    _logic.extension().collectAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Path]) has the same textual content

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/zonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/zonedDateTimeAssertions.kt
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
  * @since 0.12.0
  */
 val Expect<ZonedDateTime>.year: Expect<Int>
-    get() = _logic.year().getExpectOfFeature()
+    get() = _logic.year().transform()
 
 /**
  * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
@@ -32,7 +32,7 @@ val Expect<ZonedDateTime>.year: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<ZonedDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.year().addToInitial(assertionCreator)
+    _logic.year().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
@@ -43,7 +43,7 @@ infix fun Expect<ZonedDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): 
  * @since 0.12.0
  */
 val Expect<ZonedDateTime>.month: Expect<Int>
-    get() = _logic.month().getExpectOfFeature()
+    get() = _logic.month().transform()
 
 /**
  * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
@@ -56,7 +56,7 @@ val Expect<ZonedDateTime>.month: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<ZonedDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.month().addToInitial(assertionCreator)
+    _logic.month().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
@@ -67,7 +67,7 @@ infix fun Expect<ZonedDateTime>.month(assertionCreator: Expect<Int>.() -> Unit):
  * @since 0.12.0
  */
 val Expect<ZonedDateTime>.dayOfWeek: Expect<DayOfWeek>
-    get() = _logic.dayOfWeek().getExpectOfFeature()
+    get() = _logic.dayOfWeek().transform()
 
 /**
  * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
@@ -80,7 +80,7 @@ val Expect<ZonedDateTime>.dayOfWeek: Expect<DayOfWeek>
  * @since 0.12.0
  */
 infix fun Expect<ZonedDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.dayOfWeek().addToInitial(assertionCreator)
+    _logic.dayOfWeek().collectAndAppend(assertionCreator)
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
@@ -91,7 +91,7 @@ infix fun Expect<ZonedDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.()
  * @since 0.12.0
  */
 val Expect<ZonedDateTime>.day: Expect<Int>
-    get() = _logic.day().getExpectOfFeature()
+    get() = _logic.day().transform()
 
 /**
  * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
@@ -104,4 +104,4 @@ val Expect<ZonedDateTime>.day: Expect<Int>
  * @since 0.12.0
  */
 infix fun Expect<ZonedDateTime>.day(assertionCreator: Expect<Int>.() -> Unit): Expect<ZonedDateTime> =
-    _logic.day().addToInitial(assertionCreator)
+    _logic.day().collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/resultAssertions.kt
+++ b/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/resultAssertions.kt
@@ -17,7 +17,7 @@ import ch.tutteli.atrium.logic.kotlin_1_3.isSuccess
  * @since 0.12.0
  */
 infix fun <E, T : Result<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") success: success): Expect<E> =
-    _logic.isSuccess().getExpectOfFeature()
+    _logic.isSuccess().transform()
 
 /**
  * Expects that the subject of the assertion (a [Result]]) is a Success and
@@ -31,7 +31,7 @@ infix fun <E, T : Result<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") succes
  * @since 0.12.0
  */
 infix fun <E, T : Result<E>> Expect<T>.toBe(success: SuccessWithCreator<E>): Expect<T> =
-    _logic.isSuccess().addToInitial(success.assertionCreator)
+    _logic.isSuccess().collectAndAppend(success.assertionCreator)
 
 /**
  * Expects that the subject of the assertion (a [Result]) is a Failure and

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/FeatureExpect.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/FeatureExpect.kt
@@ -27,10 +27,10 @@ interface FeatureExpect<T, R> : Expect<R> {
         ): FeatureExpect<T, R> =
             FeatureExpectImpl(previousExpect, maybeSubject, description, assertions, featureExpectOptions)
 
-        @ExperimentalNewExpectTypes
         /**
          * Use this overload if you want to modify the options of a [FeatureExpect].
          */
+        @ExperimentalNewExpectTypes
         operator fun <T, R> invoke(
             featureExpect: FeatureExpect<T, R>,
             featureExpectOptions: FeatureExpectOptions<R>

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/FeatureExpectOptions.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/FeatureExpectOptions.kt
@@ -1,7 +1,11 @@
 package ch.tutteli.atrium.creating
 
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.creating.impl.FeatureExpectOptionsChooserImpl
+import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.reporting.translating.Untranslatable
 
 /**
  * Additional (non-mandatory) options to create a [FeatureExpect].
@@ -27,4 +31,68 @@ data class FeatureExpectOptions<R>(
             options.description ?: description,
             options.representationInsteadOfFeature ?: representationInsteadOfFeature
         )
+}
+
+
+/**
+ * Define additional (non-mandatory) options to create a [FeatureExpect] based on a given
+ * [FeatureExpectOptionsChooser]-lambda.
+ */
+@Suppress("FunctionName")
+@ExperimentalNewExpectTypes
+//using a function because overloading a constructor of a data class does not work well in Kotlin (type inference bugs)
+fun <R> FeatureExpectOptions(configuration: FeatureExpectOptionsChooser<R>.() -> Unit): FeatureExpectOptions<R> =
+    FeatureExpectOptionsChooser(configuration)
+
+/**
+ * Helper lambda to specify [FeatureExpectOptions] via convenience methods.
+ *
+ * Calling multiple times the same method overrides the previously defined value.
+ */
+@ExperimentalNewExpectTypes
+interface FeatureExpectOptionsChooser<R> {
+
+    /**
+     * Wraps the given [description] into an [Untranslatable] and passes it to the overload
+     * which expects a [Translatable] -- this is then used as custom description
+     * instead of the previously defined description.
+     *
+     */
+    fun withDescription(description: String) {
+        withDescription(Untranslatable(description))
+    }
+
+    /**
+     * Uses the given [description] as custom description instead of the previously defined description.
+     */
+    fun withDescription(description: Translatable)
+
+    /**
+     * Wraps the given [textRepresentation] into a [Text] and uses it as representation of the subject
+     * instead of the representation that has been defined so far (which defaults to the subject itself).
+     *
+     * In case [AssertionContainer.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+     */
+    fun withRepresentation(textRepresentation: String): Unit =
+        withRepresentation { Text(textRepresentation) }
+
+    /**
+     * Uses the given [representationProvider] to retrieve a representation which can be based on the current
+     * subject where this provided representation is used as new representation of the subject
+     * instead of the representation that has been defined so far (which defaults to the subject itself).
+     *
+     * Notice, if you want to use text (a [String] which is treated as raw string in reporting) as representation,
+     * then wrap it into a [Text] and pass it instead.
+     * If your text does not include the current subject, then we recommend to use the other overload which expects
+     * a `String` and does the wrapping for you.
+     *
+     * In case [AssertionContainer.maybeSubject] is not defined i.e. [None], then the previous representation is used.
+     */
+    fun withRepresentation(representationProvider: (R) -> Any)
+
+    companion object {
+        @ExperimentalNewExpectTypes
+        operator fun <R> invoke(configuration: FeatureExpectOptionsChooser<R>.() -> Unit): FeatureExpectOptions<R> =
+            FeatureExpectOptionsChooserImpl<R>().apply(configuration).build()
+    }
 }

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/FeatureExpectOptionsChooserImpl.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/FeatureExpectOptionsChooserImpl.kt
@@ -1,0 +1,22 @@
+package ch.tutteli.atrium.creating.impl
+
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.creating.FeatureExpectOptions
+import ch.tutteli.atrium.creating.FeatureExpectOptionsChooser
+import ch.tutteli.atrium.reporting.translating.Translatable
+
+@ExperimentalNewExpectTypes
+class FeatureExpectOptionsChooserImpl<R> : FeatureExpectOptionsChooser<R> {
+    private var description: Translatable? = null
+    private var representationInsteadOfFeature: ((R) -> Any)? = null
+
+    override fun withDescription(description: Translatable) {
+        this.description = description
+    }
+
+    override fun withRepresentation(representationProvider: (R) -> Any) {
+        this.representationInsteadOfFeature = representationProvider
+    }
+
+    fun build(): FeatureExpectOptions<R> = FeatureExpectOptions(description, representationInsteadOfFeature)
+}

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
@@ -22,7 +22,7 @@ fun <T : Any?> AssertionContainer<T>.toBeNull(): Assertion = _anyImpl.toBeNull(t
 fun <T : Any> AssertionContainer<T?>.toBeNullIfNullGivenElse(type: KClass<T>, assertionCreatorOrNull: (Expect<T>.() -> Unit)?): Assertion =
     _anyImpl.toBeNullIfNullGivenElse(this, type, assertionCreatorOrNull)
 
-fun <T : Any> AssertionContainer<T?>.notToBeNullBut(subType: KClass<T>): SubjectChangerBuilder.ExecutionStep<T?, T> = _anyImpl.notToBeNullBut(this, subType)
+fun <T : Any> AssertionContainer<T?>.notToBeNullButOfType(subType: KClass<T>): SubjectChangerBuilder.ExecutionStep<T?, T> = _anyImpl.notToBeNullButOfType(this, subType)
 
     //TODO restrict TSub with T once type parameter for upper bounds are supported:
     // https://youtrack.jetbrains.com/issue/KT-33262 is implemented

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/collectionLike.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/collectionLike.kt
@@ -8,11 +8,11 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.typeutils.CollectionLike
 
 
 fun <T : CollectionLike> AssertionContainer<T>.isEmpty(converter: (T) -> Collection<*>): Assertion = _collectionLikeImpl.isEmpty(this, converter)
 fun <T : CollectionLike> AssertionContainer<T>.isNotEmpty(converter: (T) -> Collection<*>): Assertion = _collectionLikeImpl.isNotEmpty(this, converter)
 
-fun <T : CollectionLike> AssertionContainer<T>.size(converter: (T) -> Collection<*>): ExtractedFeaturePostStep<T, Int> = _collectionLikeImpl.size(this, converter)
+fun <T : CollectionLike> AssertionContainer<T>.size(converter: (T) -> Collection<*>): FeatureExtractorBuilder.ExecutionStep<T, Int> = _collectionLikeImpl.size(this, converter)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/feature.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/feature.kt
@@ -8,7 +8,7 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.domain.creating.MetaFeature
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.reporting.translating.Translatable
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KFunction1
@@ -19,32 +19,32 @@ import kotlin.reflect.KFunction5
 import kotlin.reflect.KFunction6
 
     //@formatter:off
-fun <T, TProperty> AssertionContainer<T>.property(property: KProperty1<in T, TProperty>): ExtractedFeaturePostStep<T, TProperty> = _featureImpl.property(this, property)
+fun <T, TProperty> AssertionContainer<T>.property(property: KProperty1<in T, TProperty>): FeatureExtractorBuilder.ExecutionStep<T, TProperty> = _featureImpl.property(this, property)
 
-fun <T, R> AssertionContainer<T>.f0(f: KFunction1<T, R>): ExtractedFeaturePostStep<T, R> = _featureImpl.f0(this, f)
+fun <T, R> AssertionContainer<T>.f0(f: KFunction1<T, R>): FeatureExtractorBuilder.ExecutionStep<T, R> = _featureImpl.f0(this, f)
 
-fun <T, A1, R> AssertionContainer<T>.f1(f: KFunction2<T, A1, R>, a1: A1): ExtractedFeaturePostStep<T, R> =
+fun <T, A1, R> AssertionContainer<T>.f1(f: KFunction2<T, A1, R>, a1: A1): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.f1(this, f, a1)
 
-fun <T, A1, A2, R> AssertionContainer<T>.f2(f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): ExtractedFeaturePostStep<T, R> =
+fun <T, A1, A2, R> AssertionContainer<T>.f2(f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.f2(this, f, a1, a2)
 
-fun <T, A1, A2, A3, R> AssertionContainer<T>.f3(f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): ExtractedFeaturePostStep<T, R> =
+fun <T, A1, A2, A3, R> AssertionContainer<T>.f3(f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.f3(this, f, a1, a2, a3)
 
-fun <T, A1, A2, A3, A4, R> AssertionContainer<T>.f4(f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): ExtractedFeaturePostStep<T, R> =
+fun <T, A1, A2, A3, A4, R> AssertionContainer<T>.f4(f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.f4(this, f, a1, a2, a3, a4)
 
-fun <T, A1, A2, A3, A4, A5, R> AssertionContainer<T>.f5(f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): ExtractedFeaturePostStep<T, R> =
+fun <T, A1, A2, A3, A4, A5, R> AssertionContainer<T>.f5(f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.f5(this, f, a1, a2, a3, a4, a5)
     //@formatter:on
 
-fun <T, R> AssertionContainer<T>.manualFeature(description: String, provider: T.() -> R): ExtractedFeaturePostStep<T, R> =
+fun <T, R> AssertionContainer<T>.manualFeature(description: String, provider: T.() -> R): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.manualFeature(this, description, provider)
 
-fun <T, R> AssertionContainer<T>.manualFeature(description: Translatable, provider: T.() -> R): ExtractedFeaturePostStep<T, R> =
+fun <T, R> AssertionContainer<T>.manualFeature(description: Translatable, provider: T.() -> R): FeatureExtractorBuilder.ExecutionStep<T, R> =
     _featureImpl.manualFeature(this, description, provider)
 
-fun <T, R> AssertionContainer<T>.genericSubjectBasedFeature(provider: (T) -> MetaFeature<R>): ExtractedFeaturePostStep<T, R> = _featureImpl.genericSubjectBasedFeature(this, provider)
+fun <T, R> AssertionContainer<T>.genericSubjectBasedFeature(provider: (T) -> MetaFeature<R>): FeatureExtractorBuilder.ExecutionStep<T, R> = _featureImpl.genericSubjectBasedFeature(this, provider)
 
-fun <T, R> AssertionContainer<T>.genericFeature(metaFeature: MetaFeature<R>): ExtractedFeaturePostStep<T, R> = _featureImpl.genericFeature(this, metaFeature)
+fun <T, R> AssertionContainer<T>.genericFeature(metaFeature: MetaFeature<R>): FeatureExtractorBuilder.ExecutionStep<T, R> = _featureImpl.genericFeature(this, metaFeature)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/iterableLike.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/iterableLike.kt
@@ -9,12 +9,11 @@ package ch.tutteli.atrium.logic
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.NotCheckerStep
-import ch.tutteli.atrium.logic.creating.iterable.contains.steps.impl.NotCheckerStepImpl
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 
 fun <T : Any, E> AssertionContainer<T>.containsBuilder(converter: (T) -> Iterable<E>): IterableLikeContains.EntryPointStep<E, T, NoOpSearchBehaviour> = _iterableLikeImpl.containsBuilder(this, converter)
@@ -28,6 +27,6 @@ fun <T : Any, E> AssertionContainer<T>.hasNext(converter: (T) -> Iterable<E>): A
 
 fun <T : Any, E> AssertionContainer<T>.hasNotNext(converter: (T) -> Iterable<E>): Assertion = _iterableLikeImpl.hasNotNext(this, converter)
 
-fun <T : Any, E : Comparable<E>> AssertionContainer<T>.min(converter: (T) -> Iterable<E>): ExtractedFeaturePostStep<T, E> = _iterableLikeImpl.min(this, converter)
+fun <T : Any, E : Comparable<E>> AssertionContainer<T>.min(converter: (T) -> Iterable<E>): FeatureExtractorBuilder.ExecutionStep<T, E> = _iterableLikeImpl.min(this, converter)
 
-fun <T : Any, E : Comparable<E>> AssertionContainer<T>.max(converter: (T) -> Iterable<E>): ExtractedFeaturePostStep<T, E> = _iterableLikeImpl.max(this, converter)
+fun <T : Any, E : Comparable<E>> AssertionContainer<T>.max(converter: (T) -> Iterable<E>): FeatureExtractorBuilder.ExecutionStep<T, E> = _iterableLikeImpl.max(this, converter)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/list.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/list.kt
@@ -7,7 +7,7 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 
-fun <E, T : List<E>> AssertionContainer<T>.get(index: Int): ExtractedFeaturePostStep<T, E> = _listImpl.get(this, index)
+fun <E, T : List<E>> AssertionContainer<T>.get(index: Int): FeatureExtractorBuilder.ExecutionStep<T, E> = _listImpl.get(this, index)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/map.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/map.kt
@@ -11,7 +11,7 @@ package ch.tutteli.atrium.logic
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import kotlin.reflect.KClass
 
 fun <K, V, T : Map<out K, V>> AssertionContainer<T>.contains(keyValuePairs: List<Pair<K, V>>): Assertion = _mapImpl.contains(this, keyValuePairs)
@@ -25,6 +25,6 @@ fun <K, T : Map<out K, *>> AssertionContainer<T>.containsNotKey(key: K): Asserti
 fun <T : Map<*, *>> AssertionContainer<T>.isEmpty(): Assertion = _mapImpl.isEmpty(this)
 fun <T : Map<*, *>> AssertionContainer<T>.isNotEmpty(): Assertion = _mapImpl.isNotEmpty(this)
 
-fun <K, V, T : Map<out K, V>> AssertionContainer<T>.getExisting(key: K): ExtractedFeaturePostStep<T, V> = _mapImpl.getExisting(this, key)
+fun <K, V, T : Map<out K, V>> AssertionContainer<T>.getExisting(key: K): FeatureExtractorBuilder.ExecutionStep<T, V> = _mapImpl.getExisting(this, key)
 
-fun <T : Map<*, *>> AssertionContainer<T>.size(): ExtractedFeaturePostStep<T, Int> = _mapImpl.size(this)
+fun <T : Map<*, *>> AssertionContainer<T>.size(): FeatureExtractorBuilder.ExecutionStep<T, Int> = _mapImpl.size(this)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/mapEntry.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/mapEntry.kt
@@ -8,9 +8,9 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 fun <K, V, T : Map.Entry<K, V>> AssertionContainer<T>.isKeyValue(key: K, value: V): Assertion =
     _mapEntryImpl.isKeyValue(this, key, value)
-fun <K, T : Map.Entry<K, *>> AssertionContainer<T>.key(): ExtractedFeaturePostStep<T, K> = _mapEntryImpl.key(this)
-fun <V, T : Map.Entry<*, V>> AssertionContainer<T>.value(): ExtractedFeaturePostStep<T, V> = _mapEntryImpl.value(this)
+fun <K, T : Map.Entry<K, *>> AssertionContainer<T>.key(): FeatureExtractorBuilder.ExecutionStep<T, K> = _mapEntryImpl.key(this)
+fun <V, T : Map.Entry<*, V>> AssertionContainer<T>.value(): FeatureExtractorBuilder.ExecutionStep<T, V> = _mapEntryImpl.value(this)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/pair.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/pair.kt
@@ -7,7 +7,7 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
-fun <K, T : Pair<K, *>> AssertionContainer<T>.first(): ExtractedFeaturePostStep<T, K> = _pairImpl.first(this)
-fun <V, T : Pair<*, V>> AssertionContainer<T>.second(): ExtractedFeaturePostStep<T, V> = _pairImpl.second(this)
+fun <K, T : Pair<K, *>> AssertionContainer<T>.first(): FeatureExtractorBuilder.ExecutionStep<T, K> = _pairImpl.first(this)
+fun <V, T : Pair<*, V>> AssertionContainer<T>.second(): FeatureExtractorBuilder.ExecutionStep<T, V> = _pairImpl.second(this)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/AnyAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/AnyAssertions.kt
@@ -23,7 +23,7 @@ interface AnyAssertions {
         assertionCreatorOrNull: (Expect<T>.() -> Unit)?
     ): Assertion
 
-    fun <T : Any> notToBeNullBut(
+    fun <T : Any> notToBeNullButOfType(
         container: AssertionContainer<T?>,
         subType: KClass<T>
     ): SubjectChangerBuilder.ExecutionStep<T?, T>

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/CollectionLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/CollectionLikeAssertions.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.typeutils.CollectionLike
 
 /**
@@ -16,5 +16,5 @@ interface CollectionLikeAssertions {
     fun <T : CollectionLike> size(
         container: AssertionContainer<T>,
         converter: (T) -> Collection<*>
-    ): ExtractedFeaturePostStep<T, Int>
+    ): FeatureExtractorBuilder.ExecutionStep<T, Int>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/FeatureAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/FeatureAssertions.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.domain.creating.MetaFeature
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.reporting.translating.Translatable
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KFunction1
@@ -13,44 +13,44 @@ import kotlin.reflect.KFunction5
 import kotlin.reflect.KFunction6
 
 /**
- * Collection of functions which help to create feature assertions by returning [ExtractedFeaturePostStep].
+ * Collection of functions which help to create feature assertions by returning [FeatureExtractorBuilder.ExecutionStep].
  */
 interface FeatureAssertions {
     //@formatter:off
-    fun <T, TProperty> property(container: AssertionContainer<T>, property: KProperty1<in T, TProperty>): ExtractedFeaturePostStep<T, TProperty>
+    fun <T, TProperty> property(container: AssertionContainer<T>, property: KProperty1<in T, TProperty>): FeatureExtractorBuilder.ExecutionStep<T, TProperty>
 
-    fun <T, R> f0(container: AssertionContainer<T>, f: KFunction1<T, R>): ExtractedFeaturePostStep<T, R>
+    fun <T, R> f0(container: AssertionContainer<T>, f: KFunction1<T, R>): FeatureExtractorBuilder.ExecutionStep<T, R>
 
-    fun <T, A1, R> f1(container: AssertionContainer<T>, f: KFunction2<T, A1, R>, a1: A1): ExtractedFeaturePostStep<T, R>
+    fun <T, A1, R> f1(container: AssertionContainer<T>, f: KFunction2<T, A1, R>, a1: A1): FeatureExtractorBuilder.ExecutionStep<T, R>
 
-    fun <T, A1, A2, R> f2(container: AssertionContainer<T>, f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): ExtractedFeaturePostStep<T, R>
+    fun <T, A1, A2, R> f2(container: AssertionContainer<T>, f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): FeatureExtractorBuilder.ExecutionStep<T, R>
 
-    fun <T, A1, A2, A3, R> f3(container: AssertionContainer<T>, f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): ExtractedFeaturePostStep<T, R>
+    fun <T, A1, A2, A3, R> f3(container: AssertionContainer<T>, f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): FeatureExtractorBuilder.ExecutionStep<T, R>
 
-    fun <T, A1, A2, A3, A4, R> f4(container: AssertionContainer<T>, f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): ExtractedFeaturePostStep<T, R>
+    fun <T, A1, A2, A3, A4, R> f4(container: AssertionContainer<T>, f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): FeatureExtractorBuilder.ExecutionStep<T, R>
 
-    fun <T, A1, A2, A3, A4, A5, R> f5(container: AssertionContainer<T>, f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): ExtractedFeaturePostStep<T, R>
+    fun <T, A1, A2, A3, A4, A5, R> f5(container: AssertionContainer<T>, f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): FeatureExtractorBuilder.ExecutionStep<T, R>
     //@formatter:on
 
     fun <T, R> manualFeature(
         container: AssertionContainer<T>,
         description: String,
         provider: T.() -> R
-    ): ExtractedFeaturePostStep<T, R>
+    ): FeatureExtractorBuilder.ExecutionStep<T, R>
 
     fun <T, R> manualFeature(
         container: AssertionContainer<T>,
         description: Translatable,
         provider: T.() -> R
-    ): ExtractedFeaturePostStep<T, R>
+    ): FeatureExtractorBuilder.ExecutionStep<T, R>
 
     fun <T, R> genericSubjectBasedFeature(
         container: AssertionContainer<T>,
         provider: (T) -> MetaFeature<R>
-    ): ExtractedFeaturePostStep<T, R>
+    ): FeatureExtractorBuilder.ExecutionStep<T, R>
 
     fun <T, R> genericFeature(
         container: AssertionContainer<T>,
         metaFeature: MetaFeature<R>
-    ): ExtractedFeaturePostStep<T, R>
+    ): FeatureExtractorBuilder.ExecutionStep<T, R>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/IterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/IterableLikeAssertions.kt
@@ -3,12 +3,11 @@ package ch.tutteli.atrium.logic
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.NotCheckerStep
-import ch.tutteli.atrium.logic.creating.iterable.contains.steps.impl.NotCheckerStepImpl
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 /**
  * Collection of assertion functions and builders which are applicable to subjects which can be transformed to an
@@ -45,10 +44,10 @@ interface IterableLikeAssertions {
     fun <T : Any, E : Comparable<E>> min(
         container: AssertionContainer<T>,
         converter: (T) -> Iterable<E>
-    ): ExtractedFeaturePostStep<T, E>
+    ): FeatureExtractorBuilder.ExecutionStep<T, E>
 
     fun <T : Any, E : Comparable<E>> max(
         container: AssertionContainer<T>,
         converter: (T) -> Iterable<E>
-    ): ExtractedFeaturePostStep<T, E>
+    ): FeatureExtractorBuilder.ExecutionStep<T, E>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/ListAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/ListAssertions.kt
@@ -1,12 +1,12 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 /**
  * Collection of assertion functions and builders which are applicable to subjects with a [List] type.
  */
 interface ListAssertions {
 
-    fun <E, T : List<E>> get(container: AssertionContainer<T>, index: Int): ExtractedFeaturePostStep<T, E>
+    fun <E, T : List<E>> get(container: AssertionContainer<T>, index: Int): FeatureExtractorBuilder.ExecutionStep<T, E>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/MapAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/MapAssertions.kt
@@ -5,7 +5,7 @@ package ch.tutteli.atrium.logic
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import kotlin.reflect.KClass
 
 /**
@@ -29,7 +29,7 @@ interface MapAssertions {
     fun <T : Map<*, *>> isEmpty(container: AssertionContainer<T>): Assertion
     fun <T : Map<*, *>> isNotEmpty(container: AssertionContainer<T>): Assertion
 
-    fun <K, V, T : Map<out K, V>> getExisting(container: AssertionContainer<T>, key: K): ExtractedFeaturePostStep<T, V>
+    fun <K, V, T : Map<out K, V>> getExisting(container: AssertionContainer<T>, key: K): FeatureExtractorBuilder.ExecutionStep<T, V>
 
-    fun <T : Map<*, *>> size(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, Int>
+    fun <T : Map<*, *>> size(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, Int>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/MapEntryAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/MapEntryAssertions.kt
@@ -2,13 +2,13 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 /**
  * Collection of assertion functions and builders which are applicable to subjects with a [Map.Entry] type.
  */
 interface MapEntryAssertions {
     fun <K, V, T : Map.Entry<K, V>> isKeyValue(container: AssertionContainer<T>, key: K, value: V): Assertion
-    fun <K, T : Map.Entry<K, *>> key(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, K>
-    fun <V, T : Map.Entry<*, V>> value(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, V>
+    fun <K, T : Map.Entry<K, *>> key(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, K>
+    fun <V, T : Map.Entry<*, V>> value(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, V>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/PairAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/PairAssertions.kt
@@ -1,12 +1,12 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 /**
  * Collection of assertion functions and builders which are applicable to subjects with a [Pair] type.
  */
 interface PairAssertions {
-    fun <K, T : Pair<K, *>> first(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, K>
-    fun <V, T : Pair<*, V>> second(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, V>
+    fun <K, T : Pair<K, *>> first(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, K>
+    fun <V, T : Pair<*, V>> second(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, V>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
@@ -1,6 +1,3 @@
-//TODO remove with 1.0.0
-@file:Suppress("DEPRECATION")
-
 package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
@@ -1,6 +1,3 @@
-//TODO remove with 1.0.0
-@file:Suppress("DEPRECATION")
-
 package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion
@@ -58,7 +55,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
         itr: Iterator<E?>
     ): Assertion {
         return assertionCollector.collect(Some(iterableAsList)) {
-            _logic.size(::identity).addToInitial {
+            _logic.size(::identity).collectAndAppend {
                 _logicAppend { toBe(expectedSize) }
                 if (iterableAsList.size > expectedSize) {
                     addAssertion(LazyThreadUnsafeAssertionGroup {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator.kt
@@ -56,7 +56,7 @@ abstract class InOrderOnlyGroupedAssertionCreator<E, T : IterableLike, SC>(
             }
             .withoutOptions()
             .build()
-            .addToInitial {
+            .collectAndAppend {
                 addSublistAssertion(groupOfSearchCriteria)
             }
     }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/FeatureExtractor.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/FeatureExtractor.kt
@@ -1,0 +1,58 @@
+@file:Suppress("DEPRECATION")
+
+package ch.tutteli.atrium.logic.creating.transformers
+
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.FeatureExpect
+import ch.tutteli.atrium.creating.FeatureExpectOptions
+import ch.tutteli.atrium.logic.FeatureAssertions
+import ch.tutteli.atrium.reporting.translating.Translatable
+
+/**
+ * Defines the contract for sophisticated `safe feature extractions` including assertion creation for the feature.
+ *
+ * It is similar to [FeatureAssertions] but differs in the intended usage.
+ * [FeatureAssertions] are intended to make assertions about a return value of a method call or a property,
+ * assuming that the call as such always succeeds (no exception is thrown).
+ * The [FeatureExtractor] on the other hand should be used if it is already known,
+ * that the call/access fails depending on given arguments.
+ * For instance, [List.get] is a good example where it fails if the given index is out of bounds.
+ */
+interface FeatureExtractor {
+
+    /**
+     * Extracts a feature according to the given [featureExtraction], creates an [Expect] for the
+     * new subject and applies [maybeSubAssertions] in case they are specified.
+     *
+     *
+     * @param container the assertion container with the current subject (before the change)
+     * @param description Describes the feature
+     * @param representationForFailure Representation in case the extraction cannot be carried out.
+     * @param featureExtraction Extracts the feature where it returns the feature wrapped into a [Some] if the
+     *   extraction as such can be carried out, otherwise [None].
+     * @param maybeSubAssertions Optionally, subsequent assertions for the feature (the new subject).
+     *   This is especially useful if the extraction cannot be carried out, because this way we can then already
+     *   show to you (in error reporting) what you wanted to assert about the feature (which gives you more context to
+     *   the error).
+     * @param representationInsteadOfFeature Per default the feature as such is used to represent itself. However,
+     *   if you want a different representation, then use this parameter where passing `null` still means use the
+     *   feature.
+     *
+     * @return The newly created [Expect] for the extracted feature.
+     */
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalNewExpectTypes::class)
+    fun <T, R> extract(
+        container: AssertionContainer<T>,
+        description: Translatable,
+        representationForFailure: Any,
+        featureExtraction: (T) -> Option<R>,
+        maybeSubAssertions: Option<Expect<R>.() -> Unit>,
+        featureExpectOptions: FeatureExpectOptions<R>
+    ): FeatureExpect<T, R>
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder.kt
@@ -1,0 +1,276 @@
+package ch.tutteli.atrium.logic.creating.transformers
+
+import ch.tutteli.atrium.core.*
+import ch.tutteli.atrium.creating.*
+import ch.tutteli.atrium.logic.creating.transformers.impl.featureextractor.*
+import ch.tutteli.atrium.reporting.LazyRepresentation
+import ch.tutteli.atrium.reporting.Text
+import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.reporting.translating.Untranslatable
+
+/**
+ * Helps in using [FeatureExtractor] by providing a guide to set the different parameters in form of a fluent builder.
+ */
+interface FeatureExtractorBuilder {
+
+    companion object {
+        /**
+         * Entry point to use the [FeatureExtractorBuilder].
+         */
+        operator fun <T> invoke(assertionContainer: AssertionContainer<T>): DescriptionStep<T> =
+            DescriptionStep(assertionContainer)
+    }
+
+    /**
+     * Step which allows to specify the description which will be used to describe the feature.
+     *
+     * @param T the type of the current subject.
+     */
+    interface DescriptionStep<T> {
+        /**
+         * The previously specified assertion container from which we are going to extract the feature.
+         */
+        val container: AssertionContainer<T>
+
+        /**
+         * Uses [coreFactory].[newMethodCallFormatter][CoreFactory.newMethodCallFormatter] to create a description
+         * of a method call with the given [methodName] and the given [arguments].
+         *
+         * Use [withDescription] in case the feature extraction is not based on a method call.
+         */
+        fun methodCall(methodName: String, vararg arguments: Any?): RepresentationInCaseOfFailureStep<T> =
+            //TODO use methodCallFormatter from container 0.15.0
+            withDescription(coreFactory.newMethodCallFormatter().formatCall(methodName, arguments))
+
+        /**
+         * Uses the given [description], wraps it into an [Untranslatable] and uses it as description of the feature.
+         */
+        fun withDescription(description: String): RepresentationInCaseOfFailureStep<T> =
+            withDescription(Untranslatable(description))
+
+        /**
+         * Uses the given [translatable] as description of the feature.
+         */
+        fun withDescription(translatable: Translatable): RepresentationInCaseOfFailureStep<T>
+
+        companion object {
+            /**
+             * Creates a [DescriptionStep] in the context of the [FeatureExtractorBuilder].
+             */
+            operator fun <T> invoke(container: AssertionContainer<T>): DescriptionStep<T> =
+                DescriptionStepImpl(container)
+        }
+    }
+
+    /**
+     * Step which allows to to define the representation which shall be used
+     * in case the extraction cannot be performed.
+     *
+     * @param T the type of the current subject.
+     */
+    interface RepresentationInCaseOfFailureStep<T> {
+        /**
+         * The previously specified assertion container from which we are going to extract the feature.
+         */
+        val container: AssertionContainer<T>
+
+        /**
+         * The previously specified description which describes the kind of feature extraction.
+         */
+        val description: Translatable
+
+        /**
+         * Uses the given [representationProvider], by turning it into a [LazyRepresentation],
+         * to get the representation which will be used in case the extraction cannot be performed.
+         */
+        fun withRepresentationForFailure(representationProvider: () -> Any?): FeatureExtractionStep<T> =
+            withRepresentationForFailure(LazyRepresentation(representationProvider))
+
+        /**
+         * Uses the given [representation] in case the extraction cannot be performed.
+         *
+         * Notice, if you want to use text (a [String] which is treated as raw string in reporting) as representation,
+         * then wrap it into a [Text] and pass it instead.
+         */
+        fun withRepresentationForFailure(representation: Any): FeatureExtractionStep<T>
+
+        companion object {
+            /**
+             * Creates a [RepresentationInCaseOfFailureStep] in the context of the [FeatureExtractorBuilder].
+             */
+            operator fun <T> invoke(
+                container: AssertionContainer<T>,
+                description: Translatable
+            ): RepresentationInCaseOfFailureStep<T> =
+                RepresentationInCaseOfFailureStepImpl(container, description)
+        }
+    }
+
+    /**
+     * Step to define the feature extraction as such where a one can include a check by returning [None] in case the
+     * extraction should not be carried out.
+     *
+     * @param T the type of the current subject.
+     */
+    interface FeatureExtractionStep<T> {
+        /**
+         * The previously specified assertion container from which we are going to extract the feature.
+         */
+        val container: AssertionContainer<T>
+
+        /**
+         * The previously specified description which describes the kind of feature extraction.
+         */
+
+        val description: Translatable
+
+        /**
+         * The previously specified representation which will be used in case the feature cannot be extracted.
+         */
+        val representationForFailure: Any
+
+        /**
+         * Defines the feature extraction as such which is most likely based on the current subject
+         * (but does not need to be).
+         *
+         * @param extraction A function returning either [Some] with the corresponding feature or [None] in case the
+         *   extraction cannot be carried out.
+         */
+        fun <R> withFeatureExtraction(extraction: (subject: T) -> Option<R>): OptionsStep<T, R>
+
+        companion object {
+            /**
+             * Creates a [FeatureExtractionStep] in the context of the [FeatureExtractorBuilder].
+             */
+            operator fun <T> invoke(
+                container: AssertionContainer<T>,
+                description: Translatable,
+                representationForFailure: Any
+            ): FeatureExtractionStep<T> = FeatureExtractionStepImpl(
+                container, description, representationForFailure
+            )
+        }
+    }
+
+    /**
+     * Step which allows to override previously defined properties -- such as: use a different description -- but
+     * also allows to define options where usually a default value is used -- e.g. per default the subject itself is
+     * use as representation, this can be changed.
+     *
+     * @param T the type of the subject.
+     */
+    interface OptionsStep<T, R> {
+        /**
+         * The so far chosen options up to the [FeatureExtractionStep] step.
+         */
+        val featureExtractionStep: FeatureExtractionStep<T>
+
+        /**
+         * The previously specified feature extraction lambda.
+         */
+        val featureExtraction: (T) -> Option<R>
+
+        /**
+         * Allows to define the [FeatureExpectOptions] via an [FeatureExpectOptionsChooser]-lambda
+         * which provides convenience functions.
+         *
+         * A convenience function usually starts with `with...` and is sometimes overloaded to ease the configuration.
+         */
+        @ExperimentalNewExpectTypes
+        fun withOptions(configuration: FeatureExpectOptionsChooser<R>.() -> Unit): FinalStep<T, R> =
+            withOptions(FeatureExpectOptions(configuration))
+
+        /**
+         * Uses the given [expectOptions].
+         */
+        @ExperimentalNewExpectTypes
+        fun withOptions(expectOptions: FeatureExpectOptions<R>): FinalStep<T, R>
+
+        /**
+         * States explicitly that no optional [FeatureExpectOptions] are defined, which means, the [FeatureExtractor]
+         * will create a new [AssertionContainer] based on the previously defined mandatory options
+         * but without any optional options or in other words, the default values are used for the optional options.
+         *
+         * Use [withOptions] if you want to define optional [FeatureExpectOptions] such as, override the
+         * description, define an own representation etc.
+         */
+        fun withoutOptions(): FinalStep<T, R>
+
+        companion object {
+            operator fun <T, R> invoke(
+                featureExtractionStep: FeatureExtractionStep<T>,
+                featureExtraction: (T) -> Option<R>
+            ): OptionsStep<T, R> = OptionsStepImpl(featureExtractionStep, featureExtraction)
+        }
+    }
+
+    /**
+     * Final step in the help-me-to-call-[FeatureExtractor]-process, which creates an [ExecutionStep] incorporating all
+     * chosen options and is able to call [SubjectChanger] accordingly.
+     *
+     * @param T the type of the current subject.
+     * @param R the type of the new subject.
+     */
+    interface FinalStep<T, R> {
+        /**
+         * The so far chosen options up to the [FeatureExtractionStep] step.
+         */
+        val featureExtractionStep: FeatureExtractionStep<T>
+
+        /**
+         * The previously specified feature extraction lambda.
+         */
+        val featureExtraction: (T) -> Option<R>
+
+        /**
+         * Either the previously specified [FeatureExpectOptions] or `null`.
+         */
+        @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+        @UseExperimental(ExperimentalNewExpectTypes::class)
+        val featureExpectOptions: FeatureExpectOptions<R>?
+
+        /**
+         * Finishes the help-me-to-call-[FeatureExtractor]-process by creating an [ExecutionStep] incorporating all
+         * previously chosen options.
+         *
+         * @return The [ExecutionStep] which allows to define how the change shall be carried out.
+         */
+        fun build(): ExecutionStep<T, R>
+
+        companion object {
+            /**
+             * Creates the [FinalStep] in the context of the [FeatureExtractorBuilder].
+             */
+            @ExperimentalNewExpectTypes
+            operator fun <T, R> invoke(
+                featureExtractionStep: FeatureExtractionStep<T>,
+                featureExtraction: (T) -> Option<R>,
+                featureExpectOptions: FeatureExpectOptions<R>
+            ): FinalStep<T, R> = FinalStepImpl(
+                featureExtractionStep, featureExtraction, featureExpectOptions
+            )
+        }
+    }
+
+    /**
+     * Step which allows to decide how the transformation shall be executed.
+     *
+     * For instance, if it shall just perform the feature extraction and return the new [Expect] of type [R]
+     * or if it shall pass an assertionCreator-lambda which creates sub-assertions etc.
+     */
+    interface ExecutionStep<T, R> : TransformationExecutionStep<T, R, FeatureExpect<T, R>> {
+
+        companion object {
+            /**
+             * Creates the [FinalStep] in the context of the [SubjectChangerBuilder].
+             */
+            operator fun <T, R> invoke(
+                container: AssertionContainer<T>,
+                action: (AssertionContainer<T>) -> FeatureExpect<T, R>,
+                actionAndApply: (AssertionContainer<T>, Expect<R>.() -> Unit) -> Expect<R>
+            ): ExecutionStep<T, R> = ExecutionStepImpl(container, action, actionAndApply)
+        }
+    }
+
+}
+

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/SubjectChanger.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/SubjectChanger.kt
@@ -56,9 +56,7 @@ interface SubjectChanger {
      * Since the subject could also be `null` it makes sense to report this assertion instead of failing
      * with an exception.
      *
-     * @param container the assertion container with the current subject (before the change) --
-     *   if you use `ExpectImpl.changeSubject.reported(...)` within an assertion function (an extension function of
-     *   [Expect]) then you usually pass `this` (so the instance of [Expect]) for this parameter.
+     * @param container the assertion container with the current subject (before the change)
      * @param description Describes the kind of subject change (e.g. in case of a type change `is a`).
      * @param representation Representation of the change (e.g. in case of a type transformation the KClass).
      * @param transformation Provides the subject wrapped into a [Some] if the extraction as such can be carried out

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder.kt
@@ -23,8 +23,8 @@ interface SubjectChangerBuilder {
         /**
          * Entry point to use the [SubjectChangerBuilder].
          */
-        operator fun <T> invoke(assertionContainer: AssertionContainer<T>): KindStep<T> =
-            KindStepImpl(assertionContainer)
+        operator fun <T> invoke(container: AssertionContainer<T>): KindStep<T> =
+            KindStepImpl(container)
     }
 
     /**
@@ -232,10 +232,10 @@ interface SubjectChangerBuilder {
         val failureHandler: SubjectChanger.FailureHandler<T, R>
 
         /**
-         * Finishes the `reported subject change`-process by building a new [Expect] taking the previously chosen
-         * options into account.
+         * Finishes the help-me-to-call-[SubjectChanger]-process by creating an [ExecutionStep] incorporating all
+         * previously chosen options.
          *
-         * @return The [ExecutionStep] which allows to define who the change shall be carried out.
+         * @return The [ExecutionStep] which allows to define how the change shall be carried out.
          */
         fun build(): ExecutionStep<T, R>
 
@@ -254,8 +254,8 @@ interface SubjectChangerBuilder {
     /**
      * Step which allows to decide how the transformation shall be executed.
      *
-     * For instance, if it shall just perform the transformation and return the new [Expect] of type [R] or if it shall
-     * pass an assertionCreator-lambda which creates sub-assertions etc.
+     * For instance, if it shall just perform the transformation and return the new [Expect] of type [R]
+     * or if it shall pass an assertionCreator-lambda which creates sub-assertions etc.
      */
     interface ExecutionStep<T, R> : TransformationExecutionStep<T, R, Expect<R>> {
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep.kt
@@ -1,7 +1,6 @@
 package ch.tutteli.atrium.logic.creating.transformers
 
 import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 
 /**

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
@@ -1,0 +1,72 @@
+package ch.tutteli.atrium.logic.creating.transformers.impl
+
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.assertions.builders.fixedClaimGroup
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.FeatureExpect
+import ch.tutteli.atrium.creating.FeatureExpectOptions
+import ch.tutteli.atrium.domain.builders.creating.collectors.collectAssertions
+import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractor
+import ch.tutteli.atrium.logic.toExpect
+import ch.tutteli.atrium.reporting.translating.Translatable
+
+class DefaultFeatureExtractor : FeatureExtractor {
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalNewExpectTypes::class)
+    override fun <T, R> extract(
+        container: AssertionContainer<T>,
+        description: Translatable,
+        representationForFailure: Any,
+        featureExtraction: (T) -> Option<R>,
+        maybeSubAssertions: Option<Expect<R>.() -> Unit>,
+        featureExpectOptions: FeatureExpectOptions<R>
+    ): FeatureExpect<T, R> {
+        fun createFeatureExpect(subject: Option<R>, assertions: List<Assertion>) =
+            FeatureExpect(
+                container.toExpect(),
+                subject,
+                description,
+                assertions,
+                featureExpectOptions
+            )
+
+        return container.maybeSubject
+            .flatMap { subject -> featureExtraction(subject) }
+            .fold(
+                {
+                    container.addAssertion(
+                        assertionBuilder.fixedClaimGroup
+                            .withFeatureType
+                            .failing
+                            .withDescriptionAndRepresentation(description, representationForFailure)
+                            .withAssertions(maybeSubAssertions.fold({
+                                listOf<Assertion>()
+                            }) { assertionCreator ->
+                                listOf(
+                                    assertionBuilder.explanatoryGroup.withDefaultType
+                                        .collectAssertions(None, assertionCreator)
+                                        .build()
+                                )
+                            })
+                            .build()
+                    )
+                    createFeatureExpect(None, listOf())
+                },
+                { subject ->
+                    createFeatureExpect(Some(subject), maybeSubAssertions.fold({
+                        listOf<Assertion>()
+                    }) { assertionCreator ->
+                        assertionCollector.collectForComposition(Some(subject), assertionCreator)
+                    })
+                }
+            )
+    }
+
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/defaultImpls.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/defaultImpls.kt
@@ -1,0 +1,97 @@
+package ch.tutteli.atrium.logic.creating.transformers.impl.featureextractor
+
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.FeatureExpect
+import ch.tutteli.atrium.creating.FeatureExpectOptions
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
+import ch.tutteli.atrium.logic.creating.transformers.featureExtractor
+import ch.tutteli.atrium.logic.creating.transformers.impl.BaseTransformationExecutionStep
+import ch.tutteli.atrium.reporting.translating.Translatable
+
+class DescriptionStepImpl<T>(
+    override val container: AssertionContainer<T>
+) : FeatureExtractorBuilder.DescriptionStep<T> {
+
+    override fun withDescription(
+        translatable: Translatable
+    ): FeatureExtractorBuilder.RepresentationInCaseOfFailureStep<T> =
+        FeatureExtractorBuilder.RepresentationInCaseOfFailureStep(container, translatable)
+}
+
+internal class RepresentationInCaseOfFailureStepImpl<T>(
+    override val container: AssertionContainer<T>,
+    override val description: Translatable
+) : FeatureExtractorBuilder.RepresentationInCaseOfFailureStep<T> {
+    override fun withRepresentationForFailure(representation: Any): FeatureExtractorBuilder.FeatureExtractionStep<T> =
+        FeatureExtractorBuilder.FeatureExtractionStep(container, description, representation)
+}
+
+class FeatureExtractionStepImpl<T>(
+    override val container: AssertionContainer<T>,
+    override val description: Translatable,
+    override val representationForFailure: Any
+) : FeatureExtractorBuilder.FeatureExtractionStep<T> {
+
+    override fun <R> withFeatureExtraction(extraction: (T) -> Option<R>): FeatureExtractorBuilder.OptionsStep<T, R> =
+        FeatureExtractorBuilder.OptionsStep(this, extraction)
+}
+
+class OptionsStepImpl<T, R>(
+    override val featureExtractionStep: FeatureExtractorBuilder.FeatureExtractionStep<T>,
+    override val featureExtraction: (T) -> Option<R>
+) : FeatureExtractorBuilder.OptionsStep<T, R> {
+
+    @ExperimentalNewExpectTypes
+    override fun withOptions(expectOptions: FeatureExpectOptions<R>): FeatureExtractorBuilder.FinalStep<T, R> =
+        createFinalStep(expectOptions)
+
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalNewExpectTypes::class)
+    override fun withoutOptions(): FeatureExtractorBuilder.FinalStep<T, R> = createFinalStep(FeatureExpectOptions())
+
+    @ExperimentalNewExpectTypes
+    private fun createFinalStep(featureExpectOptions: FeatureExpectOptions<R>) =
+        FeatureExtractorBuilder.FinalStep(
+            featureExtractionStep,
+            featureExtraction,
+            featureExpectOptions
+        )
+}
+
+class FinalStepImpl<T, R>(
+    override val featureExtractionStep: FeatureExtractorBuilder.FeatureExtractionStep<T>,
+    override val featureExtraction: (T) -> Option<R>,
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalNewExpectTypes::class)
+    override val featureExpectOptions: FeatureExpectOptions<R>
+) : FeatureExtractorBuilder.FinalStep<T, R> {
+
+    override fun build(): FeatureExtractorBuilder.ExecutionStep<T, R> =
+        FeatureExtractorBuilder.ExecutionStep(
+            featureExtractionStep.container,
+            action = { container -> extractIt(container, None) },
+            actionAndApply = { container, assertionCreator -> extractIt(container, Some(assertionCreator)) }
+        )
+
+    private fun extractIt(container: AssertionContainer<T>, maybeSubAssertions: Option<Expect<R>.() -> Unit>): FeatureExpect<T, R> =
+        container.featureExtractor.extract(
+            container,
+            featureExtractionStep.description,
+            featureExtractionStep.representationForFailure,
+            featureExtraction,
+            maybeSubAssertions,
+            featureExpectOptions
+        )
+}
+
+class ExecutionStepImpl<T, R>(
+    container: AssertionContainer<T>,
+    action: AssertionContainer<T>.() -> FeatureExpect<T, R>,
+    actionAndApply: AssertionContainer<T>.(Expect<R>.() -> Unit) -> Expect<R>
+) : FeatureExtractorBuilder.ExecutionStep<T, R>,
+    BaseTransformationExecutionStep<T, R, FeatureExpect<T, R>>(container, action, actionAndApply)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impls.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impls.kt
@@ -2,9 +2,15 @@ package ch.tutteli.atrium.logic.creating.transformers
 
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.logic.creating.transformers.impl.DefaultFeatureExtractor
 import ch.tutteli.atrium.logic.creating.transformers.impl.DefaultSubjectChanger
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)
 val <T> AssertionContainer<T>.subjectChanger: SubjectChanger
     get() = getImpl(SubjectChanger::class) { DefaultSubjectChanger() }
+
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
+val <T> AssertionContainer<T>.featureExtractor: FeatureExtractor
+    get() = getImpl(FeatureExtractor::class) { DefaultFeatureExtractor() }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
@@ -38,10 +38,10 @@ class DefaultAnyAssertions : AnyAssertions {
         container: AssertionContainer<T?>,
         type: KClass<T>,
         assertionCreator: Expect<T>.() -> Unit
-    ) = container.notToBeNullBut(type).collect(assertionCreator)
+    ) = container.notToBeNullButOfType(type).collect(assertionCreator)
 
 
-    override fun <T : Any> notToBeNullBut(
+    override fun <T : Any> notToBeNullButOfType(
         container: AssertionContainer<T?>,
         subType: KClass<T>
     ):  SubjectChangerBuilder.ExecutionStep<T?, T> = container.isA(subType)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultCollectionLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultCollectionLikeAssertions.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.CollectionLikeAssertions
 import ch.tutteli.atrium.logic.createDescriptiveAssertion
 import ch.tutteli.atrium.logic.creating.typeutils.CollectionLike
@@ -19,6 +19,6 @@ class DefaultCollectionLikeAssertions : CollectionLikeAssertions {
     override fun <T : CollectionLike> isNotEmpty(container: AssertionContainer<T>, converter: (T) -> Collection<*>): Assertion =
         container.createDescriptiveAssertion(IS_NOT, EMPTY) { converter(it).isNotEmpty() }
 
-    override fun <T : CollectionLike> size(container: AssertionContainer<T>, converter: (T) -> Collection<*>): ExtractedFeaturePostStep<T, Int> =
+    override fun <T : CollectionLike> size(container: AssertionContainer<T>, converter: (T) -> Collection<*>): FeatureExtractorBuilder.ExecutionStep<T, Int> =
         container.manualFeature(SIZE) { converter(this).size }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFeatureAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFeatureAssertions.kt
@@ -1,11 +1,12 @@
 package ch.tutteli.atrium.logic.impl
 
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.coreFactory
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.domain.creating.MetaFeature
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.FeatureAssertions
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.extractFeature
 import ch.tutteli.atrium.logic.genericFeature
 import ch.tutteli.atrium.logic.toExpect
@@ -18,25 +19,25 @@ import kotlin.reflect.*
 class DefaultFeatureAssertions : FeatureAssertions {
 
     //@formatter:off
-    override fun <T, TProperty> property(container: AssertionContainer<T>, property: KProperty1<in T, TProperty>): ExtractedFeaturePostStep<T, TProperty> =
+    override fun <T, TProperty> property(container: AssertionContainer<T>, property: KProperty1<in T, TProperty>): FeatureExtractorBuilder.ExecutionStep<T, TProperty> =
         extractFeature(container, property.name, property::get)
 
-    override fun <T, R> f0(container: AssertionContainer<T>, f: KFunction1<T, R>): ExtractedFeaturePostStep<T, R> =
+    override fun <T, R> f0(container: AssertionContainer<T>, f: KFunction1<T, R>): FeatureExtractorBuilder.ExecutionStep<T, R> =
         extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf()), f::invoke)
 
-    override fun <T, A1, R> f1(container: AssertionContainer<T>, f: KFunction2<T, A1, R>, a1: A1): ExtractedFeaturePostStep<T, R> =
+    override fun <T, A1, R> f1(container: AssertionContainer<T>, f: KFunction2<T, A1, R>, a1: A1): FeatureExtractorBuilder.ExecutionStep<T, R> =
         extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf<Any?>(a1))) { f(it, a1) }
 
-    override fun <T, A1, A2, R> f2(container: AssertionContainer<T>, f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): ExtractedFeaturePostStep<T, R> =
+    override fun <T, A1, A2, R> f2(container: AssertionContainer<T>, f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): FeatureExtractorBuilder.ExecutionStep<T, R> =
         extractFeature(container ,coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2))) { f(it, a1, a2) }
 
-    override fun <T, A1, A2, A3, R> f3(container: AssertionContainer<T>, f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): ExtractedFeaturePostStep<T, R> =
+    override fun <T, A1, A2, A3, R> f3(container: AssertionContainer<T>, f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): FeatureExtractorBuilder.ExecutionStep<T, R> =
         extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2, a3))) { f(it, a1, a2, a3) }
 
-    override fun <T, A1, A2, A3, A4, R> f4(container: AssertionContainer<T>, f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): ExtractedFeaturePostStep<T, R> =
+    override fun <T, A1, A2, A3, A4, R> f4(container: AssertionContainer<T>, f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): FeatureExtractorBuilder.ExecutionStep<T, R> =
         extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2, a3, a4))) { f(it, a1, a2, a3, a4) }
 
-    override fun <T, A1, A2, A3, A4, A5, R> f5(container: AssertionContainer<T>, f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): ExtractedFeaturePostStep<T, R> =
+    override fun <T, A1, A2, A3, A4, A5, R> f5(container: AssertionContainer<T>, f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): FeatureExtractorBuilder.ExecutionStep<T, R> =
         extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2, a3, a4, a5))) { f(it, a1, a2, a3, a4, a5) }
     //@formatter:on
 
@@ -44,25 +45,25 @@ class DefaultFeatureAssertions : FeatureAssertions {
         container: AssertionContainer<T>,
         description: String,
         provider: T.() -> R
-    ): ExtractedFeaturePostStep<T, R> = extractFeature(container, description, provider)
+    ): FeatureExtractorBuilder.ExecutionStep<T, R> = extractFeature(container, description, provider)
 
     override fun <T, R> manualFeature(
         container: AssertionContainer<T>,
         description: Translatable,
         provider: T.() -> R
-    ): ExtractedFeaturePostStep<T, R> = container.genericFeature(createMetaFeature(container, description, provider))
+    ): FeatureExtractorBuilder.ExecutionStep<T, R> = container.genericFeature(createMetaFeature(container, description, provider))
 
     override fun <T, R> genericSubjectBasedFeature(
         container: AssertionContainer<T>,
         provider: (T) -> MetaFeature<R>
-    ): ExtractedFeaturePostStep<T, R> =
+    ): FeatureExtractorBuilder.ExecutionStep<T, R> =
         container.genericFeature(createSubjectBasedMetaFeature(container, provider))
 
     private fun <T, R> extractFeature(
         container: AssertionContainer<T>,
         description: String,
         provider: (T) -> R
-    ): ExtractedFeaturePostStep<T, R> =
+    ): FeatureExtractorBuilder.ExecutionStep<T, R> =
         container.genericFeature(createMetaFeature(container, description, provider))
 
     // TODO 0.14.0 probably not the best place
@@ -100,8 +101,10 @@ class DefaultFeatureAssertions : FeatureAssertions {
     override fun <T, R> genericFeature(
         container: AssertionContainer<T>,
         metaFeature: MetaFeature<R>
-    ): ExtractedFeaturePostStep<T, R> {
+    ): FeatureExtractorBuilder.ExecutionStep<T, R> {
         val representation: Any = metaFeature.representation ?: Text.NULL
+        @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+        @UseExperimental(ExperimentalNewExpectTypes::class)
         return container.extractFeature
             .withDescription(metaFeature.description)
             .withRepresentationForFailure(representation)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFun0Assertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFun0Assertions.kt
@@ -28,7 +28,7 @@ class DefaultFun0Assertions : Fun0Assertions {
         container.manualFeature(THROWN_EXCEPTION_WHEN_CALLED) {
             catchAndAdjustThrowable(this)
                 .fold({ it }, { /* use null as subject in case no exception occurred*/ null })
-        }.getExpectOfFeature().let { previousExpect ->
+        }.transform().let { previousExpect ->
             FeatureExpect(
                 previousExpect,
                 FeatureExpectOptions(representationInsteadOfFeature = { it ?: NO_EXCEPTION_OCCURRED })

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -4,12 +4,12 @@ import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.assertions.builders.fixedClaimGroup
 import ch.tutteli.atrium.assertions.builders.invisibleGroup
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.impl.NoOpSearchBehaviourImpl
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.impl.NotSearchBehaviourImpl
@@ -20,6 +20,7 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
@@ -109,19 +110,19 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
     override fun <T : Any, E : Comparable<E>> min(
         container: AssertionContainer<T>,
         converter: (T) -> Iterable<E>
-    ): ExtractedFeaturePostStep<T, E> = collect(container, converter, "min", Iterable<E>::min)
+    ): FeatureExtractorBuilder.ExecutionStep<T, E> = collect(container, converter, "min", Iterable<E>::min)
 
     override fun <T : Any, E : Comparable<E>> max(
         container: AssertionContainer<T>,
         converter: (T) -> Iterable<E>
-    ): ExtractedFeaturePostStep<T, E> = collect(container, converter, "max", Iterable<E>::max)
+    ): FeatureExtractorBuilder.ExecutionStep<T, E> = collect(container, converter, "max", Iterable<E>::max)
 
     private fun <T : Any, E : Comparable<E>> collect(
         container: AssertionContainer<T>,
         converter: (T) -> Iterable<E>,
         method: String,
         collect: Iterable<E>.() -> E?
-    ): ExtractedFeaturePostStep<T, E> =
+    ): FeatureExtractorBuilder.ExecutionStep<T, E> =
         container.extractFeature
             .methodCall(method)
             .withRepresentationForFailure(DescriptionIterableAssertion.NO_ELEMENTS)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultListAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultListAssertions.kt
@@ -2,14 +2,14 @@ package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.ListAssertions
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.extractFeature
 import ch.tutteli.atrium.translations.DescriptionListAssertion.INDEX_OUT_OF_BOUNDS
 
 class DefaultListAssertions : ListAssertions {
 
-    override fun <E, T : List<E>> get(container: AssertionContainer<T>, index: Int): ExtractedFeaturePostStep<T, E> =
+    override fun <E, T : List<E>> get(container: AssertionContainer<T>, index: Int): FeatureExtractorBuilder.ExecutionStep<T, E> =
         container.extractFeature
             .methodCall("get", index)
             .withRepresentationForFailure(INDEX_OUT_OF_BOUNDS)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultMapAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultMapAssertions.kt
@@ -6,8 +6,8 @@ import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.coreFactory
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.*
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic.IS
@@ -51,7 +51,7 @@ class DefaultMapAssertions : MapAssertions {
                     .withFeatureExtraction { extractKey(it, key) }
                     .withoutOptions()
                     .build()
-                    .addToInitial(assertionCreator)
+                    .collectAndAppend(assertionCreator)
             }
         }
         return assertionBuilder.list
@@ -93,7 +93,7 @@ class DefaultMapAssertions : MapAssertions {
     override fun <K, V, T : Map<out K, V>> getExisting(
         container: AssertionContainer<T>,
         key: K
-    ): ExtractedFeaturePostStep<T, V> =
+    ): FeatureExtractorBuilder.ExecutionStep<T, V> =
         container.extractFeature
             .methodCall("get", key)
             .withRepresentationForFailure(KEY_DOES_NOT_EXIST)
@@ -102,6 +102,6 @@ class DefaultMapAssertions : MapAssertions {
             .build()
 
 
-    override fun <T : Map<*, *>> size(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, Int> =
+    override fun <T : Map<*, *>> size(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, Int> =
         container.manualFeature(SIZE) { size }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultMapEntryAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultMapEntryAssertions.kt
@@ -2,20 +2,20 @@ package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.*
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 
 class DefaultMapEntryAssertions : MapEntryAssertions {
 
     override fun <K, V, T : Map.Entry<K, V>> isKeyValue(container: AssertionContainer<T>, key: K, value: V): Assertion =
         container.collect {
-            _logic.key().addToInitial { _logicAppend { toBe(key) } }
-            _logic.value().addToInitial { _logicAppend { toBe(value) } }
+            _logic.key().collectAndLogicAppend { toBe(key) }
+            _logic.value().collectAndLogicAppend { toBe(value) }
         }
 
-    override fun <K, T : Map.Entry<K, *>> key(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, K> =
+    override fun <K, T : Map.Entry<K, *>> key(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, K> =
         container.property(Map.Entry<K, *>::key)
 
-    override fun <V, T : Map.Entry<*, V>> value(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, V> =
+    override fun <V, T : Map.Entry<*, V>> value(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, V> =
         container.property(Map.Entry<*, V>::value)
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPairAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPairAssertions.kt
@@ -1,14 +1,14 @@
 package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.PairAssertions
 import ch.tutteli.atrium.logic.property
 
 class DefaultPairAssertions : PairAssertions {
-    override fun <K, T : Pair<K, *>> first(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, K> =
+    override fun <K, T : Pair<K, *>> first(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, K> =
         container.property(Pair<K, *>::first)
 
-    override fun <V, T : Pair<*, V>> second(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, V> =
+    override fun <V, T : Pair<*, V>> second(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, V> =
         container.property(Pair<*, V>::second)
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions.kt
@@ -4,12 +4,9 @@ import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.FeatureExpect
 import ch.tutteli.atrium.creating.FeatureExpectOptions
+import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
-import ch.tutteli.atrium.logic.ThrowableAssertions
-import ch.tutteli.atrium.logic.changeSubject
 import ch.tutteli.atrium.logic.creating.transformers.impl.ThrowableThrownFailureHandler
-import ch.tutteli.atrium.logic.manualFeature
-import ch.tutteli.atrium.logic.toAssertionContainer
 import ch.tutteli.atrium.translations.DescriptionThrowableAssertion
 import ch.tutteli.atrium.translations.DescriptionThrowableAssertion.OCCURRED_EXCEPTION_CAUSE
 import kotlin.reflect.KClass
@@ -22,7 +19,7 @@ class DefaultThrowableAssertions : ThrowableAssertions {
         container: AssertionContainer<out Throwable>,
         expectedType: KClass<TExpected>
     ):  SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
-        container.manualFeature(OCCURRED_EXCEPTION_CAUSE) { cause }.getExpectOfFeature().let { previousExpect ->
+        container.manualFeature(OCCURRED_EXCEPTION_CAUSE) { cause }.transform().let { previousExpect ->
             //TODO 0.14.0 factor out a pattern, we are doing this more than once, in API we have withOptions
             FeatureExpect(
                 previousExpect,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils.kt
@@ -12,10 +12,11 @@ import ch.tutteli.atrium.core.trueProvider
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.ExpectInternal
-import ch.tutteli.atrium.domain.builders.creating.changers.FeatureExtractorBuilder
 import ch.tutteli.atrium.domain.creating.collectors.AssertionCollector
 import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
+import ch.tutteli.atrium.logic.creating.transformers.TransformationExecutionStep
 import ch.tutteli.atrium.reporting.BUG_REPORT_URL
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -48,7 +49,7 @@ val <T> AssertionContainer<T>.changeSubject: SubjectChangerBuilder.KindStep<T>
  * Entry point to use the [FeatureExtractorBuilder] based on this [AssertionContainer].
  */
 val <T> AssertionContainer<T>.extractFeature: FeatureExtractorBuilder.DescriptionStep<T>
-    get() = FeatureExtractorBuilder.create(this.toExpect())
+    get() = FeatureExtractorBuilder(this)
 
 /**
  * Use this function if you want to make [Assertion]s about a feature or you perform a type transformation or any
@@ -107,3 +108,15 @@ fun <T> AssertionContainer<T>.toExpect(): Expect<T> =
         is ExpectInternal<T> -> this
         else -> throw UnsupportedOperationException("Unsupported AssertionContainer: $this -- Please open an issue that a hook shall be implemented: $BUG_REPORT_URL?template=feature_request&title=Hook%20for%20AssertionContainer.toExpect")
     }
+
+/**
+ * Finishes the transformation process by appending the [Assertion]
+ * which is returned when calling [TransformationExecutionStep.collectAndAppend] with [_logicAppend]
+ * and the given [assertionCreator].
+ *
+ * See [collect] for more information.
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ */
+fun <T, R> TransformationExecutionStep<T, R, *>.collectAndLogicAppend(assertionCreator: AssertionContainer<R>.() -> Assertion): Expect<T> =
+    collectAndAppend { _logicAppend(assertionCreator) }

--- a/logic/atrium-logic-common/src/test/kotlin/ch/tutteli/atrium/logic/creating/EitherSpec.kt
+++ b/logic/atrium-logic-common/src/test/kotlin/ch/tutteli/atrium/logic/creating/EitherSpec.kt
@@ -8,8 +8,8 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.extractFeature
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.translations.DescriptionCharSequenceAssertion
@@ -59,11 +59,11 @@ object EitherSpec : Spek({
     }
 })
 
-fun <A, B> Expect<Either<A, B>>.isLeft(): Expect<A> = extractLeft().getExpectOfFeature()
+fun <A, B> Expect<Either<A, B>>.isLeft(): Expect<A> = extractLeft().transform()
 fun <A, B> Expect<Either<A, B>>.isLeft(assertionCreator: Expect<A>.() -> Unit) =
-    extractLeft().addToInitial(assertionCreator)
+    extractLeft().collectAndAppend(assertionCreator)
 
-private fun <A, B> Expect<Either<A, B>>.extractLeft(): ExtractedFeaturePostStep<Either<A, B>, A> =
+private fun <A, B> Expect<Either<A, B>>.extractLeft(): FeatureExtractorBuilder.ExecutionStep<Either<A, B>, A> =
     _logic.extractFeature
         .withDescription("value of Left")
         .withRepresentationForFailure(Text("❗❗ is not a Left"))
@@ -73,11 +73,11 @@ private fun <A, B> Expect<Either<A, B>>.extractLeft(): ExtractedFeaturePostStep<
         .withoutOptions()
         .build()
 
-fun <A, B> Expect<Either<A, B>>.isRight(): Expect<B> = extractRight().getExpectOfFeature()
+fun <A, B> Expect<Either<A, B>>.isRight(): Expect<B> = extractRight().transform()
 fun <A, B> Expect<Either<A, B>>.isRight(assertionCreator: Expect<B>.() -> Unit) =
-    extractRight().addToInitial(assertionCreator)
+    extractRight().collectAndAppend(assertionCreator)
 
-private fun <A, B> Expect<Either<A, B>>.extractRight(): ExtractedFeaturePostStep<Either<A, B>, B> =
+private fun <A, B> Expect<Either<A, B>>.extractRight(): FeatureExtractorBuilder.ExecutionStep<Either<A, B>, B> =
     _logic.extractFeature
         .withDescription("value of Right")
         .withRepresentationForFailure(Text("❗❗ is not a Right"))

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDate.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDate.kt
@@ -12,15 +12,14 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.chrono.ChronoLocalDateTime
 
-fun AssertionContainer<LocalDate>.year(): ExtractedFeaturePostStep<LocalDate, Int> = _localDateImpl.year(this)
+fun AssertionContainer<LocalDate>.year(): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int> = _localDateImpl.year(this)
 
-fun AssertionContainer<LocalDate>.month(): ExtractedFeaturePostStep<LocalDate, Int> = _localDateImpl.month(this)
+fun AssertionContainer<LocalDate>.month(): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int> = _localDateImpl.month(this)
 
-fun AssertionContainer<LocalDate>.day(): ExtractedFeaturePostStep<LocalDate, Int> = _localDateImpl.day(this)
+fun AssertionContainer<LocalDate>.day(): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int> = _localDateImpl.day(this)
 
-fun AssertionContainer<LocalDate>.dayOfWeek(): ExtractedFeaturePostStep<LocalDate, DayOfWeek> = _localDateImpl.dayOfWeek(this)
+fun AssertionContainer<LocalDate>.dayOfWeek(): FeatureExtractorBuilder.ExecutionStep<LocalDate, DayOfWeek> = _localDateImpl.dayOfWeek(this)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDateTime.kt
@@ -12,15 +12,14 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.time.DayOfWeek
-import java.time.LocalDate
 import java.time.LocalDateTime
 
-fun AssertionContainer<LocalDateTime>.year(): ExtractedFeaturePostStep<LocalDateTime, Int> = _localDateTimeImpl.year(this)
+fun AssertionContainer<LocalDateTime>.year(): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int> = _localDateTimeImpl.year(this)
 
-fun AssertionContainer<LocalDateTime>.month(): ExtractedFeaturePostStep<LocalDateTime, Int> = _localDateTimeImpl.month(this)
+fun AssertionContainer<LocalDateTime>.month(): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int> = _localDateTimeImpl.month(this)
 
-fun AssertionContainer<LocalDateTime>.day(): ExtractedFeaturePostStep<LocalDateTime, Int> = _localDateTimeImpl.day(this)
+fun AssertionContainer<LocalDateTime>.day(): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int> = _localDateTimeImpl.day(this)
 
-fun AssertionContainer<LocalDateTime>.dayOfWeek(): ExtractedFeaturePostStep<LocalDateTime, DayOfWeek> = _localDateTimeImpl.dayOfWeek(this)
+fun AssertionContainer<LocalDateTime>.dayOfWeek(): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, DayOfWeek> = _localDateTimeImpl.dayOfWeek(this)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/optional.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/optional.kt
@@ -13,9 +13,8 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
-import java.time.LocalDateTime
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.util.*
 
 fun <T : Optional<*>> AssertionContainer<T>.isEmpty(): Assertion = _optionalImpl.isEmpty(this)
-fun <E, T : Optional<E>> AssertionContainer<T>.isPresent(): ExtractedFeaturePostStep<T, E> = _optionalImpl.isPresent(this)
+fun <E, T : Optional<E>> AssertionContainer<T>.isPresent(): FeatureExtractorBuilder.ExecutionStep<T, E> = _optionalImpl.isPresent(this)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
@@ -13,7 +13,7 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.nio.charset.Charset
 import java.nio.file.Path
 
@@ -36,8 +36,8 @@ fun <T : Path> AssertionContainer<T>.hasSameTextualContentAs(targetPath: Path, s
 
 fun <T : Path> AssertionContainer<T>.hasSameBinaryContentAs(targetPath: Path): Assertion = _pathImpl.hasSameBinaryContentAs(this, targetPath)
 
-fun <T : Path> AssertionContainer<T>.fileName(): ExtractedFeaturePostStep<T, String> = _pathImpl.fileName(this)
-fun <T : Path> AssertionContainer<T>.extension(): ExtractedFeaturePostStep<T, String> = _pathImpl.extension(this)
-fun <T : Path> AssertionContainer<T>.fileNameWithoutExtension(): ExtractedFeaturePostStep<T, String> = _pathImpl.fileNameWithoutExtension(this)
-fun <T : Path> AssertionContainer<T>.parent(): ExtractedFeaturePostStep<T, Path> = _pathImpl.parent(this)
-fun <T : Path> AssertionContainer<T>.resolve(other: String): ExtractedFeaturePostStep<T, Path> = _pathImpl.resolve(this, other)
+fun <T : Path> AssertionContainer<T>.fileName(): FeatureExtractorBuilder.ExecutionStep<T, String> = _pathImpl.fileName(this)
+fun <T : Path> AssertionContainer<T>.extension(): FeatureExtractorBuilder.ExecutionStep<T, String> = _pathImpl.extension(this)
+fun <T : Path> AssertionContainer<T>.fileNameWithoutExtension(): FeatureExtractorBuilder.ExecutionStep<T, String> = _pathImpl.fileNameWithoutExtension(this)
+fun <T : Path> AssertionContainer<T>.parent(): FeatureExtractorBuilder.ExecutionStep<T, Path> = _pathImpl.parent(this)
+fun <T : Path> AssertionContainer<T>.resolve(other: String): FeatureExtractorBuilder.ExecutionStep<T, Path> = _pathImpl.resolve(this, other)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/zonedDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/zonedDateTime.kt
@@ -12,15 +12,14 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
-import java.nio.file.Path
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-fun AssertionContainer<ZonedDateTime>.year(): ExtractedFeaturePostStep<ZonedDateTime, Int> = _zonedDateTimeImpl.year(this)
+fun AssertionContainer<ZonedDateTime>.year(): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int> = _zonedDateTimeImpl.year(this)
 
-fun AssertionContainer<ZonedDateTime>.month(): ExtractedFeaturePostStep<ZonedDateTime, Int> = _zonedDateTimeImpl.month(this)
+fun AssertionContainer<ZonedDateTime>.month(): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int> = _zonedDateTimeImpl.month(this)
 
-fun AssertionContainer<ZonedDateTime>.day(): ExtractedFeaturePostStep<ZonedDateTime, Int> = _zonedDateTimeImpl.day(this)
+fun AssertionContainer<ZonedDateTime>.day(): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int> = _zonedDateTimeImpl.day(this)
 
-fun AssertionContainer<ZonedDateTime>.dayOfWeek(): ExtractedFeaturePostStep<ZonedDateTime, DayOfWeek> = _zonedDateTimeImpl.dayOfWeek(this)
+fun AssertionContainer<ZonedDateTime>.dayOfWeek(): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, DayOfWeek> = _zonedDateTimeImpl.dayOfWeek(this)

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/LocalDateAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/LocalDateAssertions.kt
@@ -6,20 +6,19 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.chrono.ChronoLocalDateTime
 
 /**
  * Collection of assertion functions and builders which are applicable to subjects with a [LocalDate] type.
  */
 interface LocalDateAssertions {
-    fun year(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, Int>
+    fun year(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int>
 
-    fun month(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, Int>
+    fun month(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int>
 
-    fun day(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, Int>
+    fun day(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int>
 
-    fun dayOfWeek(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, DayOfWeek>
+    fun dayOfWeek(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, DayOfWeek>
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/LocalDateTimeAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/LocalDateTimeAssertions.kt
@@ -6,20 +6,19 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.time.DayOfWeek
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 /**
  * Collection of assertion functions and builders which are applicable to subjects with a [LocalDateTime] type.
  */
 interface LocalDateTimeAssertions {
-    fun year(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, Int>
+    fun year(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int>
 
-    fun month(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, Int>
+    fun month(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int>
 
-    fun day(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, Int>
+    fun day(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int>
 
-    fun dayOfWeek(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, DayOfWeek>
+    fun dayOfWeek(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, DayOfWeek>
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/OptionalAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/OptionalAssertions.kt
@@ -7,8 +7,7 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
-import java.time.LocalDateTime
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.util.*
 
 /**
@@ -16,6 +15,6 @@ import java.util.*
  */
 interface OptionalAssertions {
     fun <T : Optional<*>> isEmpty(container: AssertionContainer<T>): Assertion
-    fun <E, T : Optional<E>> isPresent(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, E>
+    fun <E, T : Optional<E>> isPresent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E>
 }
 

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
@@ -7,7 +7,7 @@ package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.nio.charset.Charset
 import java.nio.file.Path
 
@@ -38,9 +38,9 @@ interface PathAssertions {
 
     fun <T : Path> hasSameBinaryContentAs(container: AssertionContainer<T>, targetPath: Path): Assertion
 
-    fun <T : Path> fileName(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, String>
-    fun <T : Path> extension(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, String>
-    fun <T : Path> fileNameWithoutExtension(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, String>
-    fun <T : Path> parent(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, Path>
-    fun <T : Path> resolve(container: AssertionContainer<T>, other: String): ExtractedFeaturePostStep<T, Path>
+    fun <T : Path> fileName(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String>
+    fun <T : Path> extension(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String>
+    fun <T : Path> fileNameWithoutExtension(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String>
+    fun <T : Path> parent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, Path>
+    fun <T : Path> resolve(container: AssertionContainer<T>, other: String): FeatureExtractorBuilder.ExecutionStep<T, Path>
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/ZonedDateTimeAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/ZonedDateTimeAssertions.kt
@@ -6,8 +6,7 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
-import java.nio.file.Path
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
@@ -15,11 +14,11 @@ import java.time.ZonedDateTime
  * Collection of assertion functions and builders which are applicable to subjects with a [ZonedDateTime] type.
  */
 interface ZonedDateTimeAssertions {
-    fun year(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, Int>
+    fun year(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int>
 
-    fun month(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, Int>
+    fun month(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int>
 
-    fun day(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, Int>
+    fun day(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int>
 
-    fun dayOfWeek(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, DayOfWeek>
+    fun dayOfWeek(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, DayOfWeek>
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultLocalDateAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultLocalDateAssertions.kt
@@ -6,8 +6,8 @@
 package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.LocalDateAssertions
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.manualFeature
 import ch.tutteli.atrium.translations.DescriptionDateTimeLikeAssertion.*
 import java.time.DayOfWeek
@@ -15,15 +15,15 @@ import java.time.LocalDate
 
 class DefaultLocalDateAssertions : LocalDateAssertions {
 
-    override fun year(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, Int> =
+    override fun year(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int> =
         container.manualFeature(YEAR) { year }
 
-    override fun month(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, Int> =
+    override fun month(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int> =
         container.manualFeature(MONTH) { monthValue }
 
-    override fun day(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, Int> =
+    override fun day(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, Int> =
         container.manualFeature(DAY) { dayOfMonth }
 
-    override fun dayOfWeek(container: AssertionContainer<LocalDate>): ExtractedFeaturePostStep<LocalDate, DayOfWeek> =
+    override fun dayOfWeek(container: AssertionContainer<LocalDate>): FeatureExtractorBuilder.ExecutionStep<LocalDate, DayOfWeek> =
         container.manualFeature(DAY_OF_WEEK) { dayOfWeek }
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultLocalDateTimeAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultLocalDateTimeAssertions.kt
@@ -6,7 +6,7 @@
 package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.LocalDateTimeAssertions
 import ch.tutteli.atrium.logic.manualFeature
 import ch.tutteli.atrium.translations.DescriptionDateTimeLikeAssertion.*
@@ -14,15 +14,15 @@ import java.time.DayOfWeek
 import java.time.LocalDateTime
 
 class DefaultLocalDateTimeAssertions : LocalDateTimeAssertions {
-    override fun year(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, Int> =
+    override fun year(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int> =
         container.manualFeature(YEAR) { year }
 
-    override fun month(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, Int> =
+    override fun month(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int> =
         container.manualFeature(MONTH) { monthValue }
 
-    override fun day(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, Int> =
+    override fun day(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, Int> =
         container.manualFeature(DAY) { dayOfMonth }
 
-    override fun dayOfWeek(container: AssertionContainer<LocalDateTime>): ExtractedFeaturePostStep<LocalDateTime, DayOfWeek> =
+    override fun dayOfWeek(container: AssertionContainer<LocalDateTime>): FeatureExtractorBuilder.ExecutionStep<LocalDateTime, DayOfWeek> =
         container.manualFeature(DAY_OF_WEEK) { dayOfWeek }
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultOptionalAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultOptionalAssertions.kt
@@ -8,9 +8,9 @@ package ch.tutteli.atrium.logic.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.OptionalAssertions
 import ch.tutteli.atrium.logic.createDescriptiveAssertion
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.extractFeature
 import ch.tutteli.atrium.translations.DescriptionBasic.IS
 import ch.tutteli.atrium.translations.DescriptionOptionalAssertion.*
@@ -21,7 +21,7 @@ class DefaultOptionalAssertions : OptionalAssertions {
     override fun <T : Optional<*>> isEmpty(container: AssertionContainer<T>): Assertion =
         container.createDescriptiveAssertion(IS, EMPTY) { !it.isPresent }
 
-    override fun <E, T : Optional<E>> isPresent(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, E> =
+    override fun <E, T : Optional<E>> isPresent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E> =
         container.extractFeature
             .withDescription(GET)
             .withRepresentationForFailure(IS_NOT_PRESENT)

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
@@ -11,13 +11,13 @@ import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.creating.filesystem.Failure
 import ch.tutteli.atrium.logic.creating.filesystem.IoResult
 import ch.tutteli.atrium.logic.creating.filesystem.Success
 import ch.tutteli.atrium.logic.creating.filesystem.hints.*
 import ch.tutteli.atrium.logic.creating.filesystem.runCatchingIo
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
@@ -148,18 +148,18 @@ class DefaultPathAssertions : PathAssertions {
     }
 
 
-    override fun <T : Path> fileName(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, String> =
+    override fun <T : Path> fileName(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String> =
         container.manualFeature(FILE_NAME) { fileName.toString() }
 
-    override fun <T : Path> extension(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, String> =
+    override fun <T : Path> extension(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String> =
         container.manualFeature(EXTENSION) { extension }
 
     override fun <T : Path> fileNameWithoutExtension(
         container: AssertionContainer<T>
-    ): ExtractedFeaturePostStep<T, String> =
+    ): FeatureExtractorBuilder.ExecutionStep<T, String> =
         container.manualFeature(FILE_NAME_WITHOUT_EXTENSION) { fileNameWithoutExtension }
 
-    override fun <T : Path> parent(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, Path> =
+    override fun <T : Path> parent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, Path> =
         container.extractFeature
             .withDescription(PARENT)
             .withRepresentationForFailure(DOES_NOT_HAVE_PARENT)
@@ -173,6 +173,6 @@ class DefaultPathAssertions : PathAssertions {
     override fun <T : Path> resolve(
         container: AssertionContainer<T>,
         other: String
-    ): ExtractedFeaturePostStep<T, Path> = container.f1<T, String, Path>(Path::resolve, other)
+    ): FeatureExtractorBuilder.ExecutionStep<T, Path> = container.f1<T, String, Path>(Path::resolve, other)
 
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultZonedDateTimeAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultZonedDateTimeAssertions.kt
@@ -6,7 +6,7 @@
 package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.ZonedDateTimeAssertions
 import ch.tutteli.atrium.logic.manualFeature
 import ch.tutteli.atrium.translations.DescriptionDateTimeLikeAssertion
@@ -15,15 +15,15 @@ import java.time.ZonedDateTime
 
 
 class DefaultZonedDateTimeAssertions : ZonedDateTimeAssertions {
-    override fun year(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, Int> =
+    override fun year(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int> =
         container.manualFeature(DescriptionDateTimeLikeAssertion.YEAR) { year }
 
-    override fun month(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, Int> =
+    override fun month(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int> =
         container.manualFeature(DescriptionDateTimeLikeAssertion.MONTH) { monthValue }
 
-    override fun day(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, Int> =
+    override fun day(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, Int> =
         container.manualFeature(DescriptionDateTimeLikeAssertion.DAY) { dayOfMonth }
 
-    override fun dayOfWeek(container: AssertionContainer<ZonedDateTime>): ExtractedFeaturePostStep<ZonedDateTime, DayOfWeek> =
+    override fun dayOfWeek(container: AssertionContainer<ZonedDateTime>): FeatureExtractorBuilder.ExecutionStep<ZonedDateTime, DayOfWeek> =
         container.manualFeature(DescriptionDateTimeLikeAssertion.DAY_OF_WEEK) { dayOfWeek }
 }

--- a/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/generated/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/result.kt
+++ b/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/generated/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/result.kt
@@ -7,10 +7,10 @@
 package ch.tutteli.atrium.logic.kotlin_1_3
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import kotlin.reflect.KClass
 
-fun <E, T : Result<E>> AssertionContainer<T>.isSuccess(): ExtractedFeaturePostStep<T, E> = _resultImpl.isSuccess(this)
+fun <E, T : Result<E>> AssertionContainer<T>.isSuccess(): FeatureExtractorBuilder.ExecutionStep<T, E> = _resultImpl.isSuccess(this)
 
 fun <TExpected : Throwable> AssertionContainer<out Result<*>>.isFailureOfType(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = _resultImpl.isFailureOfType(this, expectedType)

--- a/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/ResultAssertions.kt
+++ b/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/ResultAssertions.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.logic.kotlin_1_3
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import kotlin.reflect.KClass
 
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
  * Collection of assertion functions and builders which are applicable to subjects with a [Result] type.
  */
 interface ResultAssertions {
-    fun <E, T : Result<E>> isSuccess(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, E>
+    fun <E, T : Result<E>> isSuccess(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E>
 
     fun <TExpected : Throwable> isFailureOfType(
         container: AssertionContainer<out Result<*>>,

--- a/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -6,8 +6,8 @@ import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.FeatureExpect
 import ch.tutteli.atrium.creating.FeatureExpectOptions
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
-import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
 import ch.tutteli.atrium.logic.changeSubject
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.impl.ThrowableThrownFailureHandler
 import ch.tutteli.atrium.logic.extractFeature
 import ch.tutteli.atrium.logic.kotlin_1_3.ResultAssertions
@@ -17,7 +17,7 @@ import ch.tutteli.atrium.translations.DescriptionResultAssertion.*
 import kotlin.reflect.KClass
 
 class DefaultResultAssertions : ResultAssertions {
-    override fun <E, T : Result<E>> isSuccess(container: AssertionContainer<T>): ExtractedFeaturePostStep<T, E> =
+    override fun <E, T : Result<E>> isSuccess(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E> =
         container.extractFeature
             .withDescription(VALUE)
             .withRepresentationForFailure(IS_NOT_SUCCESS)
@@ -33,7 +33,7 @@ class DefaultResultAssertions : ResultAssertions {
         container: AssertionContainer<out Result<*>>,
         expectedType: KClass<TExpected>
     ):  SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
-        container.manualFeature(EXCEPTION) { exceptionOrNull() }.getExpectOfFeature().let { previousExpect ->
+        container.manualFeature(EXCEPTION) { exceptionOrNull() }.transform().let { previousExpect ->
             FeatureExpect(
                 previousExpect,
                 FeatureExpectOptions(representationInsteadOfFeature = { it ?: IS_NOT_FAILURE })

--- a/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/ChangedSubjectPostStep.kt
+++ b/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/ChangedSubjectPostStep.kt
@@ -1,3 +1,6 @@
+//TODO remove with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.creating.changers
 
 import ch.tutteli.atrium.creating.Expect

--- a/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/ExtractedFeaturePostStep.kt
+++ b/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/ExtractedFeaturePostStep.kt
@@ -1,3 +1,6 @@
+//TODO remove with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.creating.changers
 
 import ch.tutteli.atrium.creating.Expect
@@ -16,7 +19,13 @@ import ch.tutteli.atrium.creating.FeatureExpect
  * @param extractAndApply The extraction of the feature which not only creates and
  *   returns a new [Expect] of type [R] but also applies a given assertionCreator lambda.
  */
-//TODO 0.14.0 move to atrium-logic
+@Deprecated(
+    "Use FeatureExtractorBuilder.ExecutionStep from atrium-logic; will be removed with 1.0.0",
+    ReplaceWith(
+        "ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder.ExecutionStep(expect._logic, extract, extractAndApply)",
+        "ch.tutteli.atrium.logic._logic"
+    )
+)
 class ExtractedFeaturePostStep<T, R>(
     expect: Expect<T>,
     extract: Expect<T>.() -> FeatureExpect<T, R>,

--- a/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/FeatureExtractor.kt
+++ b/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/FeatureExtractor.kt
@@ -1,3 +1,4 @@
+//TODO remove with 1.0.0
 @file:Suppress("DEPRECATION")
 
 package ch.tutteli.atrium.domain.creating.changers
@@ -16,6 +17,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  *
  * It loads the implementation lazily via [loadSingleService].
  */
+@Deprecated("Use _logic.featureExtractor from atrium-logic; will be removed with 1.0.0")
 val featureExtractor by lazy { loadSingleService(FeatureExtractor::class) }
 
 /**
@@ -28,7 +30,10 @@ val featureExtractor by lazy { loadSingleService(FeatureExtractor::class) }
  * that the call/access fails depending on given arguments.
  * For instance, [List.get] is a good example where it fails if the given index is out of bounds.
  */
-//TODO 0.14.0 move to atrium-logic
+@Deprecated(
+    "Use FeatureExtractor from atrium-logic; will be removed with 1.0.0",
+    ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractor")
+)
 interface FeatureExtractor {
 
     /**

--- a/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/PostFinalStep.kt
+++ b/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/changers/PostFinalStep.kt
@@ -17,7 +17,7 @@ import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
  * @property actionAndApply An action such as transform, extract etc. which not only creates and
  *   returns a new [Expect] of type [R] but also applies a given assertionCreator lambda.
  */
-//TODO 0.14.0 move to atrium-logic
+@Deprecated("Use TransformationExecutionStep from atrium-logic; will be removed with 1.0.0")
 abstract class PostFinalStep<T, R, E : Expect<R>>(
     protected val expect: Expect<T>,
     protected val action: Expect<T>.() -> E,
@@ -27,9 +27,7 @@ abstract class PostFinalStep<T, R, E : Expect<R>>(
     /**
      * Returns the newly created [Expect] for the feature.
      */
-    //TODO consider for 1.0.0: rename to getFeatureExpect in case also ChangedSubjectPostStep is returning FeatureExpect
     fun getExpectOfFeature(): E = action(expect)
-
 
     /**
      * Collects the assertions the given [assertionCreator] might create for the new [Expect] of the feature

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/FeatureExtractorBuilder.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/FeatureExtractorBuilder.kt
@@ -1,3 +1,6 @@
+//TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.builders.creating.changers
 
 import ch.tutteli.atrium.core.*
@@ -20,12 +23,23 @@ import ch.tutteli.atrium.reporting.translating.Untranslatable
  * that the call/access fails depending on given arguments.
  * For instance, [List.get] is a good example where it fails if the given index is out of bounds.
  */
+@Deprecated(
+    "Use FeatureExtractorBuilder from atrium-logic; will be removed with 1.0.0",
+    ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder")
+)
 interface FeatureExtractorBuilder {
 
     companion object {
         /**
          * Entry point to use the [FeatureExtractorBuilder].
          */
+        @Deprecated(
+            "Use FeatureExtractorBuilder from atrium-logic; will be removed with 1.0.0",
+            ReplaceWith(
+                "ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder(expect._logic)",
+                "ch.tutteli.atrium.logic._logic"
+            )
+        )
         fun <T> create(originalAssertionContainer: Expect<T>): DescriptionStep<T> =
             DescriptionStep.create(originalAssertionContainer)
     }
@@ -35,6 +49,10 @@ interface FeatureExtractorBuilder {
      *
      * @param T the type of the current subject.
      */
+    @Deprecated(
+        "Use FeatureExtractorBuilder.DescriptionStep from atrium-logic; will be removed with 1.0.0",
+        ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder.DescriptionStep")
+    )
     interface DescriptionStep<T> {
         /**
          * The previously specified assertion container from which we are going to extract the feature.
@@ -77,6 +95,10 @@ interface FeatureExtractorBuilder {
      *
      * @param T the type of the current subject.
      */
+    @Deprecated(
+        "Use FeatureExtractorBuilder.RepresentationInCaseOfFailureStep from atrium-logic; will be removed with 1.0.0",
+        ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder.RepresentationInCaseOfFailureStep")
+    )
     interface RepresentationInCaseOfFailureStep<T> {
         /**
          * The previously specified assertion container from which we are going to extract the feature.
@@ -121,6 +143,10 @@ interface FeatureExtractorBuilder {
      *
      * @param T the type of the current subject.
      */
+    @Deprecated(
+        "Use FeatureExtractorBuilder.FeatureExtractionStep from atrium-logic; will be removed with 1.0.0",
+        ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder.FeatureExtractionStep")
+    )
     interface FeatureExtractionStep<T> {
         /**
          * The previously specified assertion container from which we are going to extract the feature.
@@ -168,6 +194,10 @@ interface FeatureExtractorBuilder {
      *
      * @param T the type of the subject.
      */
+    @Deprecated(
+        "Use FeatureExtractorBuilder.OptionsStep from atrium-logic; will be removed with 1.0.0",
+        ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder.OptionsStep")
+    )
     interface OptionsStep<T, R> {
         /**
          * The so far chosen options up to the [FeatureExtractionStep] step.
@@ -215,6 +245,10 @@ interface FeatureExtractorBuilder {
      *
      * Calling multiple times the same method overrides the previously defined value.
      */
+    @Deprecated(
+        "Use FeatureExtractorBuilder from atrium-logic and thus FeatureExpectOptionsChooser; will be removed with 1.0.0",
+        ReplaceWith("ch.tutteli.atrium.creating.FeatureExpectOptionsChooser")
+    )
     interface OptionsChooser<R> {
 
         /**
@@ -268,6 +302,10 @@ interface FeatureExtractorBuilder {
      * @param T the type of the current subject.
      * @param R the type of the feature, aka the new subject.
      */
+    @Deprecated(
+        "Use FeatureExtractorBuilder.FinalStep from atrium-logic; will be removed with 1.0.0",
+        ReplaceWith("ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder.FinalStep")
+    )
     interface FinalStep<T, R> {
         /**
          * The so far chosen options up to the [FeatureExtractionStep] step.
@@ -314,6 +352,10 @@ interface FeatureExtractorBuilder {
  * @property description Defines a custom description if not null.
  * @property representationInsteadOfFeature Defines a custom representation based on a present subject if not null.
  */
+@Deprecated(
+    "Use FeatureExtractorBuilder from atrium-logic and thus FeatureExpectOptions; will be removed with 1.0.0",
+    ReplaceWith("ch.tutteli.atrium.creating.FeatureExpectOptions")
+)
 data class FeatureOptions<R>(
     val description: Translatable? = null,
     val representationInsteadOfFeature: ((R) -> Any)? = null
@@ -338,5 +380,9 @@ data class FeatureOptions<R>(
 }
 
 @Suppress("FunctionName")
+@Deprecated(
+    "Use FeatureExpectOptions from atrium-core; will be removed with 1.0.0",
+    ReplaceWith("ch.tutteli.atrium.creating.FeatureExpectOptions")
+)
 fun <R> FeatureOptions(configuration: FeatureExtractorBuilder.OptionsChooser<R>.() -> Unit): FeatureOptions<R> =
     FeatureExtractorBuilder.OptionsChooser.createAndBuild(configuration)

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/impl/featureextractor/OptionsChooserImpl.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/impl/featureextractor/OptionsChooserImpl.kt
@@ -1,3 +1,6 @@
+//TODO remove with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.builders.creating.changers.impl.featureextractor
 
 import ch.tutteli.atrium.domain.builders.creating.changers.FeatureExtractorBuilder

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/impl/featureextractor/defaultImpls.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/changers/impl/featureextractor/defaultImpls.kt
@@ -1,3 +1,6 @@
+//TODO remove with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.builders.creating.changers.impl.featureextractor
 
 import ch.tutteli.atrium.core.None

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/reporting/ExpectBuilder.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/reporting/ExpectBuilder.kt
@@ -19,6 +19,7 @@ import ch.tutteli.atrium.reporting.translating.Untranslatable
 /**
  * Defines the contract to create custom assertion verbs, `Expect<T>` respectively.
  */
+//TODO move to atrium-logic with 0.15.0
 interface ExpectBuilder {
     companion object {
 
@@ -105,6 +106,7 @@ interface ExpectBuilder {
      *
      * Calling multiple times the same method overrides the previously defined value.
      */
+    //TODO move to atrium-core with 0.15.0 (or to logic and move FeatureExpectOptionsChooser to logic as well?)
     interface OptionsChooser<T> {
 
         /**

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/VarArgHelper.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/VarArgHelper.kt
@@ -10,7 +10,7 @@ import ch.tutteli.kbox.glue
  * Represents a parameter object used to express the arguments `T, vararg T`
  * and provides utility functions to transform them.
  */
-//TODO copy/move to atrium-logic with 0.14.0
+//TODO copy/move to atrium-logic with 0.15.0
 interface VarArgHelper<out T> {
     /**
      * The first argument in the argument list `T, vararg T`

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/groupsToList.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/groupsToList.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.domain.builders.utils
 /**
  * Represents a group of [T].
  */
+//TODO copy and move to atrium-logic 0.15.0
 interface Group<out T> {
     /**
      * Returns the members of the group as [List].
@@ -26,7 +27,7 @@ interface GroupWithNullableEntries<out T : Any?> : Group<T>
  * Adds the given [firstGroup], the [secondGroup] and the [otherGroups] into a new [List] and returns it.
  * @return a [List] containing [firstGroup], [secondGroup] and [otherGroups].
  */
-//TODO copy and move to atrium-logic
+//TODO copy and move to atrium-logic 0.15.0
 fun <T> groupsToList(firstGroup: Group<T>, secondGroup: Group<T>, otherGroups: Array<out Group<T>>): List<List<T>> {
     val groups = ArrayList<List<T>>(otherGroups.size + 2)
     requireNotEmptyAndAdd(groups, firstGroup)

--- a/misc/deprecated/domain/robstoll/atrium-domain-robstoll-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/changers/FeatureExtractoImpl.kt
+++ b/misc/deprecated/domain/robstoll/atrium-domain-robstoll-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/changers/FeatureExtractoImpl.kt
@@ -1,3 +1,6 @@
+//TODO remove with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.robstoll.creating.changers
 
 import ch.tutteli.atrium.core.Option

--- a/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assert.kt
+++ b/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assert.kt
@@ -44,4 +44,4 @@ fun <T> assert(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     )
 )
 fun <T, R> Expect<T>.assert(newSubject: R): FeatureExpect<T, R> =
-    _logic.manualFeature(ASSERT) { newSubject }.getExpectOfFeature()
+    _logic.manualFeature(ASSERT) { newSubject }.transform()

--- a/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assertThat.kt
+++ b/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assertThat.kt
@@ -44,4 +44,4 @@ fun <T> assertThat(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T
     )
 )
 fun <T, R> Expect<T>.assertThat(newSubject: R): FeatureExpect<T, R> =
-    _logic.manualFeature(ASSERT_THAT) { newSubject }.getExpectOfFeature()
+    _logic.manualFeature(ASSERT_THAT) { newSubject }.transform()

--- a/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/expect.kt
+++ b/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/expect.kt
@@ -44,4 +44,4 @@ fun <T> expect(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     )
 )
 fun <T, R> Expect<T>.expect(newSubject: R): FeatureExpect<T, R> =
-    _logic.manualFeature(EXPECT) { newSubject }.getExpectOfFeature()
+    _logic.manualFeature(EXPECT) { newSubject }.transform()


### PR DESCRIPTION
- deprecate corresponding functionality in atrium-domain-builders
- rename AnyAssertions.notToBeNullBut to notToBeNullButOfType
- resolves #577
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
