### PR TITLE
Remove size check feature assertion from iterable contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,16 +1084,16 @@ expect(listOf(1, 2, 2, 4)).contains.inOrder.only.entries({ isLessThan(3) }, { is
 <a name="ex-collection-builder-1"></a>
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
+◆ ▶ size: 4        (kotlin.Int <1234789>)
+    ◾ equals: 2        (kotlin.Int <1234789>)
 ◆ contains only, in order: 
   ✔ ▶ element 0: 1        (kotlin.Int <1234789>)
       ◾ is less than: 3        (kotlin.Int <1234789>)
   ✘ ▶ element 1: 2        (kotlin.Int <1234789>)
       ◾ is less than: 2        (kotlin.Int <1234789>)
-  ✘ ▶ size: 4        (kotlin.Int <1234789>)
-      ◾ equals: 2        (kotlin.Int <1234789>)
-        ❗❗ additional elements detected: 
-           ⚬ element 2: 2        (kotlin.Int <1234789>)
-           ⚬ element 3: 4        (kotlin.Int <1234789>)
+    ❗❗ additional elements detected: 
+       ⚬ element 2: 2        (kotlin.Int <1234789>)
+       ⚬ element 3: 4        (kotlin.Int <1234789>)
 ```
 </ex-collection-builder-1>
 
@@ -1132,6 +1132,8 @@ expect(listOf(1, 2, 2, 4)).contains.inOrder.only.values(1, 2, 2, 3, 4)
 <a name="ex-collection-builder-2"></a>
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
+◆ ▶ size: 4        (kotlin.Int <1234789>)
+    ◾ equals: 5        (kotlin.Int <1234789>)
 ◆ contains only, in order: 
   ✔ ▶ element 0: 1        (kotlin.Int <1234789>)
       ◾ equals: 1        (kotlin.Int <1234789>)
@@ -1143,8 +1145,6 @@ expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>
       ◾ equals: 3        (kotlin.Int <1234789>)
   ✘ ▶ element 4: ❗❗ hasNext() returned false
         » equals: 4        (kotlin.Int <1234789>)
-  ✘ ▶ size: 4        (kotlin.Int <1234789>)
-      ◾ equals: 5        (kotlin.Int <1234789>)
 ```
 </ex-collection-builder-2>
 <hr/>
@@ -1179,8 +1179,6 @@ expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>
   ✔ an element which equals: 2        (kotlin.Int <1234789>)
   ✘ an element which equals: 3        (kotlin.Int <1234789>)
   ✔ an element which equals: 4        (kotlin.Int <1234789>)
-  ✔ ▶ size: 4
-      ◾ equals: 4
   ❗❗ following elements were mismatched: 
      ⚬ 2        (kotlin.Int <1234789>)
 ```
@@ -1195,14 +1193,14 @@ expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.only.values(4, 3, 2, 2, 1)
 <a name="ex-collection-builder-5"></a>
 ```text
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
+◆ ▶ size: 4        (kotlin.Int <1234789>)
+    ◾ equals: 5        (kotlin.Int <1234789>)
 ◆ contains only, in any order: 
   ✔ an element which equals: 4        (kotlin.Int <1234789>)
   ✘ an element which equals: 3        (kotlin.Int <1234789>)
   ✔ an element which equals: 2        (kotlin.Int <1234789>)
   ✔ an element which equals: 2        (kotlin.Int <1234789>)
   ✔ an element which equals: 1        (kotlin.Int <1234789>)
-  ✘ ▶ size: 4
-      ◾ equals: 5
 ```
 </ex-collection-builder-5>
 
@@ -1335,8 +1333,6 @@ expected that subject: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
           ◾ equals: "a"        <1234789>
       ◾ ▶ value: 2        (kotlin.Int <1234789>)
           ◾ equals: 1        (kotlin.Int <1234789>)
-  ✔ ▶ size: 2        (kotlin.Int <1234789>)
-      ◾ equals: 2        (kotlin.Int <1234789>)
 ```
 </ex-map-builder-1>
 
@@ -1364,8 +1360,6 @@ expected that subject: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
           ◾ equals: "b"        <1234789>
       ◾ ▶ value: 2        (kotlin.Int <1234789>)
           ◾ is less than: 2        (kotlin.Int <1234789>)
-  ✔ ▶ size: 2        (kotlin.Int <1234789>)
-      ◾ equals: 2        (kotlin.Int <1234789>)
 ```
 </ex-map-builder-2>
 
@@ -1461,8 +1455,6 @@ expected that subject: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
           ◾ starts with: "a"        <1234789>
       ◾ ▶ value: 2        (kotlin.Int <1234789>)
           ◾ is greater than: 2        (kotlin.Int <1234789>)
-  ✔ ▶ size: 2        (kotlin.Int <1234789>)
-      ◾ equals: 2        (kotlin.Int <1234789>)
 ```
 </ex-map-5>
 
@@ -1770,15 +1762,15 @@ also states which entries were additionally contained in the list:
 
 ```text
 expected that subject: [1, 2, 3]        (java.util.Arrays.ArrayList <1234789>)
+◆ ▶ size: 3        (kotlin.Int <1234789>)
+    ◾ equals: 2        (kotlin.Int <1234789>)
 ◆ contains only, in order: 
   ✔ ▶ element 0: 1        (kotlin.Int <1234789>)
       ◾ equals: 1        (kotlin.Int <1234789>)
   ✘ ▶ element 1: 2        (kotlin.Int <1234789>)
       ◾ equals: 3        (kotlin.Int <1234789>)
-  ✘ ▶ size: 3        (kotlin.Int <1234789>)
-      ◾ equals: 2        (kotlin.Int <1234789>)
-        ❗❗ additional elements detected: 
-           ⚬ element 2: 3        (kotlin.Int <1234789>)
+    ❗❗ additional elements detected: 
+       ⚬ element 2: 3        (kotlin.Int <1234789>)
 ```
 </exs-add-info-1-output>
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyEntriesExpectationsSpec.kt
@@ -211,7 +211,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                                     "$warningBulletPoint$mismatches:",
                                     "${listBulletPoint}4.0"
                                 )
-                                containsSize(5, 5)
+                                containsNot(sizeDescr)
                             }
                         }
                     }
