### PR TITLE
rename assertion to expectation in KDoc

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
@@ -10,36 +10,36 @@ import ch.tutteli.kbox.glue
 import kotlin.reflect.KClass
 
 /**
- * Expects that the subject of the assertion is (equal to) [expected].
+ * Expects that the subject of `this` expectation is (equal to) [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.toBe
  */
 fun <T> Expect<T>.toBe(expected: T): Expect<T> = _logicAppend { toBe(expected) }
 
 /**
- * Expects that the subject of the assertion is not (equal to) [expected].
+ * Expects that the subject of `this` expectation is not (equal to) [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.notToBe
  */
 fun <T> Expect<T>.notToBe(expected: T): Expect<T> = _logicAppend { notToBe(expected) }
 
 /**
- * Expects that the subject of the assertion is the same instance as [expected].
+ * Expects that the subject of `this` expectation is the same instance as [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.isSameAs
  */
 fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = _logicAppend { isSameAs(expected) }
 
 /**
- * Expects that the subject of the assertion is not the same instance as [expected].
+ * Expects that the subject of `this` expectation is not the same instance as [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.isNotSameAs
  */
@@ -51,7 +51,7 @@ fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = _logicAppend { isNotSame
  * @param reason The explanation for the assertion(s) created by [assertionCreator].
  * @param assertionCreator The group of assertions to make.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  *
@@ -61,10 +61,10 @@ fun <T> Expect<T>.because(reason: String, assertionCreator: Expect<T>.() -> Unit
     _logicAppend { because(reason, assertionCreator) }
 
 /**
- * Expects that the subject of the assertion is either `null` in case [assertionCreatorOrNull]
+ * Expects that the subject of `this` expectation is either `null` in case [assertionCreatorOrNull]
  * is `null` or is not `null` and holds all assertions [assertionCreatorOrNull] creates.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.toBeNullIfNullGivenElse
  */
@@ -73,7 +73,7 @@ fun <T : Any> Expect<T?>.toBeNullIfNullGivenElse(
 ): Expect<T?> = _logicAppend { toBeNullIfNullGivenElse(assertionCreatorOrNull) }
 
 /**
- * Expects that the subject of the assertion is not null and changes the subject to the non-nullable version.
+ * Expects that the subject of `this` expectation is not null and changes the subject to the non-nullable version.
  *
  * @return An [Expect] with the non-nullable type [T] (was `T?` before).
  *
@@ -86,7 +86,7 @@ internal fun <T : Any> Expect<T?>.notToBeNullButOfType(kClass: KClass<T>): Subje
     _logic.notToBeNullButOfType(kClass)
 
 /**
- * Expects that the subject of the assertion is not null and
+ * Expects that the subject of `this` expectation is not null and
  * that it holds all assertions the given [assertionCreator] creates.
  *
  * @return An [Expect] with the non-nullable type [T] (was `T?` before)
@@ -97,7 +97,7 @@ inline fun <reified T : Any> Expect<T?>.notToBeNull(noinline assertionCreator: E
     notToBeNullButOfType(T::class).transformAndAppend(assertionCreator)
 
 /**
- * Expects that the subject of the assertion *is a* [TSub] (the same type or a sub-type)
+ * Expects that the subject of `this` expectation *is a* [TSub] (the same type or a sub-type)
  * and changes the subject to this type.
  *
  * Notice, that asserting a function type is [flawed](https://youtrack.jetbrains.com/issue/KT-27846).
@@ -123,7 +123,7 @@ internal fun <TSub : Any> Expect<*>.isA(kClass: KClass<TSub>): SubjectChangerBui
     _logic.isA(kClass)
 
 /**
- * Expects that the subject of the assertion *is a* [TSub] (the same type or a sub-type) and
+ * Expects that the subject of `this` expectation *is a* [TSub] (the same type or a sub-type) and
  * that it holds all assertions the given [assertionCreator] creates.
  *
  * Notice, in contrast to other assertion functions which expect an [assertionCreator], this function returns not
@@ -174,7 +174,7 @@ inline fun <reified TSub : Any> Expect<*>.isA(noinline assertionCreator: Expect<
  * two assertions (not one assertion with two sub-assertions) - the first asserts that 1 is less than 2 and the second
  * asserts that 1 is greater than 0. If the first assertion fails, then the second assertion is not evaluated.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.andFeature
  */
@@ -188,7 +188,7 @@ inline val <T> Expect<T>.and: Expect<T> get() = this
  * second one is evaluated as a whole. Meaning, even though 1 is not even, it still evaluates that 1 is greater than 1.
  * Hence the reporting might (depending on the configured [Reporter]) contain both failing sub-assertions.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.AnyAssertionSamples.and
  */
@@ -196,9 +196,9 @@ infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     addAssertionsCreatedBy(assertionCreator)
 
 /**
- * Expects that the subject of the assertion is not (equal to) [expected] and [otherValues].
+ * Expects that the subject of `this` expectation is not (equal to) [expected] and [otherValues].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  *
@@ -208,12 +208,12 @@ fun <T> Expect<T>.isNoneOf(expected: T, vararg otherValues: T): Expect<T> =
     _logicAppend { isNotIn(expected glue otherValues) }
 
 /**
- * Expects that the subject of the assertion is not (equal to) any value of [expected].
+ * Expects that the subject of `this` expectation is not (equal to) any value of [expected].
  *
  * Notice that a runtime check applies which assures that only [Iterable], [Sequence] or one of the [Array] types
  * are passed. This function expects [IterableLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case the iterable is empty.
  *
  * @since 0.13.0

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arrayAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arrayAssertions.kt
@@ -21,7 +21,7 @@ fun <E> Expect<out Array<out E>>.asList(): Expect<List<E>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -37,7 +37,7 @@ fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): E
     apply { asList().addAssertionsCreatedBy(assertionCreator) }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -70,7 +70,7 @@ fun Expect<ByteArray>.asList(): Expect<List<Byte>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -104,7 +104,7 @@ fun Expect<CharArray>.asList(): Expect<List<Char>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -138,7 +138,7 @@ fun Expect<ShortArray>.asList(): Expect<List<Short>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -172,7 +172,7 @@ fun Expect<IntArray>.asList(): Expect<List<Int>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -206,7 +206,7 @@ fun Expect<LongArray>.asList(): Expect<List<Long>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -240,7 +240,7 @@ fun Expect<FloatArray>.asList(): Expect<List<Float>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -274,7 +274,7 @@ fun Expect<DoubleArray>.asList(): Expect<List<Double>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -308,7 +308,7 @@ fun Expect<BooleanArray>.asList(): Expect<List<Boolean>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceAssertions.kt
@@ -36,7 +36,7 @@ val <T : CharSequence> Expect<T>.containsNot: NotCheckerStep<T, NotSearchBehavio
     get() = _logic.containsNotBuilder()
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains [expected]'s [toString] representation
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains [expected]'s [toString] representation
  * and the [toString] representation of the [otherExpected] (if given), using a non disjoint search.
  *
  * It is a shortcut for `contains.atLeast(1).values(expected, *otherExpected)`.
@@ -57,7 +57,7 @@ val <T : CharSequence> Expect<T>.containsNot: NotCheckerStep<T, NotSearchBehavio
  * instead of:
  *   `contains("a", "a")`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] or one of the [otherExpected] is not a
  *   [CharSequence], [Number] or [Char].
  *
@@ -69,7 +69,7 @@ fun <T : CharSequence> Expect<T>.contains(
 ): Expect<T> = contains.atLeast(1).values(expected, *otherExpected)
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not contain [expected]'s [toString] representation
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not contain [expected]'s [toString] representation
  * and neither one of the [otherExpected]'s [toString] representation (if given).
  *
  * It is a shortcut for `containsNot.values(expected, *otherExpected)`.
@@ -78,7 +78,7 @@ fun <T : CharSequence> Expect<T>.contains(
  * This function expects [CharSequenceOrNumberOrChar] (which is a typealias for [Any]) for your convenience,
  * so that you can mix [String] and [Int] for instance.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.containsNot
  */
@@ -88,7 +88,7 @@ fun <T : CharSequence> Expect<T>.containsNot(
 ): Expect<T> = containsNot.values(expected, *otherExpected)
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [pattern] as well as the [otherPatterns] (if given), using a non disjoint search.
  *
  * It is a shortcut for `contains.atLeast(1).regex(pattern, *otherPatterns)`.
@@ -107,7 +107,7 @@ fun <T : CharSequence> Expect<T>.containsNot(
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.containsRegexString
  */
@@ -115,7 +115,7 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatt
     contains.atLeast(1).regex(pattern, *otherPatterns)
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [pattern] as well as the [otherPatterns] (if given), using a non disjoint search.
  *
  * It is a shortcut for `contains.atLeast(1).regex(pattern, *otherPatterns)`.
@@ -134,7 +134,7 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: String, vararg otherPatt
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  *
@@ -144,9 +144,9 @@ fun <T : CharSequence> Expect<T>.containsRegex(pattern: Regex, vararg otherPatte
     contains.atLeast(1).regex(pattern, *otherPatterns)
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) starts with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) starts with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.startsWith
  */
@@ -154,9 +154,9 @@ fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence): Expect<T> =
     _logicAppend { startsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) starts with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) starts with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.startsWithChar
  *
@@ -166,9 +166,9 @@ fun <T : CharSequence> Expect<T>.startsWith(expected: Char): Expect<T> =
     startsWith(expected.toString())
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not start with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not start with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.startsNotWith
  */
@@ -176,9 +176,9 @@ fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence): Expect<T
     _logicAppend { startsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not start with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not start with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  *
@@ -189,9 +189,9 @@ fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char): Expect<T> =
 
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) ends with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) ends with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.endsWith
  */
@@ -199,9 +199,9 @@ fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence): Expect<T> =
     _logicAppend { endsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) ends with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) ends with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  *
@@ -211,9 +211,9 @@ fun <T : CharSequence> Expect<T>.endsWith(expected: Char): Expect<T> =
     endsWith(expected.toString())
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not end with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not end with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.endsNotWith
  */
@@ -221,9 +221,9 @@ fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence): Expect<T> 
     _logicAppend { endsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not end with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not end with [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.endsNotWithChar
@@ -233,9 +233,9 @@ fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char): Expect<T> =
 
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isEmpty].
+ * Expects that the subject of `this` expectation (a [CharSequence]) [CharSequence].[kotlin.text.isEmpty].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.isEmpty
  */
@@ -243,9 +243,9 @@ fun <T : CharSequence> Expect<T>.isEmpty(): Expect<T> =
     _logicAppend { isEmpty() }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isNotEmpty].
+ * Expects that the subject of `this` expectation (a [CharSequence]) [CharSequence].[kotlin.text.isNotEmpty].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.isNotEmpty
  */
@@ -253,9 +253,9 @@ fun <T : CharSequence> Expect<T>.isNotEmpty(): Expect<T> =
     _logicAppend { isNotEmpty() }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isNotBlank].
+ * Expects that the subject of `this` expectation (a [CharSequence]) [CharSequence].[kotlin.text.isNotBlank].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CharSequenceExpectationsSpec.isNotBlank
  */
@@ -263,11 +263,11 @@ fun <T : CharSequence> Expect<T>.isNotBlank(): Expect<T> =
     _logicAppend { isNotBlank() }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) matches the given [expected] [Regex].
+ * Expects that the subject of `this` expectation (a [CharSequence]) matches the given [expected] [Regex].
  *
  * In contrast to [containsRegex] it does not look for a partial match but for an entire match.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  *
