### PR TITLE
move Group and co. from domain-builders to logic use it in API

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
@@ -1,8 +1,11 @@
+//TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
-import ch.tutteli.atrium.domain.builders.utils.groupsToList
+import ch.tutteli.atrium.logic.utils.Group
+import ch.tutteli.atrium.logic.utils.groupsToList
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic._logicAppend
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains.EntryPointStep

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/parameterObjects.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/parameterObjects.kt
@@ -4,12 +4,9 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
-import ch.tutteli.atrium.domain.builders.utils.GroupWithNullableEntries
-import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.utils.VarArgHelper
 import ch.tutteli.kbox.glue
-
 
 /**
  * Parameter object to express a [Group] with a single identification lambda.
@@ -23,7 +20,7 @@ import ch.tutteli.kbox.glue
  */
 class Entry<T : Any>(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?
-) : GroupWithoutNullableEntries<(Expect<T>.() -> Unit)?>, GroupWithNullableEntries<(Expect<T>.() -> Unit)?> {
+) : Group<(Expect<T>.() -> Unit)?> {
     override fun toList(): List<(Expect<T>.() -> Unit)?> = listOf(assertionCreatorOrNull)
 }
 
@@ -41,7 +38,7 @@ class Entry<T : Any>(
 class Entries<T : Any>(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
     vararg val otherAssertionCreatorsOrNulls: (Expect<T>.() -> Unit)?
-) : GroupWithoutNullableEntries<(Expect<T>.() -> Unit)?>, GroupWithNullableEntries<(Expect<T>.() -> Unit)?>,
+) : Group<(Expect<T>.() -> Unit)?>,
     VarArgHelper<(Expect<T>.() -> Unit)?> {
     override val expected: (Expect<T>.() -> Unit)? get() = assertionCreatorOrNull
     override val otherExpected: Array<out (Expect<T>.() -> Unit)?> get() = otherAssertionCreatorsOrNulls
@@ -63,7 +60,7 @@ data class KeyValue<out K, V : Any>(val key: K, val valueAssertionCreatorOrNull:
 /**
  * Represents a [Group] with a single value.
  */
-data class Value<out T>(val expected: T) : GroupWithNullableEntries<T>, GroupWithoutNullableEntries<T> {
+data class Value<out T>(val expected: T) : Group<T> {
     override fun toList(): List<T> = listOf(expected)
 }
 
@@ -73,6 +70,6 @@ data class Value<out T>(val expected: T) : GroupWithNullableEntries<T>, GroupWit
 class Values<out T>(
     override val expected: T,
     override vararg val otherExpected: T
-) : GroupWithoutNullableEntries<T>, GroupWithNullableEntries<T>, VarArgHelper<T> {
+) : Group<T>, VarArgHelper<T> {
     override fun toList(): List<T> = listOf(expected, *otherExpected)
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.notImplemented
 
 class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec :

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsSpecBase.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableContainsSpecBase.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.*
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.AtLeastCheckerStep

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entries.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entries.kt
@@ -4,9 +4,7 @@ package ch.tutteli.atrium.api.infix.en_GB.creating
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
-import ch.tutteli.atrium.domain.builders.utils.GroupWithNullableEntries
-import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.utils.VarArgHelper
 import ch.tutteli.kbox.glue
 
@@ -28,8 +26,7 @@ import ch.tutteli.kbox.glue
 class Entries<T> internal constructor(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
     val otherAssertionCreatorsOrNulls: Array<out (Expect<T>.() -> Unit)?>
-) : GroupWithoutNullableEntries<(Expect<T>.() -> Unit)?>,
-    GroupWithNullableEntries<(Expect<T>.() -> Unit)?>,
+) : Group<(Expect<T>.() -> Unit)?>,
     VarArgHelper<(Expect<T>.() -> Unit)?> {
     override val expected get() = assertionCreatorOrNull
     override val otherExpected get() = otherAssertionCreatorsOrNulls

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entry.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entry.kt
@@ -1,11 +1,10 @@
 @file:Suppress("DEPRECATION" /* TODO remove suppress with 1.0.0 */)
+
 package ch.tutteli.atrium.api.infix.en_GB.creating
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
-import ch.tutteli.atrium.domain.builders.utils.GroupWithNullableEntries
-import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
+import ch.tutteli.atrium.logic.utils.Group
 
 /**
  * Parameter object to express a [Group] with a single identification lambda.
@@ -21,8 +20,7 @@ import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
  */
 data class Entry<T : Any> internal constructor(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?
-) : GroupWithoutNullableEntries<(Expect<T>.() -> Unit)?>,
-    GroupWithNullableEntries<(Expect<T>.() -> Unit)?> {
+) : Group<(Expect<T>.() -> Unit)?> {
 
     override fun toList(): List<(Expect<T>.() -> Unit)?> = listOf(assertionCreatorOrNull)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
@@ -1,16 +1,14 @@
 @file:Suppress("DEPRECATION" /* TODO remove suppress with 1.0.0 */)
+
 package ch.tutteli.atrium.api.infix.en_GB.creating
 
-import ch.tutteli.atrium.domain.builders.utils.Group
-import ch.tutteli.atrium.domain.builders.utils.GroupWithNullableEntries
-import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
+import ch.tutteli.atrium.logic.utils.Group
 
 /**
  * Represents a [Group] with a single value.
  *
  * Use the function `value(t)` to create this representation.
  */
-data class Value<T> internal constructor(val expected: T) : GroupWithNullableEntries<T>,
-    GroupWithoutNullableEntries<T> {
+data class Value<T> internal constructor(val expected: T) : Group<T> {
     override fun toList() = listOf(expected)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Values.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Values.kt
@@ -2,9 +2,7 @@
 
 package ch.tutteli.atrium.api.infix.en_GB.creating
 
-import ch.tutteli.atrium.domain.builders.utils.Group
-import ch.tutteli.atrium.domain.builders.utils.GroupWithNullableEntries
-import ch.tutteli.atrium.domain.builders.utils.GroupWithoutNullableEntries
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.utils.VarArgHelper
 
 /**
@@ -18,6 +16,6 @@ import ch.tutteli.atrium.logic.utils.VarArgHelper
 class Values<out T> internal constructor(
     override val expected: T,
     override val otherExpected: Array<out T>
-) : GroupWithoutNullableEntries<T>, GroupWithNullableEntries<T>, VarArgHelper<T> {
+) : Group<T>, VarArgHelper<T> {
     override fun toList(): List<T> = super.toList()
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.creating.iterable
 
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
+import ch.tutteli.atrium.logic.utils.groupsToList
 
 /**
  * Parameter object to express `Group<T>, Group<T>, vararg Group<T>`.
@@ -14,7 +15,7 @@ class Order<out T, out G : Group<T>> internal constructor(
     val secondGroup: G,
     val otherExpectedGroups: Array<out G>
 ) {
-    fun toList(): List<List<T>> = ch.tutteli.atrium.domain.builders.utils.groupsToList(
+    fun toList(): List<List<T>> = groupsToList(
         firstGroup,
         secondGroup,
         otherExpectedGroups

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.Order
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic._logicAppend
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains.EntryPointStep

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 
 class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec(

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 
 class IterableContainsInOrderOnlyGroupedValuesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableContainsInOrderOnlyGroupedValuesExpectationsSpec(

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsSpecBase.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableContainsSpecBase.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.Order
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.*
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.AtLeastCheckerStep

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils/Group.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils/Group.kt
@@ -1,0 +1,12 @@
+package ch.tutteli.atrium.logic.utils
+
+/**
+ * Represents a group of [T].
+ */
+
+interface Group<out T> {
+    /**
+     * Returns the members of the group as [List].
+     */
+    fun toList(): List<T>
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils/groupsToList.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils/groupsToList.kt
@@ -1,0 +1,21 @@
+package ch.tutteli.atrium.logic.utils
+
+/**
+ * Adds the given [firstGroup], the [secondGroup] and the [otherGroups] into a new [List] and returns it.
+ * @return a [List] containing [firstGroup], [secondGroup] and [otherGroups].
+ */
+fun <T> groupsToList(firstGroup: Group<T>, secondGroup: Group<T>, otherGroups: Array<out Group<T>>): List<List<T>> {
+    val groups = ArrayList<List<T>>(otherGroups.size + 2)
+    requireNotEmptyAndAdd(groups, firstGroup)
+    requireNotEmptyAndAdd(groups, secondGroup)
+    otherGroups.forEach { requireNotEmptyAndAdd(groups, it) }
+    return groups
+}
+
+private fun <T> requireNotEmptyAndAdd(groups: ArrayList<List<T>>, group: Group<T>) {
+    val list = group.toList()
+    require(list.isNotEmpty()) {
+        "a group of values cannot be empty."
+    }
+    groups.add(list)
+}

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/containsValidators.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/containsValidators.kt
@@ -1,12 +1,13 @@
-@file:Suppress("DeprecatedCallableAddReplaceWith")
-
 package ch.tutteli.atrium.domain.builders.utils
 
 /**
  * Validates that times is not `1`; throws an IllegalArgumentException otherwise, pointing the user to use the given
  * [exactlyCall] instead of the given [atMostCall].
  */
-@Deprecated("will be only available to internal with 1.0.0")
+@Deprecated(
+    "Use validateAtMost from atrium-logic; will be removed with 0.17.0",
+    ReplaceWith("ch.tutteli.atrium.logic.creating.basic.contains.checkers.validateAtMost(times, atMostCall, atLeastCall, exactlyCall)")
+)
 fun validateAtMost(
     times: Int,
     atMostCall: (Int) -> String,
@@ -23,7 +24,10 @@ fun validateAtMost(
  * Validates that [atLeastTimes] is not equal to or greater than [butAtMostTimes]; throws IllegalArgumentException
  * otherwise, pointing the user to use the given [exactlyCall] in case [atLeastTimes] equals [butAtMostTimes].
  */
-@Deprecated("will be only available to internal with 1.0.0")
+@Deprecated(
+    "Use validateAtMost from atrium-logic; will be removed with 0.17.0",
+    ReplaceWith("ch.tutteli.atrium.logic.creating.basic.contains.checkers.validateButAtMost(atLeastTimes, butAtMostTimes, atLeastButAtMostCall, atLeastCall, butAtMostCall, exactlyCall)")
+)
 fun validateButAtMost(
     atLeastTimes: Int,
     butAtMostTimes: Int,

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/groupsToList.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/groupsToList.kt
@@ -1,9 +1,15 @@
+//TODO remove file with 0.17.0
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.domain.builders.utils
 
 /**
  * Represents a group of [T].
  */
-//TODO copy and move to atrium-logic 0.16.0
+@Deprecated(
+    "Use Group from atrium-logic; will be removed with 0.17.0",
+    ReplaceWith("ch.tutteli.atrium.logic.utils.Group<T>")
+)
 interface Group<out T> {
     /**
      * Returns the members of the group as [List].
@@ -14,20 +20,29 @@ interface Group<out T> {
 /**
  * Represents a group of [T] (where `T: Any`) which can be converted to a [List]`<T>`
  */
-@Deprecated("Use super-type Group instead; will be removed with 1.0.0", ReplaceWith("Group<T>"))
+@Deprecated(
+    "Use super-type Group instead; will be removed with 0.17.0",
+    ReplaceWith("ch.tutteli.atrium.logic.utils.Group<T>")
+)
 interface GroupWithoutNullableEntries<out T> : Group<T>
 
 /**
  * Represents a group of [T] (where `T: Any?`) which can be converted to a [List]`<T>`
  */
-@Deprecated("Use super-type Group instead; will be removed with 1.0.0", ReplaceWith("Group<T>"))
+@Deprecated(
+    "Use super-type Group instead; will be removed with 0.17.0",
+    ReplaceWith("ch.tutteli.atrium.logic.utils.Group<T>")
+)
 interface GroupWithNullableEntries<out T : Any?> : Group<T>
 
 /**
  * Adds the given [firstGroup], the [secondGroup] and the [otherGroups] into a new [List] and returns it.
  * @return a [List] containing [firstGroup], [secondGroup] and [otherGroups].
  */
-//TODO copy and move to atrium-logic 0.16.0
+@Deprecated(
+    "Use groupsToList from atrium-logic; will be removed with 0.17.0",
+    ReplaceWith("ch.tutteli.atrium.logic.utils.groupsToList<T>(firstGroup, secondGroup, otherGroups)")
+)
 fun <T> groupsToList(firstGroup: Group<T>, secondGroup: Group<T>, otherGroups: Array<out Group<T>>): List<List<T>> {
     val groups = ArrayList<List<T>>(otherGroups.size + 2)
     requireNotEmptyAndAdd(groups, firstGroup)

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/mapArguments.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/mapArguments.kt
@@ -1,6 +1,6 @@
 @file:Suppress(
-/* TODO remove annotation with 1.0.0 */ "DEPRECATION",
-/* TODO remove annotation with 1.0.0 */ "TYPEALIAS_EXPANSION_DEPRECATION"
+/* TODO remove annotation with 0.17.0 */ "DEPRECATION",
+/* TODO remove annotation with 0.17.0 */ "TYPEALIAS_EXPANSION_DEPRECATION"
 )
 
 package ch.tutteli.atrium.domain.builders.utils
@@ -21,7 +21,7 @@ import kotlin.js.JsName
  * ```
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("mapArguments(first, others)", "ch.tutteli.atrium.logic.utils.mapArguments")
 )
 fun <T> mapArguments(first: T, others: Array<out T>): ArgumentMapperBuilder<T> = ArgumentMapperBuilder(first, others)
@@ -33,7 +33,7 @@ fun <T> mapArguments(first: T, others: Array<out T>): ArgumentMapperBuilder<T> =
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <T, reified R> mapArguments(first: T, others: Array<out T>, mapper: (T) -> R): Pair<R, Array<out R>> =
@@ -44,7 +44,7 @@ inline fun <T, reified R> mapArguments(first: T, others: Array<out T>, mapper: (
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Byte, others: ByteArray): ArgumentMapperBuilder<Byte> =
@@ -57,7 +57,7 @@ fun mapArguments(first: Byte, others: ByteArray): ArgumentMapperBuilder<Byte> =
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Byte, others: ByteArray, mapper: (Byte) -> R): Pair<R, Array<out R>> =
@@ -68,7 +68,7 @@ inline fun <reified R> mapArguments(first: Byte, others: ByteArray, mapper: (Byt
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Char, others: CharArray): ArgumentMapperBuilder<Char> =
@@ -81,7 +81,7 @@ fun mapArguments(first: Char, others: CharArray): ArgumentMapperBuilder<Char> =
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Char, others: CharArray, mapper: (Char) -> R): Pair<R, Array<out R>> =
@@ -92,7 +92,7 @@ inline fun <reified R> mapArguments(first: Char, others: CharArray, mapper: (Cha
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Short, others: ShortArray): ArgumentMapperBuilder<Short> =
@@ -105,7 +105,7 @@ fun mapArguments(first: Short, others: ShortArray): ArgumentMapperBuilder<Short>
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Short, others: ShortArray, mapper: (Short) -> R): Pair<R, Array<out R>> =
@@ -116,7 +116,7 @@ inline fun <reified R> mapArguments(first: Short, others: ShortArray, mapper: (S
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Int, others: IntArray): ArgumentMapperBuilder<Int> = mapArguments(first, others.toTypedArray())
@@ -128,7 +128,7 @@ fun mapArguments(first: Int, others: IntArray): ArgumentMapperBuilder<Int> = map
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Int, others: IntArray, mapper: (Int) -> R): Pair<R, Array<out R>> =
@@ -139,7 +139,7 @@ inline fun <reified R> mapArguments(first: Int, others: IntArray, mapper: (Int) 
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Long, others: LongArray): ArgumentMapperBuilder<Long> =
@@ -152,7 +152,7 @@ fun mapArguments(first: Long, others: LongArray): ArgumentMapperBuilder<Long> =
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Long, others: LongArray, mapper: (Long) -> R): Pair<R, Array<out R>> =
@@ -163,7 +163,7 @@ inline fun <reified R> mapArguments(first: Long, others: LongArray, mapper: (Lon
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Float, others: FloatArray): ArgumentMapperBuilder<Float> =
@@ -176,7 +176,7 @@ fun mapArguments(first: Float, others: FloatArray): ArgumentMapperBuilder<Float>
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Float, others: FloatArray, mapper: (Float) -> R): Pair<R, Array<out R>> =
@@ -187,7 +187,7 @@ inline fun <reified R> mapArguments(first: Float, others: FloatArray, mapper: (F
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Double, others: DoubleArray): ArgumentMapperBuilder<Double> =
@@ -200,7 +200,7 @@ fun mapArguments(first: Double, others: DoubleArray): ArgumentMapperBuilder<Doub
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(first: Double, others: DoubleArray, mapper: (Double) -> R): Pair<R, Array<out R>> =
@@ -211,7 +211,7 @@ inline fun <reified R> mapArguments(first: Double, others: DoubleArray, mapper: 
  * specify the mapping as such using a subsequent step in the building process.
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others)")
 )
 fun mapArguments(first: Boolean, others: BooleanArray): ArgumentMapperBuilder<Boolean> =
@@ -224,7 +224,7 @@ fun mapArguments(first: Boolean, others: BooleanArray): ArgumentMapperBuilder<Bo
  * and use one of the available options as second step. For instance, `mapArguments(a, aX).toExpect<String> { ... }`
  */
 @Deprecated(
-    "Use mapArguments from atrium-logic; will be removed with 1.0.0",
+    "Use mapArguments from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.mapArguments(first, others, mapper)")
 )
 inline fun <reified R> mapArguments(
@@ -236,7 +236,7 @@ inline fun <reified R> mapArguments(
 /**
  * Builder to map variable length arguments formulated as ([first]: [T], `vararg` [others] : [T]) to something else.
  */
-@Deprecated("Use ArgumentMapperBuilder, mapArguments respectively, from atrium-logic; will be removed with 1.0.0")
+@Deprecated("Use ArgumentMapperBuilder, mapArguments respectively, from atrium-logic; will be removed with 0.17.0")
 class ArgumentMapperBuilder<out T>(
     val first: T,
     val others: Array<out T>
@@ -271,7 +271,7 @@ class ArgumentMapperBuilder<out T>(
  * @returns The mapped [ArgumentMapperBuilder.first] and [ArgumentMapperBuilder.others].
  */
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("Use ArgumentMapperBuilder, mapArguments respectively, from atrium-logic; will be removed with 1.0.0")
+@Deprecated("Use ArgumentMapperBuilder, mapArguments respectively, from atrium-logic; will be removed with 0.17.0")
 fun <T : Any> ArgumentMapperBuilder<T?>.toNullOr(): ArgumentToNullOrMapperBuilder<T> =
     ArgumentToNullOrMapperBuilder(this)
 
@@ -291,7 +291,7 @@ fun <T : Any> ArgumentMapperBuilder<T>.toNullOr(): Nothing =
  * type if the argument is not null in order that the non-nullable type can be used/passed to function which expect
  * a non-nullable type.
  */
-@Deprecated("Use ArgumentMapperBuilder, mapArguments respectively, from atrium-logic; will be removed with 1.0.0")
+@Deprecated("Use ArgumentMapperBuilder, mapArguments respectively, from atrium-logic; will be removed with 0.17.0")
 class ArgumentToNullOrMapperBuilder<T : Any>(
     val argumentMapperBuilder: ArgumentMapperBuilder<T?>
 ) {

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/nullable.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/nullable.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.*
  * `getPersons() as List<String>?` you can write `nullable(getPersons())`
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T> nullable(t: T): T? = t
@@ -30,7 +30,7 @@ inline fun <T> nullable(t: T): T? = t
  * type) of your function into a nullable type.
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T> nullable(t: KFunction0<T>): KFunction0<T?> = t
@@ -46,7 +46,7 @@ inline fun <T> nullable(t: KFunction0<T>): KFunction0<T?> = t
  * `getPersons() as Iterable<String?>` you can write `nullableContainer(getPersons())`
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(iterable)")
 )
 inline fun <T> nullableContainer(iterable: Iterable<T>): Iterable<T?> = iterable
@@ -62,7 +62,7 @@ inline fun <T> nullableContainer(iterable: Iterable<T>): Iterable<T?> = iterable
  * `getPersons() as Array<String?>` you can write `nullableContainer(getPersons())`
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(arr)")
 )
 inline fun <T> nullableContainer(arr: Array<out T>): Array<out T?> = arr
@@ -80,7 +80,7 @@ inline fun <T> nullableContainer(arr: Array<out T>): Array<out T?> = arr
  * `getPersons() as Map<String?, Person>` you can write `nullableKeyMap(getPersons())`
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(map)")
 )
 inline fun <K, V : Any> nullableKeyMap(map: Map<out K, V>): Map<out K?, V> = map
@@ -97,7 +97,7 @@ inline fun <K, V : Any> nullableKeyMap(map: Map<out K, V>): Map<out K?, V> = map
  * `getPersons() as Map<String, Person?>` you can write `nullableValueMap(getPersons())`
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(map)")
 )
 inline fun <K : Any, V> nullableValueMap(map: Map<K, V>): Map<K, V?> = map
@@ -114,7 +114,7 @@ inline fun <K : Any, V> nullableValueMap(map: Map<K, V>): Map<K, V?> = map
  * `getPersons() as Map<String?, Person?>` you can write `nullableKeyValueMap(getPersons())`
  */
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(map)")
 )
 inline fun <K, V> nullableKeyValueMap(map: Map<out K, V>): Map<out K?, V?> = map
@@ -128,7 +128,7 @@ inline fun <K, V> nullableKeyValueMap(map: Map<out K, V>): Map<out K?, V?> = map
  */
 @JvmName("nullable1")
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T1, R> nullable(t: KFunction1<T1, R>): KFunction1<T1, R?> = t
@@ -142,7 +142,7 @@ inline fun <T1, R> nullable(t: KFunction1<T1, R>): KFunction1<T1, R?> = t
  */
 @JvmName("nullable2")
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T1, T2, R> nullable(t: KFunction2<T1, T2, R>): KFunction2<T1, T2, R?> = t
@@ -156,7 +156,7 @@ inline fun <T1, T2, R> nullable(t: KFunction2<T1, T2, R>): KFunction2<T1, T2, R?
  */
 @JvmName("nullable3")
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T1, T2, T3, R> nullable(t: KFunction3<T1, T2, T3, R>): KFunction3<T1, T2, T3, R?> = t
@@ -170,7 +170,7 @@ inline fun <T1, T2, T3, R> nullable(t: KFunction3<T1, T2, T3, R>): KFunction3<T1
  */
 @JvmName("nullable4")
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T1, T2, T3, T4, R> nullable(t: KFunction4<T1, T2, T3, T4, R>): KFunction4<T1, T2, T3, T4, R?> = t
@@ -184,7 +184,7 @@ inline fun <T1, T2, T3, T4, R> nullable(t: KFunction4<T1, T2, T3, T4, R>): KFunc
  */
 @JvmName("nullable5")
 @Deprecated(
-    "Use nullable from atrium-logic; will be removed with 1.0.0",
+    "Use nullable from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("ch.tutteli.atrium.logic.utils.nullable(t)")
 )
 inline fun <T1, T2, T3, T4, T5, R> nullable(t: KFunction5<T1, T2, T3, T4, T5, R>): KFunction5<T1, T2, T3, T4, T5, R?> =

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/subAssert.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/utils/subAssert.kt
@@ -1,6 +1,7 @@
+//TODO remove file with 0.17.0
 @file:Suppress(
-/* TODO remove annotation with 1.0.0 */ "DEPRECATION",
-/* TODO remove annotation with 1.0.0 */ "TYPEALIAS_EXPANSION_DEPRECATION"
+    "DEPRECATION",
+    "TYPEALIAS_EXPANSION_DEPRECATION"
 )
 
 package ch.tutteli.atrium.domain.builders.utils
@@ -9,7 +10,7 @@ import ch.tutteli.atrium.creating.Expect
 
 @Suppress("NOTHING_TO_INLINE")
 @Deprecated(
-    "Use expectLambda from atrium-logic; will be removed with 1.0.0",
+    "Use expectLambda from atrium-logic; will be removed with 0.17.0",
     ReplaceWith("expectLambda(assertionCreator)", "ch.tutteli.atrium.logic.utils.expectLambda")
 )
 inline fun <T> subExpect(noinline assertionCreator: Expect<T>.() -> Unit) = assertionCreator

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -2,12 +2,10 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
-import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import org.spekframework.spek2.style.specification.Suite
 
 abstract class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec(

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -3,7 +3,7 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.domain.builders.utils.Group
+import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
 

--- a/misc/tools/bc-tests/build.gradle.kts
+++ b/misc/tools/bc-tests/build.gradle.kts
@@ -591,6 +591,19 @@ listOf("0.14.0", "0.15.0").forEach { version ->
                 )
             }
 
+            listOf(
+                "IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec",
+                "IterableContainsInOrderOnlyGroupedValuesAssertionsSpec"
+            ).forEach { spec ->
+                rewriteFile("src/commonMain/kotlin/main/kotlin/ch/tutteli/atrium/specs/integration/$spec.kt") {
+                    it.replaceFirst(
+                        "import ch.tutteli.atrium.domain.builders.utils.Group",
+                        "import ch.tutteli.atrium.logic.utils.Group"
+                    )
+                }
+            }
+
+
             // deleted AssertionPlant and co. in 0.16.0, hence specs don't make sense any more (it's a bc on core level not API)
             file("src/commonMain/kotlin/main/kotlin/ch/tutteli/atrium/specs/checking/").deleteRecursively()
             file("src/commonMain/kotlin/main/kotlin/ch/tutteli/atrium/specs/creating/").deleteRecursively()
@@ -620,6 +633,20 @@ listOf("0.14.0", "0.15.0").forEach { version ->
 
                 rewriteFile("src/commonTest/kotlin/ch/tutteli/atrium/api/$apiShortName/en_GB/IterableAnyAssertionsSpec.kt") {
                     it.replaceFirst("import ch.tutteli.atrium.domain.builders.ExpectImpl", "")
+                }
+
+
+                listOf(
+                    "IterableContainsInOrderOnlyGroupedEntriesAssertionsSpec",
+                    "IterableContainsInOrderOnlyGroupedValuesAssertionsSpec",
+                    "IterableContainsSpecBase"
+                ).forEach { spec ->
+                    rewriteFile("src/commonTest/kotlin/ch/tutteli/atrium/api/$apiShortName/en_GB/$spec.kt") {
+                        it.replaceFirst(
+                            "import ch.tutteli.atrium.domain.builders.utils.Group",
+                            "import ch.tutteli.atrium.logic.utils.Group"
+                        )
+                    }
                 }
             }
         }

--- a/misc/tools/bc-tests/test-engine/src/jvmMain/kotlin/ch/tutteli/atrium/bctest/Spek2ForgivingExecutionListener.kt
+++ b/misc/tools/bc-tests/test-engine/src/jvmMain/kotlin/ch/tutteli/atrium/bctest/Spek2ForgivingExecutionListener.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.bctest
 import org.spekframework.spek2.junit.JUnitEngineExecutionListenerAdapter
 import org.spekframework.spek2.runtime.execution.ExecutionListener
 import org.spekframework.spek2.runtime.execution.ExecutionResult
+import org.spekframework.spek2.runtime.scope.GroupScopeImpl
 import org.spekframework.spek2.runtime.scope.TestScopeImpl
 
 class Spek2ForgivingExecutionListener(
@@ -10,14 +11,31 @@ class Spek2ForgivingExecutionListener(
     private val forgiveRegex: Regex
 ) : ExecutionListener by listener {
 
-    override fun testExecutionFinish(test: TestScopeImpl, result: ExecutionResult) {
+    override fun groupExecutionFinish(group: GroupScopeImpl, result: ExecutionResult) {
         when (result) {
-            ExecutionResult.Success -> listener.testExecutionFinish(test, ExecutionResult.Success)
-            is ExecutionResult.Failure -> handleFailure(result, test)
+            ExecutionResult.Success -> listener.groupExecutionFinish(group, result)
+            is ExecutionResult.Failure -> handleGroupFailure(result, group)
         }
     }
 
-    private fun handleFailure(result: ExecutionResult.Failure, test: TestScopeImpl) {
+    private fun handleGroupFailure(result: ExecutionResult.Failure, group: GroupScopeImpl) {
+        if (forgiveRegex.matches(group.path.toString())) {
+            println("forgiving ${group.path}")
+            listener.groupExecutionFinish(group, ExecutionResult.Success)
+        } else {
+            println("!!!!! path of group in case you want to forgive it failing:\n${group.path}")
+            listener.groupExecutionFinish(group, result)
+        }
+    }
+
+    override fun testExecutionFinish(test: TestScopeImpl, result: ExecutionResult) {
+        when (result) {
+            ExecutionResult.Success -> listener.testExecutionFinish(test, result)
+            is ExecutionResult.Failure -> handleTestFailure(result, test)
+        }
+    }
+
+    private fun handleTestFailure(result: ExecutionResult.Failure, test: TestScopeImpl) {
         if (forgiveRegex.matches(test.path.toString())) {
             println("forgiving ${test.path}")
             listener.testExecutionFinish(test, ExecutionResult.Success)


### PR DESCRIPTION
this change introduces a binary backward compatibility break because
we expect a different type in the API.
bbc-test fail therefore. Since already the setup fails we need to be
able to forgive also groups and not only tests:
- adjust Spek2ForgivingExecutionListener accordingly



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
