### PR TITLE
#645 add samples for charSequenceAssertions of api-fluent

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
@@ -18,6 +18,8 @@ import kotlin.jvm.JvmName
  * Starts a sophisticated `contains` assertion building process based on this [Expect].
  *
  * @return The newly created builder.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.containsFeature
  */
 val <T : CharSequence> Expect<T>.contains: CharSequenceContains.EntryPointStep<T, NoOpSearchBehaviour>
     get() = _logic.containsBuilder()
@@ -27,6 +29,8 @@ val <T : CharSequence> Expect<T>.contains: CharSequenceContains.EntryPointStep<T
  * [NotCheckerStep].
  *
  * @return The newly created builder.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.containsNotFeature
  */
 val <T : CharSequence> Expect<T>.containsNot: NotCheckerStep<T, NotSearchBehaviour>
     get() = _logic.containsNotBuilder()
@@ -57,6 +61,8 @@ val <T : CharSequence> Expect<T>.containsNot: NotCheckerStep<T, NotSearchBehavio
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  * @throws IllegalArgumentException in case [expected] or one of the [otherExpected] is not a
  *   [CharSequence], [Number] or [Char].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.contains
  */
 fun <T : CharSequence> Expect<T>.contains(
     expected: CharSequenceOrNumberOrChar,
@@ -75,6 +81,8 @@ fun <T : CharSequence> Expect<T>.contains(
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.containsNot
  */
 fun <T : CharSequence> Expect<T>.containsNot(
     expected: CharSequenceOrNumberOrChar,
@@ -103,6 +111,8 @@ fun <T : CharSequence> Expect<T>.containsNot(
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.containsRegexString
  */
 fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatterns: String): Expect<T> =
     contains.atLeast(1).regex(pattern, *otherPatterns)
@@ -131,6 +141,8 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatt
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.containsRegex
  */
 fun <T : CharSequence> Expect<T>.containsRegex(pattern: Regex, vararg otherPatterns: Regex): Expect<T> =
     contains.atLeast(1).regex(pattern, *otherPatterns)
@@ -140,6 +152,8 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: Regex, vararg otherPatte
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.startsWith
  */
 fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence): Expect<T> =
     _logicAppend { startsWith(expected) }
@@ -149,6 +163,8 @@ fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.startsWithChar
  *
  * @since 0.9.0
  */
@@ -160,6 +176,8 @@ fun <T : CharSequence> Expect<T>.startsWith(expected: Char): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.startsNotWith
  */
 fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence): Expect<T> =
     _logicAppend { startsNotWith(expected) }
@@ -171,6 +189,8 @@ fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence): Expect<T
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.startsNotWithChar
  */
 fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char): Expect<T> =
     startsNotWith(expected.toString())
@@ -181,6 +201,8 @@ fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.endsWith
  */
 fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence): Expect<T> =
     _logicAppend { endsWith(expected) }
@@ -192,6 +214,8 @@ fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence): Expect<T> =
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.endsWithChar
  */
 fun <T : CharSequence> Expect<T>.endsWith(expected: Char): Expect<T> =
     endsWith(expected.toString())
@@ -201,6 +225,8 @@ fun <T : CharSequence> Expect<T>.endsWith(expected: Char): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.endsNotWith
  */
 fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence): Expect<T> =
     _logicAppend { endsNotWith(expected) }
@@ -212,6 +238,7 @@ fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence): Expect<T> 
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.endsNotWithChar
  */
 fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char): Expect<T> =
     endsNotWith(expected.toString())
@@ -222,6 +249,8 @@ fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.isEmpty
  */
 fun <T : CharSequence> Expect<T>.isEmpty(): Expect<T> =
     _logicAppend { isEmpty() }
@@ -231,6 +260,8 @@ fun <T : CharSequence> Expect<T>.isEmpty(): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.isNotEmpty
  */
 fun <T : CharSequence> Expect<T>.isNotEmpty(): Expect<T> =
     _logicAppend { isNotEmpty() }
@@ -240,6 +271,8 @@ fun <T : CharSequence> Expect<T>.isNotEmpty(): Expect<T> =
  *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.isNotBlank
  */
 fun <T : CharSequence> Expect<T>.isNotBlank(): Expect<T> =
     _logicAppend { isNotBlank() }
@@ -253,6 +286,8 @@ fun <T : CharSequence> Expect<T>.isNotBlank(): Expect<T> =
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.matches
  */
 fun <T : CharSequence> Expect<T>.matches(expected: Regex): Expect<T> =
     _logicAppend { matches(expected) }
