### PR TITLE
copy and move AssertionCollector to logic, deprecate the one in domain

### DIFF
--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/CollectingExpect.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/CollectingExpect.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.creating.impl.CollectingExpectImpl
  * Represents a container for [Assertion] which is intended to serve as receiver object for lambdas which create
  * [Assertion]s, in which this [Expect] collects the assertions created this way.
  *
- * @param T The type of the [subject] of this [Expect].
+ * @param T The type of the subject of this [Expect].
  */
 interface CollectingExpect<T> : Expect<T> {
 

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
@@ -30,7 +30,7 @@ interface ExpectInternal<T> : Expect<T>, AssertionContainer<T>
  * Note, do not use [SubjectProvider] as this interface is only temporary and will most likely be removed without
  * further notice.
  *
- * @param T The type of the [subject] of the assertion.
+ * @param T The type of the subject of the assertion.
  */
 @ExpectMarker
 interface Expect<T> : SubjectProvider<T> {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionCollector.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionCollector.kt
@@ -1,0 +1,49 @@
+package ch.tutteli.atrium.logic.creating.collectors
+
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.assertions.AssertionGroup
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.creating.Expect
+
+interface AssertionCollector {
+
+    /**
+     * Use this function if you want to make [Assertion]s about a feature or you perform a type transformation or any
+     * other action which results in an [Expect] being created for a different subject and
+     * you do not require this resulting [Expect].
+     *
+     * Or in other words, you do not want to make further assertions about the resulting subject in the resulting sub
+     * [Expect].
+     *
+     * Note that an assertion will be added which fails in case [assertionCreator] does not create a single assertion.
+     *
+     * @param maybeSubject Either [Some] wrapping the subject of the current assertion or
+     *   [None] in case a previous subject transformation was not successful -
+     *   this will be used as subject for the given [assertionCreator].
+     * @param assertionCreator A lambda which defines the expectations for the given [maybeSubject].
+     *
+     * @return The collected assertions.
+     */
+    fun <T> collect(maybeSubject: Option<T>, assertionCreator: Expect<T>.() -> Unit): Assertion
+
+
+    /**
+     * Use this function if you want to collect [Assertion]s and use it as part of another [Assertion] (e.g. as part
+     * of an [AssertionGroup]).
+     *
+     * Note that an assertion will be added which fails in case [assertionCreator] does not create a single assertion.
+     *
+     * @param maybeSubject Either [Some] wrapping the subject of the current assertion or
+     *   [None] in case a previous subject transformation was not successful -
+     *   this will be used as subject for the given [assertionCreator].
+     * @param assertionCreator A lambda which defines the expectations for the given [maybeSubject].
+     *
+     * @return The collected assertions as a `List<[Assertion]>`.
+     *
+     * @throws IllegalArgumentException in case the given [assertionCreator] did not create a single
+     *   assertion.
+     */
+    fun <T> collectForComposition(maybeSubject: Option<T>, assertionCreator: Expect<T>.() -> Unit): List<Assertion>
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
@@ -1,0 +1,19 @@
+package ch.tutteli.atrium.logic.creating.collectors
+
+import ch.tutteli.atrium.assertions.AssertionGroup
+import ch.tutteli.atrium.assertions.ExplanatoryAssertionGroupType
+import ch.tutteli.atrium.assertions.builders.AssertionsOption
+import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.Expect
+
+/**
+ * Collects the assertions [assertionCreator] creates and uses them as [AssertionGroup.assertions].
+ *
+ * //TODO 0.17.0 in case we somehow incorporate the current container in AssertionsOptions, then remove container as parameter
+ */
+fun <T, G : ExplanatoryAssertionGroupType, R> AssertionsOption<G, R>.collectAssertions(
+    container: AssertionContainer<*>,
+    maybeSubject: Option<T>,
+    assertionCreator: Expect<T>.() -> Unit
+): R = withAssertions(container.assertionCollector.collectForComposition(maybeSubject, assertionCreator))

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/impl/DefaultAssertionCollector.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/impl/DefaultAssertionCollector.kt
@@ -1,0 +1,28 @@
+package ch.tutteli.atrium.logic.creating.collectors.impl
+
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.assertions.builders.invisibleGroup
+import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.creating.CollectingExpect
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.collectors.AssertionCollector
+
+class DefaultAssertionCollector : AssertionCollector {
+    
+    override fun <T> collect(maybeSubject: Option<T>, assertionCreator: Expect<T>.() -> Unit): Assertion {
+        val collectedAssertions = collectForComposition(maybeSubject, assertionCreator)
+        return if (collectedAssertions.size > 1) {
+            assertionBuilder.invisibleGroup.withAssertions(collectedAssertions).build()
+        } else {
+            collectedAssertions[0]
+        }
+    }
+
+    override fun <T> collectForComposition(
+        maybeSubject: Option<T>,
+        assertionCreator: Expect<T>.() -> Unit
+    ): List<Assertion> = CollectingExpect(maybeSubject)
+        .addAssertionsCreatedBy(assertionCreator)
+        .getAssertions()
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/impls.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/impls.kt
@@ -1,0 +1,10 @@
+package ch.tutteli.atrium.logic.creating.collectors
+
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.logic.creating.collectors.impl.DefaultAssertionCollector
+
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalNewExpectTypes::class)
+val <T> AssertionContainer<T>.assertionCollector: AssertionCollector
+    get() = getImpl(AssertionCollector::class) { DefaultAssertionCollector() }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
@@ -46,7 +46,7 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
             val actualSize = list.size
             val assertions = mutableListOf<Assertion>()
 
-            val mismatches = createAssertionsForAllSearchCriteria(searchCriteria, list, assertions)
+            val mismatches = createAssertionsForAllSearchCriteria(container, searchCriteria, list, assertions)
             val featureAssertions = createSizeFeatureAssertion(searchCriteria, actualSize)
             if (mismatches == 0 && list.isNotEmpty()) {
                 featureAssertions.add(LazyThreadUnsafeAssertionGroup {
@@ -84,13 +84,14 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
     }
 
     private fun createAssertionsForAllSearchCriteria(
+        container: AssertionContainer<*>,
         allSearchCriteria: List<SC>,
         list: MutableList<E?>,
         assertions: MutableList<Assertion>
     ): Int {
         var mismatches = 0
         allSearchCriteria.forEach {
-            val (found, assertion) = createAssertionForSearchCriterionAndRemoveMatchFromList(it, list)
+            val (found, assertion) = createAssertionForSearchCriterionAndRemoveMatchFromList(container, it, list)
             if (!found) ++mismatches
             assertions.add(assertion)
         }
@@ -98,6 +99,7 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
     }
 
     protected abstract fun createAssertionForSearchCriterionAndRemoveMatchFromList(
+        container: AssertionContainer<*>,
         searchCriterion: SC,
         list: MutableList<E?>
     ): Pair<Boolean, Assertion>
@@ -105,9 +107,9 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
     private fun createSizeFeatureAssertion(allSearchCriteria: List<SC>, actualSize: Int): MutableList<Assertion> =
         mutableListOf(
             assertionBuilder.descriptive
-            .withTest { actualSize == allSearchCriteria.size }
-            .withDescriptionAndRepresentation(TO_BE, Text(allSearchCriteria.size.toString()))
-            .build()
+                .withTest { actualSize == allSearchCriteria.size }
+                .withDescriptionAndRepresentation(TO_BE, Text(allSearchCriteria.size.toString()))
+                .build()
         )
 
     private fun createExplanatoryGroupForMismatchesEtc(

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.assertions.builders.fixedClaimGroup
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
@@ -32,11 +33,12 @@ class InAnyOrderOnlyEntriesAssertionCreator<E : Any, T : IterableLike>(
 ) : InAnyOrderOnlyAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour) {
 
     override fun createAssertionForSearchCriterionAndRemoveMatchFromList(
+        container: AssertionContainer<*>,
         searchCriterion: (Expect<E>.() -> Unit)?,
         list: MutableList<E?>
     ): Pair<Boolean, Assertion> {
-        val explanatoryAssertionGroup = createExplanatoryAssertionGroup(searchCriterion)
-        val found = removeMatch(list, searchCriterion)
+        val explanatoryAssertionGroup = createExplanatoryAssertionGroup(container, searchCriterion)
+        val found = removeMatch(container, list, searchCriterion)
         return found to createEntryAssertion(explanatoryAssertionGroup, found)
     }
 
@@ -49,10 +51,14 @@ class InAnyOrderOnlyEntriesAssertionCreator<E : Any, T : IterableLike>(
             .build()
 
 
-    private fun removeMatch(list: MutableList<E?>, assertionCreator: (Expect<E>.() -> Unit)?): Boolean {
+    private fun removeMatch(
+        container: AssertionContainer<*>,
+        list: MutableList<E?>,
+        assertionCreator: (Expect<E>.() -> Unit)?
+    ): Boolean {
         val itr = list.iterator()
         while (itr.hasNext()) {
-            if (allCreatedAssertionsHold(itr.next(), assertionCreator)) {
+            if (allCreatedAssertionsHold(container, itr.next(), assertionCreator)) {
                 itr.remove()
                 return true
             }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -26,6 +27,7 @@ class InAnyOrderOnlyValuesAssertionCreator<E, T : IterableLike>(
 ) : InAnyOrderOnlyAssertionCreator<E, T, E>(converter, searchBehaviour) {
 
     override fun createAssertionForSearchCriterionAndRemoveMatchFromList(
+        container: AssertionContainer<*>,
         searchCriterion: E,
         list: MutableList<E?>
     ): Pair<Boolean, Assertion> {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -32,7 +33,7 @@ abstract class InOrderOnlyAssertionCreator<E, T : IterableLike, SC>(
     override fun Expect<List<E>>.addAssertionsAndReturnIndex(searchCriteria: List<SC>): Int {
         var index = 0
         searchCriteria.forEachIndexed { currentIndex, searchCriterion ->
-            addSingleEntryAssertion(currentIndex, searchCriterion, ELEMENT_WITH_INDEX)
+            _logic.addSingleEntryAssertion(currentIndex, searchCriterion, ELEMENT_WITH_INDEX)
             index = currentIndex
         }
         ++index

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
@@ -7,14 +7,10 @@ import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
-import ch.tutteli.atrium.logic._logic
-import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
-import ch.tutteli.atrium.logic.size
-import ch.tutteli.atrium.logic.toBe
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.kbox.identity
@@ -42,13 +38,13 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
             }
 
             val list = maybeList.getOrElse { emptyList() }
-            val assertion = assertionCollector.collect(maybeList) {
+            val assertion = container.collectForDifferentSubject(maybeList) {
                 val index = addAssertionsAndReturnIndex(searchCriteria)
                 val remainingList = list.ifWithinBound(index,
                     { list.subList(index, list.size) },
                     { emptyList() }
                 )
-                addAssertion(createSizeFeatureAssertionForInOrderOnly(index, list, remainingList.iterator()))
+                addAssertion(createSizeFeatureAssertionForInOrderOnly(container, index, list, remainingList.iterator()))
             }
             val description = searchBehaviour.decorateDescription(DescriptionIterableAssertion.CONTAINS)
             assertionBuilder.summary
@@ -60,11 +56,12 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
 
 
     private fun <E> createSizeFeatureAssertionForInOrderOnly(
+        container: AssertionContainer<*>,
         expectedSize: Int,
         iterableAsList: List<E?>,
         itr: Iterator<E?>
     ): Assertion {
-        return assertionCollector.collect(Some(iterableAsList)) {
+        return container.collectForDifferentSubject(Some(iterableAsList)) {
             _logic.size(::identity).collectAndAppend {
                 _logicAppend { toBe(expectedSize) }
                 if (iterableAsList.size > expectedSize) {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesMatcher.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesMatcher.kt
@@ -2,17 +2,18 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
 import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.collectForDifferentSubject
 import ch.tutteli.atrium.logic.toBeNullIfNullGivenElse
 
 class InOrderOnlyEntriesMatcher<E : Any> : InOrderOnlyMatcher<E?, (Expect<E>.() -> Unit)?> {
 
-    override fun elementAssertionCreator(
+    override fun AssertionContainer<List<E?>>.elementAssertionCreator(
         maybeElement: Option<E?>,
         searchCriterion: (Expect<E>.() -> Unit)?
-    ): Assertion = assertionCollector.collect(maybeElement) {
+    ): Assertion = collectForDifferentSubject(maybeElement) {
         _logicAppend { toBeNullIfNullGivenElse(searchCriterion) }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator.kt
@@ -5,6 +5,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.getOrElse
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
@@ -28,22 +29,22 @@ abstract class InOrderOnlyGroupedAssertionCreator<E, T : IterableLike, SC>(
             val currentIndex = index
             val untilIndex = index + group.size
             if (group.size == 1) {
-                addSingleEntryAssertion(currentIndex, group[0], DescriptionIterableAssertion.INDEX)
+                _logic.addSingleEntryAssertion(currentIndex, group[0], DescriptionIterableAssertion.INDEX)
             } else {
-                addSublistAssertion(currentIndex, untilIndex, group, maybeSubject.getOrElse { emptyList() })
+                _logic.addSublistAssertion(currentIndex, untilIndex, group, maybeSubject.getOrElse { emptyList() })
             }
             index = untilIndex
         }
         return index
     }
 
-    private fun Expect<List<E>>.addSublistAssertion(
+    private fun AssertionContainer<List<E>>.addSublistAssertion(
         currentIndex: Int,
         untilIndex: Int,
         groupOfSearchCriteria: List<SC>,
         subject: List<E>
     ) {
-        _logic.extractFeature
+        extractFeature
             .withDescription(
                 TranslatableWithArgs(DescriptionIterableAssertion.INDEX_FROM_TO, currentIndex, untilIndex - 1)
             )

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher.kt
@@ -3,14 +3,14 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.core.*
-import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
 interface InOrderOnlyMatcher<E, SC> {
-    fun elementAssertionCreator(maybeElement: Option<E>, searchCriterion: SC): Assertion
+    fun AssertionContainer<List<E>>.elementAssertionCreator(maybeElement: Option<E>, searchCriterion: SC): Assertion
 
-    fun Expect<List<E>>.addSingleEntryAssertion(
+    fun AssertionContainer<List<E>>.addSingleEntryAssertion(
         currentIndex: Int,
         searchCriterion: SC,
         translatableIndex: DescriptionIterableAssertion

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValueMatcher.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValueMatcher.kt
@@ -4,11 +4,12 @@ import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.falseProvider
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.translations.DescriptionAnyAssertion.TO_BE
 
 class InOrderOnlyValueMatcher<E> : InOrderOnlyMatcher<E, E> {
 
-    override fun elementAssertionCreator(maybeElement: Option<E>, searchCriterion: E): Assertion =
+    override fun AssertionContainer<List<E>>.elementAssertionCreator(maybeElement: Option<E>, searchCriterion: E): Assertion =
         assertionBuilder.createDescriptive(TO_BE, searchCriterion) {
             maybeElement.fold(falseProvider) { it == searchCriterion }
         }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions.kt
@@ -7,7 +7,6 @@ import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.coreFactory
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnly
@@ -191,7 +190,7 @@ class DefaultMapLikeContainsAssertions : MapLikeContainsAssertions {
             val description =
                 entryPointStepLogic.searchBehaviour.decorateDescription(CONTAINS)
             assertionBuilder.invisibleGroup.withAssertions(
-                assertionCollector.collect(Some(map)) {
+                entryPointStepLogic.container.collectForDifferentSubject(Some(map)) {
                     _logic
                         //using CollectionLike.size
                         .size { it.entries }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep.kt
@@ -3,7 +3,6 @@ package ch.tutteli.atrium.logic.creating.transformers.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
 import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.collect
 import ch.tutteli.atrium.logic.creating.transformers.TransformationExecutionStep

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
@@ -9,8 +9,8 @@ import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.FeatureExpect
 import ch.tutteli.atrium.creating.FeatureExpectOptions
-import ch.tutteli.atrium.domain.builders.creating.collectors.collectAssertions
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
+import ch.tutteli.atrium.logic.creating.collectors.assertionCollector
+import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractor
 import ch.tutteli.atrium.logic.toExpect
 import ch.tutteli.atrium.reporting.reporter
@@ -64,11 +64,11 @@ class DefaultFeatureExtractor : FeatureExtractor {
                     // function writer
                     container.maybeSubject.fold({
                         // already in an explanatory assertion group, no need to wrap again
-                        assertionCollector.collectForComposition(None, assertionCreator)
+                        container.assertionCollector.collectForComposition(None, assertionCreator)
                     }, {
                         listOf(
                             assertionBuilder.explanatoryGroup.withDefaultType
-                                .collectAssertions(None, assertionCreator)
+                                .collectAssertions(container, None, assertionCreator)
                                 .build()
                         )
                     })
@@ -87,7 +87,7 @@ class DefaultFeatureExtractor : FeatureExtractor {
                 createFeatureExpect(Some(subject), maybeSubAssertions.fold({
                     listOf<Assertion>()
                 }) { assertionCreator ->
-                    assertionCollector.collectForComposition(Some(subject), assertionCreator)
+                    container.assertionCollector.collectForComposition(Some(subject), assertionCreator)
                 })
             }
         )

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler.kt
@@ -11,7 +11,7 @@ import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.core.polyfills.stackBacktrace
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.creating.collectors.collectAssertions
+import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChanger
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -29,7 +29,7 @@ class ThrowableThrownFailureHandler<T : Throwable?, R> : SubjectChanger.FailureH
             assertions.add(
                 assertionBuilder.explanatoryGroup
                     .withDefaultType
-                    .collectAssertions(None, assertionCreator)
+                    .collectAssertions(container, None, assertionCreator)
                     .build()
             )
         }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/DefaultFailureHandlerImpl.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/DefaultFailureHandlerImpl.kt
@@ -7,7 +7,7 @@ import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.creating.collectors.collectAssertions
+import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChanger
 
 class DefaultFailureHandlerImpl<T, R> : SubjectChanger.FailureHandler<T, R> {
@@ -24,7 +24,7 @@ class DefaultFailureHandlerImpl<T, R> : SubjectChanger.FailureHandler<T, R> {
                 descriptiveAssertion,
                 assertionBuilder.explanatoryGroup
                     .withDefaultType
-                    .collectAssertions(None, assertionCreator)
+                    .collectAssertions(container, None, assertionCreator)
                     .build()
             )
             .build()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
@@ -8,7 +8,6 @@ import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import ch.tutteli.atrium.reporting.Text
@@ -44,10 +43,10 @@ class DefaultAnyAssertions : AnyAssertions {
         if (assertionCreatorOrNull == null) {
             container.toBe(null)
         } else {
-            val assertion =
-                assertionCollector.collect(container.maybeSubject.flatMap { if (it != null) Some(it) else None }) {
-                    addAssertionsCreatedBy(assertionCreatorOrNull)
-                }
+            val collectSubject = container.maybeSubject.flatMap { if (it != null) Some(it) else None }
+            val assertion = container.collectForDifferentSubject(collectSubject) {
+                addAssertionsCreatedBy(assertionCreatorOrNull)
+            }
             //TODO 0.16.0 this is a pattern which occurs over and over again, maybe incorporate into collect?
             container.maybeSubject.fold(
                 {
@@ -99,7 +98,7 @@ class DefaultAnyAssertions : AnyAssertions {
         reason: String,
         assertionCreator: Expect<T>.() -> Unit
     ): Assertion {
-        val assertion = assertionCollector.collect(container.maybeSubject, assertionCreator)
+        val assertion = container.collect(assertionCreator)
         return assertionBuilder.invisibleGroup.withAssertions(
             assertion,
             assertionBuilder.explanatoryGroup

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -98,10 +98,10 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
         val list = transformToList(container, converter)
 
         val assertions = ArrayList<Assertion>(2)
-        assertions.add(createExplanatoryAssertionGroup(assertionCreatorOrNull))
+        assertions.add(createExplanatoryAssertionGroup(container, assertionCreatorOrNull))
 
         val mismatches = createIndexAssertions(list) { (_, element) ->
-            !allCreatedAssertionsHold(element, assertionCreatorOrNull)
+            !allCreatedAssertionsHold(container, element, assertionCreatorOrNull)
         }
         assertions.add(
             assertionBuilder.explanatoryGroup

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -3,10 +3,13 @@ package ch.tutteli.atrium.logic.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
-import ch.tutteli.atrium.core.*
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.core.trueProvider
+import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.creating.collectors.collectAssertions
-import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
+import ch.tutteli.atrium.logic.collectForDifferentSubject
+import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
@@ -21,23 +24,25 @@ internal fun createHasElementAssertion(list: List<*>): Assertion {
 }
 
 internal fun <E : Any> allCreatedAssertionsHold(
+    container: AssertionContainer<*>,
     subject: E?,
     assertionCreator: (Expect<E>.() -> Unit)?
 ): Boolean = when (subject) {
     null -> assertionCreator == null
-    else -> assertionCreator != null && assertionCollector.collect(Some(subject), assertionCreator).holds()
+    else -> assertionCreator != null && container.collectForDifferentSubject(Some(subject), assertionCreator).holds()
 }
 
-
 internal fun <E : Any> createExplanatoryAssertionGroup(
+    container: AssertionContainer<*>,
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
 ): AssertionGroup {
     return assertionBuilder.explanatoryGroup
         .withDefaultType
         .let {
+//TODO 0.16.0 looks a lot like toBeNullIfNullGiven
             if (assertionCreatorOrNull != null) {
                 // we don't use a subject, we will not show it anyway
-                it.collectAssertions(None, assertionCreatorOrNull)
+                it.collectAssertions(container, None, assertionCreatorOrNull)
             } else {
                 it.withAssertion(
                     // it is for an explanatoryGroup where it does not matter if the assertion holds or not

--- a/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/collectors/AssertionCollector.kt
+++ b/misc/deprecated/domain/api/atrium-domain-api-common/src/main/kotlin/ch/tutteli/atrium/domain/creating/collectors/AssertionCollector.kt
@@ -1,29 +1,31 @@
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.creating.collectors
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
-import ch.tutteli.atrium.assertions.ExplanatoryAssertionGroupType
 import ch.tutteli.atrium.assertions.InvisibleAssertionGroupType
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.Some
-import ch.tutteli.atrium.core.coreFactory
 import ch.tutteli.atrium.core.polyfills.loadSingleService
-import ch.tutteli.atrium.creating.*
-import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.creating.Expect
 
 /**
  * The access point to an implementation of [AssertionCollector].
  *
  * It loads the implementation lazily via [loadSingleService].
  */
-//TODO 0.16.0 move to atrium-logic
+@Deprecated(
+    "Use assertionCollector from atrium-logic; will be removed with 0.17.0",
+    ReplaceWith("container.assertionCollector", "ch.tutteli.atrium.logic.creating.collectors.assertionCollector")
+)
 val assertionCollector: AssertionCollector by lazy { loadSingleService(AssertionCollector::class) }
 
 /**
  * Responsible to collect assertions made in an `assertionCreator`-lambda.
  */
-//TODO 0.16.0 move to atrium-logic
+@Deprecated("Use AssertionCollector from atrium-logic; will be removed with 0.17.0")
 interface AssertionCollector {
 
     /**
@@ -31,6 +33,7 @@ interface AssertionCollector {
      *
      * See the other overload for more information.
      */
+    @Deprecated("Use assertionCollector.collect from atrium-logic; will be removed with 0.17.0")
     fun <T> collect(
         expect: Expect<T>,
         assertionCreator: Expect<T>.() -> Unit
@@ -53,6 +56,7 @@ interface AssertionCollector {
      * @throws IllegalArgumentException in case the given [assertionCreator] did not create a single
      *   assertion.
      */
+    @Deprecated("Use collect from atrium-logic; will be removed with 0.17.0")
     fun <T> collect(maybeSubject: Option<T>, assertionCreator: Expect<T>.() -> Unit): Assertion
 
 
@@ -68,5 +72,6 @@ interface AssertionCollector {
      * @throws IllegalArgumentException in case the given [assertionCreator] did not create a single
      *   assertion.
      */
+    @Deprecated("Use collectForComposition from atrium-logic; will be removed with 0.17.0")
     fun <T> collectForComposition(maybeSubject: Option<T>, assertionCreator: Expect<T>.() -> Unit): List<Assertion>
 }

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/collectors/AssertionOptionExplantoryExtensions.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/creating/collectors/AssertionOptionExplantoryExtensions.kt
@@ -1,3 +1,6 @@
+//TODO remove file with 0.17.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.builders.creating.collectors
 
 import ch.tutteli.atrium.assertions.AssertionGroup
@@ -10,7 +13,13 @@ import ch.tutteli.atrium.domain.creating.collectors.assertionCollector
 /**
  * Collects the assertions [assertionCreator] creates and uses them as [AssertionGroup.assertions].
  */
-//TODO move to atrium-logic with 0.16.0
+@Deprecated(
+    "Use collectAssertions from atrium-logic which requires to pass an instance of an AssertionContainer; will be removed with 0.17.0",
+    ReplaceWith(
+        "collectAssertions(container, maybeSubject, assertionCreator)",
+        "ch.tutteli.atrium.logic.creating.collectors.collectAssertions"
+    )
+)
 fun <T, G : ExplanatoryAssertionGroupType, R> AssertionsOption<G, R>.collectAssertions(
     maybeSubject: Option<T>,
     assertionCreator: Expect<T>.() -> Unit

--- a/misc/deprecated/domain/robstoll/atrium-domain-robstoll-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/collectors/AssertionCollectorImpl.kt
+++ b/misc/deprecated/domain/robstoll/atrium-domain-robstoll-common/src/main/kotlin/ch/tutteli/atrium/domain/robstoll/creating/collectors/AssertionCollectorImpl.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.domain.creating.collectors.AssertionCollector
 import ch.tutteli.atrium.domain.robstoll.lib.creating.collectors._collect
 import ch.tutteli.atrium.domain.robstoll.lib.creating.collectors._collectForComposition
 
-//TODO 0.16.0 move to logic and deprecate
+@Deprecated("Use assertionCollector from atrium-logic; will be removed with 0.17.0")
 class AssertionCollectorImpl : AssertionCollector {
 
     override fun <T> collect(


### PR DESCRIPTION
For this to work, we need to pass AssertionContainer around in order
that we can use the implementation configured there.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
