### PR TITLE
Build Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -444,6 +444,7 @@ def createJsTestTask(String... subprojectNames) {
             from compileKotlin2Js.destinationDir
 
             prefixedProject('verbs-internal-js').afterEvaluate {
+                // TODO 0.16.0 or 0.17.0, check if still required with the new Kotlin MPP plugin
                 configurations.testRuntimeClasspath.allDependencies.withType(ProjectDependency).each {
                     dependsOn(it.dependencyProject.assemble)
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -444,6 +444,10 @@ def createJsTestTask(String... subprojectNames) {
             from compileKotlin2Js.destinationDir
 
             prefixedProject('verbs-internal-js').afterEvaluate {
+                configurations.testRuntimeClasspath.allDependencies.withType(ProjectDependency).each {
+                    dependsOn(it.dependencyProject.assemble)
+                }
+
                 configurations.testRuntimeClasspath.each {
                     from zipTree(it.absolutePath).matching { include '*.js', '*.js.map' }
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.parallel=true

--- a/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/filesystem/SymbolicLinkResolvingSpec.kt
+++ b/misc/deprecated/domain/robstoll-lib/atrium-domain-robstoll-lib-jvm/src/test/kotlin/ch/tutteli/atrium/assertions/filesystem/SymbolicLinkResolvingSpec.kt
@@ -21,10 +21,7 @@ import ch.tutteli.niok.createDirectory
 import ch.tutteli.niok.createFile
 import ch.tutteli.niok.createSymbolicLink
 import ch.tutteli.spek.extensions.memoizedTempFolder
-import io.mockk.confirmVerified
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import com.nhaarman.mockitokotlin2.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.lifecycle.CachingMode.TEST
@@ -41,8 +38,8 @@ object SymbolicLinkResolvingSpec : Spek({
 
     val testAssertion = assertionBuilder.createDescriptive(Untranslatable("testAssertion"), null) { true }
     val resolvedPathConsumer by memoized(TEST) {
-        mockk<(Path) -> Assertion> {
-            every { this@mockk.invoke(any()) } returns testAssertion
+        mock<(Path) -> Assertion> {
+            on { this(any()) } doReturn testAssertion
         }
     }
 
@@ -54,35 +51,35 @@ object SymbolicLinkResolvingSpec : Spek({
     describe("explainForResolvedLink", skip = ifSymlinksNotSupported) {
         describe("resolves correctly") {
             afterEachTest {
-                confirmVerified(resolvedPathConsumer)
+                verifyNoMoreInteractions(resolvedPathConsumer)
             }
 
             it("resolves an existing file to itself") {
                 val file = tempFolder.newFile("testFile").toRealPath()
 
                 explainForResolvedLink(file, resolvedPathConsumer)
-                verify { resolvedPathConsumer(file) }
+                verify(resolvedPathConsumer)(file)
             }
 
             it("resolves an existing directory to itself") {
                 val folder = tempFolder.newFile("testDir").toRealPath()
 
                 explainForResolvedLink(folder, resolvedPathConsumer)
-                verify { resolvedPathConsumer(folder) }
+                verify(resolvedPathConsumer)(folder)
             }
 
             it("resolves a non-existent path to itself") {
                 val notExisting = tempFolder.tmpDir.toRealPath().resolve("notExisting")
 
                 explainForResolvedLink(notExisting, resolvedPathConsumer)
-                verify { resolvedPathConsumer(notExisting) }
+                verify(resolvedPathConsumer)(notExisting)
             }
 
             it("resolves a relative path to its absolute target") {
                 val relativePath = Paths.get(".")
 
                 explainForResolvedLink(relativePath, resolvedPathConsumer)
-                verify { resolvedPathConsumer(relativePath.toRealPath()) }
+                verify(resolvedPathConsumer)(relativePath.toRealPath())
             }
 
             it("resolves a symbolic link to its target") {
@@ -91,7 +88,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 val link = target.createSymbolicLink(testDir.resolve("link"))
 
                 explainForResolvedLink(link, resolvedPathConsumer)
-                verify { resolvedPathConsumer(target) }
+                verify(resolvedPathConsumer)(target)
             }
 
             it("a relative symbolic link to its absolute target") {
@@ -102,7 +99,7 @@ object SymbolicLinkResolvingSpec : Spek({
                     Paths.get("..").resolve(target.fileName).createSymbolicLink(folder.resolve("testLink"))
 
                 explainForResolvedLink(relativeLink, resolvedPathConsumer)
-                verify { resolvedPathConsumer(target) }
+                verify(resolvedPathConsumer)(target)
             }
 
             it("resolves a symbolic link chain as far as possible") {
@@ -112,7 +109,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 val start = tempFolder.newSymbolicLink("start", toNowhere)
 
                 explainForResolvedLink(start, resolvedPathConsumer)
-                verify { resolvedPathConsumer(nowhere) }
+                verify(resolvedPathConsumer)(nowhere)
             }
 
             it("resolves multiple symbolic links to their target") {
@@ -128,7 +125,7 @@ object SymbolicLinkResolvingSpec : Spek({
                 )
 
                 explainForResolvedLink(linkToInnerLink, resolvedPathConsumer)
-                verify { resolvedPathConsumer(target) }
+                verify(resolvedPathConsumer)(target)
             }
         }
 

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathAssertionsSpec.kt
@@ -11,8 +11,10 @@ import ch.tutteli.atrium.translations.DescriptionPathAssertion.*
 import ch.tutteli.niok.*
 import ch.tutteli.spek.extensions.MemoizedTempFolder
 import ch.tutteli.spek.extensions.memoizedTempFolder
-import io.mockk.every
-import io.mockk.spyk
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.spy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.dsl.Skip.No
@@ -21,14 +23,13 @@ import org.spekframework.spek2.dsl.TestBody
 import org.spekframework.spek2.style.specification.Suite
 import java.io.IOException
 import java.nio.charset.Charset
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.nio.file.*
 import java.nio.file.attribute.*
 import java.nio.file.attribute.AclEntryPermission.*
 import java.nio.file.attribute.AclEntryType.ALLOW
 import java.nio.file.attribute.AclEntryType.DENY
 import java.nio.file.attribute.PosixFilePermission.*
+import java.nio.file.spi.FileSystemProvider
 import java.util.regex.Pattern.quote
 
 abstract class PathAssertionsSpec(
@@ -134,14 +135,7 @@ abstract class PathAssertionsSpec(
         // using spyk on baseFile and mocking #getFileSystem does not work on Java 8 on Linux (but everywhere else).
         // because of that, we use plain old manual delegation:
         return object : Path by baseFile {
-            override fun getFileSystem() = spyk(baseFile.fileSystem) {
-                every { provider() } returns spyk(baseFile.fileSystem.provider()) {
-                    every {
-                        readAttributes(any(), any<Class<BasicFileAttributes>>(), *anyVararg())
-                    } throws IOException(TEST_IO_EXCEPTION_MESSAGE)
-                    every { checkAccess(any(), *anyVararg()) } throws IOException(TEST_IO_EXCEPTION_MESSAGE)
-                }
-            }
+            override fun getFileSystem() = throw IOException(TEST_IO_EXCEPTION_MESSAGE)
         }
     }
 


### PR DESCRIPTION
I have a notebook running Ubuntu on a 3 year old Intel notebook processor with 2 physical / 4 virtual cores.
This PR improves the build on my machine. I tested with OpenJDK 11 with J9.

 * mockk hung the file system tests on my machine. I don’t know why. I removed mockk, which fixed the issue.
 * I enabled Gradle’s parallel build feature, which gives me build times of ~5m10s instead of ~6m20s, so a reduction of 1m10s. On machines with more cores, the the speedup should be even more pronounced.
 * I fixed the configuration of the Node.JS dependency copy task. The missing dependencies only caused a problem in a parallel build.