@@ -343,7 +343,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                                     "$warningBulletPoint$mismatches:",
                                     "${listBulletPoint}3.0"
                                 )
-                                containsSize(4, 4)
+                                containsNot(sizeDescr)
                             }
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyValuesExpectationsSpec.kt
@@ -147,7 +147,7 @@ abstract class IterableContainsInAnyOrderOnlyValuesExpectationsSpec(
                                     "$warningBulletPoint$mismatches:",
                                     "${listBulletPoint}4.0"
                                 )
-                                containsSize(5, 5)
+                                containsNot(sizeDescr)
                             }
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyEntriesExpectationsSpec.kt
@@ -2,7 +2,6 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
-import ch.tutteli.atrium.creating.ErrorMessages
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.specs.*
@@ -156,7 +155,7 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                             elementFailing(2, 3.0, "$toBeDescr: 2.0")
                             elementSuccess(3, 4.0, "$isGreaterThanDescr: 2.0")
                             elementSuccess(4, 4.0, "$toBeDescr: 4.0")
-                            containsSize(5, 5)
+                            containsNot(sizeDescr)
                         }
                     }
                 }
@@ -289,7 +288,7 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                                 elementFailing(1, 1.0, "$toBeDescr: null")
                                 elementFailing(2, "null", "$isLessThanDescr: 5.0", explaining = true)
                                 elementSuccess(3, 3.0, "$isGreaterThanDescr: 2.0")
-                                containsSize(4, 4)
+                                containsNot(sizeDescr)
                             }
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyValuesExpectationsSpec.kt
@@ -124,7 +124,7 @@ abstract class IterableContainsInOrderOnlyValuesExpectationsSpec(
                             elementFailing(2, 3.0, 2.0)
                             elementFailing(3, 4.0, 3.0)
                             elementSuccess(4, 4.0)
-                            containsSize(5, 5)
+                            containsNot(sizeDescr)
                         }
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsSpecBase.kt
@@ -44,6 +44,7 @@ abstract class IterableContainsSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val sizeExceeded = DescriptionIterableAssertion.SIZE_EXCEEDED.getDefault()
         val anElementWhichIs = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS.getDefault()
 
+        val sizeDescr = DescriptionCollectionAssertion.SIZE.getDefault()
         val atLeastDescr = DescriptionIterableAssertion.AT_LEAST.getDefault()
         val atMostDescr = DescriptionIterableAssertion.AT_MOST.getDefault()
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,8 +19,8 @@ buildscript {
                 or(
                     // improved reporting
                     "IterableContainsInOrderOnly.*Spec",
-                    "IterableContainsInAnyOrder.*error cases.*",
-                    "IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.*nullable cases.*",
+                    "IterableContainsInAnyOrder.*error cases",
+                    "IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.*nullable cases",
                     // implementation and spec was wrong
                     "IterableAssertionsSpec/.*`" + or(
                         "containsNoDuplicates",
@@ -62,9 +62,9 @@ buildscript {
             // forgive for bc and bbc
             ("(ch/tutteli/atrium/api/(fluent|infix)/en_GB/" +
                 or(
-                    "IterableContainsInOrderOnly.*Spec",
-                    "IterableContainsInAnyOrder.*error cases.*",
-                    "IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.*nullable cases.*",
+                    "IterableContainsInOrderOnly.*error cases",
+                    "IterableContainsInAnyOrder.*error cases",
+                    "IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.*nullable cases",
                     // implementation and spec was wrong
                     "IterableAssertionsSpec/.*`" + or(
                         "containsNoDuplicates",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,8 @@ buildscript {
                 or(
                     // improved reporting
                     "IterableContainsInOrderOnly.*Spec",
+                    "IterableContainsInAnyOrder.*error cases.*",
+                    "IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.*nullable cases.*",
                     // implementation and spec was wrong
                     "IterableAssertionsSpec/.*`" + or(
                         "containsNoDuplicates",
@@ -60,6 +62,9 @@ buildscript {
             // forgive for bc and bbc
             ("(ch/tutteli/atrium/api/(fluent|infix)/en_GB/" +
                 or(
+                    "IterableContainsInOrderOnly.*Spec",
+                    "IterableContainsInAnyOrder.*error cases.*",
+                    "IterableContainsInAnyOrderOnlyEntriesAssertionsSpec.*nullable cases.*",
                     // implementation and spec was wrong
                     "IterableAssertionsSpec/.*`" + or(
                         "containsNoDuplicates",


### PR DESCRIPTION
I managed to remove size check feature from contains.in.order.only.grouped.entries/values but when testing ContainsInAnyOrderOnlyEntries/Values during mismatch or missing case only size or contains assertion is returned and I can't figure out where is it getting filtered out
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
