### PR TITLE
Added dependabot labels to avoid the java label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,33 +6,45 @@ updates:
       interval: daily
       time: "04:00"
   open-pull-requests-limit: 10
+  labels:
+      - "dependencies"
 - package-ecosystem: gradle
   directory: "/samples/js/mocha"
   schedule:
       interval: daily
       time: "04:00"
   open-pull-requests-limit: 10
+  labels:
+      - "dependencies"
 - package-ecosystem: gradle
   directory: "/samples/jvm/junit5"
   schedule:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  labels:
+    - "dependencies"
 - package-ecosystem: gradle
   directory: "/samples/jvm/spek"
   schedule:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  labels:
+      - "dependencies"
 - package-ecosystem: maven
   directory: "/samples/maven"
   schedule:
       interval: daily
       time: "04:00"
   open-pull-requests-limit: 10
+  labels:
+      - "dependencies"
 - package-ecosystem: gradle
   directory: "/samples/multiplatform"
   schedule:
       interval: daily
       time: "04:00"
   open-pull-requests-limit: 10
+  labels:
+      - "dependencies"


### PR DESCRIPTION
As explained in [the dependabot documentation](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#labels), dependabot adds the labels `dependencies` and `java` whenever there are multiple gradle configurations, which I'm afraid I missed in my last PR at https://github.com/robstoll/atrium/pull/604. 

In this PR I've hard-coded the labels which should remove the extra java label in the auto PRs.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.