@@ -277,11 +277,11 @@ fun <T : CharSequence> Expect<T>.matches(expected: Regex): Expect<T> =
     _logicAppend { matches(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) mismatches the given [expected] [Regex].
+ * Expects that the subject of `this` expectation (a [CharSequence]) mismatches the given [expected] [Regex].
  *
  * In contrast to `containsNot.regex` it does not look for a partial match but for an entire match.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
@@ -36,7 +36,7 @@ import kotlin.jvm.JvmName
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.value(expected: CharSequenceOrNumberOrChar): Expect<T> =
@@ -64,7 +64,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.value(expected: CharS
  * @param expected The value which is expected to be contained within the input of the search.
  * @param otherExpected Additional values which are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] or one of the [otherExpected] is not a
  *   [CharSequence], [Number] or [Char].
  */
@@ -88,7 +88,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.values(
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 @JvmName("valueIgnoringCase")
@@ -118,7 +118,7 @@ fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.value(
  * @param expected The value which is expected to be contained within the input of the search.
  * @param otherExpected Additional values which are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] or one of the [otherExpected] is not a
  *   [CharSequence], [Number] or [Char].
  */
@@ -143,7 +143,7 @@ fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.values(
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.value(expected: CharSequenceOrNumberOrChar): Expect<T> =
@@ -168,7 +168,7 @@ fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.value(expe
  * @param expected The value which is expected to be contained within the input of the search.
  * @param otherExpected Additional values which are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] or one of the [otherExpected] is not a
  *   [CharSequence], [Number] or [Char].
  */
@@ -195,7 +195,7 @@ fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.values(
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(
     pattern: String,
@@ -220,7 +220,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -248,7 +248,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @JvmName("regexIgnoringCase")
 fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.regex(
@@ -277,7 +277,7 @@ fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.regex(
  * @param pattern The pattern which is expected to have a match against the input of the search.
  * @param otherPatterns Additional patterns which are expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.regex(
     pattern: String,
@@ -298,7 +298,7 @@ fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.regex(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *
@@ -325,7 +325,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.elementsOf(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *
@@ -352,7 +352,7 @@ fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.elementsOf(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/collectionAssertions.kt
@@ -9,9 +9,9 @@ import ch.tutteli.atrium.logic.size
 import ch.tutteli.kbox.identity
 
 /**
- * Expects that the subject of the assertion (a [Collection]) is an empty [Collection].
+ * Expects that the subject of `this` expectation (a [Collection]) is an empty [Collection].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CollectionAssertionSamples.isEmpty
  */
@@ -19,9 +19,9 @@ fun <T : Collection<*>> Expect<T>.isEmpty(): Expect<T> =
     _logicAppend { isEmpty(::identity) }
 
 /**
- * Expects that the subject of the assertion (a [Collection]) is not an empty [Collection].
+ * Expects that the subject of `this` expectation (a [Collection]) is not an empty [Collection].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CollectionAssertionSamples.isNotEmpty
  */
@@ -29,11 +29,11 @@ fun <T : Collection<*>> Expect<T>.isNotEmpty(): Expect<T> =
     _logicAppend { isNotEmpty(::identity) }
 
 /**
- * Expects that the subject of the assertion (a [Collection]) has the given [expected] size.
+ * Expects that the subject of `this` expectation (a [Collection]) has the given [expected] size.
  *
  * Shortcut for `size.toBe(expected)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CollectionAssertionSamples.hasSize
  */
@@ -41,7 +41,7 @@ fun <T : Collection<*>> Expect<T>.hasSize(expected: Int): Expect<T> =
     size { toBe(expected) }
 
 /**
- * Creates an [Expect] for the property [Collection.size] of the subject of the assertion,
+ * Creates an [Expect] for the property [Collection.size] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -52,11 +52,11 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
     get() = _logic.size(::identity).transform()
 
 /**
- * Expects that the property [Collection.size] of the subject of the assertion
+ * Expects that the property [Collection.size] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.CollectionAssertionSamples.size
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableAssertions.kt
@@ -4,10 +4,10 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
 
 /**
- * Expects that the subject of the assertion is less than [expected].
+ * Expects that the subject of `this` expectation is less than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isLessThan
  */
@@ -15,10 +15,10 @@ fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T): Expect<T> =
     _logicAppend { isLessThan(expected) }
 
 /**
- * Expects that the subject of the assertion is less than or equal [expected].
+ * Expects that the subject of `this` expectation is less than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isLessThanOrEqual
  */
@@ -26,10 +26,10 @@ fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isLessThanOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion is greater than [expected].
+ * Expects that the subject of `this` expectation is greater than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isGreaterThan
  */
@@ -37,10 +37,10 @@ fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T): Expect<T> =
     _logicAppend { isGreaterThan(expected) }
 
 /**
- * Expects that the subject of the assertion is greater than or equal [expected].
+ * Expects that the subject of `this` expectation is greater than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isGreaterThanOrEqual
  */
@@ -48,10 +48,10 @@ fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isGreaterThanOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion is equal to [expected]
+ * Expects that the subject of `this` expectation is equal to [expected]
  * where the comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/expectExtensions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/expectExtensions.kt
@@ -17,10 +17,10 @@ annotation class ExperimentalWithOptions
  * Wraps the given [textRepresentation] into a [Text] and uses it as representation of the subject
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 fun <T> RootExpect<T>.withRepresentation(textRepresentation: String): Expect<T> =
@@ -36,10 +36,10 @@ fun <T> RootExpect<T>.withRepresentation(textRepresentation: String): Expect<T> 
  * If your text does not include the current subject, then we recommend to use the other overload which expects
  * a `String` and does the wrapping for you.
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 fun <T> RootExpect<T>.withRepresentation(representationProvider: (T) -> Any): Expect<T> =
@@ -49,7 +49,7 @@ fun <T> RootExpect<T>.withRepresentation(representationProvider: (T) -> Any): Ex
  * Uses the given [configuration]-lambda to create an [ExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 fun <T> RootExpect<T>.withOptions(configuration: ExpectBuilder.OptionsChooser<T>.() -> Unit): Expect<T> =
@@ -58,7 +58,7 @@ fun <T> RootExpect<T>.withOptions(configuration: ExpectBuilder.OptionsChooser<T>
 /**
  * Uses the given [options] to override (parts) of the existing configuration.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -70,10 +70,10 @@ fun <T> RootExpect<T>.withOptions(options: ExpectOptions<T>): Expect<T> =
  * Wraps the given [textRepresentation] into a [Text] and uses it as representation of the subject
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -91,10 +91,10 @@ fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: String): E
  * If your text does not include the current subject, then we recommend to use the other overload which expects
  * a `String` and does the wrapping for you.
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -106,7 +106,7 @@ fun <T, R> FeatureExpect<T, R>.withRepresentation(representationProvider: (R) ->
  * Uses the given [configuration]-lambda to create an [FeatureExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -117,7 +117,7 @@ fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExpectOptionsCh
 /**
  * Uses the given [options] to override (parts) of the existing configuration.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/featureAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/featureAssertions.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.logic.*
 import kotlin.reflect.*
 
 /**
- * Extracts the [property] out of the current subject of the assertion,
+ * Extracts the [property] out of the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
@@ -21,12 +21,12 @@ fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect<T, R>
     _logic.property(property).transform()
 
 /**
- * Extracts the [property] out of the current subject of the assertion,
+ * Extracts the [property] out of the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -37,12 +37,12 @@ fun <T, R> Expect<T>.feature(
 
 
 /**
- * Extracts the value which is returned when calling [f] on the current subject of the assertion,
+ * Extracts the value which is returned when calling [f] on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
  * @return The newly created [Expect] for the return value of calling the method [f]
- *   on the current subject of the assertion.
+ *   on the current subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -50,12 +50,12 @@ fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
     _logic.f0(f).transform()
 
 /**
- * Extracts the value which is returned when calling [f] on the current subject of the assertion,
+ * Extracts the value which is returned when calling [f] on the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -67,12 +67,12 @@ fun <T, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
  * @return The newly created [Expect] for the return value of calling the method [f]
- *   on the current subject of the assertion.
+ *   on the current subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -83,12 +83,12 @@ fun <T, A1, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -101,12 +101,12 @@ fun <T, A1, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with arguments [a1], [a2]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
  * @return The newly created [Expect] for the return value of calling the method [f]
- *   on the current subject of the assertion.
+ *   on the current subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -117,12 +117,12 @@ fun <T, A1, A2, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -135,12 +135,12 @@ fun <T, A1, A2, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with arguments [a1], [a2], [a3]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
  * @return The newly created [Expect] for the return value of calling the method [f]
- *   on the current subject of the assertion.
+ *   on the current subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -151,12 +151,12 @@ fun <T, A1, A2, A3, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2], [a3]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -169,12 +169,12 @@ fun <T, A1, A2, A3, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with arguments [a1], [a2], [a3], [a4]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
  * @return The newly created [Expect] for the return value of calling the method [f]
- *   on the current subject of the assertion.
+ *   on the current subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -185,12 +185,12 @@ fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2], [a3], [a4]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -203,11 +203,11 @@ fun <T, A1, A2, A3, A4, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with arguments [a1], [a2], [a3], [a4], [a5]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @return The newly [Expect] for the return value of calling [f] on the current subject of the assertion.
+ * @return The newly [Expect] for the return value of calling [f] on the current subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -218,12 +218,12 @@ fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
 
 /**
  * Extracts the value which is returned when calling [f] with argument [a1], [a2], [a3], [a4], [a5]
- * on the current subject of the assertion,
+ * on the current subject of `this` expectation,
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -235,12 +235,12 @@ fun <T, A1, A2, A3, A4, A5, R> Expect<T>.feature(
 
 
 /**
- * Extracts a feature out of the current subject of the assertion
+ * Extracts a feature out of the current subject of `this` expectation
  * based on the given [provider] and using the given [description],
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @param provider Extracts the feature where the subject of the assertion is available via
+ * @param provider Extracts the feature where the subject of `this` expectation is available via
  *   implicit parameter `it`.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -251,16 +251,16 @@ fun <T, R> Expect<T>.feature(description: String, provider: T.() -> R): FeatureE
     _logic.manualFeature(description, provider).transform()
 
 /**
- * Extracts a feature out of the current subject of the assertion
+ * Extracts a feature out of the current subject of `this` expectation
  * based on the given [provider] and using the given [description],
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @param provider Extracts the feature where the subject of the assertion is available via
+ * @param provider Extracts the feature where the subject of `this` expectation is available via
  *   implicit parameter `it`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -272,12 +272,12 @@ fun <T, R> Expect<T>.feature(
 
 
 /**
- * Extracts a feature out of the current subject of the assertion,
+ * Extracts a feature out of the current subject of `this` expectation,
  * based on the given [provider],
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @param provider Creates a [MetaFeature] where the subject of the assertion is available via
+ * @param provider Creates a [MetaFeature] where the subject of `this` expectation is available via
  *   implicit parameter `it`. Usually you use [f][MetaFeatureOption.f] to create a [MetaFeature],
  *   e.g. `feature { f(it::size) }`
  *
@@ -289,16 +289,16 @@ fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFeature<R
     extractFeature(provider).transform()
 
 /**
- * Extracts a feature out of the current subject of the assertion,
+ * Extracts a feature out of the current subject of `this` expectation,
  * based on the given [provider],
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
  *
- * @param provider You need to create a [MetaFeature] where the subject of the assertion is available via
+ * @param provider You need to create a [MetaFeature] where the subject of `this` expectation is available via
  *   implicit parameter `it`. Usually you use [MetaFeatureOption.f] to create a [MetaFeature], e.g. `f(it::size)`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointAssertions.kt
@@ -10,16 +10,16 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
 /**
- * Expects that the subject of the assertion (a [Float]) is equal to [expected] with an error [tolerance]
+ * Expects that the subject of `this` expectation (a [Float]) is equal to [expected] with an error [tolerance]
  * (range including bounds).
  *
  * In detail, It compares the absolute difference between the subject and [expected];
  * as long as it is less than or equal the [tolerance] the assertion holds; otherwise it fails.
  * A more mathematical way of expressing the assertion is the following inequality:
  *
- * | `subject of the assertion` - [expected] | ≤ [tolerance]
+ * | `subject of `this` expectation` - [expected] | ≤ [tolerance]
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.FloatingPointAssertionSamples.toBeWithErrorToleranceFloat
  */
@@ -27,16 +27,16 @@ fun Expect<Float>.toBeWithErrorTolerance(expected: Float, tolerance: Float): Exp
     _logicAppend { toBeWithErrorTolerance(expected, tolerance) }
 
 /**
- * Expects that the subject of the assertion  (a [Double]) is equal to [expected] with an error [tolerance]
+ * Expects that the subject of `this` expectation  (a [Double]) is equal to [expected] with an error [tolerance]
  * (range including bounds).
  *
  * In detail, It compares the absolute difference between the subject and [expected];
  * as long as it is less than or equal the [tolerance] the assertion holds; otherwise it fails.
  * A more mathematical way of expressing the assertion is the following inequality:
  *
- * | `subject of the assertion` - [expected] | ≤ [tolerance]
+ * | `subject of `this` expectation` - [expected] | ≤ [tolerance]
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.FloatingPointAssertionSamples.toBeWithErrorToleranceDouble
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fun0Assertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fun0Assertions.kt
@@ -63,7 +63,7 @@ inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
 
 /**
  * Expects that no [Throwable] is thrown at all when calling the subject (a lambda with arity 0, i.e. without arguments)
- * and changes the subject of the assertion to the return value of type [R].
+ * and changes the subject of `this` expectation to the return value of type [R].
  *
  * @return An [Expect] with the new type [R].
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
@@ -33,7 +33,7 @@ val <E, T : Iterable<E>> Expect<T>.containsNot: NotCheckerStep<E, T, NotSearchBe
     get() = _logic.builderContainsNotInIterableLike(::identity)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains the
+ * Expects that the subject of `this` expectation (an [Iterable]) contains the
  * [expected] value and the [otherExpected] values (if given).
  *
  * It is a shortcut for `contains.inAnyOrder.atLeast(1).values(expected, *otherExpected)`
@@ -47,13 +47,13 @@ val <E, T : Iterable<E>> Expect<T>.containsNot: NotCheckerStep<E, T, NotSearchBe
  * instead of:
  *   `contains('a', 'a')`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E, T : Iterable<E>> Expect<T>.contains(expected: E, vararg otherExpected: E): Expect<T> =
     contains.inAnyOrder.atLeast(1).values(expected, *otherExpected)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains an entry holding the
+ * Expects that the subject of `this` expectation (an [Iterable]) contains an entry holding the
  * assertions created by [assertionCreatorOrNull] or an entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
@@ -63,13 +63,13 @@ fun <E, T : Iterable<E>> Expect<T>.contains(expected: E, vararg otherExpected: E
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     contains.inAnyOrder.atLeast(1).entry(assertionCreatorOrNull)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains an entry holding the
+ * Expects that the subject of `this` expectation (an [Iterable]) contains an entry holding the
  * assertions created by [assertionCreatorOrNull] or an entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null` -- likewise an entry (can be the same) is searched for each
  * of the [otherAssertionCreatorsOrNulls].
@@ -82,7 +82,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull: (Expe
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.contains(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,
@@ -90,7 +90,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.contains(
 ): Expect<T> = contains.inAnyOrder.atLeast(1).entries(assertionCreatorOrNull, *otherAssertionCreatorsOrNulls)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only
  * the [expected] value and the [otherExpected] values (if given) in the defined order.
  *
  * It is a shortcut for `contains.inOrder.only.values(expected, *otherExpected)`
@@ -99,13 +99,13 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.contains(
  * which will cause a binary backward compatibility break (see
  * [#292](https://github.com/robstoll/atrium/issues/292) for more information)
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E, vararg otherExpected: E): Expect<T> =
     contains.inOrder.only.values(expected, *otherExpected)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only an entry holding
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only an entry holding
  * the assertions created by [assertionCreatorOrNull] or only one entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
@@ -119,13 +119,13 @@ fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E, vararg otherExpe
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     contains.inOrder.only.entry(assertionCreatorOrNull)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only an entry holding
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only an entry holding
  * the assertions created by [assertionCreatorOrNull] or `null` in case [assertionCreatorOrNull] is defined as `null`
  * and likewise an additional entry for each [otherAssertionCreatorsOrNulls] (if given)
  * whereas the entries have to appear in the defined order.
@@ -142,7 +142,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(assertionCreatorOrNull
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,
@@ -150,7 +150,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
 ): Expect<T> = contains.inOrder.only.entries(assertionCreatorOrNull, *otherAssertionCreatorsOrNulls)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only elements of [expectedIterableLike]
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only elements of [expectedIterableLike]
  * in same order
  *
  * It is a shortcut for 'contains.inOrder.only.elementsOf(anotherList)'
@@ -160,7 +160,7 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [Iterable].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *
@@ -170,7 +170,7 @@ inline fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsOf(
     expectedIterableLike: IterableLike
 ): Expect<T> = contains.inOrder.only.elementsOf(expectedIterableLike)
 
-/** Expects that the subject of the assertion (an [Iterable]) contains all elements of [expectedIterableLike].
+/** Expects that the subject of `this` expectation (an [Iterable]) contains all elements of [expectedIterableLike].
  *
  * It is a shortcut for `contains.inAnyOrder.atLeast(1).elementsOf(expectedIterable)`
  *
@@ -179,7 +179,7 @@ inline fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsOf(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [Iterable].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *
@@ -190,19 +190,19 @@ inline fun <reified E, T : Iterable<E>> Expect<T>.containsElementsOf(
 ): Expect<T> = contains.inAnyOrder.atLeast(1).elementsOf(expectedIterableLike)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element and
  * that it does not contain the [expected] value and neither one of the [otherExpected] values (if given).
  *
  * It is a shortcut for `containsNot.values(expected, *otherExpected)`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E, vararg otherExpected: E): Expect<T> =
     containsNot.values(expected, *otherExpected)
 
 
 /**
- * Creates an [Expect] for the result of calling `min()` on the subject of the assertion,
+ * Creates an [Expect] for the result of calling `min()` on the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -213,11 +213,11 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(): Expect<E> =
     _logic.min(::identity).transform()
 
 /**
- * Expects that the result of calling `min()` on the subject of the assertion
+ * Expects that the result of calling `min()` on the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -225,7 +225,7 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: Expect<
     _logic.min(::identity).collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the result of calling `max()` on the subject of the assertion,
+ * Creates an [Expect] for the result of calling `max()` on the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -236,11 +236,11 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(): Expect<E> =
     _logic.max(::identity).transform()
 
 /**
- * Expects that the result of calling `max()` on  the subject of the assertion
+ * Expects that the result of calling `max()` on  the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -249,44 +249,44 @@ fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(assertionCreator: Expect<
 
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains an entry holding
+ * Expects that the subject of `this` expectation (an [Iterable]) contains an entry holding
  * the assertions created by [assertionCreatorOrNull] or an entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
  * It is a shortcut for `contains.inAnyOrder.atLeast(1).entry(assertionCreatorOrNull)`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.any(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     contains.inAnyOrder.atLeast(1).entry(assertionCreatorOrNull)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element and
  * that it either does not contain a single entry which holds all assertions created by [assertionCreatorOrNull] or
  * that it does not contain a single entry which is `null` in case [assertionCreatorOrNull] is defined as `null`.
  *
  *  It is a shortcut for `containsNot.entry(assertionCreatorOrNull)`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.none(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     containsNot.entry(assertionCreatorOrNull)
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element and
  * that either every element holds all assertions created by the [assertionCreatorOrNull] or
  * that all elements are `null` in case [assertionCreatorOrNull] is defined as `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.all(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     _logicAppend { all(::identity, assertionCreatorOrNull) }
 
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element.
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -294,9 +294,9 @@ fun <E, T : Iterable<E>> Expect<T>.hasNext(): Expect<T> =
     _logicAppend { hasNext(::identity) }
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) does not have next element.
+ * Expects that the subject of `this` expectation (an [Iterable]) does not have next element.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -304,9 +304,9 @@ fun <E, T : Iterable<E>> Expect<T>.hasNotNext(): Expect<T> =
     _logicAppend { hasNotNext(::identity) }
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) does not have duplicate elements.
+ * Expects that the subject of `this` expectation (an [Iterable]) does not have duplicate elements.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -326,13 +326,13 @@ fun <E, T : Iterable<E>> Expect<T>.containsNoDuplicates(): Expect<T> =
 fun <E, T : Iterable<E>> Expect<T>.asList(): Expect<List<E>> = _logic.changeSubject.unreported { it.toList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature of({ f(it::toList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderCreators.kt
@@ -20,7 +20,7 @@ import ch.tutteli.kbox.glue
  *
  * @param expected The value which is expected to be contained within this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -45,7 +45,7 @@ fun <E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.value(expe
  * @param expected The object which is expected to be contained within this [IterableLike].
  * @param otherExpected Additional objects which are expected to be contained within this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -65,7 +65,7 @@ fun <E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.values(
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -86,7 +86,7 @@ fun <E : Any, T: IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBehaviour>
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -109,7 +109,7 @@ fun <E : Any, T: IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBehaviour>
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not
  *   an [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
@@ -26,7 +26,7 @@ import ch.tutteli.kbox.glue
  *
  * @param expected The value which is expected to be contained within the subject (an [IterableLike]).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -45,7 +45,7 @@ fun <E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.val
  * @param expected The value which is expected to be contained within the subject (an [IterableLike]).
  * @param otherExpected Additional values which are expected to be contained within [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -69,7 +69,7 @@ fun <E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.val
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -102,7 +102,7 @@ fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBeh
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -127,7 +127,7 @@ fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBeh
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike]
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not
  *   an [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
@@ -24,7 +24,7 @@ import ch.tutteli.kbox.glue
  *
  * @param expected The value which is expected to be contained within the subject (an [IterableLike]).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -43,7 +43,7 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value
  * @param expected The value which is expected to be contained within the subject (an [IterableLike]).
  * @param otherExpected Additional values which are expected to be contained within [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -67,7 +67,7 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -92,7 +92,7 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -117,7 +117,7 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an
  *   [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.JvmName
  * @param otherExpectedGroups Additional groups of values which are expected to appear after the [secondGroup] within
  *   [IterableLike] whereas the groups have to appear in the given order.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -50,7 +50,7 @@ fun <E, T: IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBeha
  * @param otherExpectedGroups Additional groups of values which are expected to appear after the [secondGroup] within
  *   [IterableLike] whereas the groups have to appear in the given order.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iteratorAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iteratorAssertions.kt
@@ -6,9 +6,9 @@ import ch.tutteli.atrium.logic.hasNext
 import ch.tutteli.atrium.logic.hasNotNext
 
 /**
- * Expects that the subject of the assertion (an [Iterator]) has at least one element.
+ * Expects that the subject of `this` expectation (an [Iterator]) has at least one element.
  *
- * @return an [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  *
@@ -18,9 +18,9 @@ fun <E, T : Iterator<E>> Expect<T>.hasNext(): Expect<T> =
     _logicAppend { hasNext() }
 
 /**
- * Expects that the subject of the assertion (an [Iterator]) does not have a next element.
+ * Expects that the subject of `this` expectation (an [Iterator]) does not have a next element.
  *
- * @return an [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/listAssertions.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.get
 
 /**
- * Expects that the given [index] is within the bounds of the subject of the assertion (a [List]) and
+ * Expects that the given [index] is within the bounds of the subject of `this` expectation (a [List]) and
  * returns an [Expect] for the element at that position.
  *
  * @return The newly created [Expect] for the element at position [index].
@@ -16,10 +16,10 @@ fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
     _logic.get(index).transform()
 
 /**
- * Expects that the given [index] is within the bounds of the subject of the assertion (a [List]) and that
+ * Expects that the given [index] is within the bounds of the subject of `this` expectation (a [List]) and that
  * the element at that position holds all assertions the given [assertionCreator] creates for it.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ListAssertionSamples.get
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
@@ -17,7 +17,7 @@ val <K, V, T : Map<out K, V>> Expect<T>.contains: MapLikeContains.EntryPointStep
 
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains a key as defined by [keyValuePair]'s [Pair.first]
+ * Expects that the subject of `this` expectation (a [Map]) contains a key as defined by [keyValuePair]'s [Pair.first]
  * with a corresponding value as defined by [keyValuePair]'s [Pair.second] -- optionally the same assertions
  * are created for the [otherPairs].
  *
@@ -27,7 +27,7 @@ val <K, V, T : Map<out K, V>> Expect<T>.contains: MapLikeContains.EntryPointStep
  * defined as `'a' to 1` and one of the [otherPairs] is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.contains(
     keyValuePair: Pair<K, V>,
@@ -35,13 +35,13 @@ fun <K, V, T : Map<out K, V>> Expect<T>.contains(
 ): Expect<T> = contains.inAnyOrder.entries(keyValuePair, *otherPairs)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only (in any order) a key as defined by
+ * Expects that the subject of `this` expectation (a [Map]) contains only (in any order) a key as defined by
  * [keyValuePair]'s [Pair.first] with a corresponding value as defined by [keyValuePair]'s [Pair.second] -- optionally
  * the same assertions are created for the [otherPairs].
  *
  * Delegates to `contains.inAnyOrder.only.entries(keyValuePair, *otherPairs)`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(
     keyValuePair: Pair<K, V>,
@@ -49,7 +49,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(
 ): Expect<T> = contains.inAnyOrder.only.entries(keyValuePair, *otherPairs)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains a key as defined by [keyValue]'s [KeyValue.key]
+ * Expects that the subject of `this` expectation (a [Map]) contains a key as defined by [keyValue]'s [KeyValue.key]
  * with a corresponding value which either holds all assertions [keyValue]'s
  * [KeyValue.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyValue.valueAssertionCreatorOrNull] is defined as `null`
@@ -61,7 +61,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(
  * defined as `Key('a') { isGreaterThan(0) }` and one of the [otherKeyValues] is defined as `Key('a') { isLessThan(2) }`
  * , then both match, even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
     keyValue: KeyValue<K, V>,
@@ -69,7 +69,7 @@ inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
 ): Expect<T> = contains.inAnyOrder.entries(keyValue, *otherKeyValues)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only (in any order) a key as defined by
+ * Expects that the subject of `this` expectation (a [Map]) contains only (in any order) a key as defined by
  * [keyValue]'s [KeyValue.key] with a corresponding value which either holds all assertions [keyValue]'s
  * [KeyValue.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyValue.valueAssertionCreatorOrNull] is defined as `null`
@@ -77,7 +77,7 @@ inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
  *
  * Delegates to `contains.inAnyOrder.only.entries(keyValue, *otherKeyValues)`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.containsOnly(
     keyValue: KeyValue<K, V>,
@@ -85,46 +85,46 @@ inline fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.containsOnly(
 ): Expect<T> = contains.inAnyOrder.only.entries(keyValue, *otherKeyValues)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the key-value pairs of the given [mapLike].
+ * Expects that the subject of `this` expectation (a [Map]) contains the key-value pairs of the given [mapLike].
  *
  * Delegates to ` contains.inAnyOrder.entriesOf`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V : Any, T : Map<out K, V?>> Expect<T>.containsEntriesOf(
     mapLike: MapLike
 ): Expect<T> = contains.inAnyOrder.entriesOf(mapLike)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only (in any order) the key-value pairs of
+ * Expects that the subject of `this` expectation (a [Map]) contains only (in any order) the key-value pairs of
  * the given [mapLike].
  *
  * Delegates to `contains.inAnyOrder.only.entriesOf`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V : Any, T : Map<out K, V?>> Expect<T>.containsOnlyEntriesOf(
     mapLike: MapLike
 ): Expect<T> = contains.inAnyOrder.only.entriesOf(mapLike)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the given [key].
+ * Expects that the subject of `this` expectation (a [Map]) contains the given [key].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, T : Map<out K, *>> Expect<T>.containsKey(key: K): Expect<T> =
     _logicAppend { containsKey(::identity, key) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) does not contain the given [key].
+ * Expects that the subject of `this` expectation (a [Map]) does not contain the given [key].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K): Expect<T> =
     _logicAppend { containsNotKey(::identity, key) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the given [key],
+ * Expects that the subject of `this` expectation (a [Map]) contains the given [key],
  * creates an [Expect] for the corresponding value and returns the newly created assertion container,
  * so that further fluent calls are assertions about it.
  *
@@ -134,16 +134,16 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
     _logic.getExisting(::identity, key).transform()
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the given [key] and that
+ * Expects that the subject of `this` expectation (a [Map]) contains the given [key] and that
  * the corresponding value holds all assertions the given [assertionCreator] creates for it.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.getExisting(::identity, key).collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Map.keys] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.keys] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -152,17 +152,17 @@ val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
     get() = _logic.property(Map<out K, *>::keys).transform()
 
 /**
- * Expects that the property [Map.keys] of the subject of the assertion
+ * Expects that the property [Map.keys] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
     _logic.property(Map<out K, *>::keys).collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.values] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -171,11 +171,11 @@ val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
     get() = _logic.property(Map<out Any?, V>::values).transform()
 
 /**
- * Expects that the property [Map.keys] of the subject of the assertion
+ * Expects that the property [Map.keys] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
     _logic.property(Map<out K, V>::values).collectAndAppend(assertionCreator)
@@ -198,24 +198,24 @@ fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(): Expect<Set<Map.Entry<K, V>>
  * The transformation as such is not reflected in reporting.
  * Use `feature { f(it::entries) }` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit
 ): Expect<T> = apply { asEntries().addAssertionsCreatedBy(assertionCreator) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) is an empty [Map].
+ * Expects that the subject of `this` expectation (a [Map]) is an empty [Map].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : Map<*, *>> Expect<T>.isEmpty(): Expect<T> =
     _logicAppend { isEmpty(::toEntries) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) is not an empty [Map].
+ * Expects that the subject of `this` expectation (a [Map]) is not an empty [Map].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : Map<*, *>> Expect<T>.isNotEmpty(): Expect<T> =
     _logicAppend { isNotEmpty(::toEntries) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapCollectionLikeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapCollectionLikeAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.logic.size
 
 
 /**
- * Creates an [Expect] for the property [Map.size] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.size] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -17,11 +17,11 @@ val <T : Map<*, *>> Expect<T>.size: Expect<Int>
     get() = _logic.size(::toEntries).transform()
 
 /**
- * Expects that the property [Map.size] of the subject of the assertion
+ * Expects that the property [Map.size] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -4,20 +4,20 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
 
 /**
- * Expects that the property [Map.Entry.key] of the subject of the assertion
+ * Expects that the property [Map.Entry.key] of the subject of `this` expectation
  * is equal to the given [key] and the property [Map.Entry.value] is equal to the given [value].
  *
  * Kind of a shortcut for `and { key { toBe(key) }; value { toBe(value) } }` where `and` denotes an assertion group
  * block. Yet, the actual behaviour depends on implementation - could also be fail fast for instance or augment
  * reporting etc.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
     _logicAppend { isKeyValue(key, value) }
 
 /**
- * Creates an [Expect] for the property [Map.Entry.key] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.Entry.key] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -26,17 +26,17 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = _logic.key().transform()
 
 /**
- * Expects that the property [Map.Entry.key] of the subject of the assertion
+ * Expects that the property [Map.Entry.key] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.key().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.Entry.value] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -45,11 +45,11 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = _logic.value().transform()
 
 /**
- * Expects that the property [Map.Entry.value] of the subject of the assertion
+ * Expects that the property [Map.Entry.value] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.value().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInAnyOrderCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInAnyOrderCreators.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  *
  * Delegates to [entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -34,7 +34,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry
  * defined as `'a' to 1` and one of the [otherPairs] is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -52,7 +52,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entri
  *
  * Delegates to [entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -72,7 +72,7 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyO
  * defined as `Key('a') { isGreaterThan(0) }` and one of the [otherKeyValues] is defined as `Key('a') { isLessThan(2) }`
  * , then both match, even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -103,7 +103,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *
  * @param expectedMapLike The [MapLike] whose elements are expected to be contained within this [MapLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedMapLike] is not
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  *
  * Delegates to [entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -31,7 +31,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.e
  * needs to contain only the given [keyValuePair] as well as the [otherPairs] where it does not matter
  * in which order they appear.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -49,7 +49,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.e
  *
  * Delegates to [entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -65,7 +65,7 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyO
  * [KeyValue.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyValue.valueAssertionCreatorOrNull] is defined as `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -95,7 +95,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *
  * @param expectedMapLike The [MapLike] whose elements are expected to be contained within this [MapLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedMapLike] is not
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInOrderOnlyCreators.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KClass
  *
  * Delegates to [entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -33,7 +33,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePair] as well as the [otherPairs] in the specified order.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -52,7 +52,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  *
  * Delegates to [entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -69,7 +69,7 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrde
  * [KeyValue.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyValue.valueAssertionCreatorOrNull] is defined as `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -98,7 +98,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  * [MapLikeToIterablePairTransformer] and [IterableLikeToIterableTransformer]).
  * This function expects [MapLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedMapLike] is not
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pairAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.logic.first
 import ch.tutteli.atrium.logic.second
 
 /**
- * Creates an [Expect] for the property [Pair.first] of the subject of the assertion,
+ * Creates an [Expect] for the property [Pair.first] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -17,11 +17,11 @@ val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
     get() : Expect<K> = _logic.first().transform()
 
 /**
- * Expects that the property [Pair.first] of the subject of the assertion
+ * Expects that the property [Pair.first] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.PairAssertionSamples.first
  */
@@ -29,7 +29,7 @@ fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Uni
     _logic.first().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
+ * Creates an [Expect] for the property [Pair.second] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -40,11 +40,11 @@ val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
     get() : Expect<V> = _logic.second().transform()
 
 /**
- * Expects that the property [Pair.second] of the subject of the assertion
+ * Expects that the property [Pair.second] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.PairAssertionSamples.second
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceAssertions.kt
@@ -16,13 +16,13 @@ fun <E, T : Sequence<E>> Expect<T>.asIterable(): Expect<Iterable<E>> =
     _logic.changeSubject.unreported { it.asIterable() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [Iterable].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature(Sequence::asIterable, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
     apply { asIterable().addAssertionsCreatedBy(assertionCreator) }
@@ -40,13 +40,13 @@ fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<
 fun <E, T : Sequence<E>> Expect<T>.asList(): Expect<List<E>> = _logic.changeSubject.unreported { it.toList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature of({ f(it::toList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableAssertions.kt
@@ -8,26 +8,26 @@ import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import kotlin.reflect.KClass
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null,
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null,
  * creates an [Expect] for it and returns it.
  *
- * @return The newly created [Expect] for the property [Throwable.message] of the subject of the assertion.
+ * @return The newly created [Expect] for the property [Throwable.message] of the subject of `this` expectation.
  */
 val <T : Throwable> Expect<T>.message: Expect<String>
     get() = feature(Throwable::message).notToBeNull()
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null and
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null and
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : Throwable> Expect<T>.message(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
     feature(Throwable::message) { notToBeNull(assertionCreator) }
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null and contains
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null and contains
  * [expected]'s [toString] representation and the [toString] representation of the [otherExpected] (if given),
  * using a non disjoint search.
  *
@@ -38,7 +38,7 @@ fun <T : Throwable> Expect<T>.message(assertionCreator: Expect<String>.() -> Uni
  * This function expects [CharSequenceOrNumberOrChar] (which is a typealias for [Any]) for your convenience,
  * so that you can mix [String] and [Int] for instance.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : Throwable> Expect<T>.messageContains(
     expected: CharSequenceOrNumberOrChar,
@@ -50,7 +50,7 @@ fun <T : Throwable> Expect<T>.messageContains(
  * Expects that the property [Throwable.cause] of the subject *is a* [TExpected] (the same type or a sub-type),
  * creates an [Expect] of the [TExpected] type for it and returns it.
  *
- * @return The newly created [Expect] for the property [Throwable.cause] of the subject of the assertion.
+ * @return The newly created [Expect] for the property [Throwable.cause] of the subject of `this` expectation.
  *
  * @since 0.10.0
  */
@@ -71,7 +71,7 @@ internal fun <TExpected : Throwable> Expect<out Throwable>.causeIsA(
  * Notice, in contrast to other assertion functions which expect an [assertionCreator], this function returns not
  * [Expect] of the initial type, which was some type `T `, but an [Expect] of the specified type [TExpected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.10.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/bigDecimalAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/bigDecimalAssertions.kt
@@ -46,9 +46,9 @@ fun <T : BigDecimal?> Expect<T>.toBe(expected: T): Nothing = throw PleaseUseRepl
 )
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is `null`.
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.BigDecimalAssertionSamples.toBe
  */
@@ -79,7 +79,7 @@ fun <T : BigDecimal> Expect<T>.notToBe(expected: T): Nothing = throw PleaseUseRe
 )
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is numerically equal to [expected].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is numerically equal to [expected].
  *
  * By numerically is meant that it will not compare [BigDecimal.scale] (or in other words,
  * it uses `compareTo(expected) == 0`)
@@ -90,13 +90,13 @@ fun <T : BigDecimal> Expect<T>.notToBe(expected: T): Nothing = throw PleaseUseRe
  * - `expect(BigDecimal("10")).isEqualIncludingScale(BigDecimal("10.0"))` does not hold.
  * - `expect(BigDecimal("10")).isNumericallyEqualTo(BigDecimal("10.0"))` holds.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : BigDecimal> Expect<T>.isNumericallyEqualTo(expected: T): Expect<T> =
     _logicAppend { isNumericallyEqualTo(expected) }
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is not numerically equal to [expected].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is not numerically equal to [expected].
  *
  * By numerically is meant that it will not compare [BigDecimal.scale] (or in other words,
  * it uses `compareTo(expected) != 0`)
@@ -107,13 +107,13 @@ fun <T : BigDecimal> Expect<T>.isNumericallyEqualTo(expected: T): Expect<T> =
  * - `expect(BigDecimal("10")).isNotEqualIncludingScale(BigDecimal("10.0"))` holds.
  * - `expect(BigDecimal("10")).isNotNumericallyEqualTo(BigDecimal("10.0"))`  does not hold.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T): Expect<T> =
     _logicAppend { isNotNumericallyEqualTo(expected) }
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is equal to [expected] including [BigDecimal.scale].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is equal to [expected] including [BigDecimal.scale].
  *
  * Most of the time you want to use [isNumericallyEqualTo] which does not compare [BigDecimal.scale]
  * in contrast to this function.
@@ -121,13 +121,13 @@ fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T): Expect<T> =
  * - `expect(BigDecimal("10")).isEqualIncludingScale(BigDecimal("10.0"))` does not hold.
  * - `expect(BigDecimal("10")).isNumericallyEqualTo(BigDecimal("10.0"))` holds.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : BigDecimal> Expect<T>.isEqualIncludingScale(expected: T): Expect<T> =
     _logicAppend { isEqualIncludingScale(expected, this::isNumericallyEqualTo.name) }
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is not equal to [expected] including [BigDecimal.scale].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is not equal to [expected] including [BigDecimal.scale].
  *
  * Most of the time you want to use [isNotNumericallyEqualTo] which does not compare [BigDecimal.scale]
  * in contrast to this function.
@@ -135,7 +135,7 @@ fun <T : BigDecimal> Expect<T>.isEqualIncludingScale(expected: T): Expect<T> =
  * - `expect(BigDecimal("10")).isNotEqualIncludingScale(BigDecimal("10.0"))` holds.
  * - `expect(BigDecimal("10")).isNotNumericallyEqualTo(BigDecimal("10.0"))`  does not hold.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : BigDecimal> Expect<T>.isNotEqualIncludingScale(expected: T): Expect<T> =
     _logicAppend { isNotEqualIncludingScale(expected) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoLocalDateAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoLocalDateAssertions.kt
@@ -10,10 +10,10 @@ import ch.tutteli.atrium.logic.*
 import java.time.chrono.ChronoLocalDate
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -21,10 +21,10 @@ fun <T : ChronoLocalDate> Expect<T>.isBefore(expected: ChronoLocalDate): Expect<
     _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before or equal the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -32,10 +32,10 @@ fun <T : ChronoLocalDate> Expect<T>.isBeforeOrEqual(expected: ChronoLocalDate): 
     _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -43,10 +43,10 @@ fun <T : ChronoLocalDate> Expect<T>.isAfter(expected: ChronoLocalDate): Expect<T
     _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after or equal the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -54,10 +54,10 @@ fun <T : ChronoLocalDate> Expect<T>.isAfterOrEqual(expected: ChronoLocalDate): E
     _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is equal to the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -65,11 +65,11 @@ fun <T : ChronoLocalDate> Expect<T>.isEqual(expected: ChronoLocalDate): Expect<T
     _logicAppend { isEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -77,11 +77,11 @@ fun <T : ChronoLocalDate> Expect<T>.isBefore(expected: String): Expect<T> =
     _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before or equal the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -89,11 +89,11 @@ fun <T : ChronoLocalDate> Expect<T>.isBeforeOrEqual(expected: String): Expect<T>
     _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -101,11 +101,11 @@ fun <T : ChronoLocalDate> Expect<T>.isAfter(expected: String): Expect<T> =
     _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after or equal the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -113,11 +113,11 @@ fun <T : ChronoLocalDate> Expect<T>.isAfterOrEqual(expected: String): Expect<T> 
     _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is equal to the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoLocalDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoLocalDateTimeAssertions.kt
@@ -12,10 +12,10 @@ import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoLocalDateTime
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -24,10 +24,10 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before or equal the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -36,10 +36,10 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is after the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -48,10 +48,10 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is after or equal the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -60,10 +60,10 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is equal to the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -72,7 +72,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
 ): Expect<T> = _logicAppend { isEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a
@@ -82,7 +82,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -91,7 +91,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a
@@ -101,7 +101,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -110,7 +110,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a date
@@ -120,7 +120,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -129,7 +129,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a date
@@ -139,7 +139,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -148,7 +148,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a date
@@ -158,7 +158,7 @@ fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeAssertions.kt
@@ -11,10 +11,10 @@ import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoZonedDateTime
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -23,10 +23,10 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -35,10 +35,10 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is after the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -47,10 +47,10 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is after or equal the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -59,10 +59,10 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is equal to the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -71,7 +71,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
 ): Expect<T> = _logicAppend { isEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -95,7 +95,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -104,7 +104,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -128,7 +128,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -137,7 +137,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is after the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -161,7 +161,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqual(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -170,7 +170,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is after or equal the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -194,7 +194,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -203,7 +203,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is equal to the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -227,7 +227,7 @@ fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqual(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fileAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fileAssertions.kt
@@ -25,13 +25,13 @@ fun <T : File> Expect<T>.asPath(): Expect<Path> =
     _logic.changeSubject.unreported { it.toPath() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [Path].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature(File::toPath, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
@@ -12,16 +12,16 @@ import ch.tutteli.atrium.logic.*
 import java.math.BigDecimal
 
 /**
- * Expects that the subject of the assertion is equal to [expected] with an error [tolerance]
+ * Expects that the subject of `this` expectation is equal to [expected] with an error [tolerance]
  * (range including bounds).
  *
  * In detail, It compares the absolute difference between the subject and [expected];
  * as long as it is less than or equal the [tolerance] the assertion holds; otherwise it fails.
  * A more mathematical way of expressing the assertion is the following inequality:
  *
- * | `subject of the assertion` - [expected] | ≤ [tolerance]
+ * | `subject of `this` expectation` - [expected] | ≤ [tolerance]
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 fun <T : BigDecimal> Expect<T>.toBeWithErrorTolerance(expected: BigDecimal, tolerance: BigDecimal): Expect<T> =
     _logicAppend { toBeWithErrorTolerance(expected, tolerance) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateAssertions.kt
@@ -10,7 +10,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 
 /**
- * Creates an [Expect] for the property [LocalDate.year][LocalDate.getYear] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.year][LocalDate.getYear] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -21,11 +21,11 @@ val Expect<LocalDate>.year: Expect<Int>
     get() = _logic.year().transform()
 
 /**
- * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
+ * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -33,7 +33,7 @@ fun Expect<LocalDate>.year(assertionCreator: Expect<Int>.() -> Unit): Expect<Loc
     _logic.year().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -44,11 +44,11 @@ val Expect<LocalDate>.month: Expect<Int>
     get() = _logic.month().transform()
 
 /**
- * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
+ * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -56,7 +56,7 @@ fun Expect<LocalDate>.month(assertionCreator: Expect<Int>.() -> Unit): Expect<Lo
     _logic.month().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -67,11 +67,11 @@ val Expect<LocalDate>.dayOfWeek: Expect<DayOfWeek>
     get() = _logic.dayOfWeek().transform()
 
 /**
- * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
+ * Expects that the property [LocalDate.getDayOfWeek] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -80,7 +80,7 @@ fun Expect<LocalDate>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Unit):
 
 
 /**
- * Creates an [Expect] for the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -91,11 +91,11 @@ val Expect<LocalDate>.day: Expect<Int>
     get() = _logic.day().transform()
 
 /**
- * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
+ * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/localDateTimeAssertions.kt
@@ -11,7 +11,7 @@ import java.time.DayOfWeek
 import java.time.LocalDateTime
 
 /**
- * Creates an [Expect] for the property [LocalDateTime.year][[LocalDateTime.getYear] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDateTime.year][[LocalDateTime.getYear] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -22,11 +22,11 @@ val Expect<LocalDateTime>.year: Expect<Int>
     get() = _logic.year().transform()
 
 /**
- * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
+ * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -35,7 +35,7 @@ fun Expect<LocalDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -45,11 +45,11 @@ val Expect<LocalDateTime>.month: Expect<Int>
     get() = _logic.month().transform()
 
 /**
- * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
+ * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -58,7 +58,7 @@ fun Expect<LocalDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expec
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -68,11 +68,11 @@ val Expect<LocalDateTime>.dayOfWeek: Expect<DayOfWeek>
     get() = _logic.dayOfWeek().transform()
 
 /**
- * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
+ * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -81,7 +81,7 @@ fun Expect<LocalDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Un
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -91,11 +91,11 @@ val Expect<LocalDateTime>.day: Expect<Int>
     get() = _logic.day().transform()
 
 /**
- * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
+ * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalAssertions.kt
@@ -13,12 +13,12 @@ import ch.tutteli.atrium.logic.isPresent
 import java.util.*
 
 /**
- * Expects that the subject of the assertion (an [Optional]) is empty (not present).
+ * Expects that the subject of `this` expectation (an [Optional]) is empty (not present).
  *
  * Shortcut for more or less something like `feature(Optional<T>::isEmpty) { toBe(true) }`
  * depends on the underlying implementation though.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -26,7 +26,7 @@ fun <T : Optional<*>> Expect<T>.isEmpty(): Expect<T> =
     _logicAppend { isEmpty() }
 
 /**
- * Expects that the subject of the assertion (an [Optional]) is present
+ * Expects that the subject of `this` expectation (an [Optional]) is present
  * and returns an [Expect] for the inner type [E].
  *
  * Shortcut for more or less something like `feature(Optional<T>::get)` but with error handling; yet it
@@ -40,10 +40,10 @@ fun <E, T : Optional<E>> Expect<T>.isPresent(): Expect<E> =
     _logic.isPresent().transform()
 
 /**
- * Expects that the subject of the assertion (an [Optional]) is present and
+ * Expects that the subject of `this` expectation (an [Optional]) is present and
  * that it holds all assertions the given [assertionCreator] creates.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -12,9 +12,9 @@ import java.nio.charset.Charset
 import java.nio.file.Path
 
 /**
- * Expects that the subject of the assertion (a [Path]) starts with the [expected] [Path].
+ * Expects that the subject of `this` expectation (a [Path]) starts with the [expected] [Path].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -22,9 +22,9 @@ fun <T : Path> Expect<T>.startsWith(expected: Path): Expect<T> =
     _logicAppend { startsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not start with the [expected] [Path].
+ * Expects that the subject of `this` expectation (a [Path]) does not start with the [expected] [Path].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -32,9 +32,9 @@ fun <T : Path> Expect<T>.startsNotWith(expected: Path): Expect<T> =
     _logicAppend { startsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) ends with the expected [Path].
+ * Expects that the subject of `this` expectation (a [Path]) ends with the expected [Path].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -42,10 +42,10 @@ fun <T : Path> Expect<T>.endsWith(expected: Path): Expect<T> =
     _logicAppend { endsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not end with the expected [Path];
+ * Expects that the subject of `this` expectation (a [Path]) does not end with the expected [Path];
  *
  * @param expected The [Path] provided to the assertion
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -53,13 +53,13 @@ fun <T : Path> Expect<T>.endsNotWith(expected: Path): Expect<T> =
     _logicAppend { endsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) exists;
+ * Expects that the subject of `this` expectation (a [Path]) exists;
  * meaning that there is a file system entry at the location the [Path] points to.
  *
  * This assertion _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -67,13 +67,13 @@ fun <T : Path> Expect<T>.exists(): Expect<T> =
     _logicAppend { exists() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not exist;
+ * Expects that the subject of `this` expectation (a [Path]) does not exist;
  * meaning that there is no file system entry at the location the [Path] points to.
  *
  * This assertion _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -82,7 +82,7 @@ fun <T : Path> Expect<T>.existsNot(): Expect<T> =
 
 /**
  * Creates an [Expect] for the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -94,11 +94,11 @@ val <T : Path> Expect<T>.fileName: Expect<String>
 
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -107,7 +107,7 @@ fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): 
 
 /**
  * Creates an [Expect] for the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -120,10 +120,10 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
 /**
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
  * (provided via [niok](https://github.com/robstoll/niok))
- * of the subject of the assertion holds all assertions the given [assertionCreator] creates for it
- * and returns an [Expect] for the current subject of the assertion.
+ * of the subject of `this` expectation holds all assertions the given [assertionCreator] creates for it
+ * and returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -143,9 +143,9 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent], that the parent holds all assertions the
- * given [assertionCreator] creates for it and returns an [Expect] for the current subject of the assertion.
+ * given [assertionCreator] creates for it and returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -165,9 +165,9 @@ fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
 
 /**
  * Expects that [other] resolves against this [Path], that the resolved [Path] holds all assertions the
- * given [assertionCreator] creates for it and returns an [Expect] for the current subject of the assertion.
+ * given [assertionCreator] creates for it and returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.10.0
  */
@@ -175,7 +175,7 @@ fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.(
     _logic.resolve(other).collectAndAppend(assertionCreator)
 
 /**
- * Expects that the subject of the assertion (a [Path]) is readable;
+ * Expects that the subject of `this` expectation (a [Path]) is readable;
  * meaning that there is a file system entry at the location the [Path] points to and
  * that the current thread has the permission to read from it.
  *
@@ -187,7 +187,7 @@ fun <T : Path> Expect<T>.resolve(other: String, assertionCreator: Expect<Path>.(
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -195,7 +195,7 @@ fun <T : Path> Expect<T>.isReadable(): Expect<T> =
     _logicAppend { isReadable() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is writable;
+ * Expects that the subject of `this` expectation (a [Path]) is writable;
  * meaning that there is a file system entry at the location the [Path] points to and
  * that the current thread has the permission to write to it.
  *
@@ -203,7 +203,7 @@ fun <T : Path> Expect<T>.isReadable(): Expect<T> =
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -212,7 +212,7 @@ fun <T : Path> Expect<T>.isWritable(): Expect<T> =
 
 
 /**
- * Expects that the subject of the assertion (a [Path]) is executable;
+ * Expects that the subject of `this` expectation (a [Path]) is executable;
  * meaning that there is a file system entry at the location the [Path] points to and
  * that the current thread has the permission to execute it.
  *
@@ -224,7 +224,7 @@ fun <T : Path> Expect<T>.isWritable(): Expect<T> =
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -232,7 +232,7 @@ fun <T : Path> Expect<T>.isExecutable(): Expect<T> =
     _logicAppend { isExecutable() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a file;
+ * Expects that the subject of `this` expectation (a [Path]) is a file;
  * meaning that there is a file system entry at the location the [Path] points to and that is a regular file.
  *
  * This assertion _resolves_ symbolic links.
@@ -243,7 +243,7 @@ fun <T : Path> Expect<T>.isExecutable(): Expect<T> =
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -251,7 +251,7 @@ fun <T : Path> Expect<T>.isRegularFile(): Expect<T> =
     _logicAppend { isRegularFile() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a directory;
+ * Expects that the subject of `this` expectation (a [Path]) is a directory;
  * meaning that there is a file system entry at the location the [Path] points to and that is a directory.
  *
  * This assertion _resolves_ symbolic links.
@@ -262,7 +262,7 @@ fun <T : Path> Expect<T>.isRegularFile(): Expect<T> =
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -270,10 +270,10 @@ fun <T : Path> Expect<T>.isDirectory(): Expect<T> =
     _logicAppend { isDirectory() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is an absolute path;
+ * Expects that the subject of `this` expectation (a [Path]) is an absolute path;
  * meaning that the [Path] specified in this instance starts at the file system root.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -281,10 +281,10 @@ fun <T : Path> Expect<T>.isAbsolute(): Expect<T> =
     _logicAppend { isAbsolute() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a relative path;
+ * Expects that the subject of `this` expectation (a [Path]) is a relative path;
  * meaning that the [Path] specified in this instance does not start at the file system root.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -292,7 +292,7 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
     _logicAppend { isRelative() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a directory having the provided entries.
+ * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided entries.
  * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
  * Furthermore, every argument string resolved against the subject yields an existing file system entry.
  *
@@ -305,7 +305,7 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
  * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -314,7 +314,7 @@ fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String, vararg otherEntries: S
 
 /**
  * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -326,11 +326,11 @@ val <T : Path> Expect<T>.extension: Expect<String>
 
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -338,13 +338,13 @@ fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit):
     _logic.extension().collectAndAppend(assertionCreator)
 
 /**
- * Expects that the subject of the assertion (a [Path]) has the same textual content
+ * Expects that the subject of `this` expectation (a [Path]) has the same textual content
  * as [targetPath] taking the given encodings into account (UTF-8 if none given).
  *
  * @param sourceCharset source file encoding - UTF-8 per default.
  * @param targetCharset target file encoding - UTF-8 per default.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -355,10 +355,10 @@ fun <T : Path> Expect<T>.hasSameTextualContentAs(
 ): Expect<T> = _logicAppend { hasSameTextualContentAs(targetPath, sourceCharset, targetCharset) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) has the same binary content
+ * Expects that the subject of `this` expectation (a [Path]) has the same binary content
  * as [targetPath].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/zonedDateTimeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/zonedDateTimeAssertions.kt
@@ -11,7 +11,7 @@ import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
 /**
- * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion,
+ * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -22,11 +22,11 @@ val Expect<ZonedDateTime>.year: Expect<Int>
     get() = _logic.year().transform()
 
 /**
- * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
+ * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -35,7 +35,7 @@ fun Expect<ZonedDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): Expect
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -45,11 +45,11 @@ val Expect<ZonedDateTime>.month: Expect<Int>
     get() = _logic.month().transform()
 
 /**
- * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
+ * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -58,7 +58,7 @@ fun Expect<ZonedDateTime>.month(assertionCreator: Expect<Int>.() -> Unit): Expec
 
 /**
  * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -68,11 +68,11 @@ val Expect<ZonedDateTime>.dayOfWeek: Expect<DayOfWeek>
     get() = _logic.dayOfWeek().transform()
 
 /**
- * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
+ * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -81,7 +81,7 @@ fun Expect<ZonedDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> Un
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -91,11 +91,11 @@ val Expect<ZonedDateTime>.day: Expect<Int>
     get() = _logic.day().transform()
 
 /**
- * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
+ * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/resultAssertions.kt
+++ b/apis/fluent-en_GB/extensions/kotlin_1_3/atrium-api-fluent-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/resultAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.logic.kotlin_1_3.isFailureOfType
 import ch.tutteli.atrium.logic.kotlin_1_3.isSuccess
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Success
+ * Expects that the subject of `this` expectation (a [Result]) is a Success
  * and returns an [Expect] for the inner type [E].
  *
  * @return The newly created [Expect] if the given assertion is success
@@ -17,10 +17,10 @@ fun <E, T : Result<E>> Expect<T>.isSuccess(): Expect<E> =
     _logic.isSuccess().transform()
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Success and
+ * Expects that the subject of `this` expectation (a [Result]) is a Success and
  * that it holds all assertions the given [assertionCreator] creates.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.9.0
  */
@@ -28,7 +28,7 @@ fun <E, T : Result<E>> Expect<T>.isSuccess(assertionCreator: Expect<E>.() -> Uni
     _logic.isSuccess().collectAndAppend(assertionCreator)
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Failure and
+ * Expects that the subject of `this` expectation (a [Result]) is a Failure and
  * that it encapsulates an exception of type [TExpected].
  *
  * @return An [Expect] with the new type [TExpected]
@@ -39,7 +39,7 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.isFailure(): Ex
     _logic.isFailureOfType(TExpected::class).transform()
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Failure,
+ * Expects that the subject of `this` expectation (a [Result]) is a Failure,
  * it encapsulates an exception of type [TExpected] and that the exception
  * holds all assertions the given [assertionCreator] creates.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
@@ -11,32 +11,32 @@ import ch.tutteli.atrium.reporting.Reporter
 import kotlin.reflect.KClass
 
 /**
- * Expects that the subject of the assertion is (equal to) [expected].
+ * Expects that the subject of `this` expectation is (equal to) [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.AnyAssertionSamples.toBe
  */
 infix fun <T> Expect<T>.toBe(expected: T): Expect<T> = _logicAppend { toBe(expected) }
 
 /**
- * Expects that the subject of the assertion is not (equal to) [expected].
+ * Expects that the subject of `this` expectation is not (equal to) [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T> Expect<T>.notToBe(expected: T): Expect<T> = _logicAppend { notToBe(expected) }
 
 /**
- * Expects that the subject of the assertion is the same instance as [expected].
+ * Expects that the subject of `this` expectation is the same instance as [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T> Expect<T>.isSameAs(expected: T): Expect<T> = _logicAppend { isSameAs(expected) }
 
 /**
- * Expects that the subject of the assertion is not the same instance as [expected].
+ * Expects that the subject of `this` expectation is not the same instance as [expected].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = _logicAppend { isNotSameAs(expected) }
 
@@ -46,7 +46,7 @@ infix fun <T> Expect<T>.isNotSameAs(expected: T): Expect<T> = _logicAppend { isN
  * @param keyWithCreator Combines the reason with the assertionCreator-lambda. Use the function
  *   `of(reason) { ... }` to create a [KeyWithCreator].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.AnyAssertionSamples.because
@@ -61,10 +61,10 @@ fun <T> of(reason: String, assertionCreator: Expect<T>.() -> Unit): KeyWithCreat
     KeyWithCreator(reason, assertionCreator)
 
 /**
- * Expects that the subject of the assertion is either `null` in case [assertionCreatorOrNull]
+ * Expects that the subject of `this` expectation is either `null` in case [assertionCreatorOrNull]
  * is `null` or is not `null` and holds all assertions [assertionCreatorOrNull] creates.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Any> Expect<T?>.toBeNullIfNullGivenElse(
     assertionCreatorOrNull: (Expect<T>.() -> Unit)?
@@ -72,7 +72,7 @@ infix fun <T : Any> Expect<T?>.toBeNullIfNullGivenElse(
 
 
 /**
- * Expects that the subject of the assertion is not null and changes the subject to the non-nullable version.
+ * Expects that the subject of `this` expectation is not null and changes the subject to the non-nullable version.
  *
  * @param o The filler object [o].
  *
@@ -85,7 +85,7 @@ inline infix fun <reified T : Any> Expect<T?>.notToBeNull(@Suppress("UNUSED_PARA
     notToBeNullButOfType(T::class).transform()
 
 /**
- * Expects that the subject of the assertion is not null and
+ * Expects that the subject of `this` expectation is not null and
  * that it holds all assertions the given [assertionCreator] creates.
  *
  * @return An [Expect] with the non-nullable type [T] (was `T?` before)
@@ -99,7 +99,7 @@ internal fun <T : Any> Expect<T?>.notToBeNullButOfType(kClass: KClass<T>): Subje
     _logic.notToBeNullButOfType(kClass)
 
 /**
- * Expects that the subject of the assertion *is a* [TSub] (the same type or a sub-type)
+ * Expects that the subject of `this` expectation *is a* [TSub] (the same type or a sub-type)
  * and changes the subject to this type.
  *
  * Notice, that asserting a function type is [flawed](https://youtrack.jetbrains.com/issue/KT-27846).
@@ -125,7 +125,7 @@ internal fun <TSub : Any> Expect<*>.isA(kClass: KClass<TSub>): SubjectChangerBui
     _logic.isA(kClass)
 
 /**
- * Expects that the subject of the assertion *is a* [TSub] (the same type or a sub-type) and
+ * Expects that the subject of `this` expectation *is a* [TSub] (the same type or a sub-type) and
  * that it holds all assertions the given [assertionCreator] creates.
  *
  * Notice, in contrast to other assertion functions which expect an [assertionCreator], this function returns not
@@ -176,7 +176,7 @@ inline infix fun <reified TSub : Any> Expect<*>.isA(noinline assertionCreator: E
  *
  * @param o The filler object [o].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -191,7 +191,7 @@ inline infix fun <T> Expect<T>.and(@Suppress("UNUSED_PARAMETER") o: o): Expect<T
  * second one is evaluated as a whole. Meaning, even though 1 is not even, it still evaluates that 1 is greater than 1.
  * Hence the reporting might (depending on the configured [Reporter]) contain both failing sub-assertions.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     addAssertionsCreatedBy(assertionCreator)
@@ -243,12 +243,12 @@ inline val <T> Expect<T>.it: Expect<T> get() : Expect<T> = this
 inline val <T> Expect<T>.its: Expect<T> get() : Expect<T> = this
 
 /**
- * Expects that the subject of the assertion is not (equal to) in [values].
+ * Expects that the subject of `this` expectation is not (equal to) in [values].
  *
- * @param values The values which are not expected to be contained within the subject of the assertion
+ * @param values The values which are not expected to be contained within the subject of `this` expectation
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -256,12 +256,12 @@ infix fun <T> Expect<T>.isNoneOf(values: Values<T>): Expect<T> =
     _logicAppend { isNotIn(values.toList()) }
 
 /**
- * Expects that the subject of the assertion is not (equal to) any value of [expected].
+ * Expects that the subject of `this` expectation is not (equal to) any value of [expected].
  *
  * Notice that a runtime check applies which assures that only [Iterable], [Sequence] or one of the [Array] types
  * are passed. This function expects [IterableLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case the iterable is empty.
  *
  * @since 0.13.0

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
@@ -19,7 +19,7 @@ infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -33,7 +33,7 @@ infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Un
     apply { asList(o).addAssertionsCreatedBy(assertionCreator) }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -62,7 +62,7 @@ infix fun Expect<ByteArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -92,7 +92,7 @@ infix fun Expect<CharArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -122,7 +122,7 @@ infix fun Expect<ShortArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -152,7 +152,7 @@ infix fun Expect<IntArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<Li
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -182,7 +182,7 @@ infix fun Expect<LongArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -212,7 +212,7 @@ infix fun Expect<FloatArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -242,7 +242,7 @@ infix fun Expect<DoubleArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
@@ -272,7 +272,7 @@ infix fun Expect<BooleanArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expec
     _logic.changeSubject.unreported { it.asList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
@@ -36,7 +36,7 @@ infix fun <T : CharSequence> Expect<T>.containsNot(
 ): NotCheckerStep<T, NotSearchBehaviour> = _logic.containsNotBuilder()
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains the [expected]'s [toString] representation.
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains the [expected]'s [toString] representation.
  *
  * It is a shortcut for `contains o atLeast 1 value expected`.
  *
@@ -51,7 +51,7 @@ infix fun <T : CharSequence> Expect<T>.contains(expected: CharSequenceOrNumberOr
     this contains o atLeast 1 value expected
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains the [toString] representation of the
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains the [toString] representation of the
  * given [values] using a non disjoint search.
  *
  * It is a shortcut for `contains o atLeast 1 the values(expected, *otherExpected)`.
@@ -82,7 +82,7 @@ infix fun <T : CharSequence> Expect<T>.contains(values: Values<CharSequenceOrNum
     this contains o atLeast 1 the values
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not contain [expected]'s [toString] representation.
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not contain [expected]'s [toString] representation.
  *
  * It is a shortcut for `contains not value expected`.
  *
@@ -96,7 +96,7 @@ infix fun <T : CharSequence> Expect<T>.containsNot(expected: CharSequenceOrNumbe
     this containsNot o value expected
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not contain the [toString] representation
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not contain the [toString] representation
  * of the given [values].
  *
  * It is a shortcut for `contains not the values(expected, *otherExpected)`.
@@ -113,7 +113,7 @@ infix fun <T : CharSequence> Expect<T>.containsNot(values: Values<CharSequenceOr
     this containsNot o the values
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [pattern].
  *
  * It is a shortcut for `contains o atLeast 1 regex pattern`.
@@ -126,7 +126,7 @@ infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: String): Expect<T>
     this contains o atLeast 1 regex pattern
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [pattern].
  *
  * It is a shortcut for `contains o atLeast 1 matchFor pattern`.
@@ -139,7 +139,7 @@ infix fun <T : CharSequence> Expect<T>.contains(pattern: Regex): Expect<T> =
     this contains o atLeast 1 matchFor pattern
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [regexPatterns], using a non disjoint search.
  *
  * It is a shortcut for `contains o atLeast 1 the regexPatterns(pattern, *otherPatterns)`.
@@ -165,7 +165,7 @@ infix fun <T : CharSequence> Expect<T>.contains(regexPatterns: RegexPatterns): E
 
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) contains a sequence which matches the given
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [patterns], using a non disjoint search.
  *
  * It is a shortcut for `contains o atLeast 1 regex All(pattern, *otherPatterns)`.
@@ -190,7 +190,7 @@ infix fun <T : CharSequence> Expect<T>.contains(patterns: All<Regex>): Expect<T>
     this contains o atLeast 1 matchFor patterns
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) starts with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) starts with [expected].
  *
  * @return This assertion container to support a fluent API.
  */
@@ -198,7 +198,7 @@ infix fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence): Expec
     _logicAppend { startsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) starts with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) starts with [expected].
  *
  * @return This assertion container to support a fluent API.
  *
@@ -208,7 +208,7 @@ infix fun <T : CharSequence> Expect<T>.startsWith(expected: Char): Expect<T> =
     it startsWith expected.toString()
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not start with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not start with [expected].
  *
  * @return This assertion container to support a fluent API.
  */
@@ -216,7 +216,7 @@ infix fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence): Ex
     _logicAppend { startsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not start with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not start with [expected].
  *
  * @return This assertion container to support a fluent API.
  *
@@ -227,7 +227,7 @@ infix fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char): Expect<T> 
 
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) ends with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) ends with [expected].
  *
  * @return This assertion container to support a fluent API.
  */
@@ -235,7 +235,7 @@ infix fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence): Expect<
     _logicAppend { endsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) ends with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) ends with [expected].
  *
  * @return This assertion container to support a fluent API.
  *
@@ -245,7 +245,7 @@ infix fun <T : CharSequence> Expect<T>.endsWith(expected: Char): Expect<T> =
     it endsWith expected.toString()
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not end with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not end with [expected].
  *
  * @return This assertion container to support a fluent API.
  */
@@ -253,7 +253,7 @@ infix fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence): Expe
     _logicAppend { endsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) does not end with [expected].
+ * Expects that the subject of `this` expectation (a [CharSequence]) does not end with [expected].
  *
  * @return This assertion container to support a fluent API.
  *
@@ -264,7 +264,7 @@ infix fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char): Expect<T> =
 
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isEmpty].
+ * Expects that the subject of `this` expectation (a [CharSequence]) [CharSequence].[kotlin.text.isEmpty].
  *
  * @param empty Use the pseudo-keyword `empty`.
  *
@@ -274,7 +274,7 @@ infix fun <T : CharSequence> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty:
     _logicAppend { isEmpty() }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isNotEmpty].
+ * Expects that the subject of `this` expectation (a [CharSequence]) [CharSequence].[kotlin.text.isNotEmpty].
  *
  * @param empty Use the pseudo-keyword `empty`.
  *
@@ -284,7 +284,7 @@ infix fun <T : CharSequence> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") emp
     _logicAppend { isNotEmpty() }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) [CharSequence].[kotlin.text.isNotBlank].
+ * Expects that the subject of `this` expectation (a [CharSequence]) [CharSequence].[kotlin.text.isNotBlank].
  *
  * @param blank Use the pseudo-keyword `blank`.
  *
@@ -294,7 +294,7 @@ infix fun <T : CharSequence> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") bla
     _logicAppend { isNotBlank() }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) matches the given [expected] [Regex].
+ * Expects that the subject of `this` expectation (a [CharSequence]) matches the given [expected] [Regex].
  *
  * In contrast to [containsRegex] it does not look for a partial match but for an entire match.
  *
@@ -306,7 +306,7 @@ infix fun <T : CharSequence> Expect<T>.matches(expected: Regex): Expect<T> =
     _logicAppend { matches(expected) }
 
 /**
- * Expects that the subject of the assertion (a [CharSequence]) mismatches the given [expected] [Regex].
+ * Expects that the subject of `this` expectation (a [CharSequence]) mismatches the given [expected] [Regex].
  *
  * In contrast to `containsNot.regex` it does not look for a partial match but for an entire match.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceContainsCreators.kt
@@ -38,7 +38,7 @@ import kotlin.jvm.JvmName
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.value(
@@ -67,7 +67,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.value(
  * @param values The values which should not be found within the input of the search
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
 infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.the(
@@ -89,7 +89,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.the(
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 @JvmName("valueIgnoringCase")
@@ -119,7 +119,7 @@ infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.value(
  * @param values The values which are expected to be contained within the input of the search
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
 @JvmName("valuesIgnoringCase")
@@ -141,7 +141,7 @@ infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.the(
  *
  * @param expected The value which is expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  */
 infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.value(
@@ -173,7 +173,7 @@ infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.valu
  * @param values The values which are expected to be contained within the input of the search
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case one of the [values] is not a [CharSequence], [Number] or [Char].
  */
 infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.the(
@@ -188,7 +188,7 @@ infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.the(
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(pattern: String): Expect<T> =
     this the regexPatterns(pattern)
@@ -201,7 +201,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(pattern: 
  *
  * @param pattern The pattern which is expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -227,7 +227,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.matchFor(
  * @param patterns The patterns which are expected to have a match against the input of the search
  *   -- use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.the(patterns: RegexPatterns): Expect<T> =
     _logicAppend { regex(patterns.toList()) }
@@ -250,7 +250,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.the(patterns: R
  * @param patterns The patterns which are expected to have a match against the input of the search --
  *   use the function `all(Regex(...), ...)` to create a [All].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -265,7 +265,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.matchFor(patter
  *
  * @param pattern The patterns which is expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @JvmName("regexIgnoringCase")
 infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.regex(pattern: String): Expect<T> =
@@ -289,7 +289,7 @@ infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.regex(p
  * @param patterns The patterns which are expected to have a match against the input of the search
  *   -- use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @JvmName("regexIgnoringCase")
 infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.the(patterns: RegexPatterns): Expect<T> =
@@ -303,7 +303,7 @@ infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.the(pat
  *
  * @param pattern The patterns which is expected to have a match against the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.regex(pattern: String): Expect<T> =
     this atLeast 1 regex pattern
@@ -328,7 +328,7 @@ infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.rege
  * @param patterns The patterns which are expected to have a match against the input of the search --
  *   use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.the(patterns: RegexPatterns): Expect<T> =
     this atLeast 1 the patterns
@@ -347,7 +347,7 @@ infix fun <T : CharSequence> EntryPointStep<T, IgnoringCaseSearchBehaviour>.the(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *
@@ -373,7 +373,7 @@ infix fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.elementsOf(
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *
@@ -400,7 +400,7 @@ infix fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.element
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within the input of the search.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types or the given
  * [expectedIterableLike] does not have elements (is empty).
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
@@ -5,38 +5,38 @@ import ch.tutteli.atrium.logic.*
 import ch.tutteli.kbox.identity
 
 /**
- * Expects that the subject of the assertion (a [Collection]) is an empty [Collection].
+ * Expects that the subject of `this` expectation (a [Collection]) is an empty [Collection].
  *
  * @param empty Use the pseudo-keyword `empty`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Collection<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isEmpty(::identity) }
 
 /**
- * Expects that the subject of the assertion (a [Collection]) is not an empty [Collection].
+ * Expects that the subject of `this` expectation (a [Collection]) is not an empty [Collection].
  *
  * @param empty Use the pseudo-keyword `empty`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Collection<*>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isNotEmpty(::identity) }
 
 /**
- * Expects that the subject of the assertion (a [Collection]) has the given [expected] size.
+ * Expects that the subject of `this` expectation (a [Collection]) has the given [expected] size.
  *
  * Shortcut for `size.toBe(expected)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Collection<*>> Expect<T>.hasSize(expected: Int): Expect<T> =
     size { toBe(expected) }
 
 
 /**
- * Creates an [Expect] for the property [Collection.size] of the subject of the assertion,
+ * Creates an [Expect] for the property [Collection.size] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -45,11 +45,11 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
     get() = _logic.size(::identity).transform()
 
 /**
- * Expects that the property [Collection.size] of the subject of the assertion
+ * Expects that the property [Collection.size] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
     _logic.size(::identity).collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableAssertions.kt
@@ -4,46 +4,46 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
 
 /**
- * Expects that the subject of the assertion is less than [expected].
+ * Expects that the subject of `this` expectation is less than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T): Expect<T> =
     _logicAppend { isLessThan(expected) }
 
 /**
- * Expects that the subject of the assertion is less than or equal [expected].
+ * Expects that the subject of `this` expectation is less than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isLessThanOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion is greater than [expected].
+ * Expects that the subject of `this` expectation is greater than [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T): Expect<T> =
     _logicAppend { isGreaterThan(expected) }
 
 /**
- * Expects that the subject of the assertion is greater than or equal [expected].
+ * Expects that the subject of `this` expectation is greater than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isGreaterThanOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion is equal to [expected]
+ * Expects that the subject of `this` expectation is equal to [expected]
  * where the comparison is carried out with [Comparable.compareTo].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty1
  * where `X` > 1.
  *
  * @property description The description of the feature.
- * @property extractor The extractor which extracts the feature out of the subject of the assertion.
+ * @property extractor The extractor which extracts the feature out of the subject of the expectation.
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KProperty1
  * required arguments in case of a `KFunctionX` where `X` > 1.
  *
  * @property description The description of the feature.
- * @property extractor The extractor which extracts the feature out of the subject of the assertion.
+ * @property extractor The extractor which extracts the feature out of the subject of  the expectation.
  * @property assertionCreator The `assertionCreator`-lambda which defines assertions for the feature.
  *
  * @since 0.12.0

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.domain.creating.MetaFeature
  *
  * Use the function `of({ ... }) { ... }` to create this representation where the first
  * argument is a lambda with a [MetaFeatureOption] as receiver which has to create a [MetaFeature]
- * where the subject of the assertion is available via implicit parameter `it`.
+ * where the subject of the expectation is available via implicit parameter `it`.
  * Usually you use [f][MetaFeatureOption.f] to create a [MetaFeature],
  * e.g. `feature of({ f(it::size) }) { o toBe 3 }`
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/expectExtensions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/expectExtensions.kt
@@ -17,7 +17,7 @@ annotation class ExperimentalWithOptions
  * Wraps the given [textRepresentation] into a [Text] and uses it as representation of the subject
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  */
 @ExperimentalWithOptions
@@ -34,7 +34,7 @@ infix fun <T> RootExpect<T>.withRepresentation(textRepresentation: String): Expe
  * If your text does not include the current subject, then we recommend to use the other overload which expects
  * a `String` and does the wrapping for you.
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  */
 @ExperimentalWithOptions
@@ -62,10 +62,10 @@ infix fun <T> RootExpect<T>.withOptions(options: ExpectOptions<T>): Expect<T> =
  * Wraps the given [textRepresentation] into a [Text] and uses it as representation of the subject
  * instead of the representation that has been defined so far (which defaults to the subject itself).
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -83,10 +83,10 @@ infix fun <T, R> FeatureExpect<T, R>.withRepresentation(textRepresentation: Stri
  * If your text does not include the current subject, then we recommend to use the other overload which expects
  * a `String` and does the wrapping for you.
  *
- * In case the subject of the assertion is not defined (i.e. `_logic.maybeSubject` is [None]),
+ * In case the subject of `this` expectation is not defined (i.e. `_logic.maybeSubject` is [None]),
  * then the previous representation is used.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -98,7 +98,7 @@ infix fun <T, R> FeatureExpect<T, R>.withRepresentation(representationProvider: 
  * Uses the given [configuration]-lambda to create an [FeatureExpectOptions] which in turn is used
  * to override (parts) of the existing configuration.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
@@ -109,7 +109,7 @@ infix fun <T, R> FeatureExpect<T, R>.withOptions(configuration: FeatureExpectOpt
 /**
  * Uses the given [options] to override (parts) of the existing configuration.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @ExperimentalWithOptions
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/featureAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/featureAssertions.kt
@@ -13,7 +13,7 @@ import ch.tutteli.atrium.logic.*
 import kotlin.reflect.*
 
 /**
- * Extracts the [property] out of the current subject of the assertion,
+ * Extracts the [property] out of the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
@@ -25,7 +25,7 @@ infix fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect
     _logic.property(property).transform()
 
 /**
- * Extracts the value which is returned when calling the method [f] on the current subject of the assertion,
+ * Extracts the value which is returned when calling the method [f] on the current subject of `this` expectation,
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
@@ -33,7 +33,7 @@ infix fun <T, R> Expect<T>.feature(property: KProperty1<in T, R>): FeatureExpect
  * an assertion group block for it.
  *
  * @return The newly created [Expect] for the return value of calling the method [f]
- *   on the current subject of the assertion.
+ *   on the current subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -41,7 +41,7 @@ infix fun <T, R> Expect<T>.feature(f: KFunction1<T, R>): FeatureExpect<T, R> =
     _logic.f0(f).transform()
 
 /**
- * Extracts a feature out of the current subject of the assertion using the given [Feature.extractor],
+ * Extracts a feature out of the current subject of `this` expectation using the given [Feature.extractor],
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
@@ -62,7 +62,7 @@ infix fun <T, R> Expect<T>.feature(of: Feature<in T, R>): FeatureExpect<T, R> =
     _logic.manualFeature(of.description, of.extractor).transform()
 
 /**
- * Extracts a feature out of the current subject of the assertion using the given [FeatureWithCreator.extractor],
+ * Extracts a feature out of the current subject of `this` expectation using the given [FeatureWithCreator.extractor],
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [FeatureWithCreator.assertionCreator] for the feature and
  * returns the initial [Expect] with the current subject.
@@ -77,7 +77,7 @@ infix fun <T, R> Expect<T>.feature(of: Feature<in T, R>): FeatureExpect<T, R> =
  *   form of a [KProperty1] or a `KFunctionX`, the last an `assertionCreator`-lambda and the remaining arguments
  *   in-between the required arguments in case of a `KFunctionX` where `X` > 1.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -87,12 +87,12 @@ infix fun <T, R> Expect<T>.feature(of: FeatureWithCreator<in T, R>): Expect<T> =
 
 
 /**
- * Extracts a feature out of the current subject of the assertion,
+ * Extracts a feature out of the current subject of `this` expectation,
  * based on the given [provider],
  * creates a new [Expect] for it and
  * returns it so that subsequent calls are based on the feature.
  *
- * @param provider Creates a [MetaFeature] where the subject of the assertion is available via
+ * @param provider Creates a [MetaFeature] where the subject of `this` expectation is available via
  *   implicit parameter `it`. Usually you use [f][MetaFeatureOption.f] to create a [MetaFeature],
  *   e.g. `feature { f(it::size) }`
  *
@@ -104,7 +104,7 @@ infix fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFea
     _logic.genericSubjectBasedFeature { MetaFeatureOption(this).provider(it) }.transform()
 
 /**
- * Extracts a feature out of the current subject of the assertion,
+ * Extracts a feature out of the current subject of `this` expectation,
  * based on the given [MetaFeatureOptionWithCreator]
  * creates a new [Expect] for it,
  * applies an assertion group based on the given [MetaFeatureOptionWithCreator.assertionCreator] for the feature and
@@ -126,11 +126,11 @@ infix fun <T, R> Expect<T>.feature(provider: MetaFeatureOption<T>.(T) -> MetaFea
  *
  * @param of Use the function `of({ ... }) { ... }` to create the [MetaFeatureOptionWithCreator] where the first
  *   argument is a lambda with a [MetaFeatureOption] as receiver which has to create a [MetaFeature]
- *   where the subject of the assertion is available via implicit parameter `it`.
+ *   where the subject of `this` expectation is available via implicit parameter `it`.
  *   Usually you use [f][MetaFeatureOption.f] to create a [MetaFeature],
  *   e.g. `feature of({ f(it::size) }) { o toBe 3 }`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @since 0.12.0
  */
 infix fun <T, R> Expect<T>.feature(of: MetaFeatureOptionWithCreator<T, R>): Expect<T> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fun0Assertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fun0Assertions.kt
@@ -63,7 +63,7 @@ inline infix fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
 
 /**
  * Expects that no [Throwable] is thrown at all when calling the subject (a lambda with arity 0, i.e. without arguments)
- * and changes the subject of the assertion to the return value of type [R].
+ * and changes the subject of `this` expectation to the return value of type [R].
  *
  * @return An [Expect] with the new type [R].
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
@@ -41,17 +41,17 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsNot(
 ): NotCheckerStep<E, T, NotSearchBehaviour> = _logic.builderContainsNotInIterableLike(::identity)
 
 /**
- *  Expects that the subject of the assertion (an [Iterable]) contains the [expected] value.
+ *  Expects that the subject of `this` expectation (an [Iterable]) contains the [expected] value.
  *
  * It is a shortcut for `contains o inAny order atLeast 1 value expected`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Iterable<E>> Expect<T>.contains(expected: E): Expect<T> =
     it contains o inAny order atLeast 1 value expected
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains the expected [values].
+ * Expects that the subject of `this` expectation (an [Iterable]) contains the expected [values].
  *
  * It is a shortcut for `contains o inAny order atLeast 1 the values(...)`
  *
@@ -68,13 +68,13 @@ infix fun <E, T : Iterable<E>> Expect<T>.contains(expected: E): Expect<T> =
  * @param values The values which are expected to be contained within the [Iterable]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Iterable<E>> Expect<T>.contains(values: Values<E>): Expect<T> =
     it contains o inAny order atLeast 1 the values
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains an entry holding the
+ * Expects that the subject of `this` expectation (an [Iterable]) contains an entry holding the
  * assertions created by [assertionCreatorOrNull] or an entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
@@ -84,13 +84,13 @@ infix fun <E, T : Iterable<E>> Expect<T>.contains(values: Values<E>): Expect<T> 
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     it contains o inAny order atLeast 1 entry assertionCreatorOrNull
 
 /**
- *  Expects that the subject of the assertion (an [Iterable]) contains an entry holding the
+ *  Expects that the subject of `this` expectation (an [Iterable]) contains an entry holding the
  * assertions created by [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] or an entry
  * which is `null` in case [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull]
  * is defined as `null` -- likewise an entry (can be the same) is searched for each of the
@@ -101,24 +101,24 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.contains(assertionCreatorOrNull:
  * @param entries The entries which are expected to be contained within the [Iterable]
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.contains(entries: Entries<E>): Expect<T> =
     it contains o inAny order atLeast 1 the entries
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only
  * the [expected] value.
  *
  * It is a shortcut for `contains o inGiven order and only value expected`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E): Expect<T> =
     it contains o inGiven order and only value expected
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only
  * the expected [values] in the defined order.
  *
  * It is a shortcut for `contains o inGiven order and only the Values(...)`
@@ -130,13 +130,13 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsExactly(expected: E): Expect<T>
  * @param values The values which are expected to be contained within the [Iterable]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Iterable<E>> Expect<T>.containsExactly(values: Values<E>): Expect<T> =
     it contains o inGiven order and only the values
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only an entry holding
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only an entry holding
  * the assertions created by [assertionCreatorOrNull] or only one entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
@@ -150,14 +150,14 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsExactly(values: Values<E>): Exp
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
 ): Expect<T> = it contains o inGiven order and only entry assertionCreatorOrNull
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only an entry holding
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only an entry holding
  * the assertions created by [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] or
  * `null` in case [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] is defined as `null`
  * and likewise an additional entry for each
@@ -173,13 +173,13 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(
  * @param entries The entries which are expected to be contained within the [Iterable]
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(entries: Entries<E>): Expect<T> =
     it contains o inGiven order and only the entries
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains only elements of [expectedIterableLike]
+ * Expects that the subject of `this` expectation (an [Iterable]) contains only elements of [expectedIterableLike]
  * in same order
  *
  * It is a shortcut for 'contains.inOrder.only.elementsOf(anotherList)'
@@ -187,7 +187,7 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.containsExactly(entries: Entries
  * Notice that a runtime check applies which assures that only [Iterable], [Sequence] or one of the [Array] types
  * are passed. This function expects [IterableLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types
  * or the given [expectedIterableLike] does not have elements (is empty).
  *
@@ -197,7 +197,7 @@ inline infix fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsO
     expectedIterableLike: IterableLike
 ): Expect<T> = it contains o inGiven order and only elementsOf (expectedIterableLike)
 
-/** Expects that the subject of the assertion (an [Iterable]) contains all elements of [expectedIterableLike].
+/** Expects that the subject of `this` expectation (an [Iterable]) contains all elements of [expectedIterableLike].
  *
  * It is a shortcut for `contains.inAnyOrder.atLeast(1).elementsOf(expectedIterable)`
  *
@@ -206,7 +206,7 @@ inline infix fun <reified E, T : Iterable<E>> Expect<T>.containsExactlyElementsO
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [Iterable].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an [Iterable], [Sequence] or one of the [Array] types
  * or the given [expectedIterableLike] does not have elements (is empty).
  *
@@ -217,18 +217,18 @@ inline infix fun <reified E, T : Iterable<E>> Expect<T>.containsElementsOf(
 ): Expect<T> = it contains o inAny order atLeast 1 elementsOf expectedIterableLike
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element and
  * that it does not contain the [expected] value.
  *
  * It is a shortcut for `containsNot o value expected`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E): Expect<T> =
     it containsNot o value expected
 
 /**
- * Expects that the subject of the assertion (an [Iterable])  has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable])  has at least one element and
  * that it does not contain the expected [values].
  *
  * It is a shortcut for `containsNot o the values(...)`
@@ -236,13 +236,13 @@ infix fun <E, T : Iterable<E>> Expect<T>.containsNot(expected: E): Expect<T> =
  * @param values The values which should not be contained within the [Iterable]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Iterable<E>> Expect<T>.containsNot(values: Values<E>): Expect<T> =
     it containsNot o the values
 
 /**
- * Creates an [Expect] for the result of calling `min()` on the subject of the assertion,
+ * Creates an [Expect] for the result of calling `min()` on the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @param o The filler object [o].
@@ -255,11 +255,11 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(@Suppress("UNUSED_P
     _logic.min(::identity).transform()
 
 /**
- * Expects that the result of calling `min()` on the subject of the assertion
+ * Expects that the result of calling `min()` on the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -268,7 +268,7 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.min(assertionCreator: E
 
 
 /**
- * Creates an [Expect] for the result of calling `max()` on the subject of the assertion,
+ * Creates an [Expect] for the result of calling `max()` on the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @param o The filler object [o].
@@ -281,11 +281,11 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(@Suppress("UNUSED_P
     _logic.max(::identity).transform()
 
 /**
- * Expects that the result of calling `max()` on  the subject of the assertion
+ * Expects that the result of calling `max()` on  the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -294,45 +294,45 @@ infix fun <E : Comparable<E>, T : Iterable<E>> Expect<T>.max(assertionCreator: E
 
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) contains an entry holding
+ * Expects that the subject of `this` expectation (an [Iterable]) contains an entry holding
  * the assertions created by [assertionCreatorOrNull] or an entry which is `null` in case [assertionCreatorOrNull]
  * is defined as `null`.
  *
  * It is a shortcut for `contains o inAny order atLeast 1 entry assertionCreatorOrNull`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.any(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     it contains o inAny order atLeast 1 entry assertionCreatorOrNull
 
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element and
  * that it either does not contain a single entry which holds all assertions created by [assertionCreatorOrNull] or
  * that it does not contain a single entry which is `null` in case [assertionCreatorOrNull] is defined as `null`.
  *
  *  It is a shortcut for `containsNot o entry assertionCreatorOrNull`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.none(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     it containsNot o entry assertionCreatorOrNull
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element and
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element and
  * that either every element holds all assertions created by the [assertionCreatorOrNull] or
  * that all elements are `null` in case [assertionCreatorOrNull] is defined as `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : Iterable<E?>> Expect<T>.all(assertionCreatorOrNull: (Expect<E>.() -> Unit)?): Expect<T> =
     _logicAppend { all(::identity, assertionCreatorOrNull) }
 
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) has at least one element.
+ * Expects that the subject of `this` expectation (an [Iterable]) has at least one element.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -340,9 +340,9 @@ infix fun <E, T : Iterable<E>> Expect<T>.has(@Suppress("UNUSED_PARAMETER") next:
     _logicAppend { hasNext(::identity) }
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) does not have next element.
+ * Expects that the subject of `this` expectation (an [Iterable]) does not have next element.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -350,9 +350,9 @@ infix fun <E, T : Iterable<E>> Expect<T>.hasNot(@Suppress("UNUSED_PARAMETER") ne
     _logicAppend { hasNotNext(::identity) }
 
 /**
- * Expects that the subject of the assertion (an [Iterable]) does not have duplicate elements.
+ * Expects that the subject of `this` expectation (an [Iterable]) does not have duplicate elements.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -374,13 +374,13 @@ infix fun <E, T : Iterable<E>> Expect<T>.asList(
 ): Expect<List<E>> = _logic.changeSubject.unreported { it.toList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderCreators.kt
@@ -21,7 +21,7 @@ import ch.tutteli.atrium.logic.utils.toVarArg
  *
  * @param expected The value which is expected to be contained within this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -46,7 +46,7 @@ infix fun <E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.val
  * @param values The values which are expected to be contained within the [IterableLike]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -64,7 +64,7 @@ infix fun <E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.the
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -83,7 +83,7 @@ infix fun <E : Any, T : IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBeh
  * @param entries The entries which are expected to be contained within the [IterableLike]
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -104,7 +104,7 @@ infix fun <E : Any, T : IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBeh
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an
  *   [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInAnyOrderOnlyCreators.kt
@@ -26,7 +26,7 @@ import ch.tutteli.atrium.logic.utils.toVarArg
  *
  * @param expected The value which is expected to be contained within the [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
     this the values(expected)
@@ -42,7 +42,7 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehavio
  * @param values The values which are expected to be contained within the [IterableLike]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.the(values: Values<E>): Expect<T> =
     _logicAppend { valuesInAnyOrderOnly(values.toList()) }
@@ -62,7 +62,7 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehavio
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
@@ -89,7 +89,7 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  * @param entries The entries which are expected to be contained within the [IterableLike]
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.the(
@@ -112,7 +112,7 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike]
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an
  *   [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
@@ -25,7 +25,7 @@ import ch.tutteli.atrium.logic.utils.toVarArg
  *
  * @param expected The value which is expected to be contained within the [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -43,7 +43,7 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>
  * @param values The values which are expected to be contained within the [IterableLike]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -65,7 +65,7 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -87,7 +87,7 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  * @param entries The entries which are expected to be contained within the [IterableLike]
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -112,7 +112,7 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within
  *   this [IterableLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not
  *   an [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
@@ -20,7 +20,7 @@ import kotlin.jvm.JvmName
  *   -- use `order(group, group, ...)` to create an [Order] where group is either `value(e)` or `values(e, ...)`;
  *   so a call could look as follows: `inAny order(values(1, 2), value(2), values(3, 2))
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -46,7 +46,7 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSea
  *   )
  *   ```
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iteratorAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iteratorAssertions.kt
@@ -6,9 +6,9 @@ import ch.tutteli.atrium.logic.hasNext
 import ch.tutteli.atrium.logic.hasNotNext
 
 /**
- * Expects that the subject of the assertion (an [Iterator]) has at least one element.
+ * Expects that the subject of `this` expectation (an [Iterator]) has at least one element.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  *
@@ -18,9 +18,9 @@ infix fun <E, T : Iterator<E>> Expect<T>.has(@Suppress("UNUSED_PARAMETER") next:
     _logicAppend { hasNext() }
 
 /**
- * Expects that the subject of the assertion (an [Iterator]) does not have next element.
+ * Expects that the subject of `this` expectation (an [Iterator]) does not have next element.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/listAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/listAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.get
 
 /**
- * Expects that the given [index] is within the bounds of the subject of the assertion (a [List]) and
+ * Expects that the given [index] is within the bounds of the subject of `this` expectation (a [List]) and
  * returns an [Expect] for the element at that position.
  *
  * @return The newly created [Expect] for the element at position [index].
@@ -17,7 +17,7 @@ infix fun <E, T : List<E>> Expect<T>.get(index: Int): Expect<E> =
     _logic.get(index).transform()
 
 /**
- * Expects that the given [index][IndexWithCreator.index] is within the bounds of the subject of the assertion
+ * Expects that the given [index][IndexWithCreator.index] is within the bounds of the subject of `this` expectation
  * (a [List]) and that the element at that position holds all assertions the given
  * [IndexWithCreator.assertionCreator] creates for it.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
@@ -22,29 +22,29 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(
 ): MapLikeContains.EntryPointStep<K, V, T, NoOpSearchBehaviour> = _logic.builderContainsInMapLike(::identity)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains a key as defined by [keyValuePair]'s [Pair.first]
+ * Expects that the subject of `this` expectation (a [Map]) contains a key as defined by [keyValuePair]'s [Pair.first]
  * with a corresponding value as defined by [keyValuePair]'s [Pair.second]
  *
  * Delegates to 'it contains o inAny order entry keyValuePair'.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePair: Pair<K, V>): Expect<T> =
     it contains o inAny order entry keyValuePair
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only one entry with a key as defined by
+ * Expects that the subject of `this` expectation (a [Map]) contains only one entry with a key as defined by
  * [keyValuePair]'s [Pair.first] and a corresponding value as defined by [keyValuePair]'s [Pair.second]
  *
  * Delegates to 'it contains o inAny order but only entry keyValuePair'.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(keyValuePair: Pair<K, V>): Expect<T> =
     it contains o inAny order but only entry keyValuePair
 
 /**
- * Expects the subject of the assertion (a [Map]) contains for each entry in [keyValuePairs],
+ * Expects the subject of `this` expectation (a [Map]) contains for each entry in [keyValuePairs],
  * a key as defined by that entry's [Pair.first] with a corresponding value as defined by entry's [Pair.second].
  *
  * Delegates to `it contains o inAny order keyValuePairs keyValuePairs`
@@ -56,13 +56,13 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(keyValuePair: Pair<K,
  * @param keyValuePairs The key-value [Pairs] expected to be contained within this [Map]
  *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePairs: Pairs<K, V>): Expect<T> =
     it contains o inAny order the keyValuePairs
 
 /**
- * Expects the subject of the assertion (a [Map]) contains only (in any order) for each entry in [keyValuePairs],
+ * Expects the subject of `this` expectation (a [Map]) contains only (in any order) for each entry in [keyValuePairs],
  * a key as defined by that entry's [Pair.first] with a corresponding value as defined by entry's [Pair.second].
  *
  * Delegates to `it contains o inAny order but only the keyValuePairs`
@@ -70,13 +70,13 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.contains(keyValuePairs: Pairs<K, V
  * @param keyValuePairs The key-value [Pairs] expected to be contained within this [Map]
  *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(keyValuePairs: Pairs<K, V>): Expect<T> =
     it contains o inAny order but only the keyValuePairs
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains a key as defined by [keyValue]'s [KeyWithValueCreator.key]
+ * Expects that the subject of `this` expectation (a [Map]) contains a key as defined by [keyValue]'s [KeyWithValueCreator.key]
  * with a corresponding value which either holds all assertions [keyValue]'s
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
@@ -88,13 +88,13 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.containsOnly(keyValuePairs: Pairs<
  *   or needs to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
  *   -- use the function `keyValue(x) { ... }` to create a [KeyWithValueCreator].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(keyValue: KeyWithValueCreator<K, V>): Expect<T> =
     it contains o inAny order entry keyValue
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only one entry with a key as defined by
+ * Expects that the subject of `this` expectation (a [Map]) contains only one entry with a key as defined by
  * [keyValue]'s [KeyWithValueCreator.key] with a corresponding value which either holds all assertions [keyValue]'s
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
@@ -106,7 +106,7 @@ inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(key
  *   or needs to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
  *   -- use the function `keyValue(x) { ... }` to create a [KeyWithValueCreator].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.containsOnly(keyValue: KeyWithValueCreator<K, V>): Expect<T> =
     it contains o inAny order but only entry keyValue
@@ -119,7 +119,7 @@ fun <K, V : Any> keyValue(key: K, valueAssertionCreatorOrNull: (Expect<V>.() -> 
     KeyWithValueCreator(key, valueAssertionCreatorOrNull)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains for each [KeyWithValueCreator] in [allKeyValues],
+ * Expects that the subject of `this` expectation (a [Map]) contains for each [KeyWithValueCreator] in [allKeyValues],
  * a key as defined by [KeyWithValueCreator.key] with a corresponding value which either holds all
  * assertions [KeyWithValueCreator]'s [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs
  * to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
@@ -130,7 +130,7 @@ fun <K, V : Any> keyValue(key: K, valueAssertionCreatorOrNull: (Expect<V>.() -> 
  * one [KeyWithValueCreator] in [allKeyValues] is defined as `Key('a') { isGreaterThan(0) }` and
  * another one is defined as `Key('a') { isLessThan(2) }`, then both match, even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
     allKeyValues: KeyValues<K, V>
@@ -149,37 +149,37 @@ inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.contains(
 ): Expect<T> = it contains keyValues(all.expected, *all.otherExpected)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only (in any order) for each [KeyWithValueCreator]
+ * Expects that the subject of `this` expectation (a [Map]) contains only (in any order) for each [KeyWithValueCreator]
  * in [allKeyValues], a key as defined by [KeyWithValueCreator.key] with a corresponding value which either holds all
  * assertions [KeyWithValueCreator]'s [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs
  * to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
  *
  * Delegates to `it contains o inAny order but only the keyValues`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.containsOnly(
     allKeyValues: KeyValues<K, V>
 ): Expect<T> = it contains o inAny order but only the keyValues(allKeyValues.expected, *allKeyValues.otherExpected)
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the key-value pairs of the given [mapLike].
+ * Expects that the subject of `this` expectation (a [Map]) contains the key-value pairs of the given [mapLike].
  *
  * Delegates to `it contains o inAny order entriesOf`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V : Any, T : Map<out K, V?>> Expect<T>.containsEntriesOf(
     mapLike: MapLike
 ): Expect<T> = it contains o inAny order entriesOf mapLike
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains only (in any order) the key-value pairs of
+ * Expects that the subject of `this` expectation (a [Map]) contains only (in any order) the key-value pairs of
  * the given [mapLike].
  *
  * Delegates to `it contains o inAny order but only entriesOf`
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V : Any, T : Map<out K, V?>> Expect<T>.containsOnlyEntriesOf(
     mapLike: MapLike
@@ -187,23 +187,23 @@ infix fun <K, V : Any, T : Map<out K, V?>> Expect<T>.containsOnlyEntriesOf(
 
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the given [key].
+ * Expects that the subject of `this` expectation (a [Map]) contains the given [key].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, T : Map<out K, *>> Expect<T>.containsKey(key: K): Expect<T> =
     _logicAppend { containsKey(::identity, key) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) does not contain the given [key].
+ * Expects that the subject of `this` expectation (a [Map]) does not contain the given [key].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K): Expect<T> =
     _logicAppend { containsNotKey(::identity, key) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the given [key],
+ * Expects that the subject of `this` expectation (a [Map]) contains the given [key],
  * creates an [Expect] for the corresponding value and returns the newly created assertion container,
  * so that further fluent calls are assertions about it.
  *
@@ -213,13 +213,13 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
     _logic.getExisting(::identity, key).transform()
 
 /**
- * Expects that the subject of the assertion (a [Map]) contains the given [key] and that
+ * Expects that the subject of `this` expectation (a [Map]) contains the given [key] and that
  * the corresponding value holds all assertions the given [KeyWithCreator.assertionCreator] creates for it.
  *
  * @param key Use the function `key(...) { ... }` to create a [KeyWithCreator] where the first parameter corresponds
  *  to the key and the second is the `assertionCreator`-lambda
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: KeyWithCreator<K, V>): Expect<T> =
     _logic.getExisting(::identity, key.key).collectAndAppend(key.assertionCreator)
@@ -232,7 +232,7 @@ fun <K, V> key(key: K, assertionCreator: Expect<V>.() -> Unit): KeyWithCreator<K
 
 
 /**
- * Creates an [Expect] for the property [Map.keys] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.keys] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -241,17 +241,17 @@ val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
     get() = _logic.property(Map<out K, *>::keys).transform()
 
 /**
- * Expects that the property [Map.keys] of the subject of the assertion
+ * Expects that the property [Map.keys] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
     _logic.property(Map<out K, *>::keys).collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Map.values] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.values] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -260,11 +260,11 @@ val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
     get() = _logic.property(Map<out Any?, V>::values).transform()
 
 /**
- * Expects that the property [Map.keys] of the subject of the assertion
+ * Expects that the property [Map.keys] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
     _logic.property(Map<out K, V>::values).collectAndAppend(assertionCreator)
@@ -288,28 +288,28 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
  * The transformation as such is not reflected in reporting.
  * Use `feature { f(it::entries) }` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit
 ): Expect<T> = apply { asEntries(o).addAssertionsCreatedBy(assertionCreator) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) is an empty [Map].
+ * Expects that the subject of `this` expectation (a [Map]) is an empty [Map].
  *
  * @param empty Use the pseudo-keyword `empty`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Map<*, *>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isEmpty(::toEntries) }
 
 /**
- * Expects that the subject of the assertion (a [Map]) is not an empty [Map].
+ * Expects that the subject of `this` expectation (a [Map]) is not an empty [Map].
  *
  * @param empty Use the pseudo-keyword `empty`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Map<*, *>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isNotEmpty(::toEntries) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapCollectionLikeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapCollectionLikeAssertions.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.size
 
 /**
- * Creates an [Expect] for the property [Collection.size] of the subject of the assertion,
+ * Creates an [Expect] for the property [Collection.size] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -16,11 +16,11 @@ val <T : Map<*, *>> Expect<T>.size: Expect<Int>
     get() = _logic.size(::toEntries).transform()
 
 /**
- * Expects that the property [Collection.size] of the subject of the assertion
+ * Expects that the property [Collection.size] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
@@ -4,20 +4,20 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
 
 /**
- * Expects that the property [Map.Entry.key] of the subject of the assertion
+ * Expects that the property [Map.Entry.key] of the subject of `this` expectation
  * is equal to the given [key] and the property [Map.Entry.value] is equal to the given [value].
  *
  * Kind of a shortcut for `and { key { this toBe key }; value { this toBe value } }` where `and` denotes an assertion group
  * block. Yet, the actual behaviour depends on implementation - could also be fail fast for instance or augment
  * reporting etc.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K, V>): Expect<T> =
     _logicAppend { isKeyValue(keyValuePair.first, keyValuePair.second) }
 
 /**
- * Creates an [Expect] for the property [Map.Entry.key] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.Entry.key] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -26,17 +26,17 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = _logic.key().transform()
 
 /**
- * Expects that the property [Map.Entry.key] of the subject of the assertion
+ * Expects that the property [Map.Entry.key] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.key().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Map.Entry.value] of the subject of the assertion,
+ * Creates an [Expect] for the property [Map.Entry.value] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -45,11 +45,11 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = _logic.value().transform()
 
 /**
- * Expects that the property [Map.Entry.value] of the subject of the assertion
+ * Expects that the property [Map.Entry.value] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.value().collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInAnyOrderCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInAnyOrderCreators.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  *
  * Delegates to `the pairs(keyValuePair)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -36,7 +36,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  * in [pairs] is defined as `'a' to 1` and another one is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -53,7 +53,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  *
  * Delegates to `the keyValues(keyValue)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -74,7 +74,7 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * [keyValues] is defined as `Key('a') { isGreaterThan(0) }` and another one is defined as `Key('a') { isLessThan(2) }`
  * , then both match, even though they match the same entry.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -115,7 +115,7 @@ fun <K, V : Any> keyValues(
  *
  * @param expectedMapLike The [MapLike] whose elements are expected to be contained within this [MapLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedMapLike] is not
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  *
  * Delegates to `the pairs(keyValuePair)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -33,7 +33,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
  * needs to contain only the given [keyValuePairs] where it does not matter
  * in which order they appear.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -50,7 +50,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
  *
  * Delegates to `the keyValues(keyValue)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -67,7 +67,7 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -96,7 +96,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *
  * @param expectedMapLike The [MapLike] whose elements are expected to be contained within this [MapLike].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedMapLike] is not
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInOrderOnlyCreators.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KClass
  *
  * Delegates to `the pairs(keyValuePair)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -35,7 +35,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePairs] in the specified order.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -53,7 +53,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  *
  * Delegates to `the keyValues(keyValue)`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -70,7 +70,7 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
@@ -98,7 +98,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  * [MapLikeToIterablePairTransformer] and [IterableLikeToIterableTransformer]).
  * This function expects [MapLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedMapLike] is not
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pairAssertions.kt
@@ -6,7 +6,7 @@ import ch.tutteli.atrium.logic.first
 import ch.tutteli.atrium.logic.second
 
 /**
- * Creates an [Expect] for the property [Pair.first] of the subject of the assertion,
+ * Creates an [Expect] for the property [Pair.first] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -15,17 +15,17 @@ val <K, T : Pair<K, *>> Expect<T>.first: Expect<K>
     get() = _logic.first().transform()
 
 /**
- * Expects that the property [Pair.first] of the subject of the assertion
+ * Expects that the property [Pair.first] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Pair<K, V>> Expect<T>.first(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.first().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [Pair.second] of the subject of the assertion,
+ * Creates an [Expect] for the property [Pair.second] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -34,11 +34,11 @@ val <V, T : Pair<*, V>> Expect<T>.second: Expect<V>
     get() = _logic.second().transform()
 
 /**
- * Expects that the property [Pair.second] of the subject of the assertion
+ * Expects that the property [Pair.second] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <K, V, T : Pair<K, V>> Expect<T>.second(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.second().collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
@@ -17,13 +17,13 @@ infix fun <E, T : Sequence<E>> Expect<T>.asIterable(
 ): Expect<Iterable<E>> = _logic.changeSubject.unreported { it.asIterable() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [Iterable].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature of({ f(it::asIterable) }, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
     apply { asIterable(o).addAssertionsCreatedBy(assertionCreator) }
@@ -43,13 +43,13 @@ infix fun <E, T : Sequence<E>> Expect<T>.asList(
 ): Expect<List<E>> = _logic.changeSubject.unreported { it.toList() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [List].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature of({ f(it::toList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableAssertions.kt
@@ -9,39 +9,39 @@ import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import kotlin.reflect.KClass
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null,
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null,
  * creates an [Expect] for it and returns it.
  *
- * @return The newly created [Expect] for the property [Throwable.message] of the subject of the assertion.
+ * @return The newly created [Expect] for the property [Throwable.message] of the subject of `this` expectation.
  */
 val <T : Throwable> Expect<T>.message: Expect<String>
     get() = it feature Throwable::message notToBeNull o
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null and
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null and
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Throwable> Expect<T>.message(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
     it feature of(Throwable::message) { it notToBeNull assertionCreator }
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null and contains
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null and contains
  * [expected]'s [toString] representation using a non disjoint search.
  **
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed.
  * This function expects [CharSequenceOrNumberOrChar] (which is a typealias for [Any]) for your convenience,
  * so that you can mix [String] and [Int] for instance.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Throwable> Expect<T>.messageContains(expected: CharSequenceOrNumberOrChar): Expect<T> =
     this messageContains values(expected)
 
 /**
- * Expects that the property [Throwable.message] of the subject of the assertion is not null and contains
+ * Expects that the property [Throwable.message] of the subject of `this` expectation is not null and contains
  * [values]'s [toString] representation using a non disjoint search.
  **
  * Notice that a runtime check applies which assures that only [CharSequence], [Number] and [Char] are passed
@@ -50,7 +50,7 @@ infix fun <T : Throwable> Expect<T>.messageContains(expected: CharSequenceOrNumb
  * @param values The values which are expected to be contained within [Throwable.message]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <T : Throwable> Expect<T>.messageContains(values: Values<Any>): Expect<T> =
     message { contains(values) }
@@ -59,7 +59,7 @@ infix fun <T : Throwable> Expect<T>.messageContains(values: Values<Any>): Expect
  * Expects that the property [Throwable.cause] of the subject *is a* [TExpected] (the same type or a sub-type),
  * creates an [Expect] of the [TExpected] type for it and returns it.
  *
- * @return The newly created [Expect] for the property [Throwable.cause] of the subject of the assertion
+ * @return The newly created [Expect] for the property [Throwable.cause] of the subject of `this` expectation
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/workaround/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/workaround/anyAssertions.kt
@@ -19,7 +19,7 @@ import ch.tutteli.atrium.creating.Expect
  * Note that this workaround will be removed in some minor version after a major version with Kotlin 1.4 support
  * (most likely with Atrium v1.1.0 where Atrium v1.0.0 requires Kotlin 1.4)
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  */
 @Suppress("NOTHING_TO_INLINE" /* inline so that one does not actually call `it` on binary level */)
 inline infix fun <T> Expect<T>.it(noinline assertionCreator: Expect<T>.() -> Unit): Expect<T> = and(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/bigDecimalAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/bigDecimalAssertions.kt
@@ -46,9 +46,9 @@ infix fun <T : BigDecimal?> Expect<T>.toBe(expected: T): Nothing = throw PleaseU
 )
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is `null`.
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is `null`.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
 
  */
 @JvmName("toBeNull")
@@ -78,7 +78,7 @@ infix fun <T : BigDecimal> Expect<T>.notToBe(expected: T): Nothing = throw Pleas
 )
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is numerically equal to [expected].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is numerically equal to [expected].
  *
  * By numerically is meant that it will not compare [BigDecimal.scale] (or in other words,
  * it uses `compareTo(expected) == 0`)
@@ -89,14 +89,14 @@ infix fun <T : BigDecimal> Expect<T>.notToBe(expected: T): Nothing = throw Pleas
  * - `expect(BigDecimal("10")).isEqualIncludingScale(BigDecimal("10.0"))` does not hold.
  * - `expect(BigDecimal("10")).isNumericallyEqualTo(BigDecimal("10.0"))` holds.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
 
  */
 infix fun <T : BigDecimal> Expect<T>.isNumericallyEqualTo(expected: T): Expect<T> =
     _logicAppend { isNumericallyEqualTo(expected) }
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is not numerically equal to [expected].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is not numerically equal to [expected].
  *
  * By numerically is meant that it will not compare [BigDecimal.scale] (or in other words,
  * it uses `compareTo(expected) != 0`)
@@ -107,7 +107,7 @@ infix fun <T : BigDecimal> Expect<T>.isNumericallyEqualTo(expected: T): Expect<T
  * - `expect(BigDecimal("10")).isNotEqualIncludingScale(BigDecimal("10.0"))` holds.
  * - `expect(BigDecimal("10")).isNotNumericallyEqualTo(BigDecimal("10.0"))`  does not hold.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
 
  */
 infix fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T): Expect<T> =
@@ -115,7 +115,7 @@ infix fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T): Expec
 
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is equal to [expected] including [BigDecimal.scale].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is equal to [expected] including [BigDecimal.scale].
  *
  * Most of the time you want to use [isNumericallyEqualTo] which does not compare [BigDecimal.scale]
  * in contrast to this function.
@@ -123,14 +123,14 @@ infix fun <T : BigDecimal> Expect<T>.isNotNumericallyEqualTo(expected: T): Expec
  * - `expect(BigDecimal("10")).isEqualIncludingScale(BigDecimal("10.0"))` does not hold.
  * - `expect(BigDecimal("10")).isNumericallyEqualTo(BigDecimal("10.0"))` holds.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
 
  */
 infix fun <T : BigDecimal> Expect<T>.isEqualIncludingScale(expected: T): Expect<T> =
     _logicAppend { isEqualIncludingScale(expected, this::isNumericallyEqualTo.name) }
 
 /**
- * Expects that the subject of the assertion (a [BigDecimal]) is not equal to [expected] including [BigDecimal.scale].
+ * Expects that the subject of `this` expectation (a [BigDecimal]) is not equal to [expected] including [BigDecimal.scale].
  *
  * Most of the time you want to use [isNotNumericallyEqualTo] which does not compare [BigDecimal.scale]
  * in contrast to this function.
@@ -138,7 +138,7 @@ infix fun <T : BigDecimal> Expect<T>.isEqualIncludingScale(expected: T): Expect<
  * - `expect(BigDecimal("10")).isNotEqualIncludingScale(BigDecimal("10.0"))` holds.
  * - `expect(BigDecimal("10")).isNotNumericallyEqualTo(BigDecimal("10.0"))`  does not hold.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
 
  */
 infix fun <T : BigDecimal> Expect<T>.isNotEqualIncludingScale(expected: T): Expect<T> =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoLocalDateAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoLocalDateAssertions.kt
@@ -10,10 +10,10 @@ import ch.tutteli.atrium.logic.*
 import java.time.chrono.ChronoLocalDate
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -21,10 +21,10 @@ infix fun <T : ChronoLocalDate> Expect<T>.isBefore(expected: ChronoLocalDate): E
     _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before or equal the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -32,10 +32,10 @@ infix fun <T : ChronoLocalDate> Expect<T>.isBeforeOrEqual(expected: ChronoLocalD
     _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -43,10 +43,10 @@ infix fun <T : ChronoLocalDate> Expect<T>.isAfter(expected: ChronoLocalDate): Ex
     _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after or equal the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -54,10 +54,10 @@ infix fun <T : ChronoLocalDate> Expect<T>.isAfterOrEqual(expected: ChronoLocalDa
     _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is equal to the [expected] [ChronoLocalDate].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -65,11 +65,11 @@ infix fun <T : ChronoLocalDate> Expect<T>.isEqual(expected: ChronoLocalDate): Ex
     _logicAppend { isEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -77,11 +77,11 @@ infix fun <T : ChronoLocalDate> Expect<T>.isBefore(expected: String): Expect<T> 
     _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is before or equal the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -89,11 +89,11 @@ infix fun <T : ChronoLocalDate> Expect<T>.isBeforeOrEqual(expected: String): Exp
     _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -101,11 +101,11 @@ infix fun <T : ChronoLocalDate> Expect<T>.isAfter(expected: String): Expect<T> =
     _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is after or equal the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -113,11 +113,11 @@ infix fun <T : ChronoLocalDate> Expect<T>.isAfterOrEqual(expected: String): Expe
     _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDate])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDate])
  * is equal to the [expected] [java.time.LocalDate] given as [String].
  * The [expected] parameter needs to be in the form of **yyyy-mm-dd** or else a [java.time.DateTimeException] will be thrown.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoLocalDateTimeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoLocalDateTimeAssertions.kt
@@ -12,10 +12,10 @@ import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoLocalDateTime
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -24,10 +24,10 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before or equal the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -36,10 +36,10 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is after the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -48,10 +48,10 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is after or equal the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -60,10 +60,10 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is equal to the [expected] [ChronoLocalDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -72,7 +72,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
 ): Expect<T> = _logicAppend { isEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a
@@ -82,7 +82,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -91,7 +91,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a
@@ -101,7 +101,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -110,7 +110,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a date
@@ -120,7 +120,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -129,7 +129,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a date
@@ -139,7 +139,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -148,7 +148,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoLocalDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoLocalDateTime])
  * is before the [expected] [LocalDateTime] given as [String] in (modified) ISO 8601 format.
  * The string will be converted to a LocalDateTime according to ISO 8601 but with a slight deviation.
  * The alternative notation (e.g. 20200401120001 instead of 2020-04-01T12:00:01) is not supported and we accept a date
@@ -158,7 +158,7 @@ infix fun <T : ChronoLocalDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
  * yyyy-mm-ddThh:mm
  * yyyy-mm-dd
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeAssertions.kt
@@ -11,10 +11,10 @@ import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoZonedDateTime
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -23,10 +23,10 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -35,10 +35,10 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is after the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -47,10 +47,10 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is after or equal the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -59,10 +59,10 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is equal to the [expected] [ChronoZonedDateTime].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -71,7 +71,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
 ): Expect<T> = _logicAppend { isEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -95,7 +95,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isEqual(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -104,7 +104,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
 ): Expect<T> = _logicAppend { isBefore(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -128,7 +128,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBefore(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -137,7 +137,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
 ): Expect<T> = _logicAppend { isBeforeOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -161,7 +161,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isBeforeOrEqu
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -170,7 +170,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
 ): Expect<T> = _logicAppend { isAfter(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -194,7 +194,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfter(
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -203,7 +203,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
 ): Expect<T> = _logicAppend { isAfterOrEqual(expected) }
 
 /**
- * Expects that the subject of the assertion (a [ChronoZonedDateTime])
+ * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
  * is before or equals the [expected] [ChronoZonedDateTime] given as [String].
  *
  * The format is composed of {DateTime}{ZoneDesignator}.
@@ -227,7 +227,7 @@ infix fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.isAfterOrEqua
  * - 2020-01-02Z
  * - 2020-01-02+01:30
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fileAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fileAssertions.kt
@@ -25,13 +25,13 @@ infix fun <T : File> Expect<T>.asPath(@Suppress("UNUSED_PARAMETER") o: o): Expec
     _logic.changeSubject.unreported { it.toPath() }
 
 /**
- * Expects that the subject of the assertion holds all assertions the given [assertionCreator] creates for
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
  * the subject as [Path].
  *
  * The transformation as such is not reflected in reporting.
  * Use `feature of(File::toPath, assertionCreator)` if you want to show the transformation in reporting.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateAssertions.kt
@@ -11,7 +11,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 
 /**
- * Creates an [Expect] for the property [LocalDate.year][LocalDate.getYear] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.year][LocalDate.getYear] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -22,11 +22,11 @@ val Expect<LocalDate>.year: Expect<Int>
     get() = _logic.year().transform()
 
 /**
- * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of the assertion
+ * Expects that the property [LocalDate.year][LocalDate.getYear]of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -34,7 +34,7 @@ infix fun Expect<LocalDate>.year(assertionCreator: Expect<Int>.() -> Unit): Expe
     _logic.year().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -45,11 +45,11 @@ val Expect<LocalDate>.month: Expect<Int>
     get() = _logic.month().transform()
 
 /**
- * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of the assertion
+ * Expects that the property [LocalDate.monthValue][LocalDate.getMonthValue] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -57,7 +57,7 @@ infix fun Expect<LocalDate>.month(assertionCreator: Expect<Int>.() -> Unit): Exp
     _logic.month().collectAndAppend(assertionCreator)
 
 /**
- * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.getDayOfWeek] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -68,11 +68,11 @@ val Expect<LocalDate>.dayOfWeek: Expect<DayOfWeek>
     get() = _logic.dayOfWeek().transform()
 
 /**
- * Expects that the property [LocalDate.getDayOfWeek] of the subject of the assertion
+ * Expects that the property [LocalDate.getDayOfWeek] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -81,7 +81,7 @@ infix fun Expect<LocalDate>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.() -> 
 
 
 /**
- * Creates an [Expect] for the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -92,11 +92,11 @@ val Expect<LocalDate>.day: Expect<Int>
     get() = _logic.day().transform()
 
 /**
- * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of the assertion
+ * Expects that the property [LocalDate.dayOfMonth][LocalDate.getDayOfMonth] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateTimeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/localDateTimeAssertions.kt
@@ -11,7 +11,7 @@ import java.time.DayOfWeek
 import java.time.LocalDateTime
 
 /**
- * Creates an [Expect] for the property [LocalDateTime.year][[LocalDateTime.getYear] of the subject of the assertion,
+ * Creates an [Expect] for the property [LocalDateTime.year][[LocalDateTime.getYear] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -22,11 +22,11 @@ val Expect<LocalDateTime>.year: Expect<Int>
     get() = _logic.year().transform()
 
 /**
- * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of the assertion
+ * Expects that the property [LocalDateTime.year][LocalDateTime.getYear] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -35,7 +35,7 @@ infix fun Expect<LocalDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): 
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -45,11 +45,11 @@ val Expect<LocalDateTime>.month: Expect<Int>
     get() = _logic.month().transform()
 
 /**
- * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of the assertion
+ * Expects that the property [LocalDateTime.monthValue][LocalDateTime.getMonthValue]of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -58,7 +58,7 @@ infix fun Expect<LocalDateTime>.month(assertionCreator: Expect<Int>.() -> Unit):
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -68,11 +68,11 @@ val Expect<LocalDateTime>.dayOfWeek: Expect<DayOfWeek>
     get() = _logic.dayOfWeek().transform()
 
 /**
- * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of the assertion
+ * Expects that the property [LocalDateTime.dayOfWeek][LocalDateTime.getDayOfWeek]of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -81,7 +81,7 @@ infix fun Expect<LocalDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.()
 
 /**
  * Creates an [Expect] for the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -91,11 +91,11 @@ val Expect<LocalDateTime>.day: Expect<Int>
     get() = _logic.day().transform()
 
 /**
- * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of the assertion
+ * Expects that the property [LocalDateTime.dayOfMonth][LocalDateTime.getDayOfMonth] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalAssertions.kt
@@ -15,12 +15,12 @@ import ch.tutteli.atrium.logic.isPresent
 import java.util.*
 
 /**
- * Expects that the subject of the assertion (an [Optional]) is empty (not present).
+ * Expects that the subject of `this` expectation (an [Optional]) is empty (not present).
  *
  * Shortcut for more or less something like `feature(Optional<T>::isEmpty) { toBe(true) }`
  * depends on the underlying implementation though.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -28,7 +28,7 @@ infix fun <T : Optional<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: 
     _logicAppend { isEmpty() }
 
 /**
- * Expects that the subject of the assertion (an [Optional]) is present
+ * Expects that the subject of `this` expectation (an [Optional]) is present
  * and returns an [Expect] for the inner type [E].
  *
  * Shortcut for more or less something like `feature(Optional<T>::get)` but with error handling; yet it
@@ -42,10 +42,10 @@ infix fun <E, T : Optional<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") pres
     _logic.isPresent().transform()
 
 /**
- * Expects that the subject of the assertion (an [Optional]) is present and
+ * Expects that the subject of `this` expectation (an [Optional]) is present and
  * that it holds all assertions the given [PresentWithCreator.assertionCreator] creates.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -15,9 +15,9 @@ import java.nio.charset.Charset
 import java.nio.file.Path
 
 /**
- * Expects that the subject of the assertion (a [Path]) starts with the [expected] [Path].
+ * Expects that the subject of `this` expectation (a [Path]) starts with the [expected] [Path].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -25,9 +25,9 @@ infix fun <T : Path> Expect<T>.startsWith(expected: Path): Expect<T> =
     _logicAppend { startsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not start with the [expected] [Path].
+ * Expects that the subject of `this` expectation (a [Path]) does not start with the [expected] [Path].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -35,9 +35,9 @@ infix fun <T : Path> Expect<T>.startsNotWith(expected: Path): Expect<T> =
     _logicAppend { startsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) ends with the expected [Path].
+ * Expects that the subject of `this` expectation (a [Path]) ends with the expected [Path].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -45,10 +45,10 @@ infix fun <T : Path> Expect<T>.endsWith(expected: Path): Expect<T> =
     _logicAppend { endsWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not end with the expected [Path];
+ * Expects that the subject of `this` expectation (a [Path]) does not end with the expected [Path];
  *
  * @param expected The [Path] provided to the assertion
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -56,13 +56,13 @@ infix fun <T : Path> Expect<T>.endsNotWith(expected: Path): Expect<T> =
     _logicAppend { endsNotWith(expected) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) exists;
+ * Expects that the subject of `this` expectation (a [Path]) exists;
  * meaning that there is a file system entry at the location the [Path] points to.
  *
  * This assertion _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -70,13 +70,13 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") existing: exis
     _logicAppend { exists() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) does not exist;
+ * Expects that the subject of `this` expectation (a [Path]) does not exist;
  * meaning that there is no file system entry at the location the [Path] points to.
  *
  * This assertion _resolves_ symbolic links. Therefore, if a symbolic link exists at the location the subject points to,
  * then the search will continue at that location.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -85,7 +85,7 @@ infix fun <T : Path> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") existing: e
 
 /**
  * Creates an [Expect] for the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -97,11 +97,11 @@ val <T : Path> Expect<T>.fileName: Expect<String>
 
 /**
  * Expects that the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -110,7 +110,7 @@ infix fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> U
 
 /**
  * Creates an [Expect] for the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -123,10 +123,10 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
 /**
  * Expects that the property [Path.fileNameWithoutExtension][ch.tutteli.niok.fileNameWithoutExtension]
  * (provided via [niok](https://github.com/robstoll/niok))
- * of the subject of the assertion holds all assertions the given [assertionCreator] creates for it
- * and returns an [Expect] for the current subject of the assertion.
+ * of the subject of `this` expectation holds all assertions the given [assertionCreator] creates for it
+ * and returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -146,9 +146,9 @@ val <T : Path> Expect<T>.parent: Expect<Path>
 
 /**
  * Expects that this [Path] has a [parent][Path.getParent], that the parent holds all assertions the
- * given [assertionCreator] creates for it and returns an [Expect] for the current subject of the assertion.
+ * given [assertionCreator] creates for it and returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -167,7 +167,7 @@ infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
     _logic.resolve(other).transform()
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a directory having the provided [entry].
+ * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided [entry].
  * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
  * Furthermore, the argument string resolved against the subject yields an existing file system entry.
  *
@@ -180,7 +180,7 @@ infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
  * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @see [has]
  *
  * @since 0.14.0
@@ -189,7 +189,7 @@ infix fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String) =
     _logicAppend { hasDirectoryEntry(listOf(entry)) }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a directory having the provided entries.
+ * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided entries.
  * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
  * Furthermore, every argument string resolved against the subject yields an existing file system entry.
  *
@@ -202,7 +202,7 @@ infix fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String) =
  * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  * @see [directoryEntries]
  * @see [hasDirectoryEntry]
  *
@@ -221,7 +221,7 @@ fun directoryEntries(entry: String, vararg otherEntries: String) = DirectoryEntr
 /**
  * Expects that [PathWithCreator.path] resolves against this [Path], that the resolved [Path] holds all assertions the
  * given [PathWithCreator.assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
  *  Use the function `path(String) { ... }` to create a [PathWithCreator].
  *
@@ -239,7 +239,7 @@ fun <E> path(path: String, assertionCreator: Expect<E>.() -> Unit): PathWithCrea
     PathWithCreator(path, assertionCreator)
 
 /**
- * Expects that the subject of the assertion (a [Path]) is readable;
+ * Expects that the subject of `this` expectation (a [Path]) is readable;
  * meaning that there is a file system entry at the location the [Path] points to and
  * that the current thread has the permission to read from it.
  *
@@ -251,7 +251,7 @@ fun <E> path(path: String, assertionCreator: Expect<E>.() -> Unit): PathWithCrea
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -259,7 +259,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") readable: read
     _logicAppend { isReadable() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is writable;
+ * Expects that the subject of `this` expectation (a [Path]) is writable;
  * meaning that there is a file system entry at the location the [Path] points to and
  * that the current thread has the permission to write to it.
  *
@@ -267,7 +267,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") readable: read
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -275,7 +275,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") writable: writ
     _logicAppend { isWritable() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is executable;
+ * Expects that the subject of `this` expectation (a [Path]) is executable;
  * meaning that there is a file system entry at the location the [Path] points to and
  * that the current thread has the permission to execute it.
  *
@@ -287,7 +287,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") writable: writ
  * Therefore, if a symbolic link exists at the location the subject points to, search will continue
  * at the location the link points at.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -295,7 +295,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") executable: ex
     _logicAppend { isExecutable() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a file;
+ * Expects that the subject of `this` expectation (a [Path]) is a file;
  * meaning that there is a file system entry at the location the [Path] points to and that is a regular file.
  *
  * This assertion _resolves_ symbolic links.
@@ -306,7 +306,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") executable: ex
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -314,7 +314,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aRegularFile: 
     _logicAppend { isRegularFile() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a directory;
+ * Expects that the subject of `this` expectation (a [Path]) is a directory;
  * meaning that there is a file system entry at the location the [Path] points to and that is a directory.
  *
  * This assertion _resolves_ symbolic links.
@@ -325,7 +325,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aRegularFile: 
  * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
  * take place.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -333,10 +333,10 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aDirectory: aD
     _logicAppend { isDirectory() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is an absolute path;
+ * Expects that the subject of `this` expectation (a [Path]) is an absolute path;
  * meaning that the [Path] specified in this instance starts at the file system root.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -344,10 +344,10 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") absolute: abso
     _logicAppend { isAbsolute() }
 
 /**
- * Expects that the subject of the assertion (a [Path]) is a relative path;
+ * Expects that the subject of `this` expectation (a [Path]) is a relative path;
  * meaning that the [Path] specified in this instance does not start at the file system root.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
  */
@@ -357,7 +357,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") relative: rela
 
 /**
  * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion,
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -369,11 +369,11 @@ val <T : Path> Expect<T>.extension: Expect<String>
 
 /**
  * Expects that the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of the assertion
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -381,10 +381,10 @@ infix fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> 
     _logic.extension().collectAndAppend(assertionCreator)
 
 /**
- * Expects that the subject of the assertion (a [Path]) has the same textual content
+ * Expects that the subject of `this` expectation (a [Path]) has the same textual content
  * as [targetPath] (using UTF-8 for encoding)
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -408,12 +408,12 @@ fun withEncoding(
     )
 
 /**
- * Expects that the subject of the assertion (a [Path]) has the same textual content
+ * Expects that the subject of `this` expectation (a [Path]) has the same textual content
  * as [PathWithEncoding.path] in the given [pathWithEncoding] with the specified encodings.
  *
  *  Use the function `withEncoding(Path, Charset, Charset)` to create a [PathWithEncoding].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */
@@ -423,10 +423,10 @@ infix fun <T : Path> Expect<T>.hasSameTextualContentAs(pathWithEncoding: PathWit
     }
 
 /**
- * Expects that the subject of the assertion (a [Path]) has the same binary content
+ * Expects that the subject of `this` expectation (a [Path]) has the same binary content
  * as [targetPath].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.13.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/zonedDateTimeAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/zonedDateTimeAssertions.kt
@@ -11,7 +11,7 @@ import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
 /**
- * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion,
+ * Creates an [Expect] for the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
@@ -22,11 +22,11 @@ val Expect<ZonedDateTime>.year: Expect<Int>
     get() = _logic.year().transform()
 
 /**
- * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of the assertion
+ * Expects that the property [ZonedDateTime.year][ZonedDateTime.getYear] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -35,7 +35,7 @@ infix fun Expect<ZonedDateTime>.year(assertionCreator: Expect<Int>.() -> Unit): 
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -45,11 +45,11 @@ val Expect<ZonedDateTime>.month: Expect<Int>
     get() = _logic.month().transform()
 
 /**
- * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of the assertion
+ * Expects that the property [ZonedDateTime.monthValue][ZonedDateTime.getMonthValue] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -58,7 +58,7 @@ infix fun Expect<ZonedDateTime>.month(assertionCreator: Expect<Int>.() -> Unit):
 
 /**
  * Creates an [Expect] for the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -68,11 +68,11 @@ val Expect<ZonedDateTime>.dayOfWeek: Expect<DayOfWeek>
     get() = _logic.dayOfWeek().transform()
 
 /**
- * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of the assertion
+ * Expects that the property [ZonedDatetime.dayOfWeek][ZonedDateTime.getDayOfWeek] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -81,7 +81,7 @@ infix fun Expect<ZonedDateTime>.dayOfWeek(assertionCreator: Expect<DayOfWeek>.()
 
 /**
  * Creates an [Expect] for the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth]
- * of the subject of the assertion, so that further fluent calls are assertions about it.
+ * of the subject of `this` expectation, so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
@@ -91,11 +91,11 @@ val Expect<ZonedDateTime>.day: Expect<Int>
     get() = _logic.day().transform()
 
 /**
- * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of the assertion
+ * Expects that the property [ZonedDateTime.dayOfMonth][ZonedDateTime.getDayOfMonth] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of the assertion.
+ * returns an [Expect] for the current subject of `this` expectation.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/resultAssertions.kt
+++ b/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/resultAssertions.kt
@@ -8,7 +8,7 @@ import ch.tutteli.atrium.logic.kotlin_1_3.isFailureOfType
 import ch.tutteli.atrium.logic.kotlin_1_3.isSuccess
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Success
+ * Expects that the subject of `this` expectation (a [Result]) is a Success
  * and returns an [Expect] for the inner type [E].
  *
  * @return The newly created [Expect] if the given assertion is success
@@ -19,12 +19,12 @@ infix fun <E, T : Result<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") succes
     _logic.isSuccess().transform()
 
 /**
- * Expects that the subject of the assertion (a [Result]]) is a Success and
+ * Expects that the subject of `this` expectation (a [Result]]) is a Success and
  * that it holds all assertions the given [SuccessWithCreator.assertionCreator] creates.
  *
  * Use the function `success { ... }` to create a [SuccessWithCreator].
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.12.0
  */
@@ -32,7 +32,7 @@ infix fun <E, T : Result<E>> Expect<T>.toBe(success: SuccessWithCreator<E>): Exp
     _logic.isSuccess().collectAndAppend(success.assertionCreator)
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Failure and
+ * Expects that the subject of `this` expectation (a [Result]) is a Failure and
  * that it encapsulates an exception of type [TExpected].
  *
  * @return An [Expect] with the new type [TExpected]
@@ -43,7 +43,7 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.isFailure(): Ex
     _logic.isFailureOfType(TExpected::class).transform()
 
 /**
- * Expects that the subject of the assertion (a [Result]) is a Failure,
+ * Expects that the subject of `this` expectation (a [Result]) is a Failure,
  * it encapsulates an exception of type [TExpected] and that the exception
  * holds all assertions the given [assertionCreator] creates.
  *

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/assertions/builders/SubjectBasedOption.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/assertions/builders/SubjectBasedOption.kt
@@ -1,19 +1,19 @@
 package ch.tutteli.atrium.assertions.builders
 
 /**
- * Contract for sub option steps which are based on a defined or absent subject of the assertion.
+ * Contract for sub option steps which are based on a defined or absent subject of the expectation.
  */
 interface SubjectBasedOption {
 
     /**
      * Sub option step in case the subject is defined.
      *
-     * @param T The type of the subject of the assertion
+     * @param T The type of the subject of the expectation
      * @param R The resulting type which should be created.
      */
     interface DefinedOption<T, R, AO : AbsentOption<T, R>> {
         /**
-         * Defines the failure hint factory which should be used if the subject of the assertion is defined.
+         * Defines the failure hint factory which should be used if the subject of the expectation is defined.
          */
         fun ifDefined(failureHintFactory: (T) -> R): AO
     }
@@ -21,17 +21,17 @@ interface SubjectBasedOption {
     /**
      * Sub option step in case the subject is absent
      *
-     * @param T The type of the subject of the assertion
+     * @param T The type of the subject of the expectation
      * @param R The resulting type which should be created.
      */
     interface AbsentOption<T, R> {
         /**
-         * The previously defined factory in case the subject of the assertion is defined.
+         * The previously defined factory in case the subject of the expectation is defined.
          */
         val ifDefined: (T) -> R
 
         /**
-         * Defines the failure hint factory which should be used if the subject of the assertion is not defined.
+         * Defines the failure hint factory which should be used if the subject of the expectation is not defined.
          */
         infix fun ifAbsent(failureHintFactory: () -> R): Pair<() -> R, (T) -> R> =
             failureHintFactory to ifDefined

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/assertions/builders/descriptiveWithFailureHint.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/assertions/builders/descriptiveWithFailureHint.kt
@@ -22,7 +22,7 @@ fun Descriptive.DescriptionOption<Descriptive.FinalStep>.withFailureHint(
 
 /**
  * Option to create a [DescriptiveAssertion] like assertion with an additional hint
- * which is based on the subject of the assertion and
+ * which is based on the subject of the expectation and
  * which is only shown the subject is defined.
  *
  * You can use [withFailureHintBasedOnSubject] in case you want to:
@@ -30,7 +30,7 @@ fun Descriptive.DescriptionOption<Descriptive.FinalStep>.withFailureHint(
  * - do not show the hint in certain cases even if the subject is defined
  *
  * Or use [withFailureHint] which does not expect a [subjectProvider] in case your [DescriptiveAssertion] is not based
- * on the subject of the assertion.
+ * on the subject of the expectation.
  */
 //TODO if we introduce Record or something else as replacement for Assertion then not but if we keep Assertion
 // then move to logic and expect AssertionContainer with 0.16.0
@@ -51,11 +51,11 @@ fun <T> Descriptive.DescriptionOption<Descriptive.FinalStep>.withFailureHintBase
 
 /**
  * Option to create a [DescriptiveAssertion] like assertion with an additional hint
- * (which is based on the subject of the assertion)
+ * (which is based on the subject of the expectation)
  * which might be shown if the [Descriptive.DescriptionOption.test] fails.
  *
  * You can use [withFailureHint] which does not expect a [subjectProvider] in case your [DescriptiveAssertion] is not based
- * on the subject of the assertion.
+ * on the subject of the expectation.
  */
 fun <T> Descriptive.DescriptionOption<Descriptive.FinalStep>.withFailureHintBasedOnSubject(
     @Suppress("DEPRECATION") subjectProvider: ch.tutteli.atrium.creating.SubjectProvider<T>,
@@ -76,7 +76,7 @@ fun <T> Descriptive.DescriptionOption<Descriptive.FinalStep>.withFailureHintBase
 interface DescriptiveAssertionWithFailureHint {
 
     /**
-     * Sub Option step to define a failure hint based on a defined subject of the assertion.
+     * Sub Option step to define a failure hint based on a defined subject of the expectation.
      */
     interface FailureHintSubjectDefinedOption<T> :
         SubjectBasedOption.DefinedOption<T, Assertion, FailureHintSubjectAbsentOption<T>> {
@@ -87,7 +87,7 @@ interface DescriptiveAssertionWithFailureHint {
     }
 
     /**
-     * Sub Option step to define a failure hint in case the subject of the assertion is not defined.
+     * Sub Option step to define a failure hint in case the subject of the expectation is not defined.
      */
     interface FailureHintSubjectAbsentOption<T> : SubjectBasedOption.AbsentOption<T, Assertion> {
 
@@ -132,7 +132,7 @@ interface DescriptiveAssertionWithFailureHint {
 
         /**
          * Defines that the failure hint shall only be shown based on a predicate influenced by the
-         * subject of the assertion.
+         * subject of the expectation.
          *
          * You can use the other overload without [subjectProvider] in case the predicate is not based on the subject
          * of the assertion.
@@ -153,7 +153,7 @@ interface DescriptiveAssertionWithFailureHint {
     }
 
     /**
-     * Sub Option step to define a failure hint based on a defined subject of the assertion.
+     * Sub Option step to define a failure hint based on a defined subject of the expectation.
      */
     interface ShowSubjectDefinedOption<T> : SubjectBasedOption.DefinedOption<T, Boolean, ShowSubjectAbsentOption<T>> {
 
@@ -163,7 +163,7 @@ interface DescriptiveAssertionWithFailureHint {
     }
 
     /**
-     * Sub Option step to define a failure hint in case the subject of the assertion is not defined.
+     * Sub Option step to define a failure hint in case the subject of the expectation is not defined.
      */
     interface ShowSubjectAbsentOption<T> : SubjectBasedOption.AbsentOption<T, Boolean> {
 

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
  *
  * Note, do not use [SubjectProvider] as this interface will be removed with 0.17.0.
  *
- * @param T The type of the subject of the assertion.
+ * @param T The type of the subject of `this` expectation.
  */
 interface AssertionContainer<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
     /**
@@ -39,7 +39,7 @@ interface AssertionContainer<T> : @kotlin.Suppress("DEPRECATION") SubjectProvide
 //     *
 //     * @param assertion The assertion which will be appended to this container.
 //     *
-//     * @return An [Expect] for the current subject of the assertion.
+//     * @return an [Expect] for the subject of `this` expectation.
 //     *
 //     * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately evaluated.
 //     */

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
@@ -40,7 +40,7 @@ interface ExpectInternal<T> : Expect<T>, AssertionContainer<T>{
  *
  * Note, do not use [SubjectProvider] as this interface is only temporary and will be removed with 0.17.0.
  *
- * @param T The type of the subject of the assertion.
+ * @param T The type of the subject of `this` expectation.
  */
 @Suppress("DEPRECATION")
 @ExpectMarker
@@ -63,7 +63,7 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      *
      * @param assertionCreator The receiver function which should create and add assertions to this container.
      *
-     * @return An [Expect] for the current subject of the assertion.
+     * @return an [Expect] for the subject of `this` expectation.
      */
     //TODO 0.16.0 move to AssertionContainer / RecordContainer and deprecate
     fun addAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): Expect<T>
@@ -73,7 +73,7 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      *
      * @param assertion The assertion which will be added to this container.
      *
-     * @return An [Expect] for the current subject of the assertion.
+     * @return an [Expect] for the subject of `this` expectation.
      */
     //TODO 0.16.0 move to AssertionContainer / RecordContainer and deprecate
     override fun addAssertion(assertion: Assertion): Expect<T>
@@ -87,7 +87,7 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      * @param expected The expected value, e.g., `5`
      * @param test Indicates whether the assertion holds or fails.
      *
-     * @return An [Expect] for the current subject of the assertion.
+     * @return an [Expect] for the subject of `this` expectation.
      */
     //TODO 0.16.0 move to AssertionContainer / RecordContainer and deprecate
     fun createAndAddAssertion(description: String, expected: Any?, test: (T) -> Boolean): Expect<T> =
@@ -101,7 +101,7 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      * @param expected The expected value, e.g., `5`
      * @param test Indicates whether the assertion holds or fails.
      *
-     * @return An [Expect] for the current subject of the assertion.
+     * @return an [Expect] for the subject of `this` expectation.
      */
     //TODO 0.16.0 move to AssertionContainer / RecordContainer and deprecate
     fun createAndAddAssertion(description: Translatable, expected: Any?, test: (T) -> Boolean): Expect<T> =

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/Contains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/Contains.kt
@@ -22,7 +22,7 @@ interface Contains {
     interface EntryPointStep<T : Any, out S : SearchBehaviour>
 
     /**
-     * The entry point of the contract, containing the [container] -- i.e. the subject of the assertion
+     * The entry point of the contract, containing the [container] -- i.e. the subject of this expectation
      * for which the sophisticated `contain` assertion should be created -- as well as the chosen [searchBehaviour].
      *
      * The [searchBehaviour] might me modified in which case it is recommended that a new [EntryPointStep] is created (retain
@@ -97,7 +97,7 @@ interface Contains {
      * Represents the final step of a sophisticated `contains` assertion builder which creates the [AssertionGroup]
      * as such.
      *
-     * @param T The type of the subject of the assertion.
+     * @param T The type of the subject of this expectation.
      * @param SC The type of the search criteria.
      */
     interface Creator<T, in SC> {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
@@ -11,8 +11,8 @@ import ch.tutteli.atrium.reporting.translating.Translatable
 /**
  * Represents the base class for [Contains.Creator]s, providing a template to fulfill its job.
  *
- * @param T The type of the subject of the assertion.
- * @param TT The type of the subject of the assertion after making it multiple times consumable.
+ * @param T The type of the subject of this expectation.
+ * @param TT The type of the subject of this expectation after making it multiple times consumable.
  * @param SC The type of the search criteria.
  * @param C The type of the checkers in use (typically a sub interface of [Contains.Checker]).
  *
@@ -54,12 +54,12 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
     protected abstract fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<TT>
 
     /**
-     * Searches for something fulfilling the given [searchCriterion] in the subject of the assertion associated with
+     * Searches for something fulfilling the given [searchCriterion] in the subject of this expectation associated with
      * the given [multiConsumableContainer] and should pass on the number of occurrences to the given
      * [featureFactory] which creates feature assertions based on the [checkers], which in turn can be used to create
      * a resulting [AssertionGroup] representing the assertion for a search criteria as a whole.
      *
-     * @param multiConsumableContainer Provides the subject of the assertion for which the assertion is created.
+     * @param multiConsumableContainer Provides the subject of this expectation for which the assertion is created.
      * @param searchCriterion A search criterion.
      * @param featureFactory The feature factory which should be called, passing the number of occurrences (matching
      *   the given [searchCriterion]) including a translation for `number of occurrences`.

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
@@ -14,8 +14,8 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  *
  * It provides a template to fulfill the job of creating the sophisticated `contains` [Assertion].
  *
- * @param T The type of the subject of the assertion.
- * @param TT The type of the subject of the assertion after making it multiple times consumable.
+ * @param T The type of the subject of this expectation.
+ * @param TT The type of the subject of this expectation after making it multiple times consumable.
  * @param SC The type of the search criteria.
  * @param S The type of the current [Contains.SearchBehaviour].
  * @param C The type of the checkers in use (typically a sub interface of [Contains.Checker]).
@@ -66,11 +66,11 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
      * Searches for something matching the given [searchCriterion] in the subject of the given
      * [multiConsumableContainer] and returns the number of occurrences.
      *
-     * @param multiConsumableContainer The provider of the subject of the assertion in which we shall look for something
+     * @param multiConsumableContainer The provider of the subject of this expectation in which we shall look for something
      *   matching the given [searchCriterion].
      * @param searchCriterion The search criterion used to determine whether something matches or not.
      *
-     * @return The number of times the [searchCriterion] matched in the subject of the assertion.
+     * @return The number of times the [searchCriterion] matched in the subject of this expectation.
      */
     protected abstract fun search(multiConsumableContainer: AssertionContainer<TT>, searchCriterion: SC): Int
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains.kt
@@ -25,7 +25,7 @@ interface CharSequenceContains {
     interface EntryPointStep<T : CharSequence, out S : SearchBehaviour> : Contains.EntryPointStep<T, S>
 
     /**
-     * The entry point of the contract on the logic level, containing the [container] -- i.e. the subject of the assertion
+     * The entry point of the contract on the logic level, containing the [container] -- i.e. the subject of this expectation
      * for which the sophisticated `contain` assertion should be created -- as well as the chosen [searchBehaviour].
      *
      * The [searchBehaviour] might me modified in which case it is recommended that a new [EntryPointStep] is created (retain
@@ -77,7 +77,7 @@ interface CharSequenceContains {
      * Represents the final step of a sophisticated `contains` assertion builder which creates the [AssertionGroup]
      * as such.
      *
-     * @param T The type of the subject of the assertion.
+     * @param T The type of the subject of this expectation.
      * @param SC The type of the search criteria.
      */
     interface Creator<T : CharSequence, in SC> : Contains.Creator<T, SC>

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains.kt
@@ -28,7 +28,7 @@ interface IterableLikeContains {
     interface EntryPointStep<E, T : IterableLike, out S : SearchBehaviour> : Contains.EntryPointStep<T, S>
 
     /**
-     * The entry point of the contract on the logic level, containing the [container] -- i.e. the subject of the assertion
+     * The entry point of the contract on the logic level, containing the [container] -- i.e. the subject of this expectation
      * for which the sophisticated `contain` assertion should be created -- as well as the chosen [searchBehaviour].
      *
      * The [searchBehaviour] might me modified in which case it is recommended that a new [EntryPointStep] is created (retain
@@ -36,7 +36,7 @@ interface IterableLikeContains {
      */
     interface EntryPointStepLogic<E, T : IterableLike, out S : SearchBehaviour> : Contains.EntryPointStepLogic<T, S> {
         /**
-         * The converter which shall be used to turn the subject of the assertion into an [Iterable] of type [E].
+         * The converter which shall be used to turn the subject of this expectation into an [Iterable] of type [E].
          */
         val converter: (T) -> Iterable<E>
 
@@ -91,7 +91,7 @@ interface IterableLikeContains {
      * Represents the final step of a sophisticated `contains` assertion builder which creates the [AssertionGroup]
      * as such.
      *
-     * @param T The type of the subject of the assertion.
+     * @param T The type of the subject of this expectation.
      * @param SC The type of the search criteria.
      */
     interface Creator<T : IterableLike, in SC> : Contains.Creator<T, SC>

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -27,7 +27,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WH
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
  * in any order and is identified by holding a group of assertions, created by an assertion creator lambda.
  *
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  *
  * @property searchBehaviour The search behaviour -- in this case representing `in any order` which is used to
  *   decorate the description (a [Translatable]) which is used for the [AssertionGroup].

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
@@ -21,7 +21,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion.*
  * its responsibility.
  *
  * @param E The type of the elements of the [Iterable] the [converter] is going to create.
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  * @param SC The type of the search criteria.
  *
  * @property searchBehaviour The search behaviour -- in this case representing `in any order only` which is used to

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator.kt
@@ -19,7 +19,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion
  * created by an assertion creator lambda.
  *
  * @param E The type of the elements of the [Iterable] the [converter] is going to create.
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  *
  * @constructor Represents a creator of a sophisticated `contains` assertions for [Iterable] where exactly the expected
  *   entries have to appear in the [Iterable] but in any order -- an entry is identified by holding a group

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
@@ -13,7 +13,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WH
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where exactly the expected entries have
  * to appear in the [Iterable] but in any order -- an entry is identified by an expected object (equality comparison).
  *
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  *
  * @constructor Represents a creator of a sophisticated `contains` assertions for [Iterable] where exactly the expected
  *   entries have to appear in the [Iterable] but in any order -- an entry is identified by an expected

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -16,7 +16,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
  * in any order and is identified by expected objects (equality comparison).
  *
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  * @param SC The type of the elements of the iterable, used as search criteria.
  *
  * @constructor Represents a creator of a sophisticated `contains` assertions for [Iterable] where expected entries

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion.ELEMENT_WITH_
  * Represents the base class for `in order only` assertion creators and provides a corresponding template to fulfill
  * its responsibility.
  *
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  * @param SC The type of the search criteria.
  *
  * @property searchBehaviour The search behaviour -- in this case representing `in order only` which is used to

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesAssertionCreator.kt
@@ -11,7 +11,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  * have to appear in the specified order and where an entry is identified by holding a group of assertions,
  * created by an assertion creator lambda.
  *
- * @param T The type of the subject of the assertion for which the `contains` assertion is be build.
+ * @param T The type of the subject of this expectation for which the `contains` assertion is be build.
  *
  * @constructor Represents a creator of a sophisticated `contains` assertions for [Iterable] where exactly the
  *   expected entries have to appear in the specified order and where an entry is identified by holding a

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains.kt
@@ -27,7 +27,7 @@ interface MapLikeContains {
     interface EntryPointStep<K, V, T : MapLike, out S : SearchBehaviour> : Contains.EntryPointStep<T, S>
 
     /**
-     * The entry point of the contract on the logic level, containing the [container] -- i.e. the subject of the assertion
+     * The entry point of the contract on the logic level, containing the [container] -- i.e. the subject of this expectation
      * for which the sophisticated `contain` assertion should be created -- as well as the chosen [searchBehaviour].
      *
      * The [searchBehaviour] might me modified in which case it is recommended that a new [EntryPointStep] is created (retain
@@ -35,7 +35,7 @@ interface MapLikeContains {
      */
     interface EntryPointStepLogic<K, V, T : MapLike, out S : SearchBehaviour> : Contains.EntryPointStepLogic<T, S> {
         /**
-         * The converter which shall be used to turn the subject of the assertion into an [Iterable] of type [E].
+         * The converter which shall be used to turn the subject of this expectation into an [Iterable] of type [E].
          */
         val converter: (T) -> Map<out K, V>
 
@@ -89,7 +89,7 @@ interface MapLikeContains {
      * Represents the final step of a sophisticated `contains` assertion builder which creates the [AssertionGroup]
      * as such.
      *
-     * @param T The type of the subject of the assertion.
+     * @param T The type of the subject of this expectation.
      * @param SC The type of the search criteria.
      */
     interface Creator<T : MapLike, in SC> : Contains.Creator<T, SC>

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep.kt
@@ -15,7 +15,7 @@ interface TransformationExecutionStep<T, R, E : Expect<R>> {
      *
      * See [collect] for more information.
      *
-     * @return An [Expect] for the current subject of the assertion.
+     * @return an [Expect] for the subject of this expectation.
      */
     fun collectAndAppend(assertionCreator: Expect<R>.() -> Unit): Expect<T>
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep.kt
@@ -13,8 +13,8 @@ import ch.tutteli.atrium.logic.toExpect
  * and now allows to decide how it should be done, especially regarding potential sub-assertions which should be applied
  * to the new resulting subject.
  *
- * @param T The type of the current [Expect], the current subject of the assertion respectively.
- * @param R The type of the new [Expect], the new subject of the assertion respectively.
+ * @param T The parameter type of the current [Expect], of its subject respectively.
+ * @param R The parameter type of the new [Expect], of its subject respectively.
  *
  * @property container [Expect] which was involved in the building process
  *   and holds assertion for the initial subject.
@@ -34,7 +34,7 @@ abstract class BaseTransformationExecutionStep<T, R, E : Expect<R>>(
      *
      * See [collect] for more information.
      *
-     * @return An [Expect] for the current subject of the assertion.
+     * @return an [Expect] for the subject of this expectation.
      */
     final override fun collectAndAppend(assertionCreator: Expect<R>.() -> Unit): Expect<T> =
         container.toExpect().addAssertion(collect(assertionCreator))

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/utils.kt
@@ -82,7 +82,7 @@ inline fun <T> AssertionContainer<T>.collect(noinline assertionCreator: Expect<T
  *
  * Note that an assertion will be added which fails in case [assertionCreator] does not create a single assertion.
  *
- * This basically delegates to [assertionCollector] using the subject of the assertion as `maybeSubject`.
+ * This basically delegates to [assertionCollector] using the subject of `this` expectation as `maybeSubject`.
  *
  * @param maybeSubject Either [Some] wrapping the subject of the current assertion or
  *   [None] in case a previous subject transformation was not successful -
@@ -103,7 +103,7 @@ inline fun <T> AssertionContainer<*>.collectForDifferentSubject(
  *
  * Note that an assertion will be added which fails in case [assertionCreator] does not create a single assertion.
  *
- * This basically delegates to [assertionCollector] using [AssertionContainer.maybeSubject] as subject of the assertion.
+ * This basically delegates to [assertionCollector] using [AssertionContainer.maybeSubject] as subject of `this` expectation.
  *
  * @param assertionCreator A lambda which defines the expectations for the [AssertionContainer.maybeSubject].
  *
@@ -143,7 +143,7 @@ fun <T> AssertionContainer<T>.toExpect(): Expect<T> =
  *
  * See [collectForDifferentSubject] for more information.
  *
- * @return An [Expect] for the current subject of the assertion.
+ * @return an [Expect] for the subject of this expectation.
  */
 fun <T, R> TransformationExecutionStep<T, R, *>.collectAndLogicAppend(assertionCreator: AssertionContainer<R>.() -> Assertion): Expect<T> =
     collectAndAppend { _logicAppend(assertionCreator) }

--- a/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/reporting/ExpectBuilder.kt
+++ b/misc/deprecated/domain/builders/atrium-domain-builders-common/src/main/kotlin/ch/tutteli/atrium/domain/builders/reporting/ExpectBuilder.kt
@@ -37,7 +37,7 @@ interface ExpectBuilder {
      */
     interface AssertionVerbStep<T> {
         /**
-         * The previously specified subject of the assertion.
+         * The previously specified subject of `this` expectation.
          */
         val maybeSubject: Option<T>
 
@@ -60,7 +60,7 @@ interface ExpectBuilder {
      */
     interface OptionsStep<T> {
         /**
-         * The previously specified subject of the assertion.
+         * The previously specified subject of `this` expectation.
          */
         val maybeSubject: Option<T>
 
@@ -165,7 +165,7 @@ interface ExpectBuilder {
      */
     interface FinalStep<T> {
         /**
-         * The previously specified subject of the assertion.
+         * The previously specified subject of `this` expectation.
          */
         val maybeSubject: Option<T>
 


### PR DESCRIPTION
In detail:
- rename `subject of the assertion` to `subject of `this` expectation`
- rename `@return An [Expect] for the current subject of the assertion.`
  to `@return an [Expect] for the subject of `this` expectation.`



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
