### PR TITLE
Adding Path.contains

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -311,6 +311,19 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
     _logicAppend { isRelative() }
 
 /**
+ * TODO
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @since 0.14.0
+ */
+fun <T : Path> Expect<T>.containss(path: String): Expect<T> =
+    isDirectory() and {
+        resolve(path) { exists() }
+    }
+
+/**
  * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
  * so that further fluent calls are assertions about it.

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -318,7 +318,7 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  *
  * @since 0.14.0
  */
-fun <T : Path> Expect<T>.containss(path: String): Expect<T> =
+fun <T : Path> Expect<T>.containss(path: String, vararg other: String): Expect<T> =
     isDirectory() and {
         resolve(path) { exists() }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -7,6 +7,7 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
+import ch.tutteli.kbox.forElementAndForEachIn
 import java.nio.charset.Charset
 import java.nio.file.Path
 
@@ -329,10 +330,9 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  *
  * @since 0.14.0
  */
-fun <T : Path> Expect<T>.containss(path: String, vararg other: String): Expect<T> =
+fun <T : Path> Expect<T>.contains(path: String, vararg otherPaths: String): Expect<T> =
     isDirectory() and {
-        val allPaths = arrayOf(path) + other
-        allPaths.forEach { p ->
+        forElementAndForEachIn(path, otherPaths) { p ->
             resolve(p) { exists() }
         }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -311,7 +311,18 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
     _logicAppend { isRelative() }
 
 /**
- * TODO
+ * Expects that the subject of the assertion (a [Path]) is a directory;
+ * meaning that there is a file system entry at the location the [Path] points to and that is a directory.
+ *
+ * Every argument string is expected to exist as a child file or child directory for the subject of the assertion.
+ *
+ * This assertion _resolves_ symbolic links.
+ * Therefore, if a symbolic link exists at the location the subject points to, search will continue
+ * at the location the link points at.
+ *
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
@@ -320,7 +331,10 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  */
 fun <T : Path> Expect<T>.containss(path: String, vararg other: String): Expect<T> =
     isDirectory() and {
-        resolve(path) { exists() }
+        val allPaths = arrayOf(path) + other
+        allPaths.forEach { p ->
+            resolve(p) { exists() }
+        }
     }
 
 /**

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/module/module-info.java
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/module/module-info.java
@@ -1,7 +1,7 @@
 module ch.tutteli.atrium.api.fluent.en_GB {
     requires ch.tutteli.atrium.logic;
     requires kotlin.stdlib;
-
+    requires ch.tutteli.kbox;
 
     exports ch.tutteli.atrium.api.fluent.en_GB;
     exports ch.tutteli.atrium.api.fluent.en_GB.creating.charsequence.contains.builders;

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
@@ -19,7 +19,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute),
     fun0(Expect<Path>::isRelative),
-    fun1(Expect<Path>::containss),
+    fun2(Expect<Path>::contains),
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
@@ -1,10 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.fun0
-import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.fun3
-import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.*
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -22,6 +19,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute),
     fun0(Expect<Path>::isRelative),
+    fun1(Expect<Path>::containss),
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
@@ -19,7 +19,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute),
     fun0(Expect<Path>::isRelative),
-    fun2(Expect<Path>::contains),
+    fun2<Path, String, Array<out String>>(Expect<Path>::contains),
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
@@ -42,7 +42,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
         private fun isRelative(expect: Expect<Path>) = expect toBe relative
         private fun contains(expect: Expect<Path>, path: String, vararg otherPaths: String) = isDirectory(expect) and {
             forElementAndForEachIn(path, otherPaths) { p ->
-                expect resolve path(p) { exists(expect) }
+                it resolve path(p) { it toBe existing }
             }
         }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
@@ -1,12 +1,11 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.fluent.en_GB.containss
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.fun3
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
+import ch.tutteli.kbox.forElementAndForEachIn
 import java.nio.charset.Charset
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -25,7 +24,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     "toBe ${aDirectory::class.simpleName}" to Companion::isDirectory,
     "toBe ${relative::class.simpleName}" to Companion::isAbsolute,
     "toBe ${relative::class.simpleName}" to Companion::isRelative,
-    fun2(Expect<Path>::containss),
+    "contains not yet implemented in this API" to Companion::contains,
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Companion::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)
@@ -41,6 +40,11 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
         private fun isDirectory(expect: Expect<Path>) = expect toBe aDirectory
         private fun isAbsolute(expect: Expect<Path>) = expect toBe absolute
         private fun isRelative(expect: Expect<Path>) = expect toBe relative
+        private fun contains(expect: Expect<Path>, path: String, vararg otherPaths: String) = isDirectory(expect) and {
+            forElementAndForEachIn(path, otherPaths) { p ->
+                expect resolve path(p) { exists(expect) }
+            }
+        }
 
         private fun hasSameTextualContentAs(
             expect: Expect<Path>,

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
@@ -1,7 +1,9 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
+import ch.tutteli.atrium.api.fluent.en_GB.containss
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
+import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.fun3
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
@@ -23,6 +25,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     "toBe ${aDirectory::class.simpleName}" to Companion::isDirectory,
     "toBe ${relative::class.simpleName}" to Companion::isAbsolute,
     "toBe ${relative::class.simpleName}" to Companion::isRelative,
+    fun2(Expect<Path>::containss),
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Companion::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -3,14 +3,12 @@
 
 package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
+import ch.tutteli.atrium.api.fluent.en_GB.containss
 import ch.tutteli.atrium.api.fluent.en_GB.isAbsolute
 import ch.tutteli.atrium.api.fluent.en_GB.isExecutable
 import ch.tutteli.atrium.api.fluent.en_GB.isRelative
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.fun0
-import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.fun3
-import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.*
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -28,6 +26,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun0(Expect<Path>::isRelative), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
+    fun2(Expect<Path>::containss),
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -3,7 +3,7 @@
 
 package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
-import ch.tutteli.atrium.api.fluent.en_GB.containss
+import ch.tutteli.atrium.api.fluent.en_GB.contains
 import ch.tutteli.atrium.api.fluent.en_GB.isAbsolute
 import ch.tutteli.atrium.api.fluent.en_GB.isExecutable
 import ch.tutteli.atrium.api.fluent.en_GB.isRelative
@@ -26,7 +26,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun0(Expect<Path>::isRelative), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
-    fun2(Expect<Path>::containss),
+    fun2(Expect<Path>::contains), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -26,7 +26,7 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun0(Expect<Path>::isRelative), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
-    fun2(Expect<Path>::contains), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
+    fun2<Path, String, Array<out String>>(Expect<Path>::contains), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -900,34 +900,43 @@ abstract class PathAssertionsSpec(
 
            it("it throws if the first ${td.singleName} does not exist") withAndWithoutSymlink { maybeLink ->
                val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
-               maybeLink.create(td.factory.invoke(folder, "b"))
-               maybeLink.create(td.factory.invoke(folder, "c"))
+               maybeLink.create(td.factory.invoke(folder, "file2"))
+               maybeLink.create(td.factory.invoke(folder, "file3"))
                expect {
-                   expect(folder).containsFun("a", arrayOf("b", "c"))
+                   expect(folder).containsFun("file1", arrayOf("file2", "file3"))
                }.toThrow<AssertionError>().message {
                    contains("${TO.getDefault()}: ${EXIST.getDefault()}")
+                   contains("file1")
+                   containsNot("file2")
+                   containsNot("file3")
                }
            }
 
            it("it throws if the second ${td.singleName} does not exist") withAndWithoutSymlink { maybeLink ->
                val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
-               maybeLink.create(td.factory.invoke(folder, "a"))
-               maybeLink.create(td.factory.invoke(folder, "c"))
+               maybeLink.create(td.factory.invoke(folder, "file1"))
+               maybeLink.create(td.factory.invoke(folder, "file3"))
                expect {
-                   expect(folder).containsFun("a", arrayOf("b", "c"))
+                   expect(folder).containsFun("file1", arrayOf("file2", "file3"))
                }.toThrow<AssertionError>().message {
                    contains("${TO.getDefault()}: ${EXIST.getDefault()}")
+                   contains("file2")
+                   containsNot("file1")
+                   containsNot("file3")
                }
            }
 
            it("it throws if third ${td.singleName} does not exist") withAndWithoutSymlink { maybeLink ->
                val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
-               maybeLink.create(td.factory.invoke(folder, "a"))
-               maybeLink.create(td.factory.invoke(folder, "b"))
+               maybeLink.create(td.factory.invoke(folder, "file1"))
+               maybeLink.create(td.factory.invoke(folder, "file2"))
                expect {
-                   expect(folder).containsFun("a", arrayOf("b", "c"))
+                   expect(folder).containsFun("file1", arrayOf("file2", "file3"))
                }.toThrow<AssertionError>().message {
                    contains("${TO.getDefault()}: ${EXIST.getDefault()}")
+                   containsNot("file2")
+                   containsNot("file1")
+                   contains("file3")
                }
            }
         }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -939,8 +939,32 @@ abstract class PathAssertionsSpec(
                    contains("file3")
                }
            }
-        }
 
+           it("it throws if the first and third ${td.singleName} do not exist") withAndWithoutSymlink { maybeLink ->
+               val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+               maybeLink.create(td.factory.invoke(folder, "file2"))
+               expect {
+                   expect(folder).containsFun("file1", arrayOf("file2", "file3"))
+               }.toThrow<AssertionError>().message {
+                   contains("${TO.getDefault()}: ${EXIST.getDefault()}")
+                   containsNot("file2")
+                   contains("file1")
+                   contains("file3")
+               }
+           }
+
+           it("it throws if the directory does not exist") withAndWithoutSymlink { maybeLink ->
+               val folder = maybeLink.create(tempFolder.tmpDir.resolve("nonExistent"))
+               val expectedMessage = "$isDescr: ${A_DIRECTORY.getDefault()}"
+
+               expect {
+                   expect(folder).containsFun("file1", arrayOf("file2", "file3"))
+               }.toThrow<AssertionError>().message {
+                   contains(expectedMessage, FAILURE_DUE_TO_NO_SUCH_FILE.getDefault())
+                   containsExplanationFor(maybeLink)
+               }
+           }
+        }
     }
 
     describeFun(hasSameBinaryContentAs, hasSameTextualContentAs, hasSameTextualContentAsDefaultArgs) {

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -45,7 +45,7 @@ abstract class PathAssertionsSpec(
     isDirectory: Fun0<Path>,
     isAbsolute: Fun0<Path>,
     isRelative: Fun0<Path>,
-    contains: Fun1<Path, String>,
+    contains: Fun2<Path, String, Array<out String>>,
     hasSameBinaryContentAs: Fun1<Path, Path>,
     hasSameTextualContentAs: Fun3<Path, Path, Charset, Charset>,
     hasSameTextualContentAsDefaultArgs: Fun1<Path, Path>,
@@ -67,7 +67,7 @@ abstract class PathAssertionsSpec(
         isDirectory.forSubjectLess(),
         isAbsolute.forSubjectLess(),
         isRelative.forSubjectLess(),
-        contains.forSubjectLess("a"),
+        contains.forSubjectLess("a", arrayOf("b", "c")),
         hasSameBinaryContentAs.forSubjectLess(Paths.get("a")),
         hasSameTextualContentAs.forSubjectLess(Paths.get("a"), Charsets.ISO_8859_1, Charsets.ISO_8859_1),
         hasSameTextualContentAsDefaultArgs.forSubjectLess(Paths.get("a"))
@@ -874,11 +874,56 @@ abstract class PathAssertionsSpec(
         val containsFun = contains.lambda
         val expectedMessage = "$isDescr: ${A_DIRECTORY.getDefault()}"
 
-        it("does not throw if exists") withAndWithoutSymlink { maybeLink ->
+        it("does not throw if the single parameter is a child directory") withAndWithoutSymlink { maybeLink ->
             val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
             maybeLink.create(folder.newDirectory("a"))
-            expect(folder).containsFun("a")
+            expect(folder).containsFun("a", emptyArray())
         }
+
+        it("does not throw if both parameters are child directories") withAndWithoutSymlink { maybeLink ->
+            val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+            maybeLink.create(folder.newDirectory("a"))
+            maybeLink.create(folder.newDirectory("b"))
+            expect(folder).containsFun("a", arrayOf("b"))
+        }
+
+        it("does not throw if three parameters are child directories") withAndWithoutSymlink { maybeLink ->
+            val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+            maybeLink.create(folder.newDirectory("a"))
+            maybeLink.create(folder.newDirectory("b"))
+            maybeLink.create(folder.newDirectory("c"))
+            expect(folder).containsFun("a", arrayOf("b", "c"))
+        }
+
+        it("does not throw if the single parameter is a child file") withAndWithoutSymlink { maybeLink ->
+            val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+            maybeLink.create(folder.newFile("a"))
+            expect(folder).containsFun("a", emptyArray())
+        }
+
+        it("does not throw if both parameters are child files") withAndWithoutSymlink { maybeLink ->
+            val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+            maybeLink.create(folder.newFile("a"))
+            maybeLink.create(folder.newFile("b"))
+            expect(folder).containsFun("a", arrayOf("b"))
+        }
+
+        it("does not throw if three parameters are child files") withAndWithoutSymlink { maybeLink ->
+            val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+            maybeLink.create(folder.newFile("a"))
+            maybeLink.create(folder.newFile("b"))
+            maybeLink.create(folder.newFile("c"))
+            expect(folder).containsFun("a", arrayOf("b", "c"))
+        }
+//        it("throws an AssertionError for a file") withAndWithoutSymlink { maybeLink ->
+//            val file = maybeLink.create(tempFolder.newFile("test"))
+//            expect {
+//                expect(file).isDirectoryFun()
+//            }.toThrow<AssertionError>().message {
+//                contains(expectedMessage, "${WAS.getDefault()}: ${A_FILE.getDefault()}")
+//                containsExplanationFor(maybeLink)
+//            }
+//        }
     }
 
     describeFun(hasSameBinaryContentAs, hasSameTextualContentAs, hasSameTextualContentAsDefaultArgs) {

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -45,6 +45,7 @@ abstract class PathAssertionsSpec(
     isDirectory: Fun0<Path>,
     isAbsolute: Fun0<Path>,
     isRelative: Fun0<Path>,
+    contains: Fun1<Path, String>,
     hasSameBinaryContentAs: Fun1<Path, Path>,
     hasSameTextualContentAs: Fun3<Path, Path, Charset, Charset>,
     hasSameTextualContentAsDefaultArgs: Fun1<Path, Path>,
@@ -66,6 +67,7 @@ abstract class PathAssertionsSpec(
         isDirectory.forSubjectLess(),
         isAbsolute.forSubjectLess(),
         isRelative.forSubjectLess(),
+        contains.forSubjectLess("a"),
         hasSameBinaryContentAs.forSubjectLess(Paths.get("a")),
         hasSameTextualContentAs.forSubjectLess(Paths.get("a"), Charsets.ISO_8859_1, Charsets.ISO_8859_1),
         hasSameTextualContentAsDefaultArgs.forSubjectLess(Paths.get("a"))
@@ -865,6 +867,17 @@ abstract class PathAssertionsSpec(
         it("does not throw for relative path") {
             val path = Paths.get("test/bla.txt")
             expect(path).isRelativeFun()
+        }
+    }
+
+    describeFun(contains) {
+        val containsFun = contains.lambda
+        val expectedMessage = "$isDescr: ${A_DIRECTORY.getDefault()}"
+
+        it("does not throw if exists") withAndWithoutSymlink { maybeLink ->
+            val folder = maybeLink.create(tempFolder.newDirectory("startDir"))
+            maybeLink.create(folder.newDirectory("a"))
+            expect(folder).containsFun("a")
         }
     }
 


### PR DESCRIPTION
Current issues:

- Cannot use contains, causes naming conflicts
- Not using vararg for now (keeping it simple)
- Build fails

Should fix #590 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
