### PR TITLE
Add samples for api-infix' charSequenceAssertions

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
@@ -141,32 +141,6 @@ infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: String): Expect<T>
 
 /**
  * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
- * regular expression [regexPatterns], using a non disjoint search.
- *
- * It is a shortcut for `contains o atLeast 1 the RegexPatterns(pattern, *otherPatterns)`.
- *
- * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
- * [RegexPatterns] is defined as `regexPatterns("a(b)?", "a(b)?")` as well, then both match,
- * even though they match the same sequence in the input of the search.
- *
- * Meaning you might want to use:
- *   `contains o exactly 2 regex "a(b)?"`
- * instead of:
- *   `contains o atLeast 1 regex "a(b)?", "a(b)?"`
- *
- * @param regexPatterns The patterns which are expected to have a match against the input of the search --
- *   use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
- *
- * @return This assertion container to support a fluent API.
- *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexString
- */
-infix fun <T : CharSequence> Expect<T>.containsRegex(regexPatterns: RegexPatterns): Expect<T> =
-    this contains o atLeast 1 the regexPatterns
-
-/**
- * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
  * regular expression [pattern].
  *
  * It is a shortcut for `contains o atLeast 1 matchFor pattern`.
@@ -175,46 +149,7 @@ infix fun <T : CharSequence> Expect<T>.containsRegex(regexPatterns: RegexPattern
  *
  * @return This assertion container to support a fluent API.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegex
- */
-infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: Regex): Expect<T> =
-    this contains o atLeast 1 matchFor pattern
-
-/**
- * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
- * regular expression [regexPatterns], using a non disjoint search.
- *
- * It is a shortcut for `contains o atLeast 1 matchFor All(pattern, *otherPatterns)`.
- *
- * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
- * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
- * [All] is defined as `all(Regex("a(b)?"), Regex("a(b)?"))` as well, then both match,
- * even though they match the same sequence in the input of the search.
- *
- * Meaning you might want to use:
- *   `contains o exactly 2 matchFor Regex("a(b)?")`
- * instead of:
- *   `contains o atLeast 1 matchFor all(Regex("a(b)?"), Regex("a(b)?"))`
- *
- * @param regexPatterns The patterns which are expected to have a match against the input of the search --
- *   use the function `all(t, ...)` to create a [All].
- *
- * @return This assertion container to support a fluent API.
- *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegex
- */
-infix fun <T : CharSequence> Expect<T>.containsRegex(regexPatterns: All<Regex>): Expect<T> =
-    this contains o atLeast 1 matchFor regexPatterns
-
-/**
- * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
- * regular expression [pattern].
- *
- * It is a shortcut for `contains o atLeast 1 matchFor pattern`.
- *
- * @param pattern The pattern which is expected to have a match against the input of the search.
- *
- * @return This assertion container to support a fluent API.
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexSingle
  */
 infix fun <T : CharSequence> Expect<T>.contains(pattern: Regex): Expect<T> =
     this contains o atLeast 1 matchFor pattern
@@ -240,6 +175,8 @@ infix fun <T : CharSequence> Expect<T>.contains(pattern: Regex): Expect<T> =
  *   use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexStringMultiple
  */
 infix fun <T : CharSequence> Expect<T>.contains(regexPatterns: RegexPatterns): Expect<T> =
     this contains o atLeast 1 the regexPatterns
