### PR TITLE
Path.hasDirectoryEntry

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -196,7 +196,7 @@ fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.(
  * Therefore, if a symbolic link exists at the location the subject points to,
  * search will continue at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -255,7 +255,7 @@ fun <T : Path> Expect<T>.isExecutable(): Expect<T> =
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -275,7 +275,7 @@ fun <T : Path> Expect<T>.isRegularFile(): Expect<T> =
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -321,7 +321,7 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  * the link points at. If a symbolic link exists at one of the entries, this will fulfill the respective assertion and
  * the entry’s symbolic link will not be followed.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the ssertions work on.
  * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -321,7 +321,7 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  * the link points at. If a symbolic link exists at one of the entries, this will fulfill the respective assertion and
  * the entry’s symbolic link will not be followed.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the ssertions work on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -7,7 +7,7 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
-import ch.tutteli.kbox.forElementAndForEachIn
+import ch.tutteli.kbox.glue
 import java.nio.charset.Charset
 import java.nio.file.Path
 
@@ -312,17 +312,17 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
     _logicAppend { isRelative() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a directory;
- * meaning that there is a file system entry at the location the [Path] points to and that is a directory.
+ * Expects that the subject of the assertion (a [Path]) is a directory having the provided entries.
+ * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
+ * Furthermore, every argument string resolved against the subject yields an existing file system entry.
  *
- * Every argument string is expected to exist as a child file or child directory for the subject of the assertion.
+ * This assertion _resolves_ symbolic links for the subject, but not for the entries.
+ * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
+ * the link points at. If a symbolic link exists at one of the entries, this will fulfill the respective assertion and
+ * the entry’s symbolic link will not be followed.
  *
- * This assertion _resolves_ symbolic links.
- * Therefore, if a symbolic link exists at the location the subject points to, search will continue
- * at the location the link points at.
- *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
- * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
+ * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
  * @return An [Expect] for the current subject of the assertion.
@@ -330,12 +330,8 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  *
  * @since 0.14.0
  */
-fun <T : Path> Expect<T>.contains(path: String, vararg otherPaths: String): Expect<T> =
-    isDirectory() and {
-        forElementAndForEachIn(path, otherPaths) { p ->
-            resolve(p) { exists() }
-        }
-    }
+fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String, vararg otherEntries: String): Expect<T> =
+    _logicAppend { hasDirectoryEntry(entry glue otherEntries) }
 
 /**
  * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathAssertionsSpec.kt
@@ -19,15 +19,18 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute),
     fun0(Expect<Path>::isRelative),
-    fun2<Path, String, Array<out String>>(Expect<Path>::contains),
+    Expect<Path>::hasDirectoryEntry.name to Companion::hasDirectoryEntrySingle,
+    fun2<Path, String, Array<out String>>(Expect<Path>::hasDirectoryEntry),
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
-    fun1(Companion::hasSameTextualContentAsDefaultArgs)
+    Expect<Path>::hasSameTextualContentAs.name to Companion::hasSameTextualContentAsDefaultArgs
 ) {
 
     companion object {
         private fun hasSameTextualContentAsDefaultArgs(expect: Expect<Path>, targetPath: Path): Expect<Path> =
             expect.hasSameTextualContentAs(targetPath)
+
+        private fun hasDirectoryEntrySingle(expect: Expect<Path>, entry: String) = expect.hasDirectoryEntry(entry)
     }
 
     @Suppress("unused", "UNUSED_VALUE")

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.creating.path
 
 /**
- *  Parameter object which collects directory entires (as [String]s).
+ *  Parameter object which collects directory entries (as [String]s).
  *  Use the function `directoryEntry(String, vararg String)` to create this representation.
  *
  *  @since 0.14.0

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries.kt
@@ -1,0 +1,11 @@
+package ch.tutteli.atrium.api.infix.en_GB.creating.path
+
+/**
+ *  Parameter object which collects directory entires (as [String]s).
+ *  Use the function `directoryEntry(String, vararg String)` to create this representation.
+ *
+ *  @since 0.14.0
+ */
+// TODO make inline once we drop support for Kotlin 1.2
+class DirectoryEntries(val entries: List<String>)
+

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries.kt
@@ -1,11 +1,13 @@
 package ch.tutteli.atrium.api.infix.en_GB.creating.path
 
+import ch.tutteli.atrium.domain.builders.utils.VarArgHelper
+
 /**
  *  Parameter object which collects directory entries (as [String]s).
  *  Use the function `directoryEntry(String, vararg String)` to create this representation.
  *
  *  @since 0.14.0
  */
-// TODO make inline once we drop support for Kotlin 1.2
-class DirectoryEntries(val entries: List<String>)
+class DirectoryEntries(override val expected: String, override val otherExpected: Array<out String>) :
+    VarArgHelper<String>
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -262,7 +262,7 @@ fun <E> path(path: String, assertionCreator: Expect<E>.() -> Unit): PathWithCrea
  * Therefore, if a symbolic link exists at the location the subject points to,
  * search will continue at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -320,7 +320,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") executable: ex
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -340,7 +340,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aRegularFile: 
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion9 works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -5,10 +5,12 @@
 
 package ch.tutteli.atrium.api.infix.en_GB
 
+import ch.tutteli.atrium.api.infix.en_GB.creating.path.DirectoryEntries
 import ch.tutteli.atrium.api.infix.en_GB.creating.path.PathWithCreator
 import ch.tutteli.atrium.api.infix.en_GB.creating.path.PathWithEncoding
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
+import ch.tutteli.kbox.glue
 import java.nio.charset.Charset
 import java.nio.file.Path
 
@@ -175,6 +177,60 @@ infix fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit)
  */
 infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
     _logic.resolve(other).transform()
