### PR TITLE
Make generateLogic support varargs + avoid index-based regex

### DIFF
--- a/logic/generateLogic.gradle
+++ b/logic/generateLogic.gradle
@@ -123,16 +123,19 @@ def createGenerateLogicTaskForPackage(
             def identifier = /[a-zA-Z0-9]+/
             def newLine = /(?:\r\n?|\n)/
             def newLineAndIndent = /$newLine\s*/
-            def parameter = /,(?: |$newLineAndIndent)($identifier): ([^:]+?)/
-            def returnType = /(?:$newLineAndIndent)?\)(:.+)/
+            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<vararg${paramNumber}>vararg |)(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
+            def returnType = /(?:$newLineAndIndent)?\)(?<returnType>:.+)/
 
-            def typeIdentifier = / *fun (<.+?> )?($identifier)\((?:$newLineAndIndent)?$identifier: ($identifier(?:\.$identifier)*<.+>)/
-            def patterns = (6..0).collect {
-                def steps = (0..<it * 2).findAll { it % 2 == 0 }
+            def typeIdentifier = / *fun (?<generics><.+?> )?(?<funcName>$identifier)\((?:$newLineAndIndent)?$identifier: (?<type>$identifier(?:\.$identifier)*<.+>)/
+            def patterns = (6..0).collect { int amountOfParameters ->
+                def params = []
+                if (amountOfParameters > 0) {
+                    params = (1..amountOfParameters).toList()
+                }
                 new Tuple3<Pattern, String, String>(
-                    Pattern.compile(typeIdentifier + parameter * it + returnType),
-                    /fun $1$3.$2\(/ + steps.collect { /$${it + 4}: $${it + 5}/ }.join(", ") + /\)$${it * 2 + 4} =/ + (it > 1 ? "$ln    " : " "),
-                    /.$2\(this/ + (it > 0 ? ", " : "") + steps.collect { /$${it + 4}/ }.join(", ") + /\)/
+                    Pattern.compile(typeIdentifier + params.collect { paramNumber -> parameter(paramNumber)}.join("") + returnType),
+                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${vararg' + paramNumber + '}${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (amountOfParameters > 1 ? "$ln    " : " "),
+                    /.${ '${funcName}' }\(this/ + (amountOfParameters > 0 ? ", " : "") + params.collect { paramNumber -> /${ '${paramName'+ paramNumber + '}'}/ }.join(", ") + /\)/
                 )
             }
 

--- a/logic/generateLogic.gradle
+++ b/logic/generateLogic.gradle
@@ -123,7 +123,7 @@ def createGenerateLogicTaskForPackage(
             def identifier = /[a-zA-Z0-9]+/
             def newLine = /(?:\r\n?|\n)/
             def newLineAndIndent = /$newLine\s*/
-            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<vararg${paramNumber}>vararg |)(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
+            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
             def returnType = /(?:$newLineAndIndent)?\)(?<returnType>:.+)/
 
             def typeIdentifier = / *fun (?<generics><.+?> )?(?<funcName>$identifier)\((?:$newLineAndIndent)?$identifier: (?<type>$identifier(?:\.$identifier)*<.+>)/
@@ -134,7 +134,7 @@ def createGenerateLogicTaskForPackage(
                 }
                 new Tuple3<Pattern, String, String>(
                     Pattern.compile(typeIdentifier + params.collect { paramNumber -> parameter(paramNumber)}.join("") + returnType),
-                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${vararg' + paramNumber + '}${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (amountOfParameters > 1 ? "$ln    " : " "),
+                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (amountOfParameters > 1 ? "$ln    " : " "),
                     /.${ '${funcName}' }\(this/ + (amountOfParameters > 0 ? ", " : "") + params.collect { paramNumber -> /${ '${paramName'+ paramNumber + '}'}/ }.join(", ") + /\)/
                 )
             }


### PR DESCRIPTION
I started looking at https://github.com/robstoll/atrium/issues/590 and noticed one of the problems with fixing that is the use of vararg: generateLogic failed to work because it could not match that 'vararg'.

So I fixed that. Because I could not figure out the index-based regex, I moved everything to named groups first and then added the vararg. I don't like the way I had to abuse string interpolation to specify the named group referenced, but that's the best I could come up with.

Note that the vararg does not get 'expanded', so the underlying code needs to accept an `Array` instead of the vararg.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
