### PR TITLE
🚧 Adopt the ‘to+infinitive’ Convention

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
@@ -1,8 +1,8 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.*
+import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.utils.iterableLikeToIterable
 import ch.tutteli.atrium.reporting.Reporter
 import ch.tutteli.kbox.glue
@@ -30,22 +30,56 @@ fun <T> Expect<T>.notToBe(expected: T): Expect<T> = _logicAppend { notToBe(expec
 /**
  * Expects that the subject of the assertion is the same instance as [expected].
  *
+ * Deprecated as atrium moves to a consistent ‘to + infinitive’ naming convention. Use [toBeTheSameAs] instead.
+ * This function will be removed in version 1.0.0. See
+ * [atrium-roadmap#93](https://github.com/robstoll/atrium-roadmap/issues/93) for details and to give feedback.
+ *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.AnyAssertionSamples.isSameAs
  */
-fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = _logicAppend { isSameAs(expected) }
+@Deprecated(
+    "Replaced by toBeTheSameAs. Will be removed with version 1.0.0",
+    ReplaceWith("this.toBeTheSameAs<T>(expected)")
+) // TODO remove with 1.0.0
+fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = toBeTheSameAs(expected)
+
+/**
+ * Expects that the subject of `this` assertion is the same instance as [expected].
+ *
+ * @return an [Expect] for the current subject of `this` assertion.
+ * @throws AssertionError if the subject of `this` assertion is not the same instance as [expected].
+ *
+ * @since 0.16.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.AnyAssertionSamples.toBeTheSameAs
+ */
+fun <T> Expect<T>.toBeTheSameAs(expected: T): Expect<T> = _logicAppend { toBeTheSameAs(expected) }
 
 /**
  * Expects that the subject of the assertion is not the same instance as [expected].
  *
+ * Deprecated as atrium moves to a consistent ‘to + infinitive’ naming convention. Use [notToBeTheSameAs] instead.
+ * This function will be removed in version 1.0.0. See
+ * [atrium-roadmap#93](https://github.com/robstoll/atrium-roadmap/issues/93) for details and to give feedback.
+ *
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.AnyAssertionSamples.isNotSameAs
  */
-fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = _logicAppend { isNotSameAs(expected) }
+@Deprecated(
+    "Replaced by notToBeTheSameAs. Will be removed with version 1.0.0",
+    ReplaceWith("this.notToBeTheSameAs<T>(expected)")
+) // TODO remove with 1.0.0
+fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = notToBeTheSameAs(expected)
+
+/**
+ * Expects that the subject of `this` assertion is not the same instance as [expected].
+ *
+ * @return an [Expect] for the current subject of `this` assertion.
+ * @throws AssertionError if the subject of `this` assertion is the same instance as [expected].
+ *
+ * @since 0.16.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.AnyAssertionSamples.notToBeTheSameAs
+ */
+fun <T> Expect<T>.notToBeTheSameAs(expected: T): Expect<T> = _logicAppend { notToBeTheSameAs(expected) }
 
 /**
  * Expects that the subject of the assertion is either `null` in case [assertionCreatorOrNull]

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/AnyAssertionsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/AnyAssertionsSpec.kt
@@ -1,11 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.feature0
-import ch.tutteli.atrium.specs.fun1
-import ch.tutteli.atrium.specs.fun2
-import ch.tutteli.atrium.specs.withFeatureSuffix
-import ch.tutteli.atrium.specs.withNullableSuffix
+import ch.tutteli.atrium.specs.*
 import kotlin.reflect.KFunction2
 import kotlin.reflect.KProperty1
 
@@ -18,14 +14,14 @@ class AnyAssertionsSpec : ch.tutteli.atrium.specs.integration.AnyAssertionsSpec(
     fun1(Expect<DataClass>::notToBe),
     fun1(Expect<Int?>::notToBe).withNullableSuffix(),
     fun1(Expect<DataClass?>::notToBe).withNullableSuffix(),
-    fun1(Expect<Int>::isSameAs),
-    fun1(Expect<DataClass>::isSameAs),
-    fun1(Expect<Int?>::isSameAs).withNullableSuffix(),
-    fun1(Expect<DataClass?>::isSameAs).withNullableSuffix(),
-    fun1(Expect<Int>::isNotSameAs),
-    fun1(Expect<DataClass>::isNotSameAs),
-    fun1(Expect<Int?>::isNotSameAs).withNullableSuffix(),
-    fun1(Expect<DataClass?>::isNotSameAs).withNullableSuffix(),
+    fun1(Expect<Int>::toBeTheSameAs),
+    fun1(Expect<DataClass>::toBeTheSameAs),
+    fun1(Expect<Int?>::toBeTheSameAs).withNullableSuffix(),
+    fun1(Expect<DataClass?>::toBeTheSameAs).withNullableSuffix(),
+    fun1(Expect<Int>::notToBeTheSameAs),
+    fun1(Expect<DataClass>::notToBeTheSameAs),
+    fun1(Expect<Int?>::notToBeTheSameAs).withNullableSuffix(),
+    fun1(Expect<DataClass?>::notToBeTheSameAs).withNullableSuffix(),
     fun2(Expect<Int>::isNoneOf),
     fun2(Expect<DataClass>::isNoneOf),
     fun2(Expect<Int?>::isNoneOf).withNullableSuffix(),

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/AnyAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/AnyAssertionSamples.kt
@@ -38,24 +38,24 @@ class AnyAssertionSamples {
     }
 
     @Test
-    fun isSameAs() {
+    fun toBeTheSameAs() {
         val list = listOf(3)
-        expect(list).isSameAs(list)
+        expect(list).toBeTheSameAs(list)
 
         fails {
-            // fails because isSameAs is based on identity, use toBe for equality
-            expect(listOf(3)).isSameAs(listOf(3))
+            // fails because toBeTheSameAs is based on identity, use toBe for equality
+            expect(listOf(3)).toBeTheSameAs(listOf(3))
         }
     }
 
     @Test
-    fun isNotSameAs() {
-       // holds because isSameAs is based on identity, use notToBe for equality
-        expect(listOf(2)).isNotSameAs(listOf(2))
+    fun notToBeTheSameAs() {
+        // holds because notToBeTheSameAs is based on identity, use notToBe for equality
+        expect(listOf(2)).notToBeTheSameAs(listOf(2))
 
         fails {
             val list = listOf(3)
-            expect(list).isNotSameAs(list)
+            expect(list).notToBeTheSameAs(list)
         }
     }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
@@ -31,7 +31,7 @@ infix fun <T> Expect<T>.notToBe(expected: T): Expect<T> = _logicAppend { notToBe
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-infix fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = _logicAppend { isSameAs(expected) }
+infix fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = _logicAppend { toBeTheSameAs(expected) }
 
 /**
  * Expects that the subject of the assertion is not the same instance as [expected].
@@ -39,7 +39,7 @@ infix fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = _logicAppend { isSame
  * @return An [Expect] for the current subject of the assertion.
  * @throws AssertionError Might throw an [AssertionError] if the assertion made is not correct.
  */
-infix fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = _logicAppend { isNotSameAs(expected) }
+infix fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = _logicAppend { notToBeTheSameAs(expected) }
 
 /**
  * Expects that the subject of the assertion is either `null` in case [assertionCreatorOrNull]

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/any.kt
@@ -17,8 +17,8 @@ import ch.tutteli.atrium.logic.impl.DefaultAnyAssertions
 
 fun <T> AssertionContainer<T>.toBe(expected: T): Assertion = impl.toBe(this, expected)
 fun <T> AssertionContainer<T>.notToBe(expected: T): Assertion = impl.notToBe(this, expected)
-fun <T> AssertionContainer<T>.isSameAs(expected: T): Assertion = impl.isSameAs(this, expected)
-fun <T> AssertionContainer<T>.isNotSameAs(expected: T): Assertion = impl.isNotSameAs(this, expected)
+fun <T> AssertionContainer<T>.toBeTheSameAs(expected: T): Assertion = impl.toBeTheSameAs(this, expected)
+fun <T> AssertionContainer<T>.notToBeTheSameAs(expected: T): Assertion = impl.notToBeTheSameAs(this, expected)
 
 fun <T : Any?> AssertionContainer<T>.toBeNull(): Assertion = impl.toBeNull(this)
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/AnyAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/AnyAssertions.kt
@@ -12,8 +12,8 @@ import kotlin.reflect.KClass
 interface AnyAssertions {
     fun <T> toBe(container: AssertionContainer<T>, expected: T): Assertion
     fun <T> notToBe(container: AssertionContainer<T>, expected: T): Assertion
-    fun <T> isSameAs(container: AssertionContainer<T>, expected: T): Assertion
-    fun <T> isNotSameAs(container: AssertionContainer<T>, expected: T): Assertion
+    fun <T> toBeTheSameAs(container: AssertionContainer<T>, expected: T): Assertion
+    fun <T> notToBeTheSameAs(container: AssertionContainer<T>, expected: T): Assertion
 
     fun <T : Any?> toBeNull(container: AssertionContainer<T>): Assertion
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
@@ -17,10 +17,10 @@ class DefaultAnyAssertions : AnyAssertions {
     override fun <T> notToBe(container: AssertionContainer<T>, expected: T): Assertion =
         container.createDescriptiveAssertion(NOT_TO_BE, expected) { it != expected }
 
-    override fun <T> isSameAs(container: AssertionContainer<T>, expected: T): Assertion =
+    override fun <T> toBeTheSameAs(container: AssertionContainer<T>, expected: T): Assertion =
         container.createDescriptiveAssertion(IS_SAME, expected) { it === expected }
 
-    override fun <T> isNotSameAs(container: AssertionContainer<T>, expected: T): Assertion =
+    override fun <T> notToBeTheSameAs(container: AssertionContainer<T>, expected: T): Assertion =
         container.createDescriptiveAssertion(IS_NOT_SAME, expected) { it !== expected }
 
     override fun <T> toBeNull(container: AssertionContainer<T>): Assertion =

--- a/logic/atrium-logic-jvm/src/test/kotlin/ch/tutteli/atrium/logic/impl/creating/filesystem/IoResultSpec.kt
+++ b/logic/atrium-logic-jvm/src/test/kotlin/ch/tutteli/atrium/logic/impl/creating/filesystem/IoResultSpec.kt
@@ -27,7 +27,7 @@ object IoResultSpec : Spek({
             val result = testPath.runCatchingIo { throw testException }
             expect(result).isA<Failure> {
                 feature(IoResult<*>::path).toBe(testPath)
-                feature(Failure::exception).isSameAs(testException)
+                feature(Failure::exception).toBeTheSameAs(testException)
             }
         }
 

--- a/logic/atrium-logic-jvm/src/test/kotlin/ch/tutteli/atrium/logic/impl/creating/filesystem/hints/SymbolicLinkResolvingSpec.kt
+++ b/logic/atrium-logic-jvm/src/test/kotlin/ch/tutteli/atrium/logic/impl/creating/filesystem/hints/SymbolicLinkResolvingSpec.kt
@@ -133,7 +133,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 val file = tempFolder.newFile("testFile").toRealPath()
 
                 val resultAssertion = explainForResolvedLink(file, resolvedPathConsumer)
-                expect(resultAssertion).isSameAs(testAssertion)
+                expect(resultAssertion).toBeTheSameAs(testAssertion)
             }
 
             it("adds an explanation for one symbolic link") {
@@ -145,7 +145,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 expect(resultAssertion).isA<AssertionGroup>()
                     .feature { p(it::assertions) }.containsExactly(
                         { describesLink(link, target) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
 
@@ -160,7 +160,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     .feature { p(it::assertions) }.containsExactly(
                         { describesLink(start, toNowhere) },
                         { describesLink(toNowhere, nowhere) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
 
@@ -183,7 +183,7 @@ object SymbolicLinkResolvingSpec : Spek({
                         { describesLink(linkToInnerLink, innerLinkInGrandparentLink) },
                         { describesLink(grandparentLink, grandparent) },
                         { describesLink(innerLink, target) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
 
@@ -199,7 +199,7 @@ object SymbolicLinkResolvingSpec : Spek({
                         { describesLink(barLink, testDir) },
                         { describesLink(barLink, testDir) },
                         { describesLink(barLink, testDir) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
         }
@@ -216,7 +216,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     { describesLink(a, b) },
                     { describesLink(b, a) },
                     { describesLinkLoop(a, b, a) },
-                    { isSameAs(testAssertion) }
+                    { toBeTheSameAs(testAssertion) }
                 )
         }
 
@@ -232,7 +232,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     { describesLink(link, fooLink.resolve("link")) },
                     { describesLink(fooLink, foo) },
                     { describesLinkLoop(link, link) },
-                    { isSameAs(testAssertion) }
+                    { toBeTheSameAs(testAssertion) }
                 )
         }
 
@@ -260,7 +260,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     { describesLink(b, c) },
                     { describesLink(c, a) },
                     { describesLinkLoop(a, b, c, a) },
-                    { isSameAs(testAssertion) }
+                    { toBeTheSameAs(testAssertion) }
                 )
         }
     }

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/filesystem/IoResultSpec.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/filesystem/IoResultSpec.kt
@@ -30,7 +30,7 @@ object IoResultSpec : Spek({
             val result = testPath.runCatchingIo { throw testException }
             expect(result).isA<Failure> {
                 feature(IoResult<*>::path).toBe(testPath)
-                feature(Failure::exception).isSameAs(testException)
+                feature(Failure::exception).toBeTheSameAs(testException)
             }
         }
 

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/filesystem/SymbolicLinkResolvingSpec.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/filesystem/SymbolicLinkResolvingSpec.kt
@@ -137,7 +137,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 val file = tempFolder.newFile("testFile").toRealPath()
 
                 val resultAssertion = explainForResolvedLink(file, resolvedPathConsumer)
-                expect(resultAssertion).isSameAs(testAssertion)
+                expect(resultAssertion).toBeTheSameAs(testAssertion)
             }
 
             it("adds an explanation for one symbolic link") {
@@ -149,7 +149,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 expect(resultAssertion).isA<AssertionGroup>()
                     .feature { p(it::assertions) }.containsExactly(
                         { describesLink(link, target) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
 
@@ -164,7 +164,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     .feature { p(it::assertions) }.containsExactly(
                         { describesLink(start, toNowhere) },
                         { describesLink(toNowhere, nowhere) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
 
@@ -187,7 +187,7 @@ object SymbolicLinkResolvingSpec : Spek({
                         { describesLink(linkToInnerLink, innerLinkInGrandparentLink) },
                         { describesLink(grandparentLink, grandparent) },
                         { describesLink(innerLink, target) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
 
@@ -203,7 +203,7 @@ object SymbolicLinkResolvingSpec : Spek({
                         { describesLink(barLink, testDir) },
                         { describesLink(barLink, testDir) },
                         { describesLink(barLink, testDir) },
-                        { isSameAs(testAssertion) }
+                        { toBeTheSameAs(testAssertion) }
                     )
             }
         }
@@ -220,7 +220,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     { describesLink(a, b) },
                     { describesLink(b, a) },
                     { describesLinkLoop(a, b, a) },
-                    { isSameAs(testAssertion) }
+                    { toBeTheSameAs(testAssertion) }
                 )
         }
 
@@ -236,7 +236,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     { describesLink(link, fooLink.resolve("link")) },
                     { describesLink(fooLink, foo) },
                     { describesLinkLoop(link, link) },
-                    { isSameAs(testAssertion) }
+                    { toBeTheSameAs(testAssertion) }
                 )
         }
 
@@ -264,7 +264,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     { describesLink(b, c) },
                     { describesLink(c, a) },
                     { describesLinkLoop(a, b, c, a) },
-                    { isSameAs(testAssertion) }
+                    { toBeTheSameAs(testAssertion) }
                 )
         }
     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/checking/FeatureAssertionCheckerSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/checking/FeatureAssertionCheckerSpec.kt
@@ -69,7 +69,7 @@ abstract class FeatureAssertionCheckerSpec(
             it("copies the assertion") {
                 assertions.clear()
                 expect(captured).isA<AssertionGroup> {
-                    feature { f(it::assertions) }.hasSize(1).and.isNotSameAs(assertions)
+                    feature { f(it::assertions) }.hasSize(1).and.notToBeTheSameAs(assertions)
                 }
             }
         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/AnyAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/AnyAssertionsSpec.kt
@@ -24,14 +24,14 @@ abstract class AnyAssertionsSpec(
     notToBeDataClass: Fun1<DataClass, DataClass>,
     notToBeNullableInt: Fun1<Int?, Int?>,
     notToBeNullableDataClass: Fun1<DataClass?, DataClass?>,
-    isSameInt: Fun1<Int, Int>,
-    isSameDataClass: Fun1<DataClass, DataClass>,
-    isSameNullableInt: Fun1<Int?, Int?>,
-    isSameNullableDataClass: Fun1<DataClass?, DataClass?>,
-    isNotSameInt: Fun1<Int, Int>,
-    isNotSameDataClass: Fun1<DataClass, DataClass>,
-    isNotSameNullableInt: Fun1<Int?, Int?>,
-    isNotSameNullableDataClass: Fun1<DataClass?, DataClass?>,
+    toBeTheSameInt: Fun1<Int, Int>,
+    toBeTheSameDataClass: Fun1<DataClass, DataClass>,
+    toBeTheSameNullableInt: Fun1<Int?, Int?>,
+    toBeTheSameNullableDataClass: Fun1<DataClass?, DataClass?>,
+    notToBeTheSameInt: Fun1<Int, Int>,
+    notToBeTheSameDataClass: Fun1<DataClass, DataClass>,
+    notToBeTheSameNullableInt: Fun1<Int?, Int?>,
+    notToBeTheSameNullableDataClass: Fun1<DataClass?, DataClass?>,
     isNoneOfInt: Fun2<Int, Int, Array<out Int>>,
     isNoneOfDataClass: Fun2<DataClass, DataClass, Array<out DataClass>>,
     isNoneOfNullableInt: Fun2<Int?, Int?, Array<out Int?>>,
@@ -65,8 +65,8 @@ abstract class AnyAssertionsSpec(
         describePrefix,
         toBeInt.forSubjectLess(1),
         notToBeInt.forSubjectLess(1),
-        isSameInt.forSubjectLess(1),
-        isNotSameInt.forSubjectLess(1),
+        toBeTheSameInt.forSubjectLess(1),
+        notToBeTheSameInt.forSubjectLess(1),
         isNoneOfInt.forSubjectLess(1, emptyArray()),
         isNotInInt.forSubjectLess(listOf(1)),
         andPair.forSubjectLess(),
@@ -77,8 +77,8 @@ abstract class AnyAssertionsSpec(
         "$describePrefix[nullable] ",
         toBeNullableInt.forSubjectLess(1),
         notToBeNullableInt.forSubjectLess(1),
-        isSameNullableInt.forSubjectLess(1),
-        isNotSameNullableInt.forSubjectLess(1),
+        toBeTheSameNullableInt.forSubjectLess(1),
+        notToBeTheSameNullableInt.forSubjectLess(1),
         isNoneOfNullableInt.forSubjectLess(1, emptyArray()),
         isNotInNullableInt.forSubjectLess(listOf(1)),
         toBeNull.forSubjectLess(),
@@ -383,15 +383,24 @@ abstract class AnyAssertionsSpec(
         }
     }
 
-    describeFun(toBeInt, notToBeInt, isSameInt, isNotSameInt, isNoneOfInt, isNotInInt) {
-        checkInt("primitive", expect(1), toBeInt, notToBeInt, isSameInt, isNotSameInt, isNoneOfInt, isNotInInt)
+    describeFun(toBeInt, notToBeInt, toBeTheSameInt, notToBeTheSameInt, isNoneOfInt, isNotInInt) {
+        checkInt(
+            "primitive",
+            expect(1),
+            toBeInt,
+            notToBeInt,
+            toBeTheSameInt,
+            notToBeTheSameInt,
+            isNoneOfInt,
+            isNotInInt
+        )
         checkInt(
             "nullable primitive",
             expect(1 as Int?),
             toBeNullableInt,
             notToBeNullableInt,
-            isSameNullableInt,
-            isNotSameNullableInt,
+            toBeTheSameNullableInt,
+            notToBeTheSameNullableInt,
             isNoneOfNullableInt,
             isNotInNullableInt
         )
@@ -402,8 +411,8 @@ abstract class AnyAssertionsSpec(
             expect(subject),
             toBeDataClass,
             notToBeDataClass,
-            isSameDataClass,
-            isNotSameDataClass,
+            toBeTheSameDataClass,
+            notToBeTheSameDataClass,
             isNoneOfDataClass,
             isNotInDataClass,
             subject
@@ -413,8 +422,8 @@ abstract class AnyAssertionsSpec(
             expect(subject as DataClass?),
             toBeNullableDataClass,
             notToBeNullableDataClass,
-            isSameNullableDataClass,
-            isNotSameNullableDataClass,
+            toBeTheSameNullableDataClass,
+            notToBeTheSameNullableDataClass,
             isNoneOfNullableDataClass,
             isNotInNullableDataClass,
             subject
@@ -424,8 +433,8 @@ abstract class AnyAssertionsSpec(
             "null as Int?",
             toBeNullableInt,
             notToBeNullableInt,
-            isSameNullableInt,
-            isNotSameNullableInt,
+            toBeTheSameNullableInt,
+            notToBeTheSameNullableInt,
             isNoneOfNullableInt,
             isNotInNullableInt,
             2,
@@ -435,8 +444,8 @@ abstract class AnyAssertionsSpec(
             "null as DataClass?",
             toBeNullableDataClass,
             notToBeNullableDataClass,
-            isSameNullableDataClass,
-            isNotSameNullableDataClass,
+            toBeTheSameNullableDataClass,
+            notToBeTheSameNullableDataClass,
             isNoneOfNullableDataClass,
             isNotInNullableDataClass,
             subject,
@@ -697,14 +706,14 @@ abstract class AnyAssertionsSpec(
                 isASuperTypeFunctions.forEach { (name, isASuperType, _) ->
                     it("$name - does not throw if it holds") {
                         val subject = SubType()
-                        expect(subject as Any?).isASuperType { isSameAs(subject) }
+                        expect(subject as Any?).isASuperType { toBeTheSameAs(subject) }
                     }
 
                     it("$name - throws if it does not hold") {
                         val subject = SubType()
                         val otherSubType = SubType()
                         expect {
-                            expect(subject as Any?).isASuperType { isSameAs(otherSubType) }
+                            expect(subject as Any?).isASuperType { toBeTheSameAs(otherSubType) }
                         }.toThrow<AssertionError> {
                             messageContains(subject.toString(), IS_SAME.getDefault(), otherSubType.toString())
                         }
@@ -719,7 +728,7 @@ abstract class AnyAssertionsSpec(
                 it("$name - throws an AssertionError" + showsSubAssertionIf(hasExtraHint)) {
 
                     expect {
-                        expect(SuperType() as Any?).isASubType { isSameAs(SubType()) }
+                        expect(SuperType() as Any?).isASubType { toBeTheSameAs(SubType()) }
                     }.toThrow<AssertionError> {
                         messageContains(
                             SuperType::class.fullName,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/reporting/ObjectFormatterSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/reporting/ObjectFormatterSpec.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.specs.reporting
 
-import ch.tutteli.atrium.api.fluent.en_GB.isSameAs
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.api.fluent.en_GB.toBeTheSameAs
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.reporting.ObjectFormatter
 import ch.tutteli.atrium.reporting.Text
@@ -47,7 +47,7 @@ abstract class ObjectFormatterSpec(
         context("a ${Translatable::class.simpleName}") {
             val result = testee.format(ch.tutteli.atrium.api.verbs.internal.AssertionVerb.EXPECT)
             it("returns the translated string") {
-                expect(result).isSameAs(translatedText)
+                expect(result).toBeTheSameAs(translatedText)
             }
         }
 
@@ -65,7 +65,7 @@ abstract class ObjectFormatterSpec(
         context("a ${ch.tutteli.atrium.reporting.translating.TranslatableBasedRawString::class.simpleName}") {
             val result = testee.format(ch.tutteli.atrium.api.verbs.internal.AssertionVerb.EXPECT)
             it("returns the translated string") {
-                expect(result).isSameAs(translatedText)
+                expect(result).toBeTheSameAs(translatedText)
             }
         }
     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslatorIntSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslatorIntSpec.kt
@@ -152,7 +152,7 @@ abstract class TranslatorIntSpec(
                 val text = "n'est pas la même instance que"
                 it("a failing assertion contains '$text' instead of 'assert' in the error message") {
                     expect {
-                        assertWithDeCh_Fr(1).isNotSameAs(1)
+                        assertWithDeCh_Fr(1).notToBeTheSameAs(1)
                     }.toThrow<AssertionError> { messageContains("$text: 1") }
                 }
             }
@@ -297,14 +297,14 @@ abstract class TranslatorIntSpec(
                 describe("translation for $descriptionAnyAssertion.$isNotSame is provided for 'zh_$country' and zh") {
                     it("a failing assertion contains '$isNotSame zh_$country' instead of 'to be' in the error message") {
                         expect {
-                            assert.isNotSameAs(1)
+                            assert.notToBeTheSameAs(1)
                         }.toThrow<AssertionError> { messageContains("$isNotSame zh_$country: 1") }
                     }
                 }
                 describe("translation for $descriptionAnyAssertion.$isSame is not provided for 'zh_$country' but for zh") {
                     it("a failing assertion contains '$isSame zh' instead of 'to be' in the error message") {
                         expect {
-                            assert.isSameAs(2)
+                            assert.toBeTheSameAs(2)
                         }.toThrow<AssertionError> { messageContains("$isSame zh: 2") }
                     }
                 }


### PR DESCRIPTION
Let’s get the ball rolling!

This PR will introduce the [‘to+infinitive’ convention](https://github.com/robstoll/atrium-roadmap/issues/93) for atrium.
It will not be merged before the convention has been applied to all of the fluent API. 
It exists to gather feedback and find merge conflicts during the transition.