### PR TITLE
reword entry to element in IterableLike.contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,7 +926,7 @@ expect(listOf(1, 2, 2, 4)).contains(2, 3)
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
-  ⚬ an entry which is: 3        (kotlin.Int <1234789>)
+  ⚬ an element which equals: 3        (kotlin.Int <1234789>)
     ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
 ```
@@ -966,11 +966,11 @@ expect(listOf(1, 2, 2, 4)).contains(
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
-  ⚬ an entry which: 
+  ⚬ an element which: 
       » is less than: 0        (kotlin.Int <1234789>)
     ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
-  ⚬ an entry which: 
+  ⚬ an element which: 
       » is greater than: 2        (kotlin.Int <1234789>)
       » is less than: 4        (kotlin.Int <1234789>)
     ⚬ ▶ number of such entries: 0
@@ -1005,7 +1005,7 @@ expect(listOf(1, 2, 3, 4)).any { isLessThan(0) }
 ```text
 expected that subject: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
-  ⚬ an entry which: 
+  ⚬ an element which: 
       » is less than: 0        (kotlin.Int <1234789>)
     ⚬ ▶ number of such entries: 0
         ◾ is at least: 1
@@ -1021,7 +1021,7 @@ expect(listOf(1, 2, 3, 4)).none { isGreaterThan(2) }
 ```text
 expected that subject: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ does not contain: 
-  ⚬ an entry which: 
+  ⚬ an element which: 
       » is greater than: 2        (kotlin.Int <1234789>)
     ✘ ▶ number of such entries: 2
         ◾ is: 0        (kotlin.Int <1234789>)
@@ -1068,17 +1068,17 @@ expect(listOf(1, 2, 2, 4)).contains.inOrder.only.entries({ isLessThan(3) }, { is
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains only, in order: 
-  ✔ ▶ entry 0: 1        (kotlin.Int <1234789>)
-      ◾ an entry which: 
+  ✔ ▶ element 0: 1        (kotlin.Int <1234789>)
+      ◾ an element which: 
           » is less than: 3        (kotlin.Int <1234789>)
-  ✘ ▶ entry 1: 2        (kotlin.Int <1234789>)
-      ◾ an entry which: 
+  ✘ ▶ element 1: 2        (kotlin.Int <1234789>)
+      ◾ an element which: 
           » is less than: 2        (kotlin.Int <1234789>)
   ✘ ▶ size: 4        (kotlin.Int <1234789>)
       ◾ equals: 2        (kotlin.Int <1234789>)
-        ❗❗ additional entries detected: 
-           ⚬ entry 2: 2        (kotlin.Int <1234789>)
-           ⚬ entry 3: 4        (kotlin.Int <1234789>)
+        ❗❗ additional elements detected: 
+           ⚬ element 2: 2        (kotlin.Int <1234789>)
+           ⚬ element 3: 4        (kotlin.Int <1234789>)
 ```
 </ex-collection-builder-1>
 
@@ -1118,15 +1118,15 @@ expect(listOf(1, 2, 2, 4)).contains.inOrder.only.values(1, 2, 2, 3, 4)
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains only, in order: 
-  ✔ ▶ entry 0: 1        (kotlin.Int <1234789>)
+  ✔ ▶ element 0: 1        (kotlin.Int <1234789>)
       ◾ equals: 1        (kotlin.Int <1234789>)
-  ✔ ▶ entry 1: 2        (kotlin.Int <1234789>)
+  ✔ ▶ element 1: 2        (kotlin.Int <1234789>)
       ◾ equals: 2        (kotlin.Int <1234789>)
-  ✔ ▶ entry 2: 2        (kotlin.Int <1234789>)
+  ✔ ▶ element 2: 2        (kotlin.Int <1234789>)
       ◾ equals: 2        (kotlin.Int <1234789>)
-  ✘ ▶ entry 3: 4        (kotlin.Int <1234789>)
+  ✘ ▶ element 3: 4        (kotlin.Int <1234789>)
       ◾ equals: 3        (kotlin.Int <1234789>)
-  ✘ ▶ entry 4: ❗❗ hasNext() returned false
+  ✘ ▶ element 4: ❗❗ hasNext() returned false
       ◾ equals: 4        (kotlin.Int <1234789>)
   ✘ ▶ size: 4        (kotlin.Int <1234789>)
       ◾ equals: 5        (kotlin.Int <1234789>)
@@ -1142,7 +1142,7 @@ expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.atLeast(1).butAtMost(2).entries({
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
-  ⚬ an entry which: 
+  ⚬ an element which: 
       » is less than: 3        (kotlin.Int <1234789>)
     ⚬ ▶ number of such entries: 3
         ◾ is at most: 2
@@ -1158,10 +1158,10 @@ expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.only.values(1, 2, 3, 4)
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains only, in any order: 
-  ✔ an entry which is: 1        (kotlin.Int <1234789>)
-  ✔ an entry which is: 2        (kotlin.Int <1234789>)
-  ✘ an entry which is: 3        (kotlin.Int <1234789>)
-  ✔ an entry which is: 4        (kotlin.Int <1234789>)
+  ✔ an element which equals: 1        (kotlin.Int <1234789>)
+  ✔ an element which equals: 2        (kotlin.Int <1234789>)
+  ✘ an element which equals: 3        (kotlin.Int <1234789>)
+  ✔ an element which equals: 4        (kotlin.Int <1234789>)
   ✔ ▶ size: 4
       ◾ equals: 4
   ❗❗ following entries were mismatched: 
@@ -1178,11 +1178,11 @@ expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.only.values(4, 3, 2, 2, 1)
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains only, in any order: 
-  ✔ an entry which is: 4        (kotlin.Int <1234789>)
-  ✘ an entry which is: 3        (kotlin.Int <1234789>)
-  ✔ an entry which is: 2        (kotlin.Int <1234789>)
-  ✔ an entry which is: 2        (kotlin.Int <1234789>)
-  ✔ an entry which is: 1        (kotlin.Int <1234789>)
+  ✔ an element which equals: 4        (kotlin.Int <1234789>)
+  ✘ an element which equals: 3        (kotlin.Int <1234789>)
+  ✔ an element which equals: 2        (kotlin.Int <1234789>)
+  ✔ an element which equals: 2        (kotlin.Int <1234789>)
+  ✔ an element which equals: 1        (kotlin.Int <1234789>)
   ✘ ▶ size: 4
       ◾ equals: 5
 ```
@@ -1282,7 +1282,7 @@ expected that subject: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
            ⚬ index 1: "b"        <1234789>
 ◆ ▶ values: [1, 2]        (java.util.LinkedHashMap.LinkedValues <1234789>)
     ◾ does not contain: 
-      ⚬ an entry which: 
+      ⚬ an element which: 
           » is greater than: 1        (kotlin.Int <1234789>)
         ✘ ▶ number of such entries: 1
             ◾ is: 0        (kotlin.Int <1234789>)
@@ -1312,14 +1312,14 @@ expect(linkedMapOf("a" to 1, "b" to 2)).asEntries().contains.inOrder.only.entrie
 ```text
 expected that subject: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
 ◆ contains only, in order: 
-  ✔ ▶ entry 0: a=1        (java.util.LinkedHashMap.Entry <1234789>)
-      ◾ an entry which: 
+  ✔ ▶ element 0: a=1        (java.util.LinkedHashMap.Entry <1234789>)
+      ◾ an element which: 
           » ▶ key: "a"        <1234789>
               ◾ equals: "a"        <1234789>
           » ▶ value: 1        (kotlin.Int <1234789>)
               ◾ equals: 1        (kotlin.Int <1234789>)
-  ✘ ▶ entry 1: b=2        (java.util.LinkedHashMap.Entry <1234789>)
-      ◾ an entry which: 
+  ✘ ▶ element 1: b=2        (java.util.LinkedHashMap.Entry <1234789>)
+      ◾ an element which: 
           » ▶ key: "a"        <1234789>
               ◾ starts with: "a"        <1234789>
           » ▶ value: 1        (kotlin.Int <1234789>)
@@ -1593,14 +1593,14 @@ also states which entries were additionally contained in the list:
 ```text
 expected that subject: [1, 2, 3]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains only, in order: 
-  ✔ ▶ entry 0: 1        (kotlin.Int <1234789>)
+  ✔ ▶ element 0: 1        (kotlin.Int <1234789>)
       ◾ equals: 1        (kotlin.Int <1234789>)
-  ✘ ▶ entry 1: 2        (kotlin.Int <1234789>)
+  ✘ ▶ element 1: 2        (kotlin.Int <1234789>)
       ◾ equals: 3        (kotlin.Int <1234789>)
   ✘ ▶ size: 3        (kotlin.Int <1234789>)
       ◾ equals: 2        (kotlin.Int <1234789>)
-        ❗❗ additional entries detected: 
-           ⚬ entry 2: 3        (kotlin.Int <1234789>)
+        ❗❗ additional elements detected: 
+           ⚬ element 2: 3        (kotlin.Int <1234789>)
 ```
 </exs-add-info-1-output>
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -21,7 +21,7 @@ import ch.tutteli.atrium.logic.impl.createExplanatoryAssertionGroup
 import ch.tutteli.atrium.logic.impl.createHasElementAssertion
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ENTRY_WHICH
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WHICH
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
@@ -43,7 +43,10 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
     private val converter: (T) -> Iterable<E?>,
     searchBehaviour: InAnyOrderSearchBehaviour,
     checkers: List<IterableLikeContains.Checker>
-) : ContainsAssertionCreator<T, List<E?>, (Expect<E>.() -> Unit)?, IterableLikeContains.Checker>(searchBehaviour, checkers),
+) : ContainsAssertionCreator<T, List<E?>, (Expect<E>.() -> Unit)?, IterableLikeContains.Checker>(
+    searchBehaviour,
+    checkers
+),
     IterableLikeContains.Creator<T, (Expect<E>.() -> Unit)?> {
 
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
@@ -73,7 +76,7 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
         }
 
         return assertionBuilder.customType(groupType)
