### PR TITLE
#636 improve perfomance  filter duplicates

### DIFF
--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -176,13 +176,9 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
     ): Assertion = LazyThreadUnsafeAssertionGroup {
         val list = transformToList(container, converter)
 
-        val duplicates = createIndexAssertions(list) { (index, element) ->
-            list.forEachIndexed { elementIndex, elementValue ->
-                if(elementValue == element && elementIndex != index) {
-                    return@createIndexAssertions true
-                }
-            }
-            return@createIndexAssertions false
+        val lookupHashSet = HashSet<E>()
+        val duplicates = createIndexAssertions(list) { (_, element) ->
+            !lookupHashSet.add(element)
         }
         createHasElementPlusFixedClaimGroup(
             list,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -176,8 +176,13 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
     ): Assertion = LazyThreadUnsafeAssertionGroup {
         val list = transformToList(container, converter)
 
-        val duplicates = createIndexAssertions(list) { (_, element) ->
-            list.count { e -> e == element } > 1
+        val duplicates = createIndexAssertions(list) { (index, element) ->
+            list.forEachIndexed { elementIndex, elementValue ->
+                if(elementIndex != index && elementValue == element) {
+                    return@createIndexAssertions true
+                }
+            }
+            return@createIndexAssertions false
         }
         createHasElementPlusFixedClaimGroup(
             list,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -178,7 +178,7 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
 
         val duplicates = createIndexAssertions(list) { (index, element) ->
             list.forEachIndexed { elementIndex, elementValue ->
-                if(elementIndex != index && elementValue == element) {
+                if(elementValue == element && elementIndex != index) {
                     return@createIndexAssertions true
                 }
             }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableExpectationsSpec.kt
@@ -145,7 +145,7 @@ abstract class IterableExpectationsSpec(
             }.toThrow<AssertionError> {
                 message {
                     contains("$hasNotDescr: $duplicateElements")
-                    contains(index(0, 1), index(1, 2), index(2, 1), index(3, 2), index(5, 4), index(6, 4), index(7, 4))
+                    contains(index(2, 1), index(3, 2), index(6, 4), index(7, 4))
                 }
             }
         }


### PR DESCRIPTION
I have improved the algorithm search of duplications.
We iterate over the list until the first equality of elements, where the elements' indices are not equal.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