+
+/**
+ * Expects that the subject of the assertion (a [Path]) is a directory having the provided [entry].
+ * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
+ * Furthermore, the argument string resolved against the subject yields an existing file system entry.
+ *
+ * This assertion _resolves_ symbolic links for the subject, but not for the [entry].
+ * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
+ * the link points at. If a symbolic link exists at the [entry], this will fulfill the assertion and the entry’s
+ * symbolic link will not be followed.
+ *
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
+ * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ * @see [has]
+ *
+ * @since 0.14.0
+ */
+infix fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String) =
+    _logicAppend { hasDirectoryEntry(listOf(entry)) }
+
+/**
+ * Expects that the subject of the assertion (a [Path]) is a directory having the provided entries.
+ * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
+ * Furthermore, every argument string resolved against the subject yields an existing file system entry.
+ *
+ * This assertion _resolves_ symbolic links for the subject, but not for the entries.
+ * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
+ * the link points at. If a symbolic link exists at one of the entries, this will fulfill the respective assertion and
+ * the entry’s symbolic link will not be followed.
+ *
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
+ * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
+ *
+ * @return An [Expect] for the current subject of the assertion.
+ * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
+ * @see [directoryEntries]
+ * @see [hasDirectoryEntry]
+ *
+ * @since 0.14.0
+ */
+infix fun <T : Path> Expect<T>.has(directoryEntries: DirectoryEntries) =
+    _logicAppend { hasDirectoryEntry(directoryEntries.entries) }
+
+/**
+ * Helper function for [has] to create [DirectoryEntries] with the provided [entry] and the [otherEntries].
+ *
+ * @since 0.14.0
+ */
+fun directoryEntries(entry: String, vararg otherEntries: String) = DirectoryEntries(entry glue otherEntries)
 
 /**
  * Expects that [PathWithCreator.path] resolves against this [Path], that the resolved [Path] holds all assertions the

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -223,14 +223,14 @@ infix fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String) =
  * @since 0.14.0
  */
 infix fun <T : Path> Expect<T>.has(directoryEntries: DirectoryEntries) =
-    _logicAppend { hasDirectoryEntry(directoryEntries.entries) }
+    _logicAppend { hasDirectoryEntry(directoryEntries.toList()) }
 
 /**
  * Helper function for [has] to create [DirectoryEntries] with the provided [entry] and the [otherEntries].
  *
  * @since 0.14.0
  */
