### PR TITLE
Add samples for mapEntryAssertions of api-fluent

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -12,6 +12,8 @@ import ch.tutteli.atrium.logic.*
  * reporting etc.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.isKeyValue
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
     _logicAppend { isKeyValue(key, value) }
@@ -31,6 +33,8 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
  * returns an [Expect] for the current subject of `this` expectation.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.key
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.key().collectAndAppend(assertionCreator)
@@ -50,6 +54,8 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
  * returns an [Expect] for the current subject of `this` expectation.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.value
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.value().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -23,6 +23,8 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.keyFeature
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = _logic.key().transform()
@@ -44,6 +46,8 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> 
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.valueFeature
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = _logic.value().transform()

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -13,7 +13,7 @@ import ch.tutteli.atrium.logic.*
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.isKeyValue
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.isKeyValue
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
     _logicAppend { isKeyValue(key, value) }
@@ -24,7 +24,7 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.keyFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.keyFeature
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = _logic.key().transform()
@@ -36,7 +36,7 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.key
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.key
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.key().collectAndAppend(assertionCreator)
@@ -47,7 +47,7 @@ fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> 
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.valueFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.valueFeature
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = _logic.value().transform()
@@ -59,7 +59,7 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryAssertionSamples.value
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.value
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.value().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryAssertionSamples.kt
@@ -1,0 +1,47 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class MapEntryAssertionSamples {
+
+    @Test
+    fun isKeyValue() {
+        expect(mapOf(1 to "a").entries.first()).isKeyValue(1, "a")
+
+        fails {
+            expect(mapOf(1 to "a").entries.first()).isKeyValue(1, "b")
+        }
+    }
+
+    @Test
+    fun key() {
+        expect(mapOf(1 to "a").entries.first())
+            .key {
+                isEqualComparingTo(1)
+            }
+
+        fails {
+            expect(mapOf(1 to "a").entries.first())
+                .key {
+                    isEqualComparingTo(2)
+                }
+        }
+    }
+
+    @Test
+    fun value() {
+        expect(mapOf(1 to "a").entries.first())
+            .value {
+                isEqualComparingTo("a")
+            }
+
+        fails {
+            expect(mapOf(1 to "a").entries.first())
+                .value {
+                    isEqualComparingTo("b")
+                }
+        }
+    }
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryAssertionSamples.kt
@@ -16,6 +16,15 @@ class MapEntryAssertionSamples {
     }
 
     @Test
+    fun keyFeature() {
+        expect(mapOf(1 to "a").entries.first()).key.toBe(1)
+
+        fails {
+            expect(mapOf(1 to "a").entries.first()).key.toBe(2)
+        }
+    }
+
+    @Test
     fun key() {
         expect(mapOf(1 to "a").entries.first())
             .key {
@@ -27,6 +36,15 @@ class MapEntryAssertionSamples {
                 .key {
                     isEqualComparingTo(2)
                 }
+        }
+    }
+
+    @Test
+    fun valueFeature() {
+        expect(mapOf(1 to "a").entries.first()).value.toBe("a")
+
+        fails {
+            expect(mapOf(1 to "a").entries.first()).value.toBe("b")
         }
     }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
@@ -1,6 +1,7 @@
-package ch.tutteli.atrium.api.fluent.en_GB.samples
+package ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.fluent.en_GB.samples.fails
 import ch.tutteli.atrium.api.verbs.internal.expect
 import kotlin.test.Test
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
@@ -29,13 +29,13 @@ class MapEntryAssertionSamples {
     fun key() {
         expect(mapOf(1 to "a").entries.first())
             .key {
-                isEqualComparingTo(1)
+                toBe(1)
             }
 
         fails {
             expect(mapOf(1 to "a").entries.first())
                 .key {
-                    isEqualComparingTo(2)
+                    toBe(2)
                 }
         }
     }
@@ -53,13 +53,13 @@ class MapEntryAssertionSamples {
     fun value() {
         expect(mapOf(1 to "a").entries.first())
             .value {
-                isEqualComparingTo("a")
+                toBe("a")
             }
 
         fails {
             expect(mapOf(1 to "a").entries.first())
                 .value {
-                    isEqualComparingTo("b")
+                    toBe("b")
                 }
         }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
@@ -18,48 +18,56 @@ class MapEntryAssertionSamples {
 
     @Test
     fun keyFeature() {
-        expect(mapOf(1 to "a").entries.first()).key.toBe(1)
+        expect(mapOf(1 to "a").entries.first())
+            .key    // subject here is of type Int (actually 1)
+            .toBe(1)
 
         fails {
-            expect(mapOf(1 to "a").entries.first()).key.toBe(2)
+            expect(mapOf(1 to "a").entries.first())
+                .key    // subject here is of type Int (actually 1)
+                .toBe(2)    // fails because 1 is not equal to 2
         }
     }
 
     @Test
     fun key() {
         expect(mapOf(1 to "a").entries.first())
-            .key {
+            .key {  // subject inside this block is of type Int (actually 1)
                 toBe(1)
             }
 
         fails {
             expect(mapOf(1 to "a").entries.first())
-                .key {
-                    toBe(2)
+                .key {  // subject inside this block is of type Int (actually 1)
+                    toBe(2) // fails because 1 is not equal to 2
                 }
         }
     }
 
     @Test
     fun valueFeature() {
-        expect(mapOf(1 to "a").entries.first()).value.toBe("a")
+        expect(mapOf(1 to "a").entries.first())
+            .value  // subject here is of type String (actually "a")
+            .toBe("a")
 
         fails {
-            expect(mapOf(1 to "a").entries.first()).value.toBe("b")
+            expect(mapOf(1 to "a").entries.first())
+                .value  // subject here is of type String (actually "a")
+                .toBe("b")  // fails because "a" is not equal to "b"
         }
     }
 
     @Test
     fun value() {
         expect(mapOf(1 to "a").entries.first())
-            .value {
+            .value {    // subject inside this block is of type String (actually "a")
                 toBe("a")
             }
 
         fails {
             expect(mapOf(1 to "a").entries.first())
-                .value {
-                    toBe("b")
+                .value {    // subject inside this block is of type String (actually "a")
+                    toBe("b")   // fails because "a" is not equal to "b"
                 }
         }
     }


### PR DESCRIPTION
Solution for issue [#655](https://github.com/robstoll/atrium/issues/655)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