@@ -266,6 +203,8 @@ infix fun <T : CharSequence> Expect<T>.contains(regexPatterns: RegexPatterns): E
  *   use the function `all(Regex(...), ...)` to create a [All].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexMultiple
  */
 infix fun <T : CharSequence> Expect<T>.contains(patterns: All<Regex>): Expect<T> =
     this contains o atLeast 1 matchFor patterns

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
@@ -18,6 +18,8 @@ import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerSt
  * @param o The filler object [o].
  *
  * @return The newly created builder.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsBuilder
  */
 infix fun <T : CharSequence> Expect<T>.contains(
     @Suppress("UNUSED_PARAMETER") o: o
@@ -30,6 +32,8 @@ infix fun <T : CharSequence> Expect<T>.contains(
  * @param o The filler object [o].
  *
  * @return The newly created builder.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsNotBuilder
  */
 infix fun <T : CharSequence> Expect<T>.containsNot(
     @Suppress("UNUSED_PARAMETER") o: o
@@ -46,6 +50,8 @@ infix fun <T : CharSequence> Expect<T>.containsNot(
  *
  * @return This assertion container to support a fluent API.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.contains
  */
 infix fun <T : CharSequence> Expect<T>.contains(expected: CharSequenceOrNumberOrChar): Expect<T> =
     this contains o atLeast 1 value expected
@@ -77,6 +83,8 @@ infix fun <T : CharSequence> Expect<T>.contains(expected: CharSequenceOrNumberOr
  * @return This assertion container to support a fluent API.
  * @throws IllegalArgumentException in case one of the [values] is not a
  *   [CharSequence], [Number] or [Char].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.contains
  */
 infix fun <T : CharSequence> Expect<T>.contains(values: Values<CharSequenceOrNumberOrChar>): Expect<T> =
     this contains o atLeast 1 the values
@@ -91,6 +99,8 @@ infix fun <T : CharSequence> Expect<T>.contains(values: Values<CharSequenceOrNum
  * so that you can mix [String] and [Int] for instance.
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsNot
  */
 infix fun <T : CharSequence> Expect<T>.containsNot(expected: CharSequenceOrNumberOrChar): Expect<T> =
     this containsNot o value expected
@@ -108,6 +118,8 @@ infix fun <T : CharSequence> Expect<T>.containsNot(expected: CharSequenceOrNumbe
  * @param values The values which should not be found -- use the function `values(t, ...)` to create a [Values].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsNot
  */
 infix fun <T : CharSequence> Expect<T>.containsNot(values: Values<CharSequenceOrNumberOrChar>): Expect<T> =
     this containsNot o the values
@@ -121,9 +133,78 @@ infix fun <T : CharSequence> Expect<T>.containsNot(values: Values<CharSequenceOr
  * @param pattern The pattern which is expected to have a match against the input of the search.
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexString
  */
 infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: String): Expect<T> =
     this contains o atLeast 1 regex pattern
+
+/**
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
+ * regular expression [regexPatterns], using a non disjoint search.
+ *
+ * It is a shortcut for `contains o atLeast 1 the RegexPatterns(pattern, *otherPatterns)`.
+ *
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [RegexPatterns] is defined as `regexPatterns("a(b)?", "a(b)?")` as well, then both match,
+ * even though they match the same sequence in the input of the search.
+ *
+ * Meaning you might want to use:
+ *   `contains o exactly 2 regex "a(b)?"`
+ * instead of:
+ *   `contains o atLeast 1 regex "a(b)?", "a(b)?"`
+ *
+ * @param regexPatterns The patterns which are expected to have a match against the input of the search --
+ *   use the function `regexPatterns(t, ...)` to create a [RegexPatterns].
+ *
+ * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexString
+ */
+infix fun <T : CharSequence> Expect<T>.containsRegex(regexPatterns: RegexPatterns): Expect<T> =
+    this contains o atLeast 1 the regexPatterns
+
+/**
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
+ * regular expression [pattern].
+ *
+ * It is a shortcut for `contains o atLeast 1 matchFor pattern`.
+ *
+ * @param pattern The pattern which is expected to have a match against the input of the search.
+ *
+ * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegex
+ */
+infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: Regex): Expect<T> =
+    this contains o atLeast 1 matchFor pattern
+
+/**
+ * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
+ * regular expression [regexPatterns], using a non disjoint search.
+ *
+ * It is a shortcut for `contains o atLeast 1 matchFor All(pattern, *otherPatterns)`.
+ *
+ * By non disjoint is meant that `"aa"` in `"aaaa"` is found three times and not only two times.
+ * Also notice, that it does not search for unique matches. Meaning, if the input of the search is `"ab"` and
+ * [All] is defined as `all(Regex("a(b)?"), Regex("a(b)?"))` as well, then both match,
+ * even though they match the same sequence in the input of the search.
+ *
+ * Meaning you might want to use:
+ *   `contains o exactly 2 matchFor Regex("a(b)?")`
+ * instead of:
+ *   `contains o atLeast 1 matchFor all(Regex("a(b)?"), Regex("a(b)?"))`
+ *
+ * @param regexPatterns The patterns which are expected to have a match against the input of the search --
+ *   use the function `all(t, ...)` to create a [All].
+ *
+ * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegex
+ */
+infix fun <T : CharSequence> Expect<T>.containsRegex(regexPatterns: All<Regex>): Expect<T> =
+    this contains o atLeast 1 matchFor regexPatterns
 
 /**
  * Expects that the subject of `this` expectation (a [CharSequence]) contains a sequence which matches the given
@@ -193,6 +274,8 @@ infix fun <T : CharSequence> Expect<T>.contains(patterns: All<Regex>): Expect<T>
  * Expects that the subject of `this` expectation (a [CharSequence]) starts with [expected].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.startsWith
  */
 infix fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence): Expect<T> =
     _logicAppend { startsWith(expected) }
@@ -203,6 +286,8 @@ infix fun <T : CharSequence> Expect<T>.startsWith(expected: CharSequence): Expec
  * @return This assertion container to support a fluent API.
  *
  * @since 0.12.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.startsWithChar
  */
 infix fun <T : CharSequence> Expect<T>.startsWith(expected: Char): Expect<T> =
     it startsWith expected.toString()
@@ -211,6 +296,8 @@ infix fun <T : CharSequence> Expect<T>.startsWith(expected: Char): Expect<T> =
  * Expects that the subject of `this` expectation (a [CharSequence]) does not start with [expected].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.startsNotWith
  */
 infix fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence): Expect<T> =
     _logicAppend { startsNotWith(expected) }
@@ -221,6 +308,8 @@ infix fun <T : CharSequence> Expect<T>.startsNotWith(expected: CharSequence): Ex
  * @return This assertion container to support a fluent API.
  *
  * @since 0.12.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.startsNotWithChar
  */
 infix fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char): Expect<T> =
     it startsNotWith expected.toString()
@@ -230,6 +319,8 @@ infix fun <T : CharSequence> Expect<T>.startsNotWith(expected: Char): Expect<T> 
  * Expects that the subject of `this` expectation (a [CharSequence]) ends with [expected].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.endsWith
  */
 infix fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence): Expect<T> =
     _logicAppend { endsWith(expected) }
@@ -240,6 +331,8 @@ infix fun <T : CharSequence> Expect<T>.endsWith(expected: CharSequence): Expect<
  * @return This assertion container to support a fluent API.
  *
  * @since 0.12.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.endsWithChar
  */
 infix fun <T : CharSequence> Expect<T>.endsWith(expected: Char): Expect<T> =
     it endsWith expected.toString()
@@ -248,6 +341,8 @@ infix fun <T : CharSequence> Expect<T>.endsWith(expected: Char): Expect<T> =
  * Expects that the subject of `this` expectation (a [CharSequence]) does not end with [expected].
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.endsNotWith
  */
 infix fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence): Expect<T> =
     _logicAppend { endsNotWith(expected) }
@@ -258,6 +353,8 @@ infix fun <T : CharSequence> Expect<T>.endsNotWith(expected: CharSequence): Expe
  * @return This assertion container to support a fluent API.
  *
  * @since 0.12.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.endsNotWithChar
  */
 infix fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char): Expect<T> =
     it endsNotWith expected.toString()
