### PR TITLE
Rename .*FeatureAssertionSpec classes without fusing

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IteratorAssertionSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IteratorAssertionSpec.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun0
 import ch.tutteli.atrium.specs.notImplemented
 
-class IteratorFeatureAssertionSpec : ch.tutteli.atrium.specs.integration.IteratorFeatureAssertionSpec(
+class IteratorAssertionSpec : ch.tutteli.atrium.specs.integration.IteratorAssertionSpec(
     fun0(Expect<Iterator<Int>>::hasNext),
     fun0(Expect<Iterator<Int>>::hasNotNext)
 ) {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ListAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ListAssertionsSpec.kt
@@ -9,12 +9,12 @@ import ch.tutteli.atrium.specs.withNullableSuffix
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-object ListFeatureAssertionsSpec : Spek({
+object ListAssertionsSpec : Spek({
     include(ListSpec)
     include(IterableSpec)
     include(SequenceSpec)
 }) {
-    object ListSpec : ch.tutteli.atrium.specs.integration.ListFeatureAssertionsSpec(
+    object ListSpec : ch.tutteli.atrium.specs.integration.ListAssertionsSpec(
         feature1<List<Int>, Int, Int>(Expect<List<Int>>::get),
         fun2<List<Int>, Int, Expect<Int>.() -> Unit>(Expect<List<Int>>::get),
         feature1<List<Int?>, Int, Int?>(Expect<List<Int?>>::get).withNullableSuffix(),

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PairAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PairAssertionsSpec.kt
@@ -1,12 +1,11 @@
-package ch.tutteli.atrium.api.infix.en_GB
+package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
-class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatureAssertionsSpec(
+class PairAssertionsSpec : ch.tutteli.atrium.specs.integration.PairAssertionsSpec(
     property<Pair<String, Int>, String>(Expect<Pair<String, Int>>::first),
     fun1<Pair<String, Int>, Expect<String>.() -> Unit>(Expect<Pair<String, Int>>::first),
     property<Pair<String, Int>, Int>(Expect<Pair<String, Int>>::second),
@@ -16,7 +15,6 @@ class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatur
     property<Pair<String?, Int?>, Int?>(Expect<Pair<String?, Int?>>::second),
     fun1<Pair<String?, Int?>, Expect<Int?>.() -> Unit>(Expect<Pair<String?, Int?>>::second)
 ) {
-    companion object : WithAsciiReporter()
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -31,21 +29,21 @@ class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatur
         a3.first
         a4.first
         star.first
-        a1 = a1 first { }
-        a2 = a2 first { }
-        a3 = a3 first { }
-        a4 = a4 first { }
-        star = star first { }
+        a1 = a1.first { }
+        a2 = a2.first { }
+        a3 = a3.first { }
+        a4 = a4.first { }
+        star = star.first { }
 
         a1.second
         a2.second
         a3.second
         a4.second
         star.second
-        a1 = a1 second { }
-        a2 = a2 second { }
-        a3 = a3 second { }
-        a4 = a4 second { }
-        star = star second { }
+        a1 = a1.second { }
+        a2 = a2.second { }
+        a3 = a3.second { }
+        a4 = a4.second { }
+        star = star.second { }
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/LocalDateAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/LocalDateAssertionsSpec.kt
@@ -1,7 +1,4 @@
-// TODO remove file with 1.0.0
-@file:Suppress("DEPRECATION")
-
-package ch.tutteli.atrium.api.fluent.en_GB.jdk8
+package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
@@ -10,7 +7,7 @@ import ch.tutteli.atrium.specs.property
 import java.time.DayOfWeek
 import java.time.LocalDate
 
-class LocalDateFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateFeatureAssertionsSpec(
+class LocalDateAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateAssertionsSpec(
     property<LocalDate, Int>(Expect<LocalDate>::year),
     fun1<LocalDate, Expect<Int>.() -> Unit>(Expect<LocalDate>::year),
     property<LocalDate, Int>(Expect<LocalDate>::month),

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/LocalDateTimeAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/LocalDateTimeAssertionsSpec.kt
@@ -1,7 +1,4 @@
-// TODO remove file with 1.0.0
-@file:Suppress("DEPRECATION")
-
-package ch.tutteli.atrium.api.fluent.en_GB.jdk8
+package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
@@ -10,7 +7,7 @@ import ch.tutteli.atrium.specs.property
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 
-class LocalDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateTimeFeatureAssertionsSpec(
+class LocalDateTimeAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateTimeAssertionsSpec(
     property<LocalDateTime, Int>(Expect<LocalDateTime>::year),
     fun1<LocalDateTime, Expect<Int>.() -> Unit>(Expect<LocalDateTime>::year),
     property<LocalDateTime, Int>(Expect<LocalDateTime>::month),

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ZonedDateTimeAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ZonedDateTimeAssertionsSpec.kt
@@ -1,14 +1,13 @@
-package ch.tutteli.atrium.api.infix.en_GB
+package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeFeatureAssertionsSpec(
+class ZonedDateTimeAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeAssertionsSpec(
     property<ZonedDateTime, Int>(Expect<ZonedDateTime>::year),
     fun1<ZonedDateTime, Expect<Int>.() -> Unit>(Expect<ZonedDateTime>::year),
     property<ZonedDateTime, Int>(Expect<ZonedDateTime>::month),
@@ -18,22 +17,20 @@ class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Z
     property<ZonedDateTime, DayOfWeek>(Expect<ZonedDateTime>::dayOfWeek),
     fun1<ZonedDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<ZonedDateTime>::dayOfWeek)
 ) {
-    companion object : WithAsciiReporter()
-
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<ZonedDateTime> = notImplemented()
 
         a1.year
-        a1 = a1 year { }
+        a1 = a1.year { }
 
         a1.month
-        a1 = a1 month { }
+        a1 = a1.month { }
 
         a1.dayOfWeek
-        a1 = a1 dayOfWeek { }
+        a1 = a1.dayOfWeek { }
 
         a1.day
-        a1 = a1 day { }
+        a1 = a1.day { }
     }
 }

--- a/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/ResultAssertionsSpec.kt
+++ b/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/ResultAssertionsSpec.kt
@@ -3,7 +3,7 @@ package ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 
-class ResultFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ResultFeatureAssertionsSpec(
+class ResultAssertionsSpec : ch.tutteli.atrium.specs.integration.ResultAssertionsSpec(
     feature0<Result<Int>, Int>(Expect<Result<Int>>::isSuccess),
     fun1<Result<Int>, Expect<Int>.() -> Unit>(Expect<Result<Int>>::isSuccess),
     feature0<Result<Int?>, Int?>(Expect<Result<Int?>>::isSuccess).withNullableSuffix(),

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IteratorAssertionSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IteratorAssertionSpec.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import kotlin.reflect.KFunction2
 
-class IteratorFeatureAssertionSpec : ch.tutteli.atrium.specs.integration.IteratorFeatureAssertionSpec(
+class IteratorAssertionSpec : ch.tutteli.atrium.specs.integration.IteratorAssertionSpec(
     getHasNextPair(),
     getHasNotNextPair()
 ) {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ListAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ListAssertionsSpec.kt
@@ -11,12 +11,12 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import kotlin.jvm.JvmName
 
-class ListFeatureAssertionsSpec : Spek({
+class ListAssertionsSpec : Spek({
     include(ListSpec)
     include(IterableSpec)
     include(SequenceSpec)
 }) {
-    object ListSpec : ch.tutteli.atrium.specs.integration.ListFeatureAssertionsSpec(
+    object ListSpec : ch.tutteli.atrium.specs.integration.ListAssertionsSpec(
         feature1<List<Int>, Int, Int>(Expect<List<Int>>::get),
         fun2<List<Int>, Int, Expect<Int>.() -> Unit>(Companion::get),
         feature1<List<Int?>, Int, Int?>(Expect<List<Int?>>::get).withNullableSuffix(),

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PairAssertionsSpec.kt
@@ -1,11 +1,12 @@
-package ch.tutteli.atrium.api.fluent.en_GB
+package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 
-class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatureAssertionsSpec(
+class PairAssertionsSpec : ch.tutteli.atrium.specs.integration.PairAssertionsSpec(
     property<Pair<String, Int>, String>(Expect<Pair<String, Int>>::first),
     fun1<Pair<String, Int>, Expect<String>.() -> Unit>(Expect<Pair<String, Int>>::first),
     property<Pair<String, Int>, Int>(Expect<Pair<String, Int>>::second),
@@ -15,6 +16,7 @@ class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatur
     property<Pair<String?, Int?>, Int?>(Expect<Pair<String?, Int?>>::second),
     fun1<Pair<String?, Int?>, Expect<Int?>.() -> Unit>(Expect<Pair<String?, Int?>>::second)
 ) {
+    companion object : WithAsciiReporter()
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -29,21 +31,21 @@ class PairFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.PairFeatur
         a3.first
         a4.first
         star.first
-        a1 = a1.first { }
-        a2 = a2.first { }
-        a3 = a3.first { }
-        a4 = a4.first { }
-        star = star.first { }
+        a1 = a1 first { }
+        a2 = a2 first { }
+        a3 = a3 first { }
+        a4 = a4 first { }
+        star = star first { }
 
         a1.second
         a2.second
         a3.second
         a4.second
         star.second
-        a1 = a1.second { }
-        a2 = a2.second { }
-        a3 = a3.second { }
-        a4 = a4.second { }
-        star = star.second { }
+        a1 = a1 second { }
+        a2 = a2 second { }
+        a3 = a3 second { }
+        a4 = a4 second { }
+        star = star second { }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateAssertionsSpec.kt
@@ -1,13 +1,14 @@
-package ch.tutteli.atrium.api.fluent.en_GB
+package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.LocalDate
 
-class LocalDateFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateFeatureAssertionsSpec(
+class LocalDateAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateAssertionsSpec(
     property<LocalDate, Int>(Expect<LocalDate>::year),
     fun1<LocalDate, Expect<Int>.() -> Unit>(Expect<LocalDate>::year),
     property<LocalDate, Int>(Expect<LocalDate>::month),
@@ -17,21 +18,23 @@ class LocalDateFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Local
     property<LocalDate, DayOfWeek>(Expect<LocalDate>::dayOfWeek),
     fun1<LocalDate, Expect<DayOfWeek>.() -> Unit>(Expect<LocalDate>::dayOfWeek)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<LocalDate> = notImplemented()
 
         a1.year
-        a1 = a1.year { }
+        a1 = a1 year { }
 
         a1.month
-        a1 = a1.month { }
+        a1 = a1 month { }
 
         a1.dayOfWeek
-        a1 = a1.dayOfWeek { }
+        a1 = a1 dayOfWeek { }
 
         a1.day
-        a1 = a1.day { }
+        a1 = a1 day { }
     }
 }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateTimeAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/LocalDateTimeAssertionsSpec.kt
@@ -1,13 +1,14 @@
-package ch.tutteli.atrium.api.fluent.en_GB
+package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 
-class LocalDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateTimeFeatureAssertionsSpec(
+class LocalDateTimeAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateTimeAssertionsSpec(
     property<LocalDateTime, Int>(Expect<LocalDateTime>::year),
     fun1<LocalDateTime, Expect<Int>.() -> Unit>(Expect<LocalDateTime>::year),
     property<LocalDateTime, Int>(Expect<LocalDateTime>::month),
@@ -17,20 +18,22 @@ class LocalDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.L
     property<LocalDateTime, DayOfWeek>(Expect<LocalDateTime>::dayOfWeek),
     fun1<LocalDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<LocalDateTime>::dayOfWeek)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<LocalDateTime> = notImplemented()
 
         a1.year
-        a1 = a1.year { }
+        a1 = a1 year { }
 
         a1.month
-        a1 = a1.month { }
+        a1 = a1 month { }
 
         a1.day
-        a1 = a1.day { }
+        a1 = a1 day { }
 
         a1.dayOfWeek
-        a1 = a1.dayOfWeek { }
+        a1 = a1 dayOfWeek { }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ZonedDateTimeAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ZonedDateTimeAssertionsSpec.kt
@@ -1,13 +1,14 @@
-package ch.tutteli.atrium.api.fluent.en_GB
+package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
+import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeFeatureAssertionsSpec(
+class ZonedDateTimeAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeAssertionsSpec(
     property<ZonedDateTime, Int>(Expect<ZonedDateTime>::year),
     fun1<ZonedDateTime, Expect<Int>.() -> Unit>(Expect<ZonedDateTime>::year),
     property<ZonedDateTime, Int>(Expect<ZonedDateTime>::month),
@@ -17,20 +18,22 @@ class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Z
     property<ZonedDateTime, DayOfWeek>(Expect<ZonedDateTime>::dayOfWeek),
     fun1<ZonedDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<ZonedDateTime>::dayOfWeek)
 ) {
+    companion object : WithAsciiReporter()
+
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<ZonedDateTime> = notImplemented()
 
         a1.year
-        a1 = a1.year { }
+        a1 = a1 year { }
 
         a1.month
-        a1 = a1.month { }
+        a1 = a1 month { }
 
         a1.dayOfWeek
-        a1 = a1.dayOfWeek { }
+        a1 = a1 dayOfWeek { }
 
         a1.day
-        a1 = a1.day { }
+        a1 = a1 day { }
     }
 }

--- a/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/ResultAssertionsSpec.kt
+++ b/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/ResultAssertionsSpec.kt
@@ -2,12 +2,12 @@ package ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3
 
 import ch.tutteli.atrium.api.infix.en_GB.success
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.integration.ResultFeatureAssertionsSpec
+import ch.tutteli.atrium.specs.integration.ResultAssertionsSpec
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withFeatureSuffix
 import ch.tutteli.atrium.specs.withNullableSuffix
 
-class ResultFeatureAssertionsSpec : ResultFeatureAssertionsSpec(
+class ResultAssertionsSpec : ResultAssertionsSpec(
     ("toBe ${success::class::simpleName}" to (Companion::toBeSuccessFeature)).withFeatureSuffix(),
     "toBe ${success::class::simpleName}" to Companion::toBeSuccess,
     ("toBe ${success::class::simpleName}" to (Companion::toBeSuccessFeatureNullable)).withFeatureSuffix()

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/LocalDateAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/LocalDateAssertionsSpec.kt
@@ -1,14 +1,16 @@
-package ch.tutteli.atrium.api.infix.en_GB
+// TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
+package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.LocalDate
 
-class LocalDateFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateFeatureAssertionsSpec(
+class LocalDateAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateAssertionsSpec(
     property<LocalDate, Int>(Expect<LocalDate>::year),
     fun1<LocalDate, Expect<Int>.() -> Unit>(Expect<LocalDate>::year),
     property<LocalDate, Int>(Expect<LocalDate>::month),
@@ -18,23 +20,21 @@ class LocalDateFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.Local
     property<LocalDate, DayOfWeek>(Expect<LocalDate>::dayOfWeek),
     fun1<LocalDate, Expect<DayOfWeek>.() -> Unit>(Expect<LocalDate>::dayOfWeek)
 ) {
-    companion object : WithAsciiReporter()
-
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<LocalDate> = notImplemented()
 
         a1.year
-        a1 = a1 year { }
+        a1 = a1.year { }
 
         a1.month
-        a1 = a1 month { }
+        a1 = a1.month { }
 
         a1.dayOfWeek
-        a1 = a1 dayOfWeek { }
+        a1 = a1.dayOfWeek { }
 
         a1.day
-        a1 = a1 day { }
+        a1 = a1.day { }
     }
 }
 

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/LocalDateTimeAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/LocalDateTimeAssertionsSpec.kt
@@ -1,14 +1,16 @@
-package ch.tutteli.atrium.api.infix.en_GB
+// TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
+package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.property
-import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 
-class LocalDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateTimeFeatureAssertionsSpec(
+class LocalDateTimeAssertionsSpec : ch.tutteli.atrium.specs.integration.LocalDateTimeAssertionsSpec(
     property<LocalDateTime, Int>(Expect<LocalDateTime>::year),
     fun1<LocalDateTime, Expect<Int>.() -> Unit>(Expect<LocalDateTime>::year),
     property<LocalDateTime, Int>(Expect<LocalDateTime>::month),
@@ -18,22 +20,20 @@ class LocalDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.L
     property<LocalDateTime, DayOfWeek>(Expect<LocalDateTime>::dayOfWeek),
     fun1<LocalDateTime, Expect<DayOfWeek>.() -> Unit>(Expect<LocalDateTime>::dayOfWeek)
 ) {
-    companion object : WithAsciiReporter()
-
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var a1: Expect<LocalDateTime> = notImplemented()
 
         a1.year
-        a1 = a1 year { }
+        a1 = a1.year { }
 
         a1.month
-        a1 = a1 month { }
+        a1 = a1.month { }
 
         a1.day
-        a1 = a1 day { }
+        a1 = a1.day { }
 
         a1.dayOfWeek
-        a1 = a1 dayOfWeek { }
+        a1 = a1.dayOfWeek { }
     }
 }

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/ZonedDateTimeAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/ZonedDateTimeAssertionsSpec.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.specs.property
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-class ZonedDateTimeFeatureAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeFeatureAssertionsSpec(
+class ZonedDateTimeAssertionsSpec : ch.tutteli.atrium.specs.integration.ZonedDateTimeAssertionsSpec(
     property<ZonedDateTime, Int>(Expect<ZonedDateTime>::year),
     fun1<ZonedDateTime, Expect<Int>.() -> Unit>(Expect<ZonedDateTime>::year),
     property<ZonedDateTime, Int>(Expect<ZonedDateTime>::month),

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IteratorAssertionSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IteratorAssertionSpec.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 
-abstract class IteratorFeatureAssertionSpec(
+abstract class IteratorAssertionSpec(
     hasNext: Fun0<Iterator<Int>>,
     hasNotNext: Fun0<Iterator<Int>>,
     describePrefix: String = "[Atrium] "

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/KeyValueLikeAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/KeyValueLikeAssertionsSpec.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.translations.DescriptionComparableAssertion
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 
-abstract class KeyValueLikeFeatureAssertionsSpec<T : Any, TNullable : Any>(
+abstract class KeyValueLikeAssertionsSpec<T : Any, TNullable : Any>(
     creator: (String, Int) -> T,
     creatorNullable: (String?, Int?) -> TNullable,
     keyName: String,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ListAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ListAssertionsSpec.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.translations.DescriptionListAssertion
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 
-abstract class ListFeatureAssertionsSpec(
+abstract class ListAssertionsSpec(
     getFeature: Feature1<List<Int>, Int, Int>,
     get: Fun2<List<Int>, Int, Expect<Int>.() -> Unit>,
     getFeatureNullable: Feature1<List<Int?>, Int, Int?>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapEntryFeatureAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapEntryFeatureAssertionsSpec.kt
@@ -14,7 +14,7 @@ abstract class MapEntryFeatureAssertionsSpec(
     nullableValueFeature: Feature0<Map.Entry<String?, Int?>, Int?>,
     nullableValue: Fun1<Map.Entry<String?, Int?>, Expect<Int?>.() -> Unit>,
     describePrefix: String = "[Atrium] "
-) : KeyValueLikeFeatureAssertionsSpec<Map.Entry<String, Int>, Map.Entry<String?, Int?>>(
+) : KeyValueLikeAssertionsSpec<Map.Entry<String, Int>, Map.Entry<String?, Int?>>(
     ::mapEntry,
     ::mapEntry,
     "key",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/PairAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/PairAssertionsSpec.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.Feature0
 import ch.tutteli.atrium.specs.Fun1
 
-abstract class PairFeatureAssertionsSpec(
+abstract class PairAssertionsSpec(
     firstFeature: Feature0<Pair<String, Int>, String>,
     first: Fun1<Pair<String, Int>, Expect<String>.() -> Unit>,
     secondFeature: Feature0<Pair<String, Int>, Int>,
@@ -14,7 +14,7 @@ abstract class PairFeatureAssertionsSpec(
     nullableSecondFeature: Feature0<Pair<String?, Int?>, Int?>,
     nullableSecond: Fun1<Pair<String?, Int?>, Expect<Int?>.() -> Unit>,
     describePrefix: String = "[Atrium] "
-) : KeyValueLikeFeatureAssertionsSpec<Pair<String, Int>, Pair<String?, Int?>>(
+) : KeyValueLikeAssertionsSpec<Pair<String, Int>, Pair<String?, Int?>>(
     ::Pair,
     ::Pair,
     "first",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ResultAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ResultAssertionsSpec.kt
@@ -7,14 +7,13 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
-import ch.tutteli.atrium.translations.DescriptionAnyAssertion
 import ch.tutteli.atrium.translations.DescriptionCharSequenceAssertion.CONTAINS
 import ch.tutteli.atrium.translations.DescriptionCharSequenceAssertion.VALUE
 import ch.tutteli.atrium.translations.DescriptionResultAssertion
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 
-abstract class ResultFeatureAssertionsSpec(
+abstract class ResultAssertionsSpec(
     isSuccessFeature: Feature0<Result<Int>, Int>,
     isSuccess: Fun1<Result<Int>, Expect<Int>.() -> Unit>,
     isSuccessFeatureNullable: Feature0<Result<Int?>, Int?>,

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateAssertionsSpec.kt
@@ -16,7 +16,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
 
-abstract class LocalDateFeatureAssertionsSpec(
+abstract class LocalDateAssertionsSpec(
     yearFeature: Feature0<LocalDate, Int>,
     year: Fun1<LocalDate, Expect<Int>.() -> Unit>,
     monthFeature: Feature0<LocalDate, Int>,

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateTimeAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateTimeAssertionsSpec.kt
@@ -13,21 +13,21 @@ import ch.tutteli.atrium.translations.DescriptionDateTimeLikeAssertion
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 import java.time.DayOfWeek
-import java.time.ZonedDateTime
+import java.time.LocalDateTime
 
-abstract class ZonedDateTimeFeatureAssertionsSpec(
-    yearFeature: Feature0<ZonedDateTime, Int>,
-    year: Fun1<ZonedDateTime, Expect<Int>.() -> Unit>,
-    monthFeature: Feature0<ZonedDateTime, Int>,
-    month: Fun1<ZonedDateTime, Expect<Int>.() -> Unit>,
-    dayFeature: Feature0<ZonedDateTime, Int>,
-    day: Fun1<ZonedDateTime, Expect<Int>.() -> Unit>,
-    dayOfWeekFeature: Feature0<ZonedDateTime, DayOfWeek>,
-    dayOfWeek: Fun1<ZonedDateTime, Expect<DayOfWeek>.() -> Unit>,
+abstract class LocalDateTimeAssertionsSpec(
+    yearFeature: Feature0<LocalDateTime, Int>,
+    year: Fun1<LocalDateTime, Expect<Int>.() -> Unit>,
+    monthFeature: Feature0<LocalDateTime, Int>,
+    month: Fun1<LocalDateTime, Expect<Int>.() -> Unit>,
+    dayFeature: Feature0<LocalDateTime, Int>,
+    day: Fun1<LocalDateTime, Expect<Int>.() -> Unit>,
+    dayOfWeekFeature: Feature0<LocalDateTime, DayOfWeek>,
+    dayOfWeek: Fun1<LocalDateTime, Expect<DayOfWeek>.() -> Unit>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
-    include(object : SubjectLessSpec<ZonedDateTime>(describePrefix,
+    include(object : SubjectLessSpec<LocalDateTime>(describePrefix,
         yearFeature.forSubjectLess().adjustName { "$it feature" },
         year.forSubjectLess { isGreaterThan(2000) },
         monthFeature.forSubjectLess().adjustName { "$it feature" },
@@ -38,8 +38,8 @@ abstract class ZonedDateTimeFeatureAssertionsSpec(
         dayOfWeek.forSubjectLess { isLessThanOrEqual(DayOfWeek.SUNDAY) }
     ) {})
 
-    include(object : AssertionCreatorSpec<ZonedDateTime>(
-        describePrefix, ZonedDateTime.now().withYear(2040).withDayOfYear(1).withDayOfMonth(15),
+    include(object : AssertionCreatorSpec<LocalDateTime>(
+        describePrefix, LocalDateTime.of(2040, 1, 15, 10, 20, 30),
         year.forAssertionCreatorSpec("$toBeDescr: 1") { toBe(2040) },
         month.forAssertionCreatorSpec("$toBeDescr: 1") { toBe(1) },
         day.forAssertionCreatorSpec("$toBeDescr: 1") { toBe(15) },
@@ -49,16 +49,16 @@ abstract class ZonedDateTimeFeatureAssertionsSpec(
     fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
 
-    val fluent = expect(ZonedDateTime.now().withMonth(5).withYear(2009).withDayOfMonth(15))
+    val fluent = expect(LocalDateTime.of(2009, 5, 15, 10, 5))
     val monthDescr = DescriptionDateTimeLikeAssertion.MONTH.getDefault()
     val yearDescr = DescriptionDateTimeLikeAssertion.YEAR.getDefault()
-    val dayOfWeekDescr = DescriptionDateTimeLikeAssertion.DAY_OF_WEEK.getDefault()
     val dayDescr = DescriptionDateTimeLikeAssertion.DAY.getDefault()
+    val dayOfWeekDescr = DescriptionDateTimeLikeAssertion.DAY_OF_WEEK.getDefault()
 
     describeFun(yearFeature, year) {
         val yearFunctions = unifySignatures(yearFeature, year)
 
-        context("ZonedDateTime with year 2009") {
+        context("LocalDateTime with year 2009") {
             yearFunctions.forEach { (name, yearFun, _) ->
                 it("$name - is greater than 2009 holds") {
                     fluent.yearFun { isGreaterThan(2008) }
@@ -77,7 +77,7 @@ abstract class ZonedDateTimeFeatureAssertionsSpec(
     describeFun(monthFeature, month) {
         val monthFunctions = unifySignatures(monthFeature, month)
 
-        context("ZonedDateTime with month May(5)") {
+        context("LocalDateTime with month May(5)") {
             monthFunctions.forEach { (name, monthFun, _) ->
                 it("$name - is greater than February(2) holds") {
                     fluent.monthFun { isGreaterThan(2) }
@@ -93,11 +93,10 @@ abstract class ZonedDateTimeFeatureAssertionsSpec(
         }
     }
 
-
     describeFun(dayFeature, day) {
         val dayFunctions = unifySignatures(dayFeature, day)
 
-        context("LocalDate with day of month 15") {
+        context("LocalDateTime with day of month 15") {
             dayFunctions.forEach { (name, dayFun, _) ->
                 it("$name - is greater than 5 holds") {
                     fluent.dayFun { isGreaterThan(5) }
@@ -116,7 +115,7 @@ abstract class ZonedDateTimeFeatureAssertionsSpec(
     describeFun(dayOfWeekFeature, dayOfWeek) {
         val dayOfWeekFunctions = unifySignatures(dayOfWeekFeature, dayOfWeek)
 
-        context("ZonedDateTime with day of week Friday(5)") {
+        context("LocalDateTime with day of week Friday(5)") {
             dayOfWeekFunctions.forEach { (name, dayOfWeekFun, _) ->
                 it("$name - is greater than Monday(1) holds") {
                     fluent.dayOfWeekFun { isGreaterThan(DayOfWeek.MONDAY) }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/ZonedDateTimeAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/ZonedDateTimeAssertionsSpec.kt
@@ -13,21 +13,21 @@ import ch.tutteli.atrium.translations.DescriptionDateTimeLikeAssertion
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 import java.time.DayOfWeek
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
-abstract class LocalDateTimeFeatureAssertionsSpec(
-    yearFeature: Feature0<LocalDateTime, Int>,
-    year: Fun1<LocalDateTime, Expect<Int>.() -> Unit>,
-    monthFeature: Feature0<LocalDateTime, Int>,
-    month: Fun1<LocalDateTime, Expect<Int>.() -> Unit>,
-    dayFeature: Feature0<LocalDateTime, Int>,
-    day: Fun1<LocalDateTime, Expect<Int>.() -> Unit>,
-    dayOfWeekFeature: Feature0<LocalDateTime, DayOfWeek>,
-    dayOfWeek: Fun1<LocalDateTime, Expect<DayOfWeek>.() -> Unit>,
+abstract class ZonedDateTimeAssertionsSpec(
+    yearFeature: Feature0<ZonedDateTime, Int>,
+    year: Fun1<ZonedDateTime, Expect<Int>.() -> Unit>,
+    monthFeature: Feature0<ZonedDateTime, Int>,
+    month: Fun1<ZonedDateTime, Expect<Int>.() -> Unit>,
+    dayFeature: Feature0<ZonedDateTime, Int>,
+    day: Fun1<ZonedDateTime, Expect<Int>.() -> Unit>,
+    dayOfWeekFeature: Feature0<ZonedDateTime, DayOfWeek>,
+    dayOfWeek: Fun1<ZonedDateTime, Expect<DayOfWeek>.() -> Unit>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
-    include(object : SubjectLessSpec<LocalDateTime>(describePrefix,
+    include(object : SubjectLessSpec<ZonedDateTime>(describePrefix,
         yearFeature.forSubjectLess().adjustName { "$it feature" },
         year.forSubjectLess { isGreaterThan(2000) },
         monthFeature.forSubjectLess().adjustName { "$it feature" },
@@ -38,8 +38,8 @@ abstract class LocalDateTimeFeatureAssertionsSpec(
         dayOfWeek.forSubjectLess { isLessThanOrEqual(DayOfWeek.SUNDAY) }
     ) {})
 
-    include(object : AssertionCreatorSpec<LocalDateTime>(
-        describePrefix, LocalDateTime.of(2040, 1, 15, 10, 20, 30),
+    include(object : AssertionCreatorSpec<ZonedDateTime>(
+        describePrefix, ZonedDateTime.now().withYear(2040).withDayOfYear(1).withDayOfMonth(15),
         year.forAssertionCreatorSpec("$toBeDescr: 1") { toBe(2040) },
         month.forAssertionCreatorSpec("$toBeDescr: 1") { toBe(1) },
         day.forAssertionCreatorSpec("$toBeDescr: 1") { toBe(15) },
@@ -49,16 +49,16 @@ abstract class LocalDateTimeFeatureAssertionsSpec(
     fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
 
-    val fluent = expect(LocalDateTime.of(2009, 5, 15, 10, 5))
+    val fluent = expect(ZonedDateTime.now().withMonth(5).withYear(2009).withDayOfMonth(15))
     val monthDescr = DescriptionDateTimeLikeAssertion.MONTH.getDefault()
     val yearDescr = DescriptionDateTimeLikeAssertion.YEAR.getDefault()
-    val dayDescr = DescriptionDateTimeLikeAssertion.DAY.getDefault()
     val dayOfWeekDescr = DescriptionDateTimeLikeAssertion.DAY_OF_WEEK.getDefault()
+    val dayDescr = DescriptionDateTimeLikeAssertion.DAY.getDefault()
 
     describeFun(yearFeature, year) {
         val yearFunctions = unifySignatures(yearFeature, year)
 
-        context("LocalDateTime with year 2009") {
+        context("ZonedDateTime with year 2009") {
             yearFunctions.forEach { (name, yearFun, _) ->
                 it("$name - is greater than 2009 holds") {
                     fluent.yearFun { isGreaterThan(2008) }
@@ -77,7 +77,7 @@ abstract class LocalDateTimeFeatureAssertionsSpec(
     describeFun(monthFeature, month) {
         val monthFunctions = unifySignatures(monthFeature, month)
 
-        context("LocalDateTime with month May(5)") {
+        context("ZonedDateTime with month May(5)") {
             monthFunctions.forEach { (name, monthFun, _) ->
                 it("$name - is greater than February(2) holds") {
                     fluent.monthFun { isGreaterThan(2) }
@@ -93,10 +93,11 @@ abstract class LocalDateTimeFeatureAssertionsSpec(
         }
     }
 
+
     describeFun(dayFeature, day) {
         val dayFunctions = unifySignatures(dayFeature, day)
 
-        context("LocalDateTime with day of month 15") {
+        context("LocalDate with day of month 15") {
             dayFunctions.forEach { (name, dayFun, _) ->
                 it("$name - is greater than 5 holds") {
                     fluent.dayFun { isGreaterThan(5) }
@@ -115,7 +116,7 @@ abstract class LocalDateTimeFeatureAssertionsSpec(
     describeFun(dayOfWeekFeature, dayOfWeek) {
         val dayOfWeekFunctions = unifySignatures(dayOfWeekFeature, dayOfWeek)
 
-        context("LocalDateTime with day of week Friday(5)") {
+        context("ZonedDateTime with day of week Friday(5)") {
             dayOfWeekFunctions.forEach { (name, dayOfWeekFun, _) ->
                 it("$name - is greater than Monday(1) holds") {
                     fluent.dayOfWeekFun { isGreaterThan(DayOfWeek.MONDAY) }


### PR DESCRIPTION
Easier one this time: renamed specs which do not require fusing.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