-fun directoryEntries(entry: String, vararg otherEntries: String) = DirectoryEntries(entry glue otherEntries)
+fun directoryEntries(entry: String, vararg otherEntries: String) = DirectoryEntries(entry, otherEntries)
 
 /**
  * Expects that [PathWithCreator.path] resolves against this [Path], that the resolved [Path] holds all assertions the

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/module/module-info.java
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/module/module-info.java
@@ -1,6 +1,7 @@
 module ch.tutteli.atrium.api.infix.en_GB {
     requires ch.tutteli.atrium.logic;
     requires kotlin.stdlib;
+    requires ch.tutteli.kbox;
     requires java.base;
 
     exports ch.tutteli.atrium.api.infix.en_GB;

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathAssertionsSpec.kt
@@ -5,7 +5,6 @@ import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.fun3
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.testutils.WithAsciiReporter
-import ch.tutteli.kbox.forElementAndForEachIn
 import java.nio.charset.Charset
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -24,7 +23,8 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     "toBe ${aDirectory::class.simpleName}" to Companion::isDirectory,
     "toBe ${relative::class.simpleName}" to Companion::isAbsolute,
     "toBe ${relative::class.simpleName}" to Companion::isRelative,
-    "contains not yet implemented in this API" to Companion::contains,
+    fun1(Expect<Path>::hasDirectoryEntry),
+    "has ${::directoryEntries.name}" to Companion::hasDirectoryEntryMultiple,
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Companion::hasSameTextualContentAs),
     fun1(Companion::hasSameTextualContentAsDefaultArgs)
@@ -40,11 +40,8 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
         private fun isDirectory(expect: Expect<Path>) = expect toBe aDirectory
         private fun isAbsolute(expect: Expect<Path>) = expect toBe absolute
         private fun isRelative(expect: Expect<Path>) = expect toBe relative
-        private fun contains(expect: Expect<Path>, path: String, vararg otherPaths: String) = isDirectory(expect) and {
-            forElementAndForEachIn(path, otherPaths) { p ->
-                it resolve path(p) { it toBe existing }
-            }
-        }
+        private fun hasDirectoryEntryMultiple(expect: Expect<Path>, entry: String, vararg otherEntries: String) =
+            expect has directoryEntries(entry, *otherEntries)
 
         private fun hasSameTextualContentAs(
             expect: Expect<Path>,
@@ -77,6 +74,9 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
         a1 toBe relative
         a1 hasSameTextualContentAs withEncoding(Paths.get("a"))
         a1 hasSameTextualContentAs Paths.get("a")
+        a1 resolve "a"
+        a1 hasDirectoryEntry "a"
+        a1 has directoryEntries("a", "b", "c")
     }
 }
 

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
@@ -7,7 +7,13 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.creating.Expectimport ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilderimport ch.tutteli.atrium.logic.impl.DefaultAnyAssertionsimport kotlin.reflect.KClass
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
+import kotlin.reflect.KClass
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultAnyAssertions
 
 fun <T> AssertionContainer<T>.toBe(expected: T): Assertion = impl.toBe(this, expected)
 fun <T> AssertionContainer<T>.notToBe(expected: T): Assertion = impl.notToBe(this, expected)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -6,13 +7,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
-import kotlin.reflect.KClass
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultAnyAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.creating.Expectimport ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilderimport ch.tutteli.atrium.logic.impl.DefaultAnyAssertionsimport kotlin.reflect.KClass
 
 fun <T> AssertionContainer<T>.toBe(expected: T): Assertion = impl.toBe(this, expected)
 fun <T> AssertionContainer<T>.notToBe(expected: T): Assertion = impl.notToBe(this, expected)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/charSequence.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/charSequence.kt
@@ -7,7 +7,14 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContainsimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviourimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NotSearchBehaviourimport ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerStepimport ch.tutteli.atrium.logic.impl.DefaultCharSequenceAssertions
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
+import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
+import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NotSearchBehaviour
+import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerStep
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultCharSequenceAssertions
 
 
     /**

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/charSequence.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/charSequence.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -6,14 +7,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
-import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
-import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NotSearchBehaviour
-import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerStep
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultCharSequenceAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContainsimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviourimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NotSearchBehaviourimport ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerStepimport ch.tutteli.atrium.logic.impl.DefaultCharSequenceAssertions
 
 
     /**

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/collectionLike.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/collectionLike.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -6,12 +7,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
-import ch.tutteli.atrium.logic.creating.typeutils.CollectionLike
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultCollectionLikeAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilderimport ch.tutteli.atrium.logic.creating.typeutils.CollectionLikeimport ch.tutteli.atrium.logic.impl.DefaultCollectionLikeAssertions
 
 
 fun <T : CollectionLike> AssertionContainer<T>.isEmpty(converter: (T) -> Collection<*>): Assertion = impl.isEmpty(this, converter)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/collectionLike.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/collectionLike.kt
@@ -7,7 +7,12 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilderimport ch.tutteli.atrium.logic.creating.typeutils.CollectionLikeimport ch.tutteli.atrium.logic.impl.DefaultCollectionLikeAssertions
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
+import ch.tutteli.atrium.logic.creating.typeutils.CollectionLike
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultCollectionLikeAssertions
 
 
 fun <T : CollectionLike> AssertionContainer<T>.isEmpty(converter: (T) -> Collection<*>): Assertion = impl.isEmpty(this, converter)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/comparable.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/comparable.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/charSequenceContains.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/charSequenceContains.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -6,13 +7,7 @@
 
 package ch.tutteli.atrium.logic.creating.charsequence.contains.creators
 
-import ch.tutteli.atrium.assertions.AssertionGroup
-import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
-import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
-import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
-import ch.tutteli.atrium.logic.creating.typeutils.CharSequenceOrNumberOrChar
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.creating.charsequence.contains.creators.impl.DefaultCharSequenceContainsAssertions
+import ch.tutteli.atrium.assertions.AssertionGroupimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContainsimport ch.tutteli.atrium.logic.creating.charsequence.contains.creators.impl.DefaultCharSequenceContainsAssertionsimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviourimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviourimport ch.tutteli.atrium.logic.creating.typeutils.CharSequenceOrNumberOrChar
 
 
 fun <T : CharSequence> CharSequenceContains.CheckerStepLogic<T, NoOpSearchBehaviour>.values(expected: List<CharSequenceOrNumberOrChar>): AssertionGroup = impl.values(this, expected)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/charSequenceContains.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/charSequenceContains.kt
@@ -7,7 +7,13 @@
 
 package ch.tutteli.atrium.logic.creating.charsequence.contains.creators
 
-import ch.tutteli.atrium.assertions.AssertionGroupimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContainsimport ch.tutteli.atrium.logic.creating.charsequence.contains.creators.impl.DefaultCharSequenceContainsAssertionsimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviourimport ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviourimport ch.tutteli.atrium.logic.creating.typeutils.CharSequenceOrNumberOrChar
+import ch.tutteli.atrium.assertions.AssertionGroup
+import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
+import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
+import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
+import ch.tutteli.atrium.logic.creating.typeutils.CharSequenceOrNumberOrChar
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.creating.charsequence.contains.creators.impl.DefaultCharSequenceContainsAssertions
 
 
 fun <T : CharSequence> CharSequenceContains.CheckerStepLogic<T, NoOpSearchBehaviour>.values(expected: List<CharSequenceOrNumberOrChar>): AssertionGroup = impl.values(this, expected)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContains.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContainsInAnyOrder.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContainsInAnyOrder.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/feature.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/feature.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/floatingPoint.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/floatingPoint.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/fun0.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/fun0.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/iterableLike.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/iterableLike.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/iterator.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/iterator.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/list.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/list.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/map.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/map.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/mapEntry.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/mapEntry.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/pair.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/pair.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/throwable.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/throwable.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/bigDecimal.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/bigDecimal.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -11,11 +12,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import java.math.BigDecimal
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultBigDecimalAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultBigDecimalAssertionsimport java.math.BigDecimal
 
 fun <T : BigDecimal> AssertionContainer<T>.isNumericallyEqualTo(expected: T): Assertion = impl.isNumericallyEqualTo(this, expected)
 fun <T : BigDecimal> AssertionContainer<T>.isNotNumericallyEqualTo(expected: T): Assertion = impl.isNotNumericallyEqualTo(this, expected)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/bigDecimal.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/bigDecimal.kt
@@ -12,7 +12,11 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultBigDecimalAssertionsimport java.math.BigDecimal
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import java.math.BigDecimal
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultBigDecimalAssertions
 
 fun <T : BigDecimal> AssertionContainer<T>.isNumericallyEqualTo(expected: T): Assertion = impl.isNumericallyEqualTo(this, expected)
 fun <T : BigDecimal> AssertionContainer<T>.isNotNumericallyEqualTo(expected: T): Assertion = impl.isNotNumericallyEqualTo(this, expected)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDate.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDate.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -11,11 +12,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import java.time.chrono.ChronoLocalDate
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateAssertionsimport java.time.chrono.ChronoLocalDate
 
 fun <T : ChronoLocalDate> AssertionContainer<T>.isBefore(expected: ChronoLocalDate): Assertion = impl.isBefore(this, expected)
 fun <T : ChronoLocalDate> AssertionContainer<T>.isBeforeOrEqual(expected: ChronoLocalDate): Assertion = impl.isBeforeOrEqual(this, expected)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDate.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDate.kt
@@ -12,7 +12,11 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateAssertionsimport java.time.chrono.ChronoLocalDate
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import java.time.chrono.ChronoLocalDate
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateAssertions
 
 fun <T : ChronoLocalDate> AssertionContainer<T>.isBefore(expected: ChronoLocalDate): Assertion = impl.isBefore(this, expected)
 fun <T : ChronoLocalDate> AssertionContainer<T>.isBeforeOrEqual(expected: ChronoLocalDate): Assertion = impl.isBeforeOrEqual(this, expected)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDateTime.kt
@@ -12,7 +12,12 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateTimeAssertionsimport java.time.chrono.ChronoLocalDateimport java.time.chrono.ChronoLocalDateTime
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import java.time.chrono.ChronoLocalDate
+import java.time.chrono.ChronoLocalDateTime
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateTimeAssertions
 
 fun <T : ChronoLocalDateTime<out ChronoLocalDate>> AssertionContainer<T>.isBefore(expected: ChronoLocalDateTime<*>): Assertion = impl.isBefore(this, expected)
 

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoLocalDateTime.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -11,12 +12,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import java.time.chrono.ChronoLocalDate
-import java.time.chrono.ChronoLocalDateTime
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateTimeAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultChronoLocalDateTimeAssertionsimport java.time.chrono.ChronoLocalDateimport java.time.chrono.ChronoLocalDateTime
 
 fun <T : ChronoLocalDateTime<out ChronoLocalDate>> AssertionContainer<T>.isBefore(expected: ChronoLocalDateTime<*>): Assertion = impl.isBefore(this, expected)
 

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoZonedDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoZonedDateTime.kt
@@ -12,7 +12,13 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultChronoZonedDateTimeAssertionsimport java.time.chrono.ChronoLocalDateimport java.time.chrono.ChronoZonedDateTime
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.creating.AssertionContainer
+import java.time.chrono.ChronoLocalDate
+import java.time.chrono.ChronoLocalDateTime
+import java.time.chrono.ChronoZonedDateTime
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultChronoZonedDateTimeAssertions
 
 fun <T : ChronoZonedDateTime<out ChronoLocalDate>> AssertionContainer<T>.isBefore(expected: ChronoZonedDateTime<*>): Assertion = impl.isBefore(this, expected)
 

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoZonedDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/chronoZonedDateTime.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -11,13 +12,7 @@
 
 package ch.tutteli.atrium.logic
 
-import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.creating.AssertionContainer
-import java.time.chrono.ChronoLocalDate
-import java.time.chrono.ChronoLocalDateTime
-import java.time.chrono.ChronoZonedDateTime
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.logic.impl.DefaultChronoZonedDateTimeAssertions
+import ch.tutteli.atrium.assertions.Assertionimport ch.tutteli.atrium.core.ExperimentalNewExpectTypesimport ch.tutteli.atrium.creating.AssertionContainerimport ch.tutteli.atrium.logic.impl.DefaultChronoZonedDateTimeAssertionsimport java.time.chrono.ChronoLocalDateimport java.time.chrono.ChronoZonedDateTime
 
 fun <T : ChronoZonedDateTime<out ChronoLocalDate>> AssertionContainer<T>.isBefore(expected: ChronoZonedDateTime<*>): Assertion = impl.isBefore(this, expected)
 

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/floatingPointJvm.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/floatingPointJvm.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDate.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDate.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/localDateTime.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/optional.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/optional.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle
@@ -12,13 +13,13 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
-import ch.tutteli.atrium.logic.impl.DefaultPathAssertions
 import java.nio.charset.Charset
 import java.nio.file.LinkOption
 import java.nio.file.Path
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.logic.impl.DefaultPathAssertions
 
 fun <T : Path> AssertionContainer<T>.startsWith(expected: Path): Assertion = impl.startsWith(this, expected)
 fun <T : Path> AssertionContainer<T>.startsNotWith(expected: Path): Assertion = impl.startsNotWith(this, expected)
@@ -26,8 +27,7 @@ fun <T : Path> AssertionContainer<T>.endsWith(expected: Path): Assertion = impl.
 fun <T : Path> AssertionContainer<T>.endsNotWith(expected: Path): Assertion = impl.endsNotWith(this, expected)
 
 fun <T : Path> AssertionContainer<T>.exists(vararg linkOptions: LinkOption): Assertion = impl.exists(this, *linkOptions)
-fun <T : Path> AssertionContainer<T>.existsNot(vararg linkOptions: LinkOption): Assertion =
-    impl.existsNot(this, *linkOptions)
+fun <T : Path> AssertionContainer<T>.existsNot(vararg linkOptions: LinkOption): Assertion = impl.existsNot(this, *linkOptions)
 
 fun <T : Path> AssertionContainer<T>.isReadable(): Assertion = impl.isReadable(this)
 fun <T : Path> AssertionContainer<T>.isWritable(): Assertion = impl.isWritable(this)
@@ -37,11 +37,7 @@ fun <T : Path> AssertionContainer<T>.isDirectory(): Assertion = impl.isDirectory
 fun <T : Path> AssertionContainer<T>.isAbsolute(): Assertion = impl.isAbsolute(this)
 fun <T : Path> AssertionContainer<T>.isRelative(): Assertion = impl.isRelative(this)
 
-fun <T : Path> AssertionContainer<T>.hasSameTextualContentAs(
-    targetPath: Path,
-    sourceCharset: Charset,
-    targetCharset: Charset
-): Assertion =
+fun <T : Path> AssertionContainer<T>.hasSameTextualContentAs(targetPath: Path, sourceCharset: Charset, targetCharset: Charset): Assertion =
     impl.hasSameTextualContentAs(this, targetPath, sourceCharset, targetCharset)
 
 fun <T : Path> AssertionContainer<T>.hasSameBinaryContentAs(targetPath: Path): Assertion = impl.hasSameBinaryContentAs(this, targetPath)
@@ -50,11 +46,9 @@ fun <T : Path> AssertionContainer<T>.fileName(): FeatureExtractorBuilder.Executi
 fun <T : Path> AssertionContainer<T>.extension(): FeatureExtractorBuilder.ExecutionStep<T, String> = impl.extension(this)
 fun <T : Path> AssertionContainer<T>.fileNameWithoutExtension(): FeatureExtractorBuilder.ExecutionStep<T, String> = impl.fileNameWithoutExtension(this)
 fun <T : Path> AssertionContainer<T>.parent(): FeatureExtractorBuilder.ExecutionStep<T, Path> = impl.parent(this)
-fun <T : Path> AssertionContainer<T>.resolve(other: String): FeatureExtractorBuilder.ExecutionStep<T, Path> =
-    impl.resolve(this, other)
+fun <T : Path> AssertionContainer<T>.resolve(other: String): FeatureExtractorBuilder.ExecutionStep<T, Path> = impl.resolve(this, other)
 
-fun <T : Path> AssertionContainer<T>.hasDirectoryEntry(entries: List<String>): Assertion =
-    impl.hasDirectoryEntry(this, entries)
+fun <T : Path> AssertionContainer<T>.hasDirectoryEntry(entries: List<String>): Assertion = impl.hasDirectoryEntry(this, entries)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
@@ -26,8 +26,8 @@ fun <T : Path> AssertionContainer<T>.startsNotWith(expected: Path): Assertion = 
 fun <T : Path> AssertionContainer<T>.endsWith(expected: Path): Assertion = impl.endsWith(this, expected)
 fun <T : Path> AssertionContainer<T>.endsNotWith(expected: Path): Assertion = impl.endsNotWith(this, expected)
 
-fun <T : Path> AssertionContainer<T>.exists(vararg linkOptions: LinkOption): Assertion = impl.exists(this, *linkOptions)
-fun <T : Path> AssertionContainer<T>.existsNot(vararg linkOptions: LinkOption): Assertion = impl.existsNot(this, *linkOptions)
+fun <T : Path> AssertionContainer<T>.exists(linkOption: LinkOption? = null): Assertion = impl.exists(this, linkOption)
+fun <T : Path> AssertionContainer<T>.existsNot(linkOption: LinkOption? = null): Assertion = impl.existsNot(this, linkOption)
 
 fun <T : Path> AssertionContainer<T>.isReadable(): Assertion = impl.isReadable(this)
 fun <T : Path> AssertionContainer<T>.isWritable(): Assertion = impl.isWritable(this)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
@@ -12,20 +12,22 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
-import java.nio.charset.Charset
-import java.nio.file.Path
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.logic.impl.DefaultPathAssertions
+import java.nio.charset.Charset
+import java.nio.file.LinkOption
+import java.nio.file.Path
 
 fun <T : Path> AssertionContainer<T>.startsWith(expected: Path): Assertion = impl.startsWith(this, expected)
 fun <T : Path> AssertionContainer<T>.startsNotWith(expected: Path): Assertion = impl.startsNotWith(this, expected)
 fun <T : Path> AssertionContainer<T>.endsWith(expected: Path): Assertion = impl.endsWith(this, expected)
 fun <T : Path> AssertionContainer<T>.endsNotWith(expected: Path): Assertion = impl.endsNotWith(this, expected)
 
-fun <T : Path> AssertionContainer<T>.exists(): Assertion = impl.exists(this)
-fun <T : Path> AssertionContainer<T>.existsNot(): Assertion = impl.existsNot(this)
+fun <T : Path> AssertionContainer<T>.exists(vararg linkOptions: LinkOption): Assertion = impl.exists(this, *linkOptions)
+fun <T : Path> AssertionContainer<T>.existsNot(vararg linkOptions: LinkOption): Assertion =
+    impl.existsNot(this, *linkOptions)
 
 fun <T : Path> AssertionContainer<T>.isReadable(): Assertion = impl.isReadable(this)
 fun <T : Path> AssertionContainer<T>.isWritable(): Assertion = impl.isWritable(this)
@@ -35,7 +37,11 @@ fun <T : Path> AssertionContainer<T>.isDirectory(): Assertion = impl.isDirectory
 fun <T : Path> AssertionContainer<T>.isAbsolute(): Assertion = impl.isAbsolute(this)
 fun <T : Path> AssertionContainer<T>.isRelative(): Assertion = impl.isRelative(this)
 
-fun <T : Path> AssertionContainer<T>.hasSameTextualContentAs(targetPath: Path, sourceCharset: Charset, targetCharset: Charset): Assertion =
+fun <T : Path> AssertionContainer<T>.hasSameTextualContentAs(
+    targetPath: Path,
+    sourceCharset: Charset,
+    targetCharset: Charset
+): Assertion =
     impl.hasSameTextualContentAs(this, targetPath, sourceCharset, targetCharset)
 
 fun <T : Path> AssertionContainer<T>.hasSameBinaryContentAs(targetPath: Path): Assertion = impl.hasSameBinaryContentAs(this, targetPath)
@@ -44,7 +50,11 @@ fun <T : Path> AssertionContainer<T>.fileName(): FeatureExtractorBuilder.Executi
 fun <T : Path> AssertionContainer<T>.extension(): FeatureExtractorBuilder.ExecutionStep<T, String> = impl.extension(this)
 fun <T : Path> AssertionContainer<T>.fileNameWithoutExtension(): FeatureExtractorBuilder.ExecutionStep<T, String> = impl.fileNameWithoutExtension(this)
 fun <T : Path> AssertionContainer<T>.parent(): FeatureExtractorBuilder.ExecutionStep<T, Path> = impl.parent(this)
-fun <T : Path> AssertionContainer<T>.resolve(other: String): FeatureExtractorBuilder.ExecutionStep<T, Path> = impl.resolve(this, other)
+fun <T : Path> AssertionContainer<T>.resolve(other: String): FeatureExtractorBuilder.ExecutionStep<T, Path> =
+    impl.resolve(this, other)
+
+fun <T : Path> AssertionContainer<T>.hasDirectoryEntry(entries: List<String>): Assertion =
+    impl.hasDirectoryEntry(this, entries)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/zonedDateTime.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/zonedDateTime.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
@@ -21,8 +21,8 @@ interface PathAssertions {
     fun <T : Path> endsWith(container: AssertionContainer<T>, expected: Path): Assertion
     fun <T : Path> endsNotWith(container: AssertionContainer<T>, expected: Path): Assertion
 
-    fun <T : Path> exists(container: AssertionContainer<T>, vararg linkOptions: LinkOption): Assertion
-    fun <T : Path> existsNot(container: AssertionContainer<T>, vararg linkOptions: LinkOption): Assertion
+    fun <T : Path> exists(container: AssertionContainer<T>, linkOption: LinkOption? = null): Assertion
+    fun <T : Path> existsNot(container: AssertionContainer<T>, linkOption: LinkOption? = null): Assertion
 
     fun <T : Path> isReadable(container: AssertionContainer<T>): Assertion
     fun <T : Path> isWritable(container: AssertionContainer<T>): Assertion

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
@@ -9,6 +9,7 @@ import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import java.nio.charset.Charset
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 /**
@@ -20,8 +21,8 @@ interface PathAssertions {
     fun <T : Path> endsWith(container: AssertionContainer<T>, expected: Path): Assertion
     fun <T : Path> endsNotWith(container: AssertionContainer<T>, expected: Path): Assertion
 
-    fun <T : Path> exists(container: AssertionContainer<T>): Assertion
-    fun <T : Path> existsNot(container: AssertionContainer<T>): Assertion
+    fun <T : Path> exists(container: AssertionContainer<T>, vararg linkOptions: LinkOption): Assertion
+    fun <T : Path> existsNot(container: AssertionContainer<T>, vararg linkOptions: LinkOption): Assertion
 
     fun <T : Path> isReadable(container: AssertionContainer<T>): Assertion
     fun <T : Path> isWritable(container: AssertionContainer<T>): Assertion
@@ -44,5 +45,10 @@ interface PathAssertions {
     fun <T : Path> extension(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String>
     fun <T : Path> fileNameWithoutExtension(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, String>
     fun <T : Path> parent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, Path>
-    fun <T : Path> resolve(container: AssertionContainer<T>, other: String): FeatureExtractorBuilder.ExecutionStep<T, Path>
+    fun <T : Path> resolve(
+        container: AssertionContainer<T>,
+        other: String
+    ): FeatureExtractorBuilder.ExecutionStep<T, Path>
+
+    fun <T : Path> hasDirectoryEntry(container: AssertionContainer<T>, entries: List<String>): Assertion
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
@@ -187,7 +187,7 @@ class DefaultPathAssertions : PathAssertions {
         assertionBuilder.invisibleGroup.withAssertions(
             listOf(container.isDirectory()) +
                 entries.map { entry ->
-                    container.resolve(entry).collect { _logic.exists(NOFOLLOW_LINKS) }
+                    container.resolve(entry).collect { _logicAppend { exists(NOFOLLOW_LINKS) } }
                 }
         ).build()
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
@@ -7,6 +7,7 @@ package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.assertions.builders.invisibleGroup
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.creating.AssertionContainer
@@ -24,10 +25,8 @@ import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionPathAssertion.*
 import ch.tutteli.niok.*
 import java.nio.charset.Charset
-import java.nio.file.AccessDeniedException
-import java.nio.file.AccessMode
-import java.nio.file.NoSuchFileException
-import java.nio.file.Path
+import java.nio.file.*
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.attribute.BasicFileAttributes
 
 class DefaultPathAssertions : PathAssertions {
@@ -60,8 +59,11 @@ class DefaultPathAssertions : PathAssertions {
             it.readAllBytes().contentEquals(targetPath.readAllBytes())
         }
 
-    override fun <T : Path> exists(container: AssertionContainer<T>): Assertion =
-        changeSubjectToFileAttributes(container) { fileAttributesExpect ->
+    override fun <T : Path> exists(
+        container: AssertionContainer<T>,
+        vararg linkOptions: LinkOption
+    ): Assertion =
+        changeSubjectToFileAttributes(container, *linkOptions) { fileAttributesExpect ->
             assertionBuilder.descriptive
                 .withTest(fileAttributesExpect) { it is Success }
                 .withIOExceptionFailureHint(fileAttributesExpect) { realPath, exception ->
@@ -78,8 +80,12 @@ class DefaultPathAssertions : PathAssertions {
                 .build()
         }
 
-    override fun <T : Path> existsNot(container: AssertionContainer<T>): Assertion =
-        changeSubjectToFileAttributes(container) { fileAttributesExpect ->
+
+    override fun <T : Path> existsNot(
+        container: AssertionContainer<T>,
+        vararg linkOptions: LinkOption
+    ): Assertion =
+        changeSubjectToFileAttributes(container, *linkOptions) { fileAttributesExpect ->
             assertionBuilder.descriptive
                 .withTest(fileAttributesExpect) { it is Failure && it.exception is NoSuchFileException }
                 .withFileAttributesFailureHint(fileAttributesExpect)
@@ -89,9 +95,10 @@ class DefaultPathAssertions : PathAssertions {
 
     private inline fun <T : Path, R> changeSubjectToFileAttributes(
         container: AssertionContainer<T>,
+        vararg linkOptions: LinkOption,
         block: (Expect<IoResult<BasicFileAttributes>>) -> R
     ): R = container.changeSubject.unreported {
-        it.runCatchingIo { readAttributes<BasicFileAttributes>() }
+        it.runCatchingIo { readAttributes<BasicFileAttributes>(*linkOptions) }
     }.let(block)
 
     override fun <T : Path> isReadable(container: AssertionContainer<T>): Assertion =
@@ -180,4 +187,12 @@ class DefaultPathAssertions : PathAssertions {
         other: String
     ): FeatureExtractorBuilder.ExecutionStep<T, Path> = container.f1<T, String, Path>(Path::resolve, other)
 
+    override fun <T : Path> hasDirectoryEntry(container: AssertionContainer<T>, entries: List<String>): Assertion =
+        assertionBuilder.invisibleGroup.withAssertions(
+            listOf(isDirectory(container)) +
+                entries.map { entry ->
+                    resolve(container, entry)
+                        .collect { _logic.addAssertion(exists(_logic, NOFOLLOW_LINKS)) }
+                }
+        ).build()
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
@@ -185,10 +185,9 @@ class DefaultPathAssertions : PathAssertions {
 
     override fun <T : Path> hasDirectoryEntry(container: AssertionContainer<T>, entries: List<String>): Assertion =
         assertionBuilder.invisibleGroup.withAssertions(
-            listOf(isDirectory(container)) +
+            listOf(container.isDirectory()) +
                 entries.map { entry ->
-                    resolve(container, entry)
-                        .collect { _logic.addAssertion(exists(_logic, NOFOLLOW_LINKS)) }
+                    container.resolve(entry).collect { _logic.exists(NOFOLLOW_LINKS) }
                 }
         ).build()
 }

--- a/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/generated/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/result.kt
+++ b/logic/extensions/kotlin_1_3/atrium-logic-kotlin_1_3-common/src/generated/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/result.kt
@@ -1,3 +1,4 @@
+// @formatter:off
 //---------------------------------------------------
 //  Generated content, modify:
 //  logic/generateLogic.gradle

--- a/logic/generateLogic.gradle
+++ b/logic/generateLogic.gradle
@@ -54,7 +54,7 @@ def createGenerateLogicTaskForPackage(
 
     String generatedFolder = project.generatedFolder
 
-    return task("generateLogic_${relativePackagePath.replaceAll('/', '_')}", description: "generates ext. methods for pacakge $relativePackagePath") {
+    return task("generateLogic_${relativePackagePath.replaceAll('/', '_')}", description: "generates ext. methods for package $relativePackagePath") {
         def packagePath = 'ch/tutteli/atrium/logic' + relativePackagePath + (suffix != '' ? "/" + suffix : '')
         def fullPackage = packagePath.replaceAll('/', '.')
         def path = "$project.projectDir/src/main/kotlin/$packagePath/"
@@ -84,7 +84,7 @@ def createGenerateLogicTaskForPackage(
             def identifier = /[a-zA-Z0-9]+/
             def newLine = /(?:\r\n?|\n)/
             def newLineAndIndent = /$newLine\s*/
