### PR TITLE
catch exceptions during feature extraction and show it in reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,18 +448,18 @@ expect {
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/samples/readme-examples/src/main/kotlin/readme/examples/ReadmeSpec.kt#L94)</sub> ↓ <sub>Output</sub>
 ```text
 expected that subject: () -> kotlin.Nothing        (readme.examples.ReadmeSpec$1$7$1 <1234789>)
-◆ does not: throw when called
-  » Properties of the unexpected IllegalArgumentException
-    » message: "name is empty"        <1234789>
-    » stacktrace: 
-      ⚬ readme.examples.ReadmeSpec$1$7$1.invoke(ReadmeSpec.kt:97)
-      ⚬ readme.examples.ReadmeSpec$1$7$1.invoke(ReadmeSpec.kt:51)
-      ⚬ readme.examples.ReadmeSpec$1$7.invoke(ReadmeSpec.kt:98)
-      ⚬ readme.examples.ReadmeSpec$1$7.invoke(ReadmeSpec.kt:51)
-    » cause: java.lang.RuntimeException
-        » message: "a cause"        <1234789>
+◆ ▶ invoke(): ❗❗ threw java.lang.IllegalArgumentException
+      » Properties of the unexpected IllegalArgumentException
+        » message: "name is empty"        <1234789>
         » stacktrace: 
           ⚬ readme.examples.ReadmeSpec$1$7$1.invoke(ReadmeSpec.kt:97)
+          ⚬ readme.examples.ReadmeSpec$1$7$1.invoke(ReadmeSpec.kt:51)
+          ⚬ readme.examples.ReadmeSpec$1$7.invoke(ReadmeSpec.kt:98)
+          ⚬ readme.examples.ReadmeSpec$1$7.invoke(ReadmeSpec.kt:51)
+        » cause: java.lang.RuntimeException
+            » message: "a cause"        <1234789>
+            » stacktrace: 
+              ⚬ readme.examples.ReadmeSpec$1$7$1.invoke(ReadmeSpec.kt:97)
 ```
 </ex-notToThrow>
 

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/feature.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/feature.kt
@@ -8,16 +8,9 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.MetaFeature
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.reporting.translating.Translatable
-import kotlin.reflect.KProperty1
-import kotlin.reflect.KFunction1
-import kotlin.reflect.KFunction2
-import kotlin.reflect.KFunction3
-import kotlin.reflect.KFunction4
-import kotlin.reflect.KFunction5
-import kotlin.reflect.KFunction6
+import kotlin.reflect.*
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.logic.impl.DefaultFeatureAssertions
 
@@ -42,15 +35,8 @@ fun <T, A1, A2, A3, A4, A5, R> AssertionContainer<T>.f5(f: KFunction6<T, A1, A2,
     impl.f5(this, f, a1, a2, a3, a4, a5)
     //@formatter:on
 
-fun <T, R> AssertionContainer<T>.manualFeature(description: String, provider: T.() -> R): FeatureExtractorBuilder.ExecutionStep<T, R> =
-    impl.manualFeature(this, description, provider)
-
 fun <T, R> AssertionContainer<T>.manualFeature(description: Translatable, provider: T.() -> R): FeatureExtractorBuilder.ExecutionStep<T, R> =
     impl.manualFeature(this, description, provider)
-
-fun <T, R> AssertionContainer<T>.genericSubjectBasedFeature(provider: (T) -> MetaFeature<R>): FeatureExtractorBuilder.ExecutionStep<T, R> = impl.genericSubjectBasedFeature(this, provider)
-
-fun <T, R> AssertionContainer<T>.genericFeature(metaFeature: MetaFeature<R>): FeatureExtractorBuilder.ExecutionStep<T, R> = impl.genericFeature(this, metaFeature)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/fun0.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/fun0.kt
@@ -8,6 +8,7 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import kotlin.reflect.KClass
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
@@ -16,7 +17,7 @@ import ch.tutteli.atrium.logic.impl.DefaultFun0Assertions
 
 fun <TExpected : Throwable> AssertionContainer<out () -> Any?>.toThrow(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<*, TExpected> = impl.toThrow(this, expectedType)
 
-fun <R, T : () -> R> AssertionContainer<T>.notToThrow(): SubjectChangerBuilder.ExecutionStep<*, R> = impl.notToThrow(this)
+fun <R, T : () -> R> AssertionContainer<T>.notToThrow(): FeatureExtractorBuilder.ExecutionStep<*, R> = impl.notToThrow(this)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/FeatureAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/FeatureAssertions.kt
@@ -1,16 +1,9 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.domain.creating.MetaFeature
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.reporting.translating.Translatable
-import kotlin.reflect.KProperty1
-import kotlin.reflect.KFunction1
-import kotlin.reflect.KFunction2
-import kotlin.reflect.KFunction3
-import kotlin.reflect.KFunction4
-import kotlin.reflect.KFunction5
-import kotlin.reflect.KFunction6
+import kotlin.reflect.*
 
 /**
  * Collection of functions which help to create feature assertions by returning [FeatureExtractorBuilder.ExecutionStep].
@@ -34,23 +27,7 @@ interface FeatureAssertions {
 
     fun <T, R> manualFeature(
         container: AssertionContainer<T>,
-        description: String,
-        provider: T.() -> R
-    ): FeatureExtractorBuilder.ExecutionStep<T, R>
-
-    fun <T, R> manualFeature(
-        container: AssertionContainer<T>,
         description: Translatable,
         provider: T.() -> R
-    ): FeatureExtractorBuilder.ExecutionStep<T, R>
-
-    fun <T, R> genericSubjectBasedFeature(
-        container: AssertionContainer<T>,
-        provider: (T) -> MetaFeature<R>
-    ): FeatureExtractorBuilder.ExecutionStep<T, R>
-
-    fun <T, R> genericFeature(
-        container: AssertionContainer<T>,
-        metaFeature: MetaFeature<R>
     ): FeatureExtractorBuilder.ExecutionStep<T, R>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/Fun0Assertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/Fun0Assertions.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.logic
 
 import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import kotlin.reflect.KClass
 
@@ -14,5 +15,5 @@ interface Fun0Assertions {
         expectedType: KClass<TExpected>
     ): SubjectChangerBuilder.ExecutionStep<*, TExpected>
 
-    fun <R, T : () -> R> notToThrow(container: AssertionContainer<T>): SubjectChangerBuilder.ExecutionStep<*, R>
+    fun <R, T : () -> R> notToThrow(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<*, R>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
@@ -3,10 +3,8 @@ package ch.tutteli.atrium.logic.creating.transformers.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.assertions.builders.fixedClaimGroup
-import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
-import ch.tutteli.atrium.core.None
-import ch.tutteli.atrium.core.Option
-import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.core.*
+import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.FeatureExpect
@@ -15,7 +13,10 @@ import ch.tutteli.atrium.domain.builders.creating.collectors.collectAssertions
 import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractor
 import ch.tutteli.atrium.logic.toExpect
+import ch.tutteli.atrium.reporting.reporter
 import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
+import ch.tutteli.atrium.translations.DescriptionFunLikeAssertion
 
 class DefaultFeatureExtractor : FeatureExtractor {
     @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -37,36 +38,51 @@ class DefaultFeatureExtractor : FeatureExtractor {
                 featureExpectOptions
             )
 
-        return container.maybeSubject
-            .flatMap { subject -> featureExtraction(subject) }
-            .fold(
-                {
-                    container.addAssertion(
-                        assertionBuilder.fixedClaimGroup
-                            .withFeatureType
-                            .failing
-                            .withDescriptionAndRepresentation(description, representationForFailure)
-                            .withAssertions(maybeSubAssertions.fold({
-                                listOf<Assertion>()
-                            }) { assertionCreator ->
-                                listOf(
-                                    assertionBuilder.explanatoryGroup.withDefaultType
-                                        .collectAssertions(None, assertionCreator)
-                                        .build()
-                                )
-                            })
+        val either: Either<Option<Throwable>, R> = container.maybeSubject.fold({ Left(None) }, { subject ->
+            try {
+                featureExtraction(subject).fold({ Left(None) }, { Right(it) })
+            } catch (throwable: Throwable) {
+                //TODO 0.15.0 should be taken from `container`
+                reporter.atriumErrorAdjuster.adjust(throwable)
+                Left(Some(throwable))
+            }
+        })
+
+        return either.fold(
+            { maybeThrowable ->
+                val (failureHintAssertions, repForFailure) = maybeThrowable.fold(
+                    { listOf<Assertion>() to representationForFailure },
+                    { throwable ->
+                        listOf(ThrowableThrownFailureHandler.propertiesOfThrowable(throwable)) to
+                            TranslatableWithArgs(DescriptionFunLikeAssertion.THREW, throwable::class.fullName)
+                    })
+
+                val subAssertions = maybeSubAssertions.fold({
+                    listOf<Assertion>()
+                }) { assertionCreator ->
+                    listOf(
+                        assertionBuilder.explanatoryGroup.withDefaultType
+                            .collectAssertions(None, assertionCreator)
                             .build()
                     )
-                    createFeatureExpect(None, listOf())
-                },
-                { subject ->
-                    createFeatureExpect(Some(subject), maybeSubAssertions.fold({
-                        listOf<Assertion>()
-                    }) { assertionCreator ->
-                        assertionCollector.collectForComposition(Some(subject), assertionCreator)
-                    })
                 }
-            )
+                container.addAssertion(
+                    assertionBuilder.fixedClaimGroup
+                        .withFeatureType
+                        .failing
+                        .withDescriptionAndRepresentation(description, repForFailure)
+                        .withAssertions(failureHintAssertions + subAssertions)
+                        .build()
+                )
+                createFeatureExpect(None, listOf())
+            },
+            { subject ->
+                createFeatureExpect(Some(subject), maybeSubAssertions.fold({
+                    listOf<Assertion>()
+                }) { assertionCreator ->
+                    assertionCollector.collectForComposition(Some(subject), assertionCreator)
+                })
+            }
+        )
     }
-
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultSubjectChanger.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultSubjectChanger.kt
@@ -44,7 +44,7 @@ class DefaultSubjectChanger : SubjectChanger {
 
         if (shallTransform) {
             expect.addAssertion(descriptiveAssertion)
-            maybeSubAssertions.fold({ /*nothing to do */ }) { assertionCreator ->
+            maybeSubAssertions.fold({ /* nothing to do */ }) { assertionCreator ->
                 expect.addAssertionsCreatedBy(assertionCreator)
             }
         } else {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler.kt
@@ -17,7 +17,6 @@ import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionThrowableAssertion.*
 
-//TODO extend SubjectChanger from logic
 class ThrowableThrownFailureHandler<T : Throwable?, R> : SubjectChanger.FailureHandler<T, R> {
 
     override fun createAssertion(
@@ -61,6 +60,7 @@ class ThrowableThrownFailureHandler<T : Throwable?, R> : SubjectChanger.FailureH
             explanation: Assertion = createExplanation(throwable)
         ): AssertionGroup =
             assertionBuilder.explanatoryGroup
+                // TODO change to InformationType with 0.15.0
                 .withDefaultType
                 .withAssertions(
                     explanation,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/featureExtensions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/featureExtensions.kt
@@ -1,0 +1,47 @@
+package ch.tutteli.atrium.logic
+
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.domain.creating.MetaFeature
+import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
+import ch.tutteli.atrium.reporting.Text
+import ch.tutteli.atrium.reporting.translating.Untranslatable
+import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.translations.ErrorMessages
+
+/**
+ * Convenience method to pass a [String] as [description] which is wrapped into an [Untranslatable] instead of passing
+ * a [Translatable].
+ */
+fun <T, R> AssertionContainer<T>.manualFeature(
+    description: String,
+    provider: T.() -> R
+): FeatureExtractorBuilder.ExecutionStep<T, R> = manualFeature(Untranslatable(description), provider)
+
+//TODO use MetaFeature from logic with 0.15.0
+fun <T, R> AssertionContainer<T>.genericSubjectBasedFeature(
+    provider: (T) -> MetaFeature<R>
+): FeatureExtractorBuilder.ExecutionStep<T, R> =
+    genericFeature(this, maybeSubject.fold(::createFeatureSubjectNotDefined) { provider(it) })
+
+private fun <R> createFeatureSubjectNotDefined(): MetaFeature<R> =
+    MetaFeature(
+        ErrorMessages.DEDSCRIPTION_BASED_ON_SUBJECT,
+        ErrorMessages.REPRESENTATION_BASED_ON_SUBJECT_NOT_DEFINED,
+        None
+    )
+private fun <T, R> genericFeature(
+    container: AssertionContainer<T>,
+    metaFeature: MetaFeature<R>
+): FeatureExtractorBuilder.ExecutionStep<T, R> {
+    val representation: Any = metaFeature.representation ?: Text.NULL
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalNewExpectTypes::class)
+    return container.extractFeature
+        .withDescription(metaFeature.description)
+        .withRepresentationForFailure(representation)
+        .withFeatureExtraction { metaFeature.maybeSubject }
+        .withOptions { withRepresentation { representation } }
+        .build()
+}

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/Fun0AssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/Fun0AssertionsSpec.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
@@ -84,7 +85,7 @@ abstract class Fun0AssertionsSpec(
                         expect<() -> Any?> { /* no exception occurs */ 1 }.toThrowFun { toBe(IllegalArgumentException("what")) }
                     }.toThrow<AssertionError> {
                         message {
-                            contains.exactly(1).regex(
+                            contains.exactly(1).values(
                                 "${DescriptionFunLikeAssertion.THROWN_EXCEPTION_WHEN_CALLED.getDefault()}: " +
                                     DescriptionFunLikeAssertion.NO_EXCEPTION_OCCURRED.getDefault(),
                                 "$isADescr: ${IllegalArgumentException::class.simpleName}"
@@ -98,6 +99,16 @@ abstract class Fun0AssertionsSpec(
             notToThrowFunctions.forEach { (name, notToThrowFun, _) ->
                 it("$name - does not throw, allows to make a sub assertion") {
                     expect { 1 }.notToThrowFun { toBe(1) }
+                }
+            }
+
+            notToThrowFunctions.forEach { (name, notToThrowFun, _) ->
+                it("$name - shows return value in case sub-assertion fails") {
+                    expect {
+                        expect { 123456789 }.notToThrowFun { toBe(1) }
+                    }.toThrow<AssertionError>() {
+                        messageContains("123456789")
+                    }
                 }
             }
         }
@@ -146,8 +157,10 @@ abstract class Fun0AssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             containsRegex(
-                                "${DescriptionFunLikeAssertion.IS_NOT_THROWING_1.getDefault()}: "+
-                                    DescriptionFunLikeAssertion.IS_NOT_THROWING_2.getDefault(),
+                                "\\Qinvoke()\\E: ${
+                                    DescriptionFunLikeAssertion.THREW.getDefault()
+                                        .format(UnsupportedOperationException::class.fullName)
+                                }",
                                 UnsupportedOperationException::class.simpleName + separator +
                                     messageAndStackTrace(errMessage)
                             )

--- a/misc/tools/atrium-bc-test/build.gradle
+++ b/misc/tools/atrium-bc-test/build.gradle
@@ -176,9 +176,6 @@ def createBcAndBbcTasks(String apiName, String oldVersion, String forgive) {
             add(confCommon, "$groupId:atrium-specs:$oldVersion") {
                 exclude group: 'ch.tutteli.atrium'
             }
-            add(confCommon, prefixedProject("api-fluent-en_GB-jvm")) {  //required by atrium-specs
-                exclude group: '*'
-            }
             add(confCommon, prefixedProject("verbs-internal-jvm")) {  //required by specs in the APIs
                 exclude group: '*'
             }
@@ -186,6 +183,7 @@ def createBcAndBbcTasks(String apiName, String oldVersion, String forgive) {
 
         //TODO keep only if branch, remove the rest with 1.0.0
         if (isFluentOrInfix) {
+            //required by atrium-specs
             add(confCommon, prefixedProject("$apiName-jvm"))
         } else if (!apiName.endsWith('en_UK')) {
             add(confCommon, prefixedProject("$apiName-robstoll-jvm"))
@@ -382,18 +380,32 @@ createBcAndBbcTasksForApis('0.10.0',
     'fluent-en_GB'
 )
 createBcAndBbcTasksForApis('0.11.1',
-    'forgive=(ch/tutteli/atrium/api/fluent/en_GB/ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual).*)',
+    'forgive=(ch/tutteli/atrium/api/fluent/en_GB/('+
+        '(ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual))|'+
+        '(Fun0AssertionsSpec.*/notToThrow( \\(feature\\))? - throws an AssertionError)'+
+        ').*)',
     'fluent-en_GB'
 )
 createBcAndBbcTasksForApis('0.12.0',
     'forgive=(ch/tutteli/atrium/api/fluent/en_GB/(' +
-        '(PathAssertionsSpec/.*`is(Readable|Writable|RegularFile|Directory)`.*)' +
-    '))|(ch/tutteli/atrium/api/infix/en_GB/(' +
-        '(Fun0AssertionsJvmSpec/.*)|' +
-        '(PathAssertionsSpec/.*`toBe (readable|writable|aRegularFile|aDirectory)`.*)' +
-    '))|(ch/tutteli/atrium/api/(fluent|infix)/en_GB/ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual).*)',
+        '(PathAssertionsSpec/.*`is(Readable|Writable|RegularFile|Directory)`)'+
+    ').*)|(ch/tutteli/atrium/api/infix/en_GB/(' +
+        '(Fun0AssertionsJvmSpec/)|' +
+        '(PathAssertionsSpec/.*`toBe (readable|writable|aRegularFile|aDirectory)`)' +
+    ').*)|(ch/tutteli/atrium/api/(fluent|infix)/en_GB/('+
+        '(ComparableAssertionsSpec.*(isLessThanOrEqual|isGreaterThanOrEqual))|'+
+        '(Fun0AssertionsSpec.*/notToThrow( \\(feature\\))? - throws an AssertionError)'+
+    ').*)',
     'fluent-en_GB','infix-en_GB'
 )
+// we are not setting up bbc/bc tests for 0.13.0. The problem is:
+// We inline toThrow, making atrium-logic part of the API in binary terms. atrium-logic is experimental though and we
+// changed toThrow -- we are no longer using ChangedSubjectPostStep -- making almost every spec fail. Forgiving each
+// does not make sensen
+//createBcAndBbcTasksForApis('0.13.0',
+////    'forgive=(.*(\\(feature\\)|(describe empty assertion creator lambda)).*)',
+//    'forgive=^$',
+//    'fluent-en_GB', 'infix-en_GB')
 //@formatter:on
 
 

--- a/misc/tools/atrium-bc-test/src/main/kotlin/ch/tutteil/atrium/bctest/DeprecationSpek2ExecutionListener.kt
+++ b/misc/tools/atrium-bc-test/src/main/kotlin/ch/tutteil/atrium/bctest/DeprecationSpek2ExecutionListener.kt
@@ -22,7 +22,7 @@ class DeprecationSpek2ExecutionListener(
             println("forgiving ${test.path}")
             listener.testExecutionFinish(test, ExecutionResult.Success)
         } else {
-            println("path of test in case you want to forgive it failing:\n ${test.path}")
+            println("!!!!! path of test in case you want to forgive it failing:\n ${test.path}")
             listener.testExecutionFinish(test, result)
         }
     }

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionFunLikeAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionFunLikeAssertion.kt
@@ -7,8 +7,11 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  * Contains the [DescriptiveAssertion.description]s of the assertion functions which are applicable to [Any].
  */
 enum class DescriptionFunLikeAssertion(override val value: String) : StringBasedTranslatable {
+    @Deprecated("Will be removed with 1.0.0")
     IS_NOT_THROWING_1("wirft"),
+    @Deprecated("Will be removed with 1.0.0")
     IS_NOT_THROWING_2("keine Exception bei Aufruf"),
     NO_EXCEPTION_OCCURRED("❗❗ keine Exception wurde geworfen"),
     THROWN_EXCEPTION_WHEN_CALLED("geworfene Exception bei Aufruf"),
+    THREW("❗❗ warf %s")
 }

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionFunLikeAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionFunLikeAssertion.kt
@@ -7,8 +7,11 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  * Contains the [DescriptiveAssertion.description]s of the assertion functions which are applicable to [Any].
  */
 enum class DescriptionFunLikeAssertion(override val value: String) : StringBasedTranslatable {
+    @Deprecated("Will be removed with 1.0.0")
     IS_NOT_THROWING_1("does not"),
-    IS_NOT_THROWING_2("throw when called"),
+    @Deprecated("Will be removed with 1.0.0")
+    IS_NOT_THROWING_2("throw when invoked"),
     NO_EXCEPTION_OCCURRED("❗❗ no exception occurred"),
     THROWN_EXCEPTION_WHEN_CALLED("thrown exception when called"),
+    THREW("❗❗ threw %s")
 }


### PR DESCRIPTION
- re-use this for notToThrow, change to feature extraction as we want
  to show the value in case of a success (fixes #628)
- remove genericFeature and genericSubjectBasedFeature based on
  MetaFeature from logic



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
