### PR TITLE
add convenience shortcut for `Path.toBeASymbolicLink` feature

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -270,6 +270,21 @@ fun <T : Path> Expect<T>.isDirectory(): Expect<T> =
     _logicAppend { isDirectory() }
 
 /**
+ * Expects that the subject of `this` expectation (a [Path]) is a symbolic link;
+ * meaning that there is a file system entry at the location the [Path] points to and that is a symbolic link.
+ *
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
+ * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.16.0
+ */
+fun <T : Path> Expect<T>.toBeASymbolicLink(): Expect<T> =
+    _logicAppend { toBeASymbolicLink() }
+
+/**
  * Expects that the subject of `this` expectation (a [Path]) is an absolute path;
  * meaning that the [Path] specified in this instance starts at the file system root.
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathExpectationsSpec.kt
@@ -17,6 +17,7 @@ class PathExpectationsSpec : ch.tutteli.atrium.specs.integration.PathExpectation
     fun0(Expect<Path>::isExecutable),
     fun0(Expect<Path>::isRegularFile),
     fun0(Expect<Path>::isDirectory),
+    fun0(Expect<Path>::toBeASymbolicLink),
     fun0(Expect<Path>::isAbsolute),
     fun0(Expect<Path>::isRelative),
     Expect<Path>::hasDirectoryEntry.name to Companion::hasDirectoryEntrySingle,
@@ -57,6 +58,7 @@ class PathExpectationsSpec : ch.tutteli.atrium.specs.integration.PathExpectation
         a1.isWritable()
         a1.isRegularFile()
         a1.isDirectory()
+        a1.toBeASymbolicLink()
         a1.hasSameBinaryContentAs(Paths.get("a"))
         a1.hasSameTextualContentAs(Paths.get("a"))
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathAssertionSamples.kt
@@ -1,0 +1,31 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBeASymbolicLink
+import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.niok.newFile
+import java.nio.file.Files
+import kotlin.test.Test
+
+class PathAssertionSamples {
+
+    private val tempDir = Files.createTempDirectory("PathAssertionSamples")
+
+    @Test
+    fun isASymbolicLink() {
+        val target = tempDir.newFile("target")
+        val link = Files.createSymbolicLink(tempDir.resolve("link"), target)
+
+        // Passes, as subject `link` is a symbolic link
+        expect(link).toBeASymbolicLink()
+    }
+
+    @Test
+    fun isNotASymbolicLink() {
+        val path = tempDir.newFile("somePath")
+
+        // Fails, as subject `path` is a not a symbolic link
+        fails {
+            expect(path).toBeASymbolicLink()
+        }
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/keywords.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/keywords.kt
@@ -23,6 +23,12 @@ object aRegularFile : Keyword
 object aDirectory : Keyword
 
 /**
+ * A helper construct to allow expressing assertions about a path being a symbolic link.
+ * It can be used for a parameterless function so that it has one parameter and thus can be used as infix function.
+ */
+object aSymbolicLink : Keyword
+
+/**
  * A helper construct to allow expressing assertions about a path being absolute.
  * It can be used for a parameterless function so that it has one parameter and thus can be used as infix function.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -333,6 +333,21 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aDirectory: aD
     _logicAppend { isDirectory() }
 
 /**
+ * Expects that the subject of `this` expectation (a [Path]) is a symbolic link;
+ * meaning that there is a file system entry at the location the [Path] points to and that is a symbolic link.
+ *
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertion works on.
+ * Its result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.16.0
+ */
+infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aSymbolicLink: aSymbolicLink): Expect<T> =
+    _logicAppend { toBeASymbolicLink() }
+
+/**
  * Expects that the subject of `this` expectation (a [Path]) is an absolute path;
  * meaning that the [Path] specified in this instance starts at the file system root.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/PathExpectationsSpec.kt
@@ -19,6 +19,7 @@ class PathExpectationsSpec : ch.tutteli.atrium.specs.integration.PathExpectation
     "toBe ${executable::class.simpleName}" to Companion::isExecutable,
     "toBe ${aRegularFile::class.simpleName}" to Companion::isRegularFile,
     "toBe ${aDirectory::class.simpleName}" to Companion::isDirectory,
+    "toBe ${aSymbolicLink::class.simpleName}" to Companion::toBeASymbolicLink,
     "toBe ${relative::class.simpleName}" to Companion::isAbsolute,
     "toBe ${relative::class.simpleName}" to Companion::isRelative,
     fun1(Expect<Path>::hasDirectoryEntry),
@@ -46,6 +47,7 @@ class PathExpectationsSpec : ch.tutteli.atrium.specs.integration.PathExpectation
         private fun isExecutable(expect: Expect<Path>) = expect toBe executable
         private fun isRegularFile(expect: Expect<Path>) = expect toBe aRegularFile
         private fun isDirectory(expect: Expect<Path>) = expect toBe aDirectory
+        private fun toBeASymbolicLink(expect: Expect<Path>) = expect toBe aSymbolicLink
         private fun isAbsolute(expect: Expect<Path>) = expect toBe absolute
         private fun isRelative(expect: Expect<Path>) = expect toBe relative
         private fun hasDirectoryEntryMultiple(expect: Expect<Path>, entry: String, vararg otherEntries: String) =

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/PathAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/PathAssertionSamples.kt
@@ -1,0 +1,32 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.aSymbolicLink
+import ch.tutteli.atrium.api.infix.en_GB.toBe
+import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.niok.newFile
+import java.nio.file.Files
+import kotlin.test.Test
+
+class PathAssertionSamples {
+
+    private val tempDir = Files.createTempDirectory("PathAssertionSamples")
+
+    @Test
+    fun isASymbolicLink() {
+        val target = tempDir.newFile("target")
+        val link = Files.createSymbolicLink(tempDir.resolve("link"), target)
+
+        // Passes, as subject `link` is a symbolic link
+        expect(link) toBe aSymbolicLink
+    }
+
+    @Test
+    fun isNotASymbolicLink() {
+        val path = tempDir.newFile("somePath")
+
+        // Fails, as subject `path` is a not a symbolic link
+        fails {
+            expect(path) toBe aSymbolicLink
+        }
+    }
+}

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
@@ -34,6 +34,7 @@ fun <T : Path> AssertionContainer<T>.isWritable(): Assertion = impl.isWritable(t
 fun <T : Path> AssertionContainer<T>.isExecutable(): Assertion = impl.isExecutable(this)
 fun <T : Path> AssertionContainer<T>.isRegularFile(): Assertion = impl.isRegularFile(this)
 fun <T : Path> AssertionContainer<T>.isDirectory(): Assertion = impl.isDirectory(this)
+fun <T : Path> AssertionContainer<T>.toBeASymbolicLink(): Assertion = impl.toBeASymbolicLink(this)
 fun <T : Path> AssertionContainer<T>.isAbsolute(): Assertion = impl.isAbsolute(this)
 fun <T : Path> AssertionContainer<T>.isRelative(): Assertion = impl.isRelative(this)
 

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
@@ -29,6 +29,7 @@ interface PathAssertions {
     fun <T : Path> isExecutable(container: AssertionContainer<T>): Assertion
     fun <T : Path> isRegularFile(container: AssertionContainer<T>): Assertion
     fun <T : Path> isDirectory(container: AssertionContainer<T>): Assertion
+    fun <T : Path> toBeASymbolicLink(container: AssertionContainer<T>): Assertion
     fun <T : Path> isAbsolute(container: AssertionContainer<T>): Assertion
     fun <T : Path> isRelative(container: AssertionContainer<T>): Assertion
 

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultPathAssertions.kt
@@ -112,6 +112,9 @@ class DefaultPathAssertions : PathAssertions {
     override fun <T : Path> isDirectory(container: AssertionContainer<T>): Assertion =
         fileTypeAssertion(container, A_DIRECTORY) { it.isDirectory }
 
+    override fun <T : Path> toBeASymbolicLink(container: AssertionContainer<T>): Assertion =
+        fileTypeAssertion(container, A_SYMBOLIC_LINK, NOFOLLOW_LINKS) { it.isSymbolicLink }
+
     override fun <T : Path> isAbsolute(container: AssertionContainer<T>): Assertion =
         container.createDescriptiveAssertion(DescriptionBasic.IS, ABSOLUTE_PATH) { it.isAbsolute }
 
@@ -147,8 +150,9 @@ class DefaultPathAssertions : PathAssertions {
     private inline fun <T : Path> fileTypeAssertion(
         container: AssertionContainer<T>,
         typeName: Translatable,
+        linkOption: LinkOption? = null,
         crossinline typeTest: (BasicFileAttributes) -> Boolean
-    ) = changeSubjectToFileAttributes(container) { fileAttributesExpect ->
+    ) = changeSubjectToFileAttributes(container, linkOption) { fileAttributesExpect ->
         assertionBuilder.descriptive
             .withTest(fileAttributesExpect) { it is Success && typeTest(it.value) }
             .withFileAttributesFailureHint(fileAttributesExpect)


### PR DESCRIPTION
For both infix and fluent API styles



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