-            .withDescriptionAndEmptyRepresentation(AN_ENTRY_WHICH)
+            .withDescriptionAndEmptyRepresentation(AN_ELEMENT_WHICH)
             .withAssertions(assertions)
             .build()
     }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
@@ -50,7 +50,7 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
             val featureAssertions = createSizeFeatureAssertion(searchCriteria, actualSize)
             if (mismatches == 0 && list.isNotEmpty()) {
                 featureAssertions.add(LazyThreadUnsafeAssertionGroup {
-                    createExplanatoryGroupForMismatchesEtc(list, WARNING_ADDITIONAL_ENTRIES)
+                    createExplanatoryGroupForMismatchesEtc(list, WARNING_ADDITIONAL_ELEMENTS)
                 })
             }
             assertions.add(

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ENTRY_WHICH_IS
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where exactly the expected entries have
@@ -30,6 +30,6 @@ class InAnyOrderOnlyValuesAssertionCreator<E, T : IterableLike>(
         list: MutableList<E?>
     ): Pair<Boolean, Assertion> {
         val found: Boolean = list.remove(searchCriterion)
-        return found to assertionBuilder.createDescriptive(AN_ENTRY_WHICH_IS, searchCriterion) { found }
+        return found to assertionBuilder.createDescriptive(AN_ELEMENT_WHICH_EQUALS, searchCriterion) { found }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -36,7 +36,7 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
 
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES
-    override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ENTRY_WHICH_IS
+    override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
 
     override fun getAssertionGroupType(): AssertionGroupType {
         return if (searchBehaviour is NotSearchBehaviour) {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrd
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion.ELEMENT_WITH_INDEX
 
 /**
  * Represents the base class for `in order only` assertion creators and provides a corresponding template to fulfill
@@ -32,7 +33,7 @@ abstract class InOrderOnlyAssertionCreator<E, T : IterableLike, SC>(
     override fun Expect<List<E>>.createAssertionsAndReturnIndex(searchCriteria: List<SC>): Int {
         var index = 0
         searchCriteria.forEachIndexed { currentIndex, searchCriterion ->
-            createSingleEntryAssertion(currentIndex, searchCriterion, DescriptionIterableAssertion.ENTRY_WITH_INDEX)
+            createSingleEntryAssertion(currentIndex, searchCriterion, ELEMENT_WITH_INDEX)
             index = currentIndex
         }
         ++index

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
@@ -61,7 +61,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
                     addAssertion(LazyThreadUnsafeAssertionGroup {
                         val additionalEntries = itr.mapRemainingWithCounter { counter, it ->
                             val description = TranslatableWithArgs(
-                                DescriptionIterableAssertion.ENTRY_WITH_INDEX,
+                                DescriptionIterableAssertion.ELEMENT_WITH_INDEX,
                                 expectedSize + counter
                             )
                             assertionBuilder.descriptive
@@ -74,7 +74,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
                             .withWarningType
                             .withAssertion(
                                 assertionBuilder.list
-                                    .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.WARNING_ADDITIONAL_ENTRIES)
+                                    .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.WARNING_ADDITIONAL_ELEMENTS)
                                     .withAssertions(additionalEntries)
                                     .build()
                             )

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -64,7 +64,7 @@ internal fun createEntryAssertion(explanatoryGroup: AssertionGroup, found: Boole
     return assertionBuilder.fixedClaimGroup
         .withListType
         .withClaim(found)
-        .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.AN_ENTRY_WHICH)
+        .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.AN_ELEMENT_WHICH)
         .withAssertion(explanatoryGroup)
         .build()
 }

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/containsHelperFun.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/containsHelperFun.kt
@@ -53,7 +53,7 @@ internal fun createEntryAssertion(explanatoryGroup: AssertionGroup, found: Boole
     return assertionBuilder.fixedClaimGroup
         .withListType
         .withClaim(found)
-        .withDescriptionAndEmptyRepresentation(AN_ENTRY_WHICH)
+        .withDescriptionAndEmptyRepresentation(AN_ELEMENT_WHICH)
         .withAssertion(explanatoryGroup)
         .build()
 }
@@ -100,7 +100,7 @@ internal fun <E> createSizeFeatureAssertionForInOrderOnly(
             if (iterableAsList.size > expectedSize) {
                 addAssertion(LazyThreadUnsafeAssertionGroup {
                     val additionalEntries = itr.mapRemainingWithCounter { counter, it ->
-                        val description = TranslatableWithArgs(ENTRY_WITH_INDEX, expectedSize + counter)
+                        val description = TranslatableWithArgs(ELEMENT_WITH_INDEX, expectedSize + counter)
                         assertionBuilder.descriptive
                             .holding
                             .withDescriptionAndRepresentation(description, it)
@@ -111,7 +111,7 @@ internal fun <E> createSizeFeatureAssertionForInOrderOnly(
                         .withWarningType
                         .withAssertion(
                             assertionBuilder.list
-                                .withDescriptionAndEmptyRepresentation(WARNING_ADDITIONAL_ENTRIES)
+                                .withDescriptionAndEmptyRepresentation(WARNING_ADDITIONAL_ELEMENTS)
                                 .withAssertions(additionalEntries)
                                 .build()
                         )

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderEntriesAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderEntriesAssertionCreator.kt
@@ -20,7 +20,7 @@ import ch.tutteli.atrium.domain.robstoll.lib.creating.iterable.contains.createEx
 import ch.tutteli.atrium.domain.robstoll.lib.creating.iterable.contains.createHasElementAssertion
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ENTRY_WHICH
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WHICH
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
@@ -72,7 +72,7 @@ class InAnyOrderEntriesAssertionCreator<E : Any, in T : Iterable<E?>>(
         }
 
         return assertionBuilder.customType(groupType)
-            .withDescriptionAndEmptyRepresentation(AN_ENTRY_WHICH)
+            .withDescriptionAndEmptyRepresentation(AN_ELEMENT_WHICH)
             .withAssertions(assertions)
             .build()
     }

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderEntriesDeprecatedAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderEntriesDeprecatedAssertionCreator.kt
@@ -22,7 +22,7 @@ import ch.tutteli.atrium.domain.robstoll.lib.creating.iterable.contains.collectI
 import ch.tutteli.atrium.domain.robstoll.lib.creating.iterable.contains.createHasElementAssertion
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ENTRY_WHICH
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WHICH
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
@@ -80,7 +80,7 @@ class InAnyOrderEntriesDeprecatedAssertionCreator<E : Any, in T : Iterable<E?>>(
         }
 
         return AssertImpl.builder.customType(groupType)
-            .withDescriptionAndEmptyRepresentation(AN_ENTRY_WHICH)
+            .withDescriptionAndEmptyRepresentation(AN_ELEMENT_WHICH)
             .withAssertions(assertions)
             .build()
     }

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderOnlyAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderOnlyAssertionCreator.kt
@@ -50,7 +50,7 @@ abstract class InAnyOrderOnlyAssertionCreator<E, in T : Iterable<E?>, in SC>(
             val featureAssertions = createSizeFeatureAssertion(searchCriteria, actualSize)
             if (mismatches == 0 && list.isNotEmpty()) {
                 featureAssertions.add(LazyThreadUnsafeAssertionGroup {
-                    createExplanatoryGroupForMismatchesEtc(list, WARNING_ADDITIONAL_ENTRIES)
+                    createExplanatoryGroupForMismatchesEtc(list, WARNING_ADDITIONAL_ELEMENTS)
                 })
             }
             assertions.add(

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderOnlyValuesAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderOnlyValuesAssertionCreator.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.domain.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.reporting.translating.Translatable
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ENTRY_WHICH_IS
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where exactly the expected entries have
@@ -28,6 +28,6 @@ class InAnyOrderOnlyValuesAssertionCreator<E, in T : Iterable<E?>>(
         list: MutableList<E?>
     ): Pair<Boolean, Assertion> {
         val found: Boolean = list.remove(searchCriterion)
-        return found to assertionBuilder.createDescriptive(AN_ENTRY_WHICH_IS, searchCriterion) { found }
+        return found to assertionBuilder.createDescriptive(AN_ELEMENT_WHICH_EQUALS, searchCriterion) { found }
     }
 }

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderValuesAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InAnyOrderValuesAssertionCreator.kt
@@ -34,7 +34,7 @@ class InAnyOrderValuesAssertionCreator<SC, in T : Iterable<SC>>(
 
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES
-    override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ENTRY_WHICH_IS
+    override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
 
     override fun getAssertionGroupType(): AssertionGroupType {
         return if (searchBehaviour is NotSearchBehaviour) {

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InOrderOnlyAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InOrderOnlyAssertionCreator.kt
@@ -30,7 +30,7 @@ abstract class InOrderOnlyAssertionCreator<E, in T : Iterable<E>, SC>(
     override fun Expect<List<E>>.createAssertionsAndReturnIndex(searchCriteria: List<SC>): Int {
         var index = 0
         searchCriteria.forEachIndexed { currentIndex, searchCriterion ->
-            createSingleEntryAssertion(currentIndex, searchCriterion, DescriptionIterableAssertion.ENTRY_WITH_INDEX)
+            createSingleEntryAssertion(currentIndex, searchCriterion, DescriptionIterableAssertion.ELEMENT_WITH_INDEX)
             index = currentIndex
         }
         ++index

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InOrderOnlyDeprecatedAssertionCreator.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/lib/creating/iterable/contains/creators/InOrderOnlyDeprecatedAssertionCreator.kt
@@ -48,7 +48,7 @@ abstract class InOrderOnlyDeprecatedAssertionCreator<E, in T : Iterable<E>, SC>(
                     createSingleEntryAssertion(
                         currentIndex,
                         searchCriterion,
-                        DescriptionIterableAssertion.ENTRY_WITH_INDEX
+                        DescriptionIterableAssertion.ELEMENT_WITH_INDEX
                     )
                     index = currentIndex
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ArrayAsListAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ArrayAsListAssertionsSpec.kt
@@ -80,12 +80,12 @@ abstract class ArrayAsListAssertionsSpec(
     fun doubles(vararg doubles: Double) = doubles
     fun booleans(vararg booleans: Boolean) = booleans
 
-    val anEntryWhich = DescriptionIterableAssertion.AN_ENTRY_WHICH_IS.getDefault()
+    val anElementWhich = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS.getDefault()
     include(object : AssertionCreatorSpec<Array<Int>>(
         "$describePrefix[arr] ", arrayOf(1),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrWithCreator.invoke(this) { contains(1) } },
             { arrWithCreator.invoke(this) {} })
     ) {})
@@ -93,7 +93,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrByte] ", bytes(1),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrByteWithCreator.invoke(this) { contains(1) } },
             { arrByteWithCreator.invoke(this) {} })
     ) {})
@@ -101,7 +101,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrChar] ", chars('a'),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrCharWithCreator.invoke(this) { contains('a') } },
             { arrCharWithCreator.invoke(this) {} })
     ) {})
@@ -109,7 +109,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrShort] ", shorts(1),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrShortWithCreator.invoke(this) { contains(1) } },
             { arrShortWithCreator.invoke(this) {} })
     ) {})
@@ -117,7 +117,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrInt] ", ints(1),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrIntWithCreator.invoke(this) { contains(1) } },
             { arrIntWithCreator.invoke(this) {} })
     ) {})
@@ -125,7 +125,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrLong] ", longs(1),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrLongWithCreator.invoke(this) { contains(1) } },
             { arrLongWithCreator.invoke(this) {} })
     ) {})
@@ -133,7 +133,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrFloat] ", floats(1.0f),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrFloatWithCreator.invoke(this) { contains(1.0f) } },
             { arrFloatWithCreator.invoke(this) {} })
     ) {})
@@ -141,7 +141,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrDouble] ", doubles(1.0),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrDoubleWithCreator.invoke(this) { contains(1.0) } },
             { arrDoubleWithCreator.invoke(this) {} })
     ) {})
@@ -149,7 +149,7 @@ abstract class ArrayAsListAssertionsSpec(
         "$describePrefix[arrBoolean] ", booleans(true),
         assertionCreatorSpecTriple(
             asListFunName,
-            anEntryWhich,
+            anElementWhich,
             { arrBooleanWithCreator.invoke(this) { contains(true) } },
             { arrBooleanWithCreator.invoke(this) {} })
     ) {})

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsEntriesSpecBase.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.isGreaterThan
 import ch.tutteli.atrium.api.fluent.en_GB.isLessThan
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.name
@@ -26,7 +27,7 @@ abstract class IterableContainsEntriesSpecBase(
         var isGreaterThanFun = ""
         var toBeFun = ""
         var returnValueOfFun = ""
-        val anEntryWhich = DescriptionIterableAssertion.AN_ENTRY_WHICH.getDefault()
+        val anEntryWhich = DescriptionIterableAssertion.AN_ELEMENT_WHICH.getDefault()
         val isLessThanDescr = DescriptionComparableAssertion.IS_LESS_THAN.getDefault()
         val isGreaterThanDescr = DescriptionComparableAssertion.IS_GREATER_THAN.getDefault()
     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec.kt
@@ -41,7 +41,7 @@ abstract class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec(
                 }.toThrow<AssertionError> {
                     messageContains(
                         "$rootBulletPoint$containsInAnyOrder: $separator",
-                        "$anEntryWhichIs: 1.0",
+                        "$anElementWhichIs: 1.0",
                         "$numberOfOccurrences: 0",
                         "$atLeast: 1"
                     )
@@ -73,7 +73,7 @@ abstract class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         messageContains(
                             "$rootBulletPoint$containsInAnyOrder: $separator",
-                            "$anEntryWhichIs: 9.5",
+                            "$anElementWhichIs: 9.5",
                             "$numberOfOccurrences: 0",
                             "$atLeast: 1"
                         )
@@ -90,8 +90,8 @@ abstract class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec(
                             )
                             contains.exactly(1).values(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 9.5",
-                                "$anEntryWhichIs: 7.1"
+                                "$anElementWhichIs: 9.5",
+                                "$anElementWhichIs: 7.1"
                             )
                         }
                     }
@@ -101,8 +101,8 @@ abstract class IterableContainsInAnyOrderAtLeast1ValuesAssertionsSpec(
                         expect(oneToSeven()).containsFun(1.0, 9.5)
                     }.toThrow<AssertionError> {
                         message {
-                            containsRegex("$containsInAnyOrder: $separator.*$anEntryWhichIs: 9.5")
-                            containsNot.regex("$containsInAnyOrder: $separator.*$anEntryWhichIs: 1.0")
+                            containsRegex("$containsInAnyOrder: $separator.*$anElementWhichIs: 9.5")
+                            containsNot.regex("$containsInAnyOrder: $separator.*$anElementWhichIs: 1.0")
                         }
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtLeastValuesAssertionSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtLeastValuesAssertionSpec.kt
@@ -91,15 +91,15 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                 it("${containsAtLeastPair.first("1.1", "once")} throws AssertionError") {
                     expect {
                         expect(oneToSeven()).containsAtLeastFun(1, 1.1)
-                    }.toThrow<AssertionError> { messageContains("$atLeast: 1", "$anEntryWhichIs: 1.1") }
+                    }.toThrow<AssertionError> { messageContains("$atLeast: 1", "$anElementWhichIs: 1.1") }
                 }
                 it("${containsAtLeastPair.first("1.0, 2.3", "once")} throws AssertionError mentioning only 2.3") {
                     expect {
                         expect(oneToSeven()).containsAtLeastFun(1, 1.0, 2.3)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$atLeast: 1", "$anEntryWhichIs: 2.3")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$atLeast: 1", "$anElementWhichIs: 2.3")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -108,8 +108,8 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                         expect(oneToSeven()).containsAtLeastFun(1, 2.3, 1.0)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$atLeast: 1", "$anEntryWhichIs: 2.3")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$atLeast: 1", "$anElementWhichIs: 2.3")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -124,8 +124,8 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                             )
                             contains.exactly(1).values(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 2.3",
-                                "$anEntryWhichIs: 3.1"
+                                "$anElementWhichIs: 2.3",
+                                "$anElementWhichIs: 3.1"
                             )
                         }
                     }
@@ -152,7 +152,7 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2$separator"
                             )
                             endsWith("$atLeast: 3")
@@ -179,11 +179,11 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2$separator"
                             )
                             endsWith("$atLeast: 3")
-                            containsNot("$anEntryWhichIs: 4.0")
+                            containsNot("$anElementWhichIs: 4.0")
                         }
                     }
                 }
@@ -206,11 +206,11 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 4.0",
+                                "$anElementWhichIs: 4.0",
                                 "$numberOfOccurrences: 3$separator"
                             )
                             endsWith("$atMost: 2")
-                            containsNot(atLeast, "$anEntryWhichIs: 5.0")
+                            containsNot(atLeast, "$anElementWhichIs: 5.0")
                         }
                     }
                 }
@@ -232,11 +232,11 @@ abstract class IterableContainsInAnyOrderAtLeastValuesAssertionSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2$separator"
                             )
                             endsWith("$atLeast: 3")
-                            containsNot(atMost, "$anEntryWhichIs: 4.0")
+                            containsNot(atMost, "$anElementWhichIs: 4.0")
                         }
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtMostValuesAssertionSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtMostValuesAssertionSpec.kt
@@ -67,15 +67,15 @@ abstract class IterableContainsInAnyOrderAtMostValuesAssertionSpec(
                 it("${containsAtMostPair.first("4.0", "twice")} throws AssertionError") {
                     expect {
                         expect(oneToSeven()).containsAtMostFun(2, 4.0)
-                    }.toThrow<AssertionError> { messageContains("$atMost: 2", "$anEntryWhichIs: 4.0") }
+                    }.toThrow<AssertionError> { messageContains("$atMost: 2", "$anElementWhichIs: 4.0") }
                 }
                 it("${containsAtMostPair.first("1.0, 4.0", "twice")} throws AssertionError mentioning only 4.0") {
                     expect {
                         expect(oneToSeven()).containsAtMostFun(2, 1.0, 4.0)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$atMost: 2", "$anEntryWhichIs: 4.0")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$atMost: 2", "$anElementWhichIs: 4.0")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -84,8 +84,8 @@ abstract class IterableContainsInAnyOrderAtMostValuesAssertionSpec(
                         expect(oneToSeven()).containsAtMostFun(2, 4.0, 1.0)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$atMost: 2", "$anEntryWhichIs: 4.0")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$atMost: 2", "$anElementWhichIs: 4.0")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -96,10 +96,10 @@ abstract class IterableContainsInAnyOrderAtMostValuesAssertionSpec(
                         message {
                             contains.exactly(1).values(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 3.1",
+                                "$anElementWhichIs: 3.1",
                                 "$numberOfOccurrences: 0",
                                 "$atLeast: 1",
-                                "$anEntryWhichIs: 4.0",
+                                "$anElementWhichIs: 4.0",
                                 "$numberOfOccurrences: 3",
                                 "$atMost: 2"
                             )
@@ -117,9 +117,9 @@ abstract class IterableContainsInAnyOrderAtMostValuesAssertionSpec(
                             )
                             contains.exactly(1).values(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 21.1",
-                                "$anEntryWhichIs: 34.0",
-                                "$anEntryWhichIs: 11.23"
+                                "$anElementWhichIs: 21.1",
+                                "$anElementWhichIs: 34.0",
+                                "$anElementWhichIs: 11.23"
                             )
                         }
                     }
@@ -147,11 +147,11 @@ abstract class IterableContainsInAnyOrderAtMostValuesAssertionSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 4.0",
+                                "$anElementWhichIs: 4.0",
                                 "$numberOfOccurrences: 3$separator"
                             )
                             endsWith("$atMost: 2")
-                            containsNot("$anEntryWhichIs: 5.0")
+                            containsNot("$anElementWhichIs: 5.0")
                         }
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderExactlyValuesAssertionsSpec.kt
@@ -63,7 +63,7 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                 it("${containsExactlyPair.first("4.0", "once")} throws AssertionError") {
                     expect {
                         expect(oneToSeven()).containsExactlyFun(1, 4.0)
-                    }.toThrow<AssertionError> { messageContains("$exactly: 1", "$anEntryWhichIs: 4.0") }
+                    }.toThrow<AssertionError> { messageContains("$exactly: 1", "$anElementWhichIs: 4.0") }
                 }
 
                 it("${containsExactlyPair.first("1.0, 2.3", "once")} throws AssertionError mentioning only 2.3") {
@@ -71,8 +71,8 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                         expect(oneToSeven()).containsExactlyFun(1, 1.0, 2.3)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$exactly: 1", "$anEntryWhichIs: 2.3")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$exactly: 1", "$anElementWhichIs: 2.3")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -82,8 +82,8 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                         expect(oneToSeven()).containsExactlyFun(1, 2.3, 1.0)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$exactly: 1", "$anEntryWhichIs: 2.3")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$exactly: 1", "$anElementWhichIs: 2.3")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -100,8 +100,8 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                             )
                             contains.exactly(1).values(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 2.3",
-                                "$anEntryWhichIs: 3.1"
+                                "$anElementWhichIs: 2.3",
+                                "$anElementWhichIs: 3.1"
                             )
                         }
                     }
@@ -130,7 +130,7 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2$separator"
                             )
                             endsWith("$exactly: 3")
@@ -145,11 +145,11 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 4.0",
+                                "$anElementWhichIs: 4.0",
                                 "$numberOfOccurrences: 3$separator"
                             )
                             endsWith("$exactly: 2")
-                            containsNot("$anEntryWhichIs: 5.0")
+                            containsNot("$anElementWhichIs: 5.0")
                         }
                     }
                 }
@@ -168,11 +168,11 @@ abstract class IterableContainsInAnyOrderExactlyValuesAssertionsSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2$separator"
                             )
                             endsWith("$exactly: 3")
-                            containsNot("$anEntryWhichIs: 4.0")
+                            containsNot("$anElementWhichIs: 4.0")
                         }
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec.kt
@@ -63,15 +63,15 @@ abstract class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec(
                 it("${containsNotOrAtMostPair.first("4.0", "once")} throws AssertionError") {
                     expect {
                         expect(oneToSeven()).containsNotOrAtMostFun(1, 4.0)
-                    }.toThrow<AssertionError> { messageContains("$atMost: 1", "$anEntryWhichIs: 4.0") }
+                    }.toThrow<AssertionError> { messageContains("$atMost: 1", "$anElementWhichIs: 4.0") }
                 }
                 it("${containsNotOrAtMostPair.first("1.0, 4.0", "once")} throws AssertionError mentioning only 4.0") {
                     expect {
                         expect(oneToSeven()).containsNotOrAtMostFun(1, 1.0, 4.0)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$atMost: 1", "$anEntryWhichIs: 4.0")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$atMost: 1", "$anElementWhichIs: 4.0")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -85,8 +85,8 @@ abstract class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec(
                         expect(oneToSeven()).containsNotOrAtMostFun(1, 4.0, 1.0)
                     }.toThrow<AssertionError> {
                         message {
-                            contains("$atMost: 1", "$anEntryWhichIs: 4.0")
-                            containsNot("$anEntryWhichIs: 1.0")
+                            contains("$atMost: 1", "$anElementWhichIs: 4.0")
+                            containsNot("$anElementWhichIs: 1.0")
                         }
                     }
                 }
@@ -100,9 +100,9 @@ abstract class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec(
                             )
                             contains.exactly(1).values(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2",
-                                "$anEntryWhichIs: 4.0",
+                                "$anElementWhichIs: 4.0",
                                 "$numberOfOccurrences: 3"
                             )
                         }
@@ -123,7 +123,7 @@ abstract class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 5.0",
+                                "$anElementWhichIs: 5.0",
                                 "$numberOfOccurrences: 2$separator"
                             )
                             endsWith("$atMost: 1")
@@ -151,11 +151,11 @@ abstract class IterableContainsInAnyOrderNotOrAtMostValuesAssertionsSpec(
                         message {
                             contains(
                                 "$rootBulletPoint$containsInAnyOrder: $separator",
-                                "$anEntryWhichIs: 4.0",
+                                "$anElementWhichIs: 4.0",
                                 "$numberOfOccurrences: 3$separator"
                             )
                             endsWith("$atMost: 2")
-                            containsNot("$anEntryWhichIs: 5.0")
+                            containsNot("$anElementWhichIs: 5.0")
                         }
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.kt
@@ -80,7 +80,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
                             "$rootBulletPoint$containsInAnyOrderOnly:",
                             "$failingBulletPoint$anEntryAfterFailing$isLessThanDescr: 1.0"
                         )
-                        containsNot(additionalEntries)
+                        containsNot(additionalElements)
                         containsSize(0, 1)
                     }
                 }
@@ -95,7 +95,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
                             "$failingBulletPoint$anEntryAfterFailing$isLessThanDescr: 1.0",
                             "$failingBulletPoint$anEntryAfterFailing$isGreaterThanDescr: 4.0"
                         )
-                        containsNot(additionalEntries)
+                        containsNot(additionalElements)
                         containsSize(0, 2)
                     }
                 }
@@ -179,7 +179,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
                                     "$successfulBulletPoint$anEntryAfterSuccess$toBeDescr: 2.0",
                                     "$successfulBulletPoint$anEntryAfterSuccess$toBeDescr: 3.0",
                                     "$successfulBulletPoint$anEntryAfterSuccess$toBeDescr: 4.0",
-                                    "$warningBulletPoint$additionalEntries:",
+                                    "$warningBulletPoint$additionalElements:",
                                     "${listBulletPoint}4.0"
                                 )
                                 containsSize(5, 4)
@@ -196,7 +196,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
                                     "$successfulBulletPoint$anEntryAfterSuccess$isLessThanDescr: 3.0",
                                     "$successfulBulletPoint$anEntryAfterSuccess$isGreaterThanDescr: 3.0",
-                                    "$warningBulletPoint$additionalEntries:",
+                                    "$warningBulletPoint$additionalElements:",
                                     "${listBulletPoint}2.0",
                                     "${listBulletPoint}3.0",
                                     "${listBulletPoint}4.0"
@@ -281,7 +281,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
                                 contains.exactly(2)
                                     .value("$successfulBulletPoint$anEntryAfterSuccess$toBeDescr: 4.0")
                                 containsSize(5, 6)
-                                containsNot(additionalEntries, mismatches, mismatchesAdditionalEntries)
+                                containsNot(additionalElements, mismatches, mismatchesAdditionalEntries)
                             }
                         }
                     }
@@ -332,7 +332,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesAssertionsSpec(
                                     "$successfulBulletPoint$anEntryAfterSuccess$isDescr: null",
                                     "$successfulBulletPoint$anEntryAfterSuccess$toBeDescr: 1.0",
                                     "$successfulBulletPoint$anEntryAfterSuccess$toBeDescr: 3.0",
-                                    "$warningBulletPoint$additionalEntries:",
+                                    "$warningBulletPoint$additionalElements:",
                                     "${listBulletPoint}null"
                                 )
                                 containsSize(4, 3)

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyValuesAssertionsSpec.kt
@@ -49,9 +49,9 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                     message {
                         contains(
                             "$rootBulletPoint$containsInAnyOrderOnly:",
-                            "$failingBulletPoint$anEntryWhichIs: 1.0"
+                            "$failingBulletPoint$anElementWhichIs: 1.0"
                         )
-                        containsNot(additionalEntries)
+                        containsNot(additionalElements)
                         containsSize(0, 1)
                     }
                 }
@@ -63,10 +63,10 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                     message {
                         contains.exactly(1).values(
                             "$rootBulletPoint$containsInAnyOrderOnly:",
-                            "$failingBulletPoint$anEntryWhichIs: 1.0",
-                            "$failingBulletPoint$anEntryWhichIs: 4.0"
+                            "$failingBulletPoint$anElementWhichIs: 1.0",
+                            "$failingBulletPoint$anElementWhichIs: 4.0"
                         )
-                        containsNot(additionalEntries)
+                        containsNot(additionalElements)
                         containsSize(0, 2)
                     }
                 }
@@ -100,11 +100,11 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                             message {
                                 contains.exactly(1).values(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
-                                    "$successfulBulletPoint$anEntryWhichIs: 1.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 2.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 3.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 4.0",
-                                    "$warningBulletPoint$additionalEntries:",
+                                    "$successfulBulletPoint$anElementWhichIs: 1.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 2.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 3.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 4.0",
+                                    "$warningBulletPoint$additionalElements:",
                                     "${listBulletPoint}4.0"
                                 )
                                 containsSize(5, 4)
@@ -119,9 +119,9 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                             message {
                                 contains.exactly(1).values(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
-                                    "$successfulBulletPoint$anEntryWhichIs: 1.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 4.0",
-                                    "$warningBulletPoint$additionalEntries:",
+                                    "$successfulBulletPoint$anElementWhichIs: 1.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 4.0",
+                                    "$warningBulletPoint$additionalElements:",
                                     "${listBulletPoint}2.0",
                                     "${listBulletPoint}3.0",
                                     "${listBulletPoint}4.0"
@@ -140,10 +140,10 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                             message {
                                 contains.exactly(1).values(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
-                                    "$successfulBulletPoint$anEntryWhichIs: 1.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 2.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 3.0",
-                                    "$failingBulletPoint$anEntryWhichIs: 5.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 1.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 2.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 3.0",
+                                    "$failingBulletPoint$anElementWhichIs: 5.0",
                                     "$warningBulletPoint$mismatches:",
                                     "${listBulletPoint}4.0"
                                 )
@@ -161,9 +161,9 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                             message {
                                 contains.exactly(1).values(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
-                                    "$successfulBulletPoint$anEntryWhichIs: 1.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 3.0",
-                                    "$failingBulletPoint$anEntryWhichIs: 5.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 1.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 3.0",
+                                    "$failingBulletPoint$anElementWhichIs: 5.0",
                                     "$warningBulletPoint$mismatchesAdditionalEntries:",
                                     "${listBulletPoint}2.0"
                                 )
@@ -182,14 +182,14 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                             message {
                                 contains.exactly(1).values(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
-                                    "$successfulBulletPoint$anEntryWhichIs: 1.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 2.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 3.0",
-                                    "$failingBulletPoint$anEntryWhichIs: 5.0"
+                                    "$successfulBulletPoint$anElementWhichIs: 1.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 2.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 3.0",
+                                    "$failingBulletPoint$anElementWhichIs: 5.0"
                                 )
-                                contains.exactly(2).value("$successfulBulletPoint$anEntryWhichIs: 4.0")
+                                contains.exactly(2).value("$successfulBulletPoint$anElementWhichIs: 4.0")
                                 containsSize(5, 6)
-                                containsNot(additionalEntries, mismatches, mismatchesAdditionalEntries)
+                                containsNot(additionalElements, mismatches, mismatchesAdditionalEntries)
                             }
                         }
                     }
@@ -228,10 +228,10 @@ abstract class IterableContainsInAnyOrderOnlyValuesAssertionsSpec(
                             message {
                                 contains.exactly(1).values(
                                     "$rootBulletPoint$containsInAnyOrderOnly:",
-                                    "$successfulBulletPoint$anEntryWhichIs: null",
-                                    "$successfulBulletPoint$anEntryWhichIs: 1.0",
-                                    "$successfulBulletPoint$anEntryWhichIs: 3.0",
-                                    "$warningBulletPoint$additionalEntries:",
+                                    "$successfulBulletPoint$anElementWhichIs: null",
+                                    "$successfulBulletPoint$anElementWhichIs: 1.0",
+                                    "$successfulBulletPoint$anElementWhichIs: 3.0",
+                                    "$warningBulletPoint$additionalElements:",
                                     "${listBulletPoint}null"
                                 )
                                 containsSize(4, 3)

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyEntriesAssertionsSpec.kt
@@ -69,18 +69,16 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
     val anEntryAfterFailing = "$entryWhichWithFeature: $separator$indentBulletPoint$indentFailingBulletPoint$explanatoryPointWithIndent"
     //@formatter:on
 
-    fun entry(index: Int) = String.format(entryWithIndex, index)
-
-    fun Expect<String>.entrySuccess(index: Int, actual: Any, expected: String): Expect<String> {
+    fun Expect<String>.elementSuccess(index: Int, actual: Any, expected: String): Expect<String> {
         return this.contains.exactly(1).regex(
-            "\\Q$successfulBulletPoint$featureArrow${entry(index)}: $actual\\E.*$separator" +
+            "\\Q$successfulBulletPoint$featureArrow${elementWithIndex(index)}: $actual\\E.*$separator" +
                 "$indentBulletPoint$indentSuccessfulBulletPoint$anEntryAfterSuccess$expected"
         )
     }
 
-    fun Expect<String>.entryFailing(index: Int, actual: Any, expected: String): Expect<String> {
+    fun Expect<String>.elementFailing(index: Int, actual: Any, expected: String): Expect<String> {
         return this.contains.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${entry(index)}: $actual\\E.*$separator" +
+            "\\Q$failingBulletPoint$featureArrow${elementWithIndex(index)}: $actual\\E.*$separator" +
                 "$indentBulletPoint$indentFailingBulletPoint$anEntryAfterFailing$expected"
         )
     }
@@ -103,8 +101,8 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                 }.toThrow<AssertionError> {
                     message {
                         contains("$rootBulletPoint$containsInOrderOnly:")
-                        entryFailing(0, sizeExceeded, "$isLessThanDescr: 1.0")
-                        containsNot(additionalEntries)
+                        elementFailing(0, sizeExceeded, "$isLessThanDescr: 1.0")
+                        containsNot(additionalElements)
                         containsSize(0, 1)
                     }
                 }
@@ -115,9 +113,9 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                 }.toThrow<AssertionError> {
                     message {
                         contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                        entryFailing(0, sizeExceeded, "$isLessThanDescr: 1.0")
-                        entryFailing(1, sizeExceeded, "$isGreaterThanDescr: 4.0")
-                        containsNot(additionalEntries)
+                        elementFailing(0, sizeExceeded, "$isLessThanDescr: 1.0")
+                        elementFailing(1, sizeExceeded, "$isGreaterThanDescr: 4.0")
+                        containsNot(additionalElements)
                         containsSize(0, 2)
                     }
                 }
@@ -170,11 +168,11 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0, "$isLessThanDescr: 5.0")
-                            entryFailing(1, 2.0, "$toBeDescr: 1.0")
-                            entryFailing(2, 3.0, "$toBeDescr: 2.0")
-                            entrySuccess(3, 4.0, "$isGreaterThanDescr: 2.0")
-                            entrySuccess(4, 4.0, "$toBeDescr: 4.0")
+                            elementSuccess(0, 1.0, "$isLessThanDescr: 5.0")
+                            elementFailing(1, 2.0, "$toBeDescr: 1.0")
+                            elementFailing(2, 3.0, "$toBeDescr: 2.0")
+                            elementSuccess(3, 4.0, "$isGreaterThanDescr: 2.0")
+                            elementSuccess(4, 4.0, "$toBeDescr: 4.0")
                             containsSize(5, 5)
                         }
                     }
@@ -190,13 +188,13 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0, "$toBeDescr: 1.0")
-                            entrySuccess(1, 2.0, "$toBeDescr: 2.0")
-                            entrySuccess(2, 3.0, "$toBeDescr: 3.0")
-                            entrySuccess(3, 4.0, "$toBeDescr: 4.0")
+                            elementSuccess(0, 1.0, "$toBeDescr: 1.0")
+                            elementSuccess(1, 2.0, "$toBeDescr: 2.0")
+                            elementSuccess(2, 3.0, "$toBeDescr: 3.0")
+                            elementSuccess(3, 4.0, "$toBeDescr: 4.0")
                             contains(
-                                "$warningBulletPoint$additionalEntries:",
-                                "$listBulletPoint${entry(4)}: 4.0"
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
                             )
                             containsSize(5, 4)
                         }
@@ -209,13 +207,13 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0, "$toBeDescr: 1.0")
-                            entryFailing(1, 2.0, "$toBeDescr: 4.0")
+                            elementSuccess(0, 1.0, "$toBeDescr: 1.0")
+                            elementFailing(1, 2.0, "$toBeDescr: 4.0")
                             contains(
-                                "$warningBulletPoint$additionalEntries:",
-                                "$listBulletPoint${entry(2)}: 3.0",
-                                "$listBulletPoint${entry(3)}: 4.0",
-                                "$listBulletPoint${entry(4)}: 4.0"
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(2)}: 3.0",
+                                "$listBulletPoint${elementWithIndex(3)}: 4.0",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
                             )
                             containsSize(5, 2)
                         }
@@ -227,13 +225,13 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0, "$toBeDescr: 1.0")
-                            entryFailing(1, 2.0, "$toBeDescr: 3.0")
-                            entryFailing(2, 3.0, "$isGreaterThanDescr: 4.0")
+                            elementSuccess(0, 1.0, "$toBeDescr: 1.0")
+                            elementFailing(1, 2.0, "$toBeDescr: 3.0")
+                            elementFailing(2, 3.0, "$isGreaterThanDescr: 4.0")
                             contains(
-                                "$warningBulletPoint$additionalEntries:",
-                                "$listBulletPoint${entry(3)}: 4.0",
-                                "$listBulletPoint${entry(4)}: 4.0"
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(3)}: 4.0",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
                             )
                             containsSize(5, 3)
                         }
@@ -251,12 +249,12 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0, "$toBeDescr: 1.0")
-                            entrySuccess(1, 2.0, "$toBeDescr: 2.0")
-                            entrySuccess(2, 3.0, "$toBeDescr: 3.0")
-                            entrySuccess(3, 4.0, "$toBeDescr: 4.0")
-                            entrySuccess(4, 4.0, "$toBeDescr: 4.0")
-                            entryFailing(5, sizeExceeded, "$toBeDescr: 5.0")
+                            elementSuccess(0, 1.0, "$toBeDescr: 1.0")
+                            elementSuccess(1, 2.0, "$toBeDescr: 2.0")
+                            elementSuccess(2, 3.0, "$toBeDescr: 3.0")
+                            elementSuccess(3, 4.0, "$toBeDescr: 4.0")
+                            elementSuccess(4, 4.0, "$toBeDescr: 4.0")
+                            elementFailing(5, sizeExceeded, "$toBeDescr: 5.0")
                             containsSize(5, 6)
                         }
                     }
@@ -304,10 +302,10 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                         }.toThrow<AssertionError> {
                             message {
                                 contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                                entrySuccess(0, "null", "$isDescr: null")
-                                entryFailing(1, 1.0, "$isDescr: null")
-                                entryFailing(2, "null", "$isLessThanDescr: 5.0")
-                                entrySuccess(3, 3.0, "$isGreaterThanDescr: 2.0")
+                                elementSuccess(0, "null", "$isDescr: null")
+                                elementFailing(1, 1.0, "$isDescr: null")
+                                elementFailing(2, "null", "$isLessThanDescr: 5.0")
+                                elementSuccess(3, 3.0, "$isGreaterThanDescr: 2.0")
                                 containsSize(4, 4)
                             }
                         }
@@ -325,11 +323,11 @@ abstract class IterableContainsInOrderOnlyEntriesAssertionsSpec(
                         }.toThrow<AssertionError> {
                             message {
                                 contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                                entrySuccess(0, "null", "$isDescr: null")
-                                entrySuccess(1, 1.0, "$toBeDescr: 1.0")
-                                entrySuccess(2, "null", "$isDescr: null")
-                                entrySuccess(3, 3.0, "$toBeDescr: 3.0")
-                                entryFailing(4, sizeExceeded, "$isDescr: null")
+                                elementSuccess(0, "null", "$isDescr: null")
+                                elementSuccess(1, 1.0, "$toBeDescr: 1.0")
+                                elementSuccess(2, "null", "$isDescr: null")
+                                elementSuccess(3, 3.0, "$toBeDescr: 3.0")
+                                elementFailing(4, sizeExceeded, "$isDescr: null")
                                 containsSize(4, 5)
                             }
                         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec.kt
@@ -70,12 +70,10 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec(
 
     fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
 
-    fun entryWithIndex(index: Int) = String.format(entryWithIndex, index)
-
     fun index(fromIndex: Int, toIndex: Int) =
         String.format(DescriptionIterableAssertion.INDEX_FROM_TO.getDefault(), fromIndex, toIndex)
 
-    fun entry(prefix: String, bulletPoint: String, indentBulletPoint: String, expected: Array<out String>) =
+    fun element(prefix: String, bulletPoint: String, indentBulletPoint: String, expected: Array<out String>) =
         expected.joinToString(".*$separator") {
             "$prefix\\Q$bulletPoint$anEntryWhich: \\E$separator" +
                 "$prefix$indentBulletPoint$indentListBulletPoint$explanatoryBulletPoint$it"
@@ -87,10 +85,10 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec(
 
     val afterFail = "$indentBulletPoint$indentFailingBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
     fun failAfterFail(vararg expected: String) =
-        entry(afterFail, failingBulletPoint, indentFailingBulletPoint, expected)
+        element(afterFail, failingBulletPoint, indentFailingBulletPoint, expected)
 
     fun successAfterFail(vararg expected: String) =
-        entry(afterFail, successfulBulletPoint, indentSuccessfulBulletPoint, expected)
+        element(afterFail, successfulBulletPoint, indentSuccessfulBulletPoint, expected)
 
     fun failSizeAfterFail(actual: Int, expected: Int) = size(afterFail, failingBulletPoint, actual, expected)
 
@@ -103,12 +101,12 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec(
     fun mismatchesAfterFail(vararg mismatched: Double) = warning(mismatches, mismatched.toTypedArray()) { "$it" }
 
     fun additional(vararg entryWithValue: Pair<Int, Double>) =
-        warning(additionalEntries, entryWithValue) { "${entryWithIndex(it.first)}: ${it.second}" }
+        warning(additionalElements, entryWithValue) { "${elementWithIndex(it.first)}: ${it.second}" }
 
 
     val afterSuccess = "$indentBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
     fun successAfterSuccess(vararg expected: String) =
-        entry(afterSuccess, successfulBulletPoint, indentSuccessfulBulletPoint, expected)
+        element(afterSuccess, successfulBulletPoint, indentSuccessfulBulletPoint, expected)
 
     fun successSizeAfterSuccess(size: Int) = size(afterSuccess, successfulBulletPoint, size, size)
 
@@ -207,7 +205,7 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec(
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnlyGrouped:")
                             indexFail(0, sizeExceeded, "$toBeDescr: 1.0")
                             indexFail(1, sizeExceeded, "$toBeDescr: 1.2")
-                            containsNot(additionalEntries)
+                            containsNot(additionalElements)
                             containsSize(0, 2)
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedValuesAssertionsSpec.kt
@@ -54,13 +54,11 @@ abstract class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec(
 
     fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
 
-    fun entryWithIndex(index: Int) = String.format(entryWithIndex, index)
-
     fun index(fromIndex: Int, toIndex: Int) =
         String.format(DescriptionIterableAssertion.INDEX_FROM_TO.getDefault(), fromIndex, toIndex)
 
     fun entry(prefix: String, bulletPoint: String, expected: Array<out Double?>) =
-        expected.joinToString(".*$separator") { "$prefix\\Q$bulletPoint$anEntryWhichIs: $it\\E" }
+        expected.joinToString(".*$separator") { "$prefix\\Q$bulletPoint$anElementWhichIs: $it\\E" }
 
     fun size(prefix: String, bulletPoint: String, actual: Int, expected: Int) =
         "$prefix\\Q$bulletPoint\\E${featureArrow}${DescriptionCollectionAssertion.SIZE.getDefault()}: $actual[^:]+: $expected"
@@ -81,7 +79,7 @@ abstract class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec(
     fun mismatchesAfterFail(vararg mismatched: Double) = warning(mismatches, mismatched.toTypedArray()) { "$it" }
 
     fun additional(vararg entryWithValue: Pair<Int, Double>) =
-        warning(additionalEntries, entryWithValue) { "${entryWithIndex(it.first)}: ${it.second}" }
+        warning(additionalElements, entryWithValue) { "${elementWithIndex(it.first)}: ${it.second}" }
 
 
     val afterSuccess = "$indentBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
@@ -172,7 +170,7 @@ abstract class IterableContainsInOrderOnlyGroupedValuesAssertionsSpec(
                         contains.exactly(1).value("$rootBulletPoint$containsInOrderOnlyGrouped:")
                         indexFail(0, sizeExceeded, 1.0)
                         indexFail(1, sizeExceeded, 1.2)
-                        containsNot(additionalEntries)
+                        containsNot(additionalElements)
                         containsSize(0, 2)
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyValuesAssertionsSpec.kt
@@ -40,20 +40,18 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
     val toBeAfterSuccess = "$indentBulletPoint$indentSuccessfulBulletPoint$toBeWithFeature"
     val toBeAfterFailing = "$indentBulletPoint$indentFailingBulletPoint$toBeWithFeature"
 
-    fun entry(index: Int) = String.format(entryWithIndex, index)
-
-    fun Expect<String>.entrySuccess(index: Int, expected: String): Expect<String> {
+    fun Expect<String>.elementSuccess(index: Int, expected: String): Expect<String> {
         return this.contains.exactly(1).regex(
-            "\\Q$successfulBulletPoint$featureArrow${entry(index)}: $expected\\E.*$separator" +
+            "\\Q$successfulBulletPoint$featureArrow${elementWithIndex(index)}: $expected\\E.*$separator" +
                 "$toBeAfterSuccess: $expected"
         )
     }
 
-    fun Expect<String>.entrySuccess(index: Int, expected: Double) = entrySuccess(index, expected.toString())
+    fun Expect<String>.elementSuccess(index: Int, expected: Double) = elementSuccess(index, expected.toString())
 
-    fun Expect<String>.entryFailing(index: Int, actual: Any, expected: Double): Expect<String> {
+    fun Expect<String>.elementFailing(index: Int, actual: Any, expected: Double): Expect<String> {
         return this.contains.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${entry(index)}: $actual\\E.*$separator" +
+            "\\Q$failingBulletPoint$featureArrow${elementWithIndex(index)}: $actual\\E.*$separator" +
                 "$toBeAfterFailing: $expected"
         )
     }
@@ -74,8 +72,8 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                 }.toThrow<AssertionError> {
                     message {
                         contains("$rootBulletPoint$containsInOrderOnly:")
-                        entryFailing(0, sizeExceeded, 1.0)
-                        containsNot(additionalEntries)
+                        elementFailing(0, sizeExceeded, 1.0)
+                        containsNot(additionalElements)
                         containsSize(0, 1)
                     }
                 }
@@ -86,9 +84,9 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                 }.toThrow<AssertionError> {
                     message {
                         contains("$rootBulletPoint$containsInOrderOnly:")
-                        entryFailing(0, sizeExceeded, 1.0)
-                        entryFailing(1, sizeExceeded, 4.0)
-                        containsNot(additionalEntries)
+                        elementFailing(0, sizeExceeded, 1.0)
+                        elementFailing(1, sizeExceeded, 4.0)
+                        containsNot(additionalElements)
                         containsSize(0, 2)
                     }
                 }
@@ -111,11 +109,11 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entryFailing(0, 1.0, 4.0)
-                            entryFailing(1, 2.0, 1.0)
-                            entryFailing(2, 3.0, 2.0)
-                            entryFailing(3, 4.0, 3.0)
-                            entrySuccess(4, 4.0)
+                            elementFailing(0, 1.0, 4.0)
+                            elementFailing(1, 2.0, 1.0)
+                            elementFailing(2, 3.0, 2.0)
+                            elementFailing(3, 4.0, 3.0)
+                            elementSuccess(4, 4.0)
                             containsSize(5, 5)
                         }
                     }
@@ -127,13 +125,13 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0)
-                            entrySuccess(1, 2.0)
-                            entrySuccess(2, 3.0)
-                            entrySuccess(3, 4.0)
+                            elementSuccess(0, 1.0)
+                            elementSuccess(1, 2.0)
+                            elementSuccess(2, 3.0)
+                            elementSuccess(3, 4.0)
                             contains(
-                                "$warningBulletPoint$additionalEntries:",
-                                "$listBulletPoint${entry(4)}: 4.0"
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
                             )
                             containsSize(5, 4)
                         }
@@ -146,13 +144,13 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0)
-                            entryFailing(1, 2.0, 4.0)
+                            elementSuccess(0, 1.0)
+                            elementFailing(1, 2.0, 4.0)
                             contains(
-                                "$warningBulletPoint$additionalEntries:",
-                                "$listBulletPoint${entry(2)}: 3.0",
-                                "$listBulletPoint${entry(3)}: 4.0",
-                                "$listBulletPoint${entry(4)}: 4.0"
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(2)}: 3.0",
+                                "$listBulletPoint${elementWithIndex(3)}: 4.0",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
                             )
                             containsSize(5, 2)
                         }
@@ -164,13 +162,13 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0)
-                            entryFailing(1, 2.0, 3.0)
-                            entryFailing(2, 3.0, 5.0)
+                            elementSuccess(0, 1.0)
+                            elementFailing(1, 2.0, 3.0)
+                            elementFailing(2, 3.0, 5.0)
                             contains(
-                                "$warningBulletPoint$additionalEntries:",
-                                "$listBulletPoint${entry(3)}: 4.0",
-                                "$listBulletPoint${entry(4)}: 4.0"
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(3)}: 4.0",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
                             )
                             containsSize(5, 3)
                         }
@@ -182,12 +180,12 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                            entrySuccess(0, 1.0)
-                            entrySuccess(1, 2.0)
-                            entrySuccess(2, 3.0)
-                            entrySuccess(3, 4.0)
-                            entrySuccess(4, 4.0)
-                            entryFailing(5, sizeExceeded, 5.0)
+                            elementSuccess(0, 1.0)
+                            elementSuccess(1, 2.0)
+                            elementSuccess(2, 3.0)
+                            elementSuccess(3, 4.0)
+                            elementSuccess(4, 4.0)
+                            elementFailing(5, sizeExceeded, 5.0)
                             containsSize(5, 6)
                         }
                     }
@@ -215,12 +213,12 @@ abstract class IterableContainsInOrderOnlyValuesAssertionsSpec(
                         }.toThrow<AssertionError> {
                             message {
                                 contains.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
-                                entrySuccess(0, Text.NULL.string)
-                                entrySuccess(1, 1.0)
-                                entryFailing(2, Text.NULL.string, 3.0)
+                                elementSuccess(0, Text.NULL.string)
+                                elementSuccess(1, 1.0)
+                                elementFailing(2, Text.NULL.string, 3.0)
                                 contains(
-                                    "$warningBulletPoint$additionalEntries:",
-                                    "$listBulletPoint${entry(3)}: 3.0"
+                                    "$warningBulletPoint$additionalElements:",
+                                    "$listBulletPoint${elementWithIndex(3)}: 3.0"
                                 )
                                 containsSize(4, 3)
                             }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsNotValuesAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsNotValuesAssertionsSpec.kt
@@ -8,7 +8,6 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
-import org.spekframework.spek2.style.specification.Suite
 
 abstract class IterableContainsNotValuesAssertionsSpec(
     containsNotValues: Fun2<Iterable<Double>, Double, Array<out Double>>,
@@ -50,7 +49,7 @@ abstract class IterableContainsNotValuesAssertionsSpec(
     val isAfterSuccess = "$indentBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow\\Q$featureBulletPoint\\E$isDescr"
     //@formatter:on
 
-    val anEntryWhichIsWithIndent = "$indentBulletPoint$listBulletPoint$anEntryWhichIs"
+    val anElementWhichIsWithIndent = "$indentBulletPoint$listBulletPoint$anElementWhichIs"
 
     nonNullableCases(
         describePrefix,
@@ -70,7 +69,7 @@ abstract class IterableContainsNotValuesAssertionsSpec(
                     message {
                         containsRegex(
                             "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                "$anEntryWhichIsWithIndent: 4.0.*$separator" +
+                                "$anElementWhichIsWithIndent: 4.0.*$separator" +
                                 "$featureSuccess$numberOfOccurrences: 0$separator" +
                                 "$isAfterSuccess: 0.*$separator" +
                                 "$featureFailing$hasElement: false$separator" +
@@ -103,7 +102,7 @@ abstract class IterableContainsNotValuesAssertionsSpec(
                         message {
                             containsRegex(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                    "$anEntryWhichIsWithIndent: 4.0.*$separator" +
+                                    "$anElementWhichIsWithIndent: 4.0.*$separator" +
                                     "$featureFailing$numberOfOccurrences: 3$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +
@@ -119,12 +118,12 @@ abstract class IterableContainsNotValuesAssertionsSpec(
                         message {
                             containsRegex(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                    "$anEntryWhichIsWithIndent: 1.0.*$separator" +
+                                    "$anElementWhichIsWithIndent: 1.0.*$separator" +
                                     "$featureFailing$numberOfOccurrences: 1$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +
                                     "$isAfterSuccess: true$separator" +
-                                    "$anEntryWhichIsWithIndent: 4.0.*$separator" +
+                                    "$anElementWhichIsWithIndent: 4.0.*$separator" +
                                     "$featureFailing$numberOfOccurrences: 3$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +
@@ -140,12 +139,12 @@ abstract class IterableContainsNotValuesAssertionsSpec(
                         message {
                             containsRegex(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                    "$anEntryWhichIsWithIndent: 4.0.*$separator" +
+                                    "$anElementWhichIsWithIndent: 4.0.*$separator" +
                                     "$featureFailing$numberOfOccurrences: 3$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +
                                     "$isAfterSuccess: true$separator" +
-                                    "$anEntryWhichIsWithIndent: 1.0.*$separator" +
+                                    "$anElementWhichIsWithIndent: 1.0.*$separator" +
                                     "$featureFailing$numberOfOccurrences: 1$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +
@@ -174,7 +173,7 @@ abstract class IterableContainsNotValuesAssertionsSpec(
                         message {
                             containsRegex(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                    "$anEntryWhichIsWithIndent: null$separator" +
+                                    "$anElementWhichIsWithIndent: null$separator" +
                                     "$featureFailing$numberOfOccurrences: 2$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +
@@ -191,7 +190,7 @@ abstract class IterableContainsNotValuesAssertionsSpec(
                         message {
                             containsRegex(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                    "$anEntryWhichIsWithIndent: null$separator" +
+                                    "$anElementWhichIsWithIndent: null$separator" +
                                     "$featureFailing$numberOfOccurrences: 2$separator" +
                                     "$isAfterFailing: 0.*$separator" +
                                     "$featureSuccess$hasElement: true$separator" +

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsSpecBase.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.contains
 import ch.tutteli.atrium.api.fluent.en_GB.exactly
 import ch.tutteli.atrium.api.fluent.en_GB.regex
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
@@ -17,7 +18,8 @@ abstract class IterableContainsSpecBase(spec: Root.() -> Unit) : Spek(spec) {
     companion object {
         val oneToFour = { sequenceOf(1.0, 2.0, 3.0, 4.0, 4.0).constrainOnce().asIterable() }
         val oneToSeven = { sequenceOf(1.0, 2.0, 4.0, 4.0, 5.0, 3.0, 5.0, 6.0, 4.0, 7.0).constrainOnce().asIterable() }
-        val oneToSevenNullable = { sequenceOf(1.0, null, 4.0, 4.0, 5.0, null, 5.0, 6.0, 4.0, 7.0).constrainOnce().asIterable() }
+        val oneToSevenNullable =
+            { sequenceOf(1.0, null, 4.0, 4.0, 5.0, null, 5.0, 6.0, 4.0, 7.0).constrainOnce().asIterable() }
 
         val containsInAnyOrder = String.format(
             DescriptionIterableAssertion.IN_ANY_ORDER.getDefault(),
@@ -36,13 +38,12 @@ abstract class IterableContainsSpecBase(spec: Root.() -> Unit) : Spek(spec) {
             DescriptionIterableAssertion.CONTAINS.getDefault()
         )
         val numberOfOccurrences = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES.getDefault()
-        val additionalEntries = DescriptionIterableAssertion.WARNING_ADDITIONAL_ENTRIES.getDefault()
+        val additionalElements = DescriptionIterableAssertion.WARNING_ADDITIONAL_ELEMENTS.getDefault()
         val mismatches = DescriptionIterableAssertion.WARNING_MISMATCHES.getDefault()
         val mismatchesAdditionalEntries =
             DescriptionIterableAssertion.WARNING_MISMATCHES_ADDITIONAL_ENTRIES.getDefault()
         val sizeExceeded = DescriptionIterableAssertion.SIZE_EXCEEDED.getDefault()
-        val entryWithIndex = DescriptionIterableAssertion.ENTRY_WITH_INDEX.getDefault()
-        val anEntryWhichIs = DescriptionIterableAssertion.AN_ENTRY_WHICH_IS.getDefault()
+        val anElementWhichIs = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS.getDefault()
 
         val atLeast = DescriptionIterableAssertion.AT_LEAST.getDefault()
         val atMost = DescriptionIterableAssertion.AT_MOST.getDefault()
@@ -60,6 +61,8 @@ abstract class IterableContainsSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         fun Root.nullableCases(describePrefix: String, body: Suite.() -> Unit) {
             describe("$describePrefix nullable cases", body = body)
         }
+
+        fun elementWithIndex(index: Int) = DescriptionIterableAssertion.ELEMENT_WITH_INDEX.getDefault().format(index)
 
         fun <F> Root.nonNullableCases(
             describePrefix: String,

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -8,13 +8,19 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class DescriptionIterableAssertion(override val value: String) : StringBasedTranslatable {
     ALL("alle Einträge"),
-    AN_ENTRY_WHICH("ein Eintrag, welcher"),
-    AN_ENTRY_WHICH_IS("Eintrag"),
+    AN_ELEMENT_WHICH("ein Element, welches"),
+    AN_ELEMENT_WHICH_EQUALS("Element"),
+    @Deprecated("Use AN_ELEMENT_WHICH; will be removed with 1.0.0", ReplaceWith("AN_ELEMENT_WHICH"))
+    AN_ENTRY_WHICH(AN_ELEMENT_WHICH.getDefault()),
+    @Deprecated("Use AN_ELEMENT_WHICH_EQUALS; will be removed with 1.0.0", ReplaceWith("AN_ELEMENT_WHICH_EQUALS"))
+    AN_ENTRY_WHICH_IS(AN_ELEMENT_WHICH_EQUALS.getDefault()),
     AT_LEAST("ist zumindest"),
     AT_MOST("ist höchstens"),
     CONTAINS("enthält"),
     CONTAINS_NOT("enthält nicht"),
-    ENTRY_WITH_INDEX("Eintrag %s"),
+    ELEMENT_WITH_INDEX("Element %s"),
+    @Deprecated("Use ELEMENT_WITH_INDEX; will be removed with 1.0.0", ReplaceWith("ELEMENT_WITH_INDEX"))
+    ENTRY_WITH_INDEX(ELEMENT_WITH_INDEX.getDefault()),
     EXACTLY("ist genau"),
     HAS_ELEMENT("hat mindestens ein Element"),
     IN_ANY_ORDER("%s, in beliebiger Reihenfolge"),
@@ -30,7 +36,9 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     CANNOT_EVALUATE_SUBJECT_EMPTY_ITERABLE("$COULD_NOT_EVALUATE_DEFINED_ASSERTIONS -- `Iterable` gibt keinen nächsten Eintrag zurück.\n$VISIT_COULD_NOT_EVALUATE_ASSERTIONS"),
     @Deprecated("Will be removed with 1.0.0")
     CANNOT_EVALUATE_SUBJECT_ONLY_NULL("$COULD_NOT_EVALUATE_DEFINED_ASSERTIONS -- `Iterable` gibt nur `null` zurück.\n$VISIT_COULD_NOT_EVALUATE_ASSERTIONS"),
-    WARNING_ADDITIONAL_ENTRIES("zusätzliche Einträge entdeckt"),
+    WARNING_ADDITIONAL_ELEMENTS("zusätzliche Elemente entdeckt"),
+    @Deprecated("Use WARNING_ADDITIONAL_ELEMENTS; will be removed with 1.0.0", ReplaceWith("WARNING_ADDITIONAL_ELEMENTS"))
+    WARNING_ADDITIONAL_ENTRIES(WARNING_ADDITIONAL_ELEMENTS.getDefault()),
     WARNING_MISMATCHES("folgende Einträge erfüllten keine Aussage (Diskrepanzen)"),
     WARNING_MISMATCHES_ADDITIONAL_ENTRIES("Diskrepanzen und zusätzliche Einträge entdeckt"),
     NEXT_ELEMENT("ein nächstes Element"),

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -8,13 +8,19 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class DescriptionIterableAssertion(override val value: String) : StringBasedTranslatable {
     ALL("all entries"),
-    AN_ENTRY_WHICH("an entry which"),
-    AN_ENTRY_WHICH_IS("an entry which is"),
+    AN_ELEMENT_WHICH("an element which"),
+    AN_ELEMENT_WHICH_EQUALS("an element which equals"),
+    @Deprecated("Use AN_ELEMENT_WHICH; will be removed with 1.0.0", ReplaceWith("AN_ELEMENT_WHICH"))
+    AN_ENTRY_WHICH(AN_ELEMENT_WHICH.getDefault()),
+    @Deprecated("Use AN_ELEMENT_WHICH_EQUALS; will be removed with 1.0.0", ReplaceWith("AN_ELEMENT_WHICH_EQUALS"))
+    AN_ENTRY_WHICH_IS(AN_ELEMENT_WHICH_EQUALS.getDefault()),
     AT_LEAST("is at least"),
     AT_MOST("is at most"),
     CONTAINS("contains"),
     CONTAINS_NOT("does not contain"),
-    ENTRY_WITH_INDEX("entry %s"),
+    ELEMENT_WITH_INDEX("element %s"),
+    @Deprecated("Use ELEMENT_WITH_INDEX; will be removed with 1.0.0", ReplaceWith("ELEMENT_WITH_INDEX"))
+    ENTRY_WITH_INDEX(ELEMENT_WITH_INDEX.getDefault()),
     EXACTLY("is exactly"),
     HAS_ELEMENT("has at least one element"),
     IN_ANY_ORDER("%s, in any order"),
@@ -30,7 +36,9 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     CANNOT_EVALUATE_SUBJECT_EMPTY_ITERABLE("$COULD_NOT_EVALUATE_DEFINED_ASSERTIONS -- `Iterable` has no next entry.\n$VISIT_COULD_NOT_EVALUATE_ASSERTIONS"),
     @Deprecated("Will be removed with 1.0.0")
     CANNOT_EVALUATE_SUBJECT_ONLY_NULL("$COULD_NOT_EVALUATE_DEFINED_ASSERTIONS -- `Iterable` returns only `null` for `next()`.\n$VISIT_COULD_NOT_EVALUATE_ASSERTIONS"),
-    WARNING_ADDITIONAL_ENTRIES("additional entries detected"),
+    WARNING_ADDITIONAL_ELEMENTS("additional elements detected"),
+    @Deprecated("Use WARNING_ADDITIONAL_ELEMENTS; will be removed with 1.0.0", ReplaceWith("WARNING_ADDITIONAL_ELEMENTS"))
+    WARNING_ADDITIONAL_ENTRIES(WARNING_ADDITIONAL_ELEMENTS.getDefault()),
     WARNING_MISMATCHES("following entries were mismatched"),
     WARNING_MISMATCHES_ADDITIONAL_ENTRIES("mismatches and additional entries detected"),
     NEXT_ELEMENT("a next element"),


### PR DESCRIPTION
and use `equals` instead of `is`



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
