### PR TITLE
use MethodCallFormatter from components instead of CoreFactory

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature.kt
@@ -1,5 +1,8 @@
 package ch.tutteli.atrium.api.infix.en_GB.creating.feature
 
+import ch.tutteli.atrium.creating.ComponentFactoryContainer
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.creating.impl.DefaultComponentFactoryContainer
 import kotlin.reflect.KProperty1
 
 /**
@@ -15,4 +18,15 @@ import kotlin.reflect.KProperty1
  *
  * @since 0.12.0
  */
-data class Feature<T, R> internal constructor(val description: String, val extractor: (T) -> R)
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalComponentFactoryContainer::class)
+data class Feature<T, R> internal constructor(
+    val descriptionProvider: (ComponentFactoryContainer) -> String,
+    val extractor: (T) -> R
+) {
+    internal constructor(description: String, extractor: (T) -> R) :
+        this({ description }, extractor)
+
+    @Deprecated("Use descriptionProvider instead; will be removed with 0.17.0")
+    val description: String = descriptionProvider(DefaultComponentFactoryContainer)
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator.kt
@@ -1,6 +1,9 @@
 package ch.tutteli.atrium.api.infix.en_GB.creating.feature
 
+import ch.tutteli.atrium.creating.ComponentFactoryContainer
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.creating.impl.DefaultComponentFactoryContainer
 import kotlin.reflect.KProperty1
 
 /**
@@ -18,8 +21,16 @@ import kotlin.reflect.KProperty1
  *
  * @since 0.12.0
  */
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalComponentFactoryContainer::class)
 data class FeatureWithCreator<T, R> internal constructor(
-    val description: String,
+    val descriptionProvider: (ComponentFactoryContainer) -> String,
     val extractor: (T) -> R,
     val assertionCreator: Expect<R>.() -> Unit
-)
+) {
+    internal constructor(description: String, extractor: (T) -> R, assertionCreator: Expect<R>.() -> Unit) :
+        this({ description }, extractor, assertionCreator)
+
+    @Deprecated("Use descriptionProvider instead; will be removed with 0.17.0")
+    val description: String = descriptionProvider(DefaultComponentFactoryContainer)
+}

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/core/CoreFactory.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/core/CoreFactory.kt
@@ -61,6 +61,7 @@ interface CoreFactoryCommon {
      *
      * @return The newly created method call formatter.
      */
+    @Deprecated("Create a new MethodCallFormatter via the ComponentFactoryContainer, e.g. via _logic.components.build<MethodCallFormatter>(); will be removed with 0.17.0")
     fun newMethodCallFormatter(): MethodCallFormatter
 
 

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/ComponentFactoryContainerImpl.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/ComponentFactoryContainerImpl.kt
@@ -4,12 +4,14 @@ import ch.tutteli.atrium.creating.ComponentFactoryContainer
 import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.creating.build
 import ch.tutteli.atrium.reporting.AtriumErrorAdjuster
+import ch.tutteli.atrium.reporting.MethodCallFormatter
 import ch.tutteli.atrium.reporting.Reporter
 import ch.tutteli.atrium.reporting.erroradjusters.MultiAtriumErrorAdjuster
 import ch.tutteli.atrium.reporting.erroradjusters.RemoveAtriumFromAtriumError
 import ch.tutteli.atrium.reporting.erroradjusters.RemoveRunnerAtriumError
 import ch.tutteli.atrium.reporting.erroradjusters.impl.RemoveAtriumFromAtriumErrorImpl
 import ch.tutteli.atrium.reporting.erroradjusters.impl.RemoveRunnerAtriumErrorImpl
+import ch.tutteli.atrium.reporting.impl.TextMethodCallFormatter
 import ch.tutteli.atrium.reporting.reporter
 import kotlin.reflect.KClass
 
@@ -80,7 +82,8 @@ object DefaultComponentFactoryContainer : ComponentFactoryContainer by Component
                 c.build<RemoveRunnerAtriumError>(),
                 emptyList()
             )
