### PR TITLE
reformat usages of toVarArg use `.let`, reads better

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
@@ -317,10 +317,10 @@ fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.regex(
  */
 fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
-    return values(first, *rest)
-}
+): Expect<T> =
+    _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
+        .let { (first, rest) -> values(first, *rest) }
+
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where all elements of the [expectedIterableLike]
@@ -346,10 +346,9 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.elementsOf(
 @JvmName("elementsOfIgnoringCase")
 fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
-    return values(first, *rest)
-}
+): Expect<T> =
+    _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
+        .let { (first, rest) -> values(first, *rest) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where all elements of the [expectedIterableLike]
@@ -375,7 +374,6 @@ fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.elementsOf(
 @JvmName("elementsOfIgnoringCase")
 fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
-    return values(first, *rest)
-}
+): Expect<T> =
+    _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
+        .let { (first, rest) -> values(first, *rest) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderCreators.kt
@@ -120,7 +120,4 @@ fun <E : Any, T: IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBehaviour>
  */
 inline fun <reified E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<E>(expectedIterableLike)
-    return values(first, *rest)
-}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> values(first, *rest) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
@@ -143,7 +143,4 @@ fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBeh
  */
 inline fun <reified E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<E>(expectedIterableLike)
-    return values(first, *rest)
-}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> values(first, *rest) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
@@ -129,7 +129,4 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  */
 inline fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<E>(expectedIterableLike)
-    return values(first, *rest)
-}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> values(first, *rest) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
@@ -370,11 +370,9 @@ infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.the(
  */
 infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
-    return this the Values(first, rest)
-}
-
+): Expect<T> =
+    _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
+        .let { (first, rest) -> this the Values(first, rest) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where all elements of the [expectedIterableLike]
@@ -400,10 +398,9 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.elementsOf(
 @JvmName("elementsOfIgnoringCase")
 infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
-    return this the Values(first, rest)
-}
+): Expect<T>  =
+    _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
+        .let { (first, rest) -> this the Values(first, rest) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where all elements of the [expectedIterableLike]
@@ -429,7 +426,6 @@ infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.element
 @JvmName("elementsOfIgnoringCase")
 infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
-    return this the Values(first, rest)
-}
+): Expect<T> =
+    _logic.toVarArg<CharSequenceOrNumberOrChar>(expectedIterableLike)
+        .let { (first, rest) -> this the Values(first, rest) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderCreators.kt
@@ -114,7 +114,4 @@ infix fun <E : Any, T : IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBeh
  */
 inline infix fun <reified E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<E>(expectedIterableLike)
-    return this the values(first, *rest)
-}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> this the values(first, *rest) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
@@ -127,7 +127,4 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  */
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<E>(expectedIterableLike)
-    return this the values(first, *rest)
-}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> this the values(first, *rest) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
@@ -127,7 +127,4 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  */
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
-): Expect<T> {
-    val (first, rest) = _logic.toVarArg<E>(expectedIterableLike)
-    return this the values(first, *rest)
-}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> this the values(first, *rest) }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep.kt
@@ -5,8 +5,9 @@ import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 
 /**
  * Represents the extension point for another step after a `contains at least`-check within a sophisticated
- * `contains` assertion building process for [CharSequence].
+ * `contains` assertion building process for [IterableLike].
  *
+ * @param E The element type of the IterableLike type [T].
  * @param T The input type of the search.
  * @param S The search behaviour which should be applied for the input of the search.
  */


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