-            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
+            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<vararg$paramNumber>vararg )?(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
             def returnType = /(?:$newLineAndIndent)?\)(?<returnType>:.+)/
 
             def typeIdentifier = / *fun (?<generics><.+?> )?(?<funcName>$identifier)\((?:$newLineAndIndent)?$identifier: (?<type>$identifier(?:\.$identifier)*<.+>)/
@@ -92,8 +92,8 @@ def createGenerateLogicTaskForPackage(
                 def params = numOfParams > 0 ? (1..numOfParams) : []
                 new Tuple3<Pattern, String, String>(
                     Pattern.compile(typeIdentifier + params.collect { paramNumber -> parameter(paramNumber)}.join("") + returnType),
-                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (numOfParams > 1 ? "$ln    " : " "),
-                    /.${ '${funcName}' }\(this/ + (numOfParams > 0 ? ", " : "") + params.collect { paramNumber -> /${ '${paramName'+ paramNumber + '}'}/ }.join(", ") + /\)/
+                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${vararg' + paramNumber + '}'}${'${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (numOfParams > 1 ? "$ln    " : " "),
+                    /.${ '${funcName}' }\(this/ + (numOfParams > 0 ? ", " : "") + params.collect { paramNumber -> /${'${vararg' + paramNumber + '}'}${ '${paramName'+ paramNumber + '}'}/ }.join(", ") + /\)/
                 )
             }
 
@@ -117,6 +117,9 @@ def createGenerateLogicTaskForPackage(
                 patterns.forEach { triple ->
                     tmp = tmp.replaceAll(triple.first, triple.second + implValName + triple.third)
                 }
+                // when calling a varargs method, the call needs to use the spread operator (“*”), but the regex
+                // can only generate the string “vararg ”
+                tmp = tmp.replaceAll(/(=.*)vararg /, /$1\*/)
 
                 String generatedContent = tmp.substring(0, tmp.lastIndexOf("}"))
                 output.withWriter('utf-8') { w ->

--- a/logic/generateLogic.gradle
+++ b/logic/generateLogic.gradle
@@ -73,6 +73,7 @@ def createGenerateLogicTaskForPackage(
             //TODO delete all files in folder first (as we might have removed things)
 
             def header = """\
+                // @formatter:off
                 //---------------------------------------------------
                 //  Generated content, modify:
                 //  logic/generateLogic.gradle

--- a/logic/generateLogic.gradle
+++ b/logic/generateLogic.gradle
@@ -85,7 +85,7 @@ def createGenerateLogicTaskForPackage(
             def identifier = /[a-zA-Z0-9]+/
             def newLine = /(?:\r\n?|\n)/
             def newLineAndIndent = /$newLine\s*/
-            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<vararg$paramNumber>vararg )?(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
+            def parameter = { paramNumber -> /,(?: |$newLineAndIndent)(?<paramName$paramNumber>$identifier): (?<typeName$paramNumber>[^:]+?)/}
             def returnType = /(?:$newLineAndIndent)?\)(?<returnType>:.+)/
 
             def typeIdentifier = / *fun (?<generics><.+?> )?(?<funcName>$identifier)\((?:$newLineAndIndent)?$identifier: (?<type>$identifier(?:\.$identifier)*<.+>)/
@@ -93,8 +93,8 @@ def createGenerateLogicTaskForPackage(
                 def params = numOfParams > 0 ? (1..numOfParams) : []
                 new Tuple3<Pattern, String, String>(
                     Pattern.compile(typeIdentifier + params.collect { paramNumber -> parameter(paramNumber)}.join("") + returnType),
-                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${vararg' + paramNumber + '}'}${'${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (numOfParams > 1 ? "$ln    " : " "),
-                    /.${ '${funcName}' }\(this/ + (numOfParams > 0 ? ", " : "") + params.collect { paramNumber -> /${'${vararg' + paramNumber + '}'}${ '${paramName'+ paramNumber + '}'}/ }.join(", ") + /\)/
+                    /fun ${ '${generics}${type}.${funcName}' }\(/ + params.collect { paramNumber -> /${'${paramName' + paramNumber + '}'}: ${ '${typeName' + paramNumber + '}'}/ }.join(", ") + /\)${ '${returnType}' } =/ + (numOfParams > 1 ? "$ln    " : " "),
+                    /.${ '${funcName}' }\(this/ + (numOfParams > 0 ? ", " : "") + params.collect { paramNumber -> /${ '${paramName'+ paramNumber + '}'}/ }.join(", ") + /\)/
                 )
             }
 
@@ -118,9 +118,6 @@ def createGenerateLogicTaskForPackage(
                 patterns.forEach { triple ->
                     tmp = tmp.replaceAll(triple.first, triple.second + implValName + triple.third)
                 }
-                // when calling a varargs method, the call needs to use the spread operator (“*”), but the regex
-                // can only generate the string “vararg ”
-                tmp = tmp.replaceAll(/(=.*)vararg /, /$1\*/)
 
                 String generatedContent = tmp.substring(0, tmp.lastIndexOf("}"))
                 output.withWriter('utf-8') { w ->

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/pathAssertions.kt
@@ -254,7 +254,7 @@ fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.(
  * Therefore, if a symbolic link exists at the location the subject points to,
  * search will continue at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -297,7 +297,7 @@ fun <T : Path> Expect<T>.isWritable(): Expect<T> = addAssertion(ExpectImpl.path.
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
@@ -320,7 +320,7 @@ fun <T : Path> Expect<T>.isRegularFile(): Expect<T> = addAssertion(ExpectImpl.pa
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions works on.
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *

--- a/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
+++ b/misc/deprecated/apis/fluent-en_GB-jdk8/atrium-api-fluent-en_GB-jdk8-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/jdk8/PathAssertionsSpec.kt
@@ -3,7 +3,7 @@
 
 package ch.tutteli.atrium.api.fluent.en_GB.jdk8
 
-import ch.tutteli.atrium.api.fluent.en_GB.contains
+import ch.tutteli.atrium.api.fluent.en_GB.hasDirectoryEntry
 import ch.tutteli.atrium.api.fluent.en_GB.isAbsolute
 import ch.tutteli.atrium.api.fluent.en_GB.isExecutable
 import ch.tutteli.atrium.api.fluent.en_GB.isRelative
@@ -26,15 +26,18 @@ class PathAssertionsSpec : ch.tutteli.atrium.specs.integration.PathAssertionsSpe
     fun0(Expect<Path>::isDirectory),
     fun0(Expect<Path>::isAbsolute), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun0(Expect<Path>::isRelative), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
-    fun2<Path, String, Array<out String>>(Expect<Path>::contains), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
+    Expect<Path>::hasDirectoryEntry.name to Companion::hasDirectoryEntrySingle, // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
+    fun2<Path, String, Array<out String>>(Expect<Path>::hasDirectoryEntry), // checks the new function from fluent-jvm because it is not implemented in fluent-jkd8
     fun1(Expect<Path>::hasSameBinaryContentAs),
     fun3(Expect<Path>::hasSameTextualContentAs),
-    fun1(Companion::hasSameTextualContentAsDefaultArgs)
+    Expect<Path>::hasSameTextualContentAs.name to Companion::hasSameTextualContentAsDefaultArgs
 ) {
 
     companion object {
         private fun hasSameTextualContentAsDefaultArgs(expect: Expect<Path>, targetPath: Path): Expect<Path> =
             expect.hasSameTextualContentAs(targetPath)
+
+        private fun hasDirectoryEntrySingle(expect: Expect<Path>, entry: String) = expect.hasDirectoryEntry(entry)
     }
 
     @Suppress("unused", "UNUSED_VALUE")


### PR DESCRIPTION
 * rename `Expect<Path>.contains` to `Expect<Path>.hasDirectoryEntry`
 * expose it in the infix API
 * fix its symlink behaviour

Exposes `LinkOptions` for `exists` and `existsNot` on the Domain, but not on the API level.
We can pick it up from there should we ever want to expose it.