-        }
+        },
+        MethodCallFormatter::class to { _ -> TextMethodCallFormatter }
     ),
     //TODO 0.16.0 define default chainable types like TextFormatter
     emptyMap()

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/reporting/MethodCallFormatter.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/reporting/MethodCallFormatter.kt
@@ -13,7 +13,7 @@ interface MethodCallFormatter {
      *
      * @return An lambda containing the logic to build the representation.
      */
-    @Deprecated("Use the overload which returns a string right away, wrap it into a lamba on your own if you need this functionality")
+    @Deprecated("Use the overload which returns a string right away, wrap it into a lambda on your own if you need this functionality; will be removed with 0.17.0")
     fun format(methodName: String, arguments: Array<out Any?>): () -> String
 
     /**

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/reporting/impl/TextMethodCallFormatter.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/reporting/impl/TextMethodCallFormatter.kt
@@ -1,0 +1,28 @@
+package ch.tutteli.atrium.reporting.impl
+
+import ch.tutteli.atrium.reporting.MethodCallFormatter
+import ch.tutteli.atrium.reporting.Text
+
+/**
+ * Responsible to format a method call for text output (e.g. to the console) where it represents arguments of a
+ * method call by using their [Any.toString] representation with a few exceptions.
+ *
+ * The exceptions are:
+ * - [CharSequence], is wrapped in quotes (`"`) and \r as well as \n are escaped.
+ * - [Char] is wrapped in apostrophes (`'`)
+ */
+object TextMethodCallFormatter : MethodCallFormatter {
+    override fun formatCall(methodName: String, arguments: Array<out Any?>): String =
+        arguments.joinToString(", ", prefix = "$methodName(", postfix = ")") { formatArgument(it) }
+
+    override fun format(methodName: String, arguments: Array<out Any?>): () -> String = {
+        formatCall(methodName, arguments)
+    }
+
+    override fun formatArgument(argument: Any?): String = when (argument) {
+        null -> Text.NULL.string
+        is CharSequence -> "\"$argument\"".replace("\r", "\\r").replace("\n", "\\n")
+        is Char -> "'$argument'"
+        else -> argument.toString()
+    }
+}

--- a/core/api/atrium-core-api-jvm/src/module/module-info.java
+++ b/core/api/atrium-core-api-jvm/src/module/module-info.java
@@ -17,5 +17,6 @@ module ch.tutteli.atrium.core.api {
     // TODO 0.17.0 or 0.18.0 remove once DefaultComponentFactoryContainer is internal
     exports ch.tutteli.atrium.creating.impl to
         ch.tutteli.atrium.logic,
-        ch.tutteli.atrium.domain.robstoll.lib;
+        ch.tutteli.atrium.domain.robstoll.lib,
+        ch.tutteli.atrium.api.infix.en_GB;
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions.kt
@@ -7,6 +7,8 @@ import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.coreFactory
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.creating.build
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnly
@@ -101,18 +103,15 @@ class DefaultMapLikeContainsAssertions : MapLikeContainsAssertions {
     private fun <K> entryWithKeyTranslation(
         methodCallFormatter: MethodCallFormatter,
         key: K
-    ) = TranslatableWithArgs(
-        ENTRY_WITH_KEY,
-        methodCallFormatter.formatArgument(key)
-    )
+    ) = TranslatableWithArgs(ENTRY_WITH_KEY, methodCallFormatter.formatArgument(key))
 
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalComponentFactoryContainer::class)
     private fun getMethodCallFormatter(
         @Suppress(/* don't suppress once we use MethodCallFormatter from container */ "UNUSED_PARAMETER")
         entryPointStepLogic: MapLikeContains.EntryPointStepLogic<*, *, *, *>
-    ): MethodCallFormatter {
-        //TODO we should actually make MethodCallFormatter configurable in ReporterBuilder and then get it via Expect
-        return coreFactory.newMethodCallFormatter()
-    }
+    ) = entryPointStepLogic.container.components.build<MethodCallFormatter>()
+
 
     private fun <K, T : Map<out K, V>, V> extractKey(it: T, key: K): Option<V> {
         return Option.someIf(it.containsKey(key)) {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.logic.creating.FeatureExpectOptions
 import ch.tutteli.atrium.logic.creating.FeatureExpectOptionsChooser
 import ch.tutteli.atrium.logic.creating.transformers.impl.featureextractor.*
 import ch.tutteli.atrium.reporting.LazyRepresentation
+import ch.tutteli.atrium.reporting.MethodCallFormatter
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.Untranslatable
@@ -35,14 +36,17 @@ interface FeatureExtractorBuilder {
         val container: AssertionContainer<T>
 
         /**
-         * Uses [coreFactory].[newMethodCallFormatter][CoreFactory.newMethodCallFormatter] to create a description
+         * Uses the configured [MethodCallFormatter] to create a description
          * of a method call with the given [methodName] and the given [arguments].
          *
          * Use [withDescription] in case the feature extraction is not based on a method call.
          */
         fun methodCall(methodName: String, vararg arguments: Any?): RepresentationInCaseOfFailureStep<T> =
-            //TODO use methodCallFormatter from container 0.16.0
-            withDescription(coreFactory.newMethodCallFormatter().formatCall(methodName, arguments))
+            withDescription(
+                @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+                @UseExperimental(ExperimentalComponentFactoryContainer::class)
+                container.components.build<MethodCallFormatter>().formatCall(methodName, arguments)
+            )
 
         /**
          * Uses the given [description], wraps it into an [Untranslatable] and uses it as description of the feature.

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFeatureAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFeatureAssertions.kt
@@ -4,9 +4,12 @@ import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.coreFactory
 import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.creating.build
 import ch.tutteli.atrium.logic.FeatureAssertions
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.extractFeature
+import ch.tutteli.atrium.reporting.MethodCallFormatter
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.Untranslatable
 import ch.tutteli.atrium.translations.ErrorMessages
@@ -19,24 +22,29 @@ class DefaultFeatureAssertions : FeatureAssertions {
         extractFeature(container, property.name, property::get)
 
     override fun <T, R> f0(container: AssertionContainer<T>, f: KFunction1<T, R>): FeatureExtractorBuilder.ExecutionStep<T, R> =
-        //TODO 0.16.0 use methodCallFormatter from container via getImpl
-        extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf()), f::invoke)
+        extractFeature(container, buildMethodCallFormatter(container).formatCall(f.name, arrayOf()), f::invoke)
+
 
     override fun <T, A1, R> f1(container: AssertionContainer<T>, f: KFunction2<T, A1, R>, a1: A1): FeatureExtractorBuilder.ExecutionStep<T, R> =
-        extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf<Any?>(a1))) { f(it, a1) }
+        extractFeature(container, buildMethodCallFormatter(container).formatCall(f.name, arrayOf<Any?>(a1))) { f(it, a1) }
 
     override fun <T, A1, A2, R> f2(container: AssertionContainer<T>, f: KFunction3<T, A1, A2, R>, a1: A1, a2: A2): FeatureExtractorBuilder.ExecutionStep<T, R> =
-        extractFeature(container ,coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2))) { f(it, a1, a2) }
+        extractFeature(container ,buildMethodCallFormatter(container).formatCall(f.name, arrayOf(a1, a2))) { f(it, a1, a2) }
 
     override fun <T, A1, A2, A3, R> f3(container: AssertionContainer<T>, f: KFunction4<T, A1, A2, A3, R>, a1: A1, a2: A2, a3: A3): FeatureExtractorBuilder.ExecutionStep<T, R> =
-        extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2, a3))) { f(it, a1, a2, a3) }
+        extractFeature(container, buildMethodCallFormatter(container).formatCall(f.name, arrayOf(a1, a2, a3))) { f(it, a1, a2, a3) }
 
     override fun <T, A1, A2, A3, A4, R> f4(container: AssertionContainer<T>, f: KFunction5<T, A1, A2, A3, A4, R>, a1: A1, a2: A2, a3: A3, a4: A4): FeatureExtractorBuilder.ExecutionStep<T, R> =
-        extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2, a3, a4))) { f(it, a1, a2, a3, a4) }
+        extractFeature(container, buildMethodCallFormatter(container).formatCall(f.name, arrayOf(a1, a2, a3, a4))) { f(it, a1, a2, a3, a4) }
 
     override fun <T, A1, A2, A3, A4, A5, R> f5(container: AssertionContainer<T>, f: KFunction6<T, A1, A2, A3, A4, A5, R>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): FeatureExtractorBuilder.ExecutionStep<T, R> =
-        extractFeature(container, coreFactory.newMethodCallFormatter().formatCall(f.name, arrayOf(a1, a2, a3, a4, a5))) { f(it, a1, a2, a3, a4, a5) }
+        extractFeature(container, buildMethodCallFormatter(container).formatCall(f.name, arrayOf(a1, a2, a3, a4, a5))) { f(it, a1, a2, a3, a4, a5) }
     //@formatter:on
+
+    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+    @UseExperimental(ExperimentalComponentFactoryContainer::class)
+    private fun <T> buildMethodCallFormatter(container: AssertionContainer<T>) =
+        container.components.build<MethodCallFormatter>()
 
     override fun <T, R> manualFeature(
         container: AssertionContainer<T>,


### PR DESCRIPTION
moreover:
- deprecate newMethodCallFormatter in CoreFactory
- introduce a descriptionProvider for Feature and FeatureWithCreator
  in api-infix.
  - deprecate the usage of `description` accordingly



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