@@ -269,6 +366,8 @@ infix fun <T : CharSequence> Expect<T>.endsNotWith(expected: Char): Expect<T> =
  * @param empty Use the pseudo-keyword `empty`.
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.isEmpty
  */
 infix fun <T : CharSequence> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isEmpty() }
@@ -279,6 +378,8 @@ infix fun <T : CharSequence> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty:
  * @param empty Use the pseudo-keyword `empty`.
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.isNotEmpty
  */
 infix fun <T : CharSequence> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isNotEmpty() }
@@ -289,6 +390,8 @@ infix fun <T : CharSequence> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") emp
  * @param blank Use the pseudo-keyword `blank`.
  *
  * @return This assertion container to support a fluent API.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.isNotBlank
  */
 infix fun <T : CharSequence> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") blank: blank): Expect<T> =
     _logicAppend { isNotBlank() }
@@ -301,6 +404,8 @@ infix fun <T : CharSequence> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") bla
  * @return This assertion container to support a fluent API.
  *
  * @since 0.12.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.matches
  */
 infix fun <T : CharSequence> Expect<T>.matches(expected: Regex): Expect<T> =
     _logicAppend { matches(expected) }
@@ -313,6 +418,8 @@ infix fun <T : CharSequence> Expect<T>.matches(expected: Regex): Expect<T> =
  * @return This assertion container to support a fluent API.
  *
  * @since 0.12.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.mismatches
  */
 infix fun <T : CharSequence> Expect<T>.mismatches(expected: Regex): Expect<T> =
     _logicAppend { mismatches(expected) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceAssertions.kt
@@ -134,7 +134,7 @@ infix fun <T : CharSequence> Expect<T>.containsNot(values: Values<CharSequenceOr
  *
  * @return This assertion container to support a fluent API.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexString
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CharSequenceAssertionSamples.containsRegexStringSingle
  */
 infix fun <T : CharSequence> Expect<T>.containsRegex(pattern: String): Expect<T> =
     this contains o atLeast 1 regex pattern

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
@@ -202,7 +202,7 @@ class CharSequenceAssertionSamples {
             expect("") notToBe empty
         }
 
-        // use notToBe blank to check for whitespaces
+        // use `notToBe blank` to check for whitespaces
         expect(" ") notToBe empty
     }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
@@ -78,7 +78,7 @@ class CharSequenceAssertionSamples {
         // all regex patterns match
         expect("ABC") contains regexPatterns("A(B)?", "(B)?C")
 
-        // holds because `containsRegex` does not search for unique matches
+        // holds because `contains regexPatterns(...)` does not search for unique matches
         // use `contains exactly 2 regex "A(B)?"` to check if subject contains the regex two times
         expect("ABC") contains regexPatterns("A(B)?", "A(B)?")
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
@@ -32,76 +32,83 @@ class CharSequenceAssertionSamples {
 
     @Test
     fun contains() {
-        expect("ABC") contains o exactly 1 value "B"
+        expect("ABC") contains "B"
 
         expect("ABC123") contains values("AB", 'C', 12)
 
         // holds because `contains` does not search for unique matches
         // use `contains o exactly 2 value "A"` to check if subject contains two "A"s
-        expect("ABC") contains o exactly 1 the values("A", "A")
+        expect("ABC") contains values("A", "A")
 
         fails {
-            expect("ABC") contains o exactly 1 value  "X"
+            expect("ABC") contains "X"
         }
 
         fails { // because subject does not contain all values
-            expect("ABC") contains o exactly 1 the values("A", 99)
+            expect("ABC") contains values("A", 99)
         }
     }
 
     @Test
     fun containsNot() {
-        expect("ABC") containsNot o value "X"
+        expect("ABC") containsNot "X"
 
-        expect("ABC") containsNot o the values("X", 'Y', 1)
+        expect("ABC") containsNot values("X", 'Y', 1)
 
         fails {
-            expect("ABC") containsNot o value "B"
+            expect("ABC") containsNot "B"
         }
 
         fails {
-            expect("ABC") containsNot o the values("B", "X")
+            expect("ABC") containsNot values("B", "X")
         }
     }
 
     @Test
-    fun containsRegexString() {
+    fun containsRegexStringSingle() {
         expect("ABC") containsRegex "A(B)?"
 
         fails {
             expect("ABC") containsRegex "X"
         }
+    }
 
+    @Test
+    fun containsRegexStringMultiple() {
         // all regex patterns match
-        expect("ABC") containsRegex regexPatterns("A(B)?", "(B)?C")
+        expect("ABC") contains regexPatterns("A(B)?", "(B)?C")
 
         // holds because `containsRegex` does not search for unique matches
         // use `contains exactly 2 regex "A(B)?"` to check if subject contains the regex two times
-        expect("ABC") containsRegex regexPatterns("A(B)?", "A(B)?")
+        expect("ABC") contains regexPatterns("A(B)?", "A(B)?")
 
         fails { // because second regex doesn't match
-            expect("ABC") containsRegex regexPatterns("A", "X")
+            expect("ABC") contains regexPatterns("A", "X")
         }
     }
 
     @Test
-    fun containsRegex() {
-        expect("ABC") containsRegex "(B)?C".toRegex()
+    fun containsRegexSingle() {
+        expect("ABC") contains "(B)?C".toRegex()
 
         fails {
-            expect("ABC") containsRegex "X".toRegex()
+            expect("ABC") contains "X".toRegex()
         }
 
+    }
+
+    @Test
+    fun containsRegexMultiple() {
         // all regex patterns match
-        expect("ABC") containsRegex all("A".toRegex(), "B".toRegex())
+        expect("ABC") contains all("A".toRegex(), "B".toRegex())
 
         // holds because `containsRegex` does not search for unique matches
         // use `contains exactly 2 regex regex` to check if subject contains the regex two times
         val regex = "A(B)?".toRegex()
-        expect("ABC") containsRegex all(regex, regex)
+        expect("ABC") contains all(regex, regex)
 
         fails { // because second regex doesn't match
-            expect("ABC") containsRegex all("A".toRegex(), "X".toRegex())
+            expect("ABC") contains all("A".toRegex(), "X".toRegex())
         }
     }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
@@ -102,7 +102,7 @@ class CharSequenceAssertionSamples {
         // all regex patterns match
         expect("ABC") contains all("A".toRegex(), "B".toRegex())
 
-        // holds because `containsRegex` does not search for unique matches
+        // holds because `contains all(...)` does not search for unique matches
         // use `contains exactly 2 regex regex` to check if subject contains the regex two times
         val regex = "A(B)?".toRegex()
         expect("ABC") contains all(regex, regex)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CharSequenceAssertionSamples.kt
@@ -1,0 +1,232 @@
+//TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
+package ch.tutteli.atrium.api.infix.en_GB.samples.deprecated
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.infix.en_GB.samples.fails
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class CharSequenceAssertionSamples {
+
+    @Test
+    fun containsBuilder() {
+        expect("ABC") contains o exactly 1 value "A"
+
+        expect("ABBC") contains o atLeast 2 value "B"
+
+        fails {
+            expect("AAAAAA") contains o atMost 3 value "A"
+        }
+    }
+
+    @Test
+    fun containsNotBuilder() {
+        expect("ABC") containsNot o value "X"
+
+        fails {
+            expect("ABC") containsNot o value "B"
+        }
+    }
+
+    @Test
+    fun contains() {
+        expect("ABC") contains o exactly 1 value "B"
+
+        expect("ABC123") contains values("AB", 'C', 12)
+
+        // holds because `contains` does not search for unique matches
+        // use `contains o exactly 2 value "A"` to check if subject contains two "A"s
+        expect("ABC") contains o exactly 1 the values("A", "A")
+
+        fails {
+            expect("ABC") contains o exactly 1 value  "X"
+        }
+
+        fails { // because subject does not contain all values
+            expect("ABC") contains o exactly 1 the values("A", 99)
+        }
+    }
+
+    @Test
+    fun containsNot() {
+        expect("ABC") containsNot o value "X"
+
+        expect("ABC") containsNot o the values("X", 'Y', 1)
+
+        fails {
+            expect("ABC") containsNot o value "B"
+        }
+
+        fails {
+            expect("ABC") containsNot o the values("B", "X")
+        }
+    }
+
+    @Test
+    fun containsRegexString() {
+        expect("ABC") containsRegex "A(B)?"
+
+        fails {
+            expect("ABC") containsRegex "X"
+        }
+
+        // all regex patterns match
+        expect("ABC") containsRegex regexPatterns("A(B)?", "(B)?C")
+
+        // holds because `containsRegex` does not search for unique matches
+        // use `contains exactly 2 regex "A(B)?"` to check if subject contains the regex two times
+        expect("ABC") containsRegex regexPatterns("A(B)?", "A(B)?")
+
+        fails { // because second regex doesn't match
+            expect("ABC") containsRegex regexPatterns("A", "X")
+        }
+    }
+
+    @Test
+    fun containsRegex() {
+        expect("ABC") containsRegex "(B)?C".toRegex()
+
+        fails {
+            expect("ABC") containsRegex "X".toRegex()
+        }
+
+        // all regex patterns match
+        expect("ABC") containsRegex all("A".toRegex(), "B".toRegex())
+
+        // holds because `containsRegex` does not search for unique matches
+        // use `contains exactly 2 regex regex` to check if subject contains the regex two times
+        val regex = "A(B)?".toRegex()
+        expect("ABC") containsRegex all(regex, regex)
+
+        fails { // because second regex doesn't match
+            expect("ABC") containsRegex all("A".toRegex(), "X".toRegex())
+        }
+    }
+
+    @Test
+    fun startsWith() {
+        expect("ABC") startsWith "AB"
+
+        fails {
+            expect("ABC") startsWith "X"
+        }
+    }
+
+    @Test
+    fun startsWithChar() {
+        expect("ABC") startsWith 'A'
+
+        fails {
+            expect("ABC") startsWith 'X'
+        }
+    }
+
+    @Test
+    fun startsNotWith() {
+        expect("ABC") startsNotWith "X"
+
+        fails {
+            expect("ABC") startsNotWith "AB"
+        }
+    }
+
+    @Test
+    fun startsNotWithChar() {
+        expect("ABC") startsNotWith 'X'
+
+        fails {
+            expect("ABC") startsNotWith 'A'
+        }
+    }
+
+
+    @Test
+    fun endsWith() {
+        expect("ABC") endsWith "BC"
+
+        fails {
+            expect("ABC") endsWith "X"
+        }
+    }
+
+    @Test
+    fun endsWithChar() {
+        expect("ABC") endsWith 'C'
+
+        fails {
+            expect("ABC") endsWith 'X'
+        }
+    }
+
+    @Test
+    fun endsNotWith() {
+        expect("ABC") endsNotWith "X"
+
+        fails {
+            expect("ABC") endsNotWith "BC"
+        }
+    }
+
+    @Test
+    fun endsNotWithChar() {
+        expect("ABC") endsNotWith 'X'
+
+        fails {
+            expect("ABC") endsNotWith 'C'
+        }
+    }
+
+    @Test
+    fun isEmpty() {
+        expect("") toBe empty
+
+        fails {
+            expect("XYZ") toBe empty
+        }
+    }
+
+    @Test
+    fun isNotEmpty() {
+        expect("XYZ") notToBe empty
+
+        fails {
+            expect("") notToBe empty
+        }
+
+        // use notToBe blank to check for whitespaces
+        expect(" ") notToBe empty
+    }
+
+    @Test
+    fun isNotBlank() {
+        expect("XZY") notToBe blank
+
+        fails {
+            expect(" ") notToBe blank
+        }
+
+        fails { // because subject is empty but contains no whitespaces
+            expect("") notToBe blank
+        }
+    }
+
+    @Test
+    fun matches() {
+        expect("ABC") matches "A(B)?C".toRegex() // subject is fully matched
+
+        fails { // because subject isn't fully matched, use containsRegex for partial matching
+            expect("ABC") matches "A".toRegex()
+        }
+    }
+
+    @Test
+    fun mismatches() {
+        expect("ABC") mismatches "A".toRegex() // subject isn't fully matched
+
+        fails { // because subject is fully matched, use containsNot.regex for partial matching
+            expect("ABC")  mismatches "A(B)?C".toRegex()
+        }
+    }
+}


### PR DESCRIPTION
- Copied `fluent/../CharSequenceAssertionSamples` into
  `infix/../CharSequenceAssertionSamples`.
- Corrected the imports and translated the fluent syntax into the infix
  one.
- Added 3 `containsRegex` infix functions overloads in
  `infix/../charSequenceAssertions.kt` each accepting a RegexPaterns(),
  Regex() and a All() parameter respectively. This was needed to give
  meaning to the containsRegexString() and containsRegex() tests from
  `infix/../CharSequenceAssertionSamples`, otherwise they had to be
  executed using the `contains` constructor, which already has its own
  contains() test. Copied KDoc from similar overloads and adapted
  according to their respective definition.
- Added @sample to every charSequenceAssertions.kt infix function that
  is being called in any of the CharSequenceAssertionSamples test
  functions. I don't see the point of a @sample link in an overload
  which has not being called in the
  `infix/../CharSequenceAssertionSamples` file, meaning it has no
  sample of its own to show. Either that or I should have included a
  sample of the missing ones in their respective tests.
- Checked that KDoc Intellij prompts are nicely formatted.

resolve: #686



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