@@ -266,6 +301,8 @@ fun <T : CharSequence> Expect<T>.matches(expected: Regex): Expect<T> =
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  *
  * @since 0.9.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceAssertionsSpec.mismatches
  */
 fun <T : CharSequence> Expect<T>.mismatches(expected: Regex): Expect<T> =
     _logicAppend { mismatches(expected) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CharSequenceAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CharSequenceAssertionsSpec.kt
@@ -1,0 +1,232 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class CharSequenceAssertionsSpec {
+
+    @Test
+    fun containsFeature() {
+        expect("ABC")
+            .contains.exactly(1).value("A")
+
+        expect("ABBC")
+            .contains.atLeast(2).value("B")
+
+        fails {
+            expect("AAAAAA")
+                .contains.atMost(3).value("A")
+        }
+    }
+
+    @Test
+    fun containsNotFeature() {
+        expect("ABC").containsNot.value("X")
+
+        fails {
+            expect("ABC").containsNot.value("B")
+        }
+    }
+
+    @Test
+    fun contains() {
+        expect("ABC").contains("B")
+
+        expect("ABC123").contains("AB", 'C', 12)
+
+        // holds because `contains` does not search for unique matches
+        // use `contains.exactly(2).value("A")` to check if subject contains two "A"s
+        expect("ABC").contains("A", "A")
+
+        fails {
+            expect("ABC").contains("X")
+        }
+
+        fails { // because subject does not contain all values
+            expect("ABC").contains("A", 99)
+        }
+    }
+
+    @Test
+    fun containsNot() {
+        expect("ABC").containsNot("X")
+
+        expect("ABC").containsNot("X", 'Y', 1)
+
+        fails {
+            expect("ABC").containsNot("B")
+        }
+
+        fails {
+            expect("ABC").containsNot("B", "X")
+        }
+    }
+
+    @Test
+    fun containsRegexString() {
+        expect("ABC").containsRegex("A(B)?")
+
+        fails {
+            expect("ABC").containsRegex("X")
+        }
+
+        expect("ABC")
+            .containsRegex("A(B)?", "(B)?C") // all regex patterns match
+
+        // holds because `containsRegex` does not search for unique matches
+        // use `contains.exactly(2).regex("A(B)?")` to check if subject contains the regex two times
+        expect("ABC")
+            .containsRegex("A(B)?", "A(B)?")
+
+        fails { // because second regex doesn't match
+            expect("ABC").containsRegex("A", "X")
+        }
+    }
+
+    @Test
+    fun containsRegex() {
+        expect("ABC").containsRegex("(B)?C".toRegex())
+
+        fails {
+            expect("ABC").containsRegex("X".toRegex())
+        }
+
+        expect("ABC")
+            .containsRegex("A".toRegex(), "B".toRegex()) // all regex patterns match
+
+        // holds because `containsRegex` does not search for unique matches
+        // use `contains.exactly(2).regex(regex)` to check if subject contains the regex two times
+        val regex = "A(B)?".toRegex()
+        expect("ABC").containsRegex(regex, regex)
+
+        fails { // because second regex doesn't match
+            expect("ABC").containsRegex("A".toRegex(), "X".toRegex())
+        }
+    }
+
+    @Test
+    fun startsWith() {
+        expect("ABC").startsWith("AB")
+
+        fails {
+            expect("ABC").startsWith("X")
+        }
+    }
+
+    @Test
+    fun startsWithChar() {
+        expect("ABC").startsWith('A')
+
+        fails {
+            expect("ABC").startsWith('X')
+        }
+    }
+
+    @Test
+    fun startsNotWith() {
+        expect("ABC").startsNotWith("X")
+
+        fails {
+            expect("ABC").startsNotWith("AB")
+        }
+    }
+
+    @Test
+    fun startsNotWithChar() {
+        expect("ABC").startsNotWith('X')
+
+        fails {
+            expect("ABC").startsNotWith('A')
+        }
+    }
+
+
+    @Test
+    fun endsWith() {
+        expect("ABC").endsWith("BC")
+
+        fails {
+            expect("ABC").endsWith("X")
+        }
+    }
+
+    @Test
+    fun endsWithChar() {
+        expect("ABC").endsWith('C')
+
+        fails {
+            expect("ABC").endsWith('X')
+        }
+    }
+
+    @Test
+    fun endsNotWith() {
+        expect("ABC").endsNotWith("X")
+
+        fails {
+            expect("ABC").endsNotWith("BC")
+        }
+    }
+
+    @Test
+    fun endsNotWithChar() {
+        expect("ABC").endsNotWith('X')
+
+        fails {
+            expect("ABC").endsNotWith('C')
+        }
+    }
+
+    @Test
+    fun isEmpty() {
+        expect("").isEmpty()
+
+        fails {
+            expect("XYZ").isEmpty()
+        }
+    }
+
+    @Test
+    fun isNotEmpty() {
+        expect("XYZ").isNotEmpty()
+
+        fails {
+            expect("").isNotEmpty()
+        }
+
+        // use isNotBlank to check for whitespaces
+        expect(" ").isNotEmpty()
+    }
+
+    @Test
+    fun isNotBlank() {
+        expect("XZY").isNotBlank()
+
+        fails {
+            expect(" ").isNotBlank()
+        }
+
+        fails { // because subject is empty but contains no whitespaces
+            expect("").isNotBlank()
+        }
+    }
+
+    @Test
+    fun matches() {
+        expect("ABC").matches("A(B)?C".toRegex()) // subject is fully matched
+
+        fails { // because subject isn't fully matched, use containsRegex for partial matching
+            expect("ABC").matches("A".toRegex())
+        }
+    }
+
+    @Test
+    fun mismatches() {
+        expect("ABC").mismatches("A".toRegex()) // subject isn't fully matched
+
+        fails { // because subject is fully matched, use containsNot.regex for partial matching
+            expect("ABC").mismatches("A(B)?C".toRegex())
+        }
+    }
+}


### PR DESCRIPTION
Resolve #645 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
