### PR TITLE
fix readme re-generation, use always ReadmeObjectFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ import ch.tutteli.atrium.api.verbs.expect
 val x = 10
 expect(x).toBe(9)
 ```
-↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/FirstExampleSpec.kt#L30)</sub> ↓ <sub>[Output](#ex-first)</sub>
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/FirstExampleSpec.kt#L31)</sub> ↓ <sub>[Output](#ex-first)</sub>
 <a name="ex-first"></a>
 ```text
 expected that subject: 10        (kotlin.Int <1234789>)
@@ -1180,7 +1180,7 @@ expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>
   ✘ an element which equals: 3        (kotlin.Int <1234789>)
   ✔ an element which equals: 4        (kotlin.Int <1234789>)
   ❗❗ following elements were mismatched: 
-     ⚬ 2        (kotlin.Int <1943296756>)
+     ⚬ 2        (kotlin.Int <1234789>)
 ```
 </ex-collection-builder-4>
 <hr/>
@@ -1951,7 +1951,7 @@ and its usage:
 ```kotlin
 expect(12).isMultipleOf(5)
 ```
-↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L34)</sub> ↓ <sub>[Output](#ex-own-boolean-1)</sub>
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L39)</sub> ↓ <sub>[Output](#ex-own-boolean-1)</sub>
 <a name="ex-own-boolean-1"></a>
 ```text
 expected that subject: 12        (kotlin.Int <1234789>)
@@ -2001,7 +2001,7 @@ Its usage looks then as follows:
 ```kotlin
 expect(13).isEven()
 ```
-↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L45)</sub> ↓ <sub>[Output](#ex-own-boolean-2)</sub>
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L50)</sub> ↓ <sub>[Output](#ex-own-boolean-2)</sub>
 <a name="ex-own-boolean-2"></a>
 ```text
 expected that subject: 13        (kotlin.Int <1234789>)
@@ -2100,7 +2100,7 @@ Its usage is then as follows:
 expect(Person("Susanne", "Whitley", 43, listOf()))
     .hasNumberOfChildren(2)
 ```
-↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L62)</sub> ↓ <sub>[Output](#ex-own-compose-3)</sub>
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L67)</sub> ↓ <sub>[Output](#ex-own-compose-3)</sub>
 <a name="ex-own-compose-3"></a>
 ```text
 expected that subject: Person(firstName=Susanne, lastName=Whitley, age=43, children=[])        (readme.examples.Person <1234789>)
@@ -2134,7 +2134,7 @@ but we do not have to, as `all` already checks that there is at least one elemen
 expect(Person("Susanne", "Whitley", 43, listOf()))
     .hasAdultChildren()
 ```
-↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L77)</sub> ↓ <sub>[Output](#ex-own-compose-4)</sub>
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L82)</sub> ↓ <sub>[Output](#ex-own-compose-4)</sub>
 <a name="ex-own-compose-4"></a>
 ```text
 expected that subject: Person(firstName=Susanne, lastName=Whitley, age=43, children=[])        (readme.examples.Person <1234789>)
@@ -2176,7 +2176,7 @@ expect(Person("Susanne", "Whitley", 43, listOf(Person("Petra", "Whitley", 12, li
     .children // using the val -> subsequent assertions are about children and fail fast
     .hasSize(2)
 ```
-↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L87)</sub> ↓ <sub>[Output](#ex-own-compose-5)</sub>
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt#L92)</sub> ↓ <sub>[Output](#ex-own-compose-5)</sub>
 <a name="ex-own-compose-5"></a>
 ```text
 expected that subject: Person(firstName=Susanne, lastName=Whitley, age=43, children=[Person(firstName=Petra, lastName=Whitley, age=12, children=[])])        (readme.examples.Person <1234789>)
@@ -2203,7 +2203,7 @@ because Kotlin cannot infer the types automatically.
 <code-own-compose-6>
 
 ```kotlin
-//snippet-mapArguments-insert
+import ch.tutteli.atrium.logic.utils.mapArguments
 
 fun <T : List<Pair<String, String>>> Expect<T>.areNamesOf(
     person: Person, vararg otherPersons: Person
@@ -2334,29 +2334,48 @@ which is used internally of Atrium in tests and uses a different `AtriumErrorAdj
 
 Another example, say you prefer multi-line reporting over single-line reporting,
 then you can use `withOptions` as follows:
-```kotlin
-withOptions {
-    withComponent(TextAssertionPairFormatter::class) { c ->
-        TextAssertionPairFormatter.newNextLine(c.build(), c.build())
-    }
-}
-```
 
-The output looks then as follows:
+<code-own-expectation-verb>
+
 ```kotlin
-expect(x).toBe(9)
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.creating.build
+
+@OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
+fun <T> expect(subject: T): RootExpect<T> =
+    RootExpectBuilder.forSubject(subject)
+        .withVerb("expected the subject")
+        .withOptions {
+            withComponent(TextAssertionPairFormatter::class) { c ->
+                TextAssertionPairFormatter.newNextLine(c.build(), c.build())
+            }
+        }
+        .build()
 ```
-Would then look as follows:
+</code-own-expectation-verb>
+
+Following an example using the expectation verb
+
+<ex-own-expectation-verb>
+
+```kotlin
+expect(10).toBe(9)
+```
+↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationVerbSpec.kt#L51)</sub> ↓ <sub>[Output](#ex-own-expectation-verb)</sub>
+<a name="ex-own-expectation-verb"></a>
 ```text
-expect: 
-  10        (kotlin.Int <934275857>)
-◆ to be: 
-  9        (kotlin.Int <1364913072>)
+expected the subject:
+  10        (kotlin.Int <1234789>)
+◆ equals:
+  9        (kotlin.Int <1234789>)
 ```
-instead of:
+</ex-own-expectation-verb>
+
+Compare the above output with what we would get per default:
 ```
-expect: 10        (kotlin.Int <934275857>)
-◆ to be: 9        (kotlin.Int <1364913072>)
+expected the subject: 10        (kotlin.Int <1234789>)
+◆ to be: 9        (kotlin.Int <1234789>)
 ```
 
 You prefer another reporting style but Atrium does not yet support it? 

--- a/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
+++ b/core/api/atrium-core-api-common/src/main/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
@@ -17,7 +17,7 @@ expect class DefaultTextObjectFormatter(translator: Translator) : TextObjectForm
  */
 abstract class TextObjectFormatterCommon(
     private val translator: Translator
-) : ObjectFormatter {
+) : TextObjectFormatter {
 
     /**
      * Returns a formatted version of the given [value].

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -39,7 +39,7 @@ internal fun <E : Any> createExplanatoryAssertionGroup(
     return assertionBuilder.explanatoryGroup
         .withDefaultType
         .let {
-//TODO 0.16.0 looks a lot like toBeNullIfNullGiven
+            //TODO 0.16.0 looks a lot like toBeNullIfNullGiven
             if (assertionCreatorOrNull != null) {
                 // we don't use a subject, we will not show it anyway
                 it.collectAssertions(container, None, assertionCreatorOrNull)

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/FirstExampleSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/FirstExampleSpec.kt
@@ -5,6 +5,7 @@ package readme.examples
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.expect
 //snippet-import-end
+//@formatter:on
 
 import ch.tutteli.atrium.creating.Expect
 import org.spekframework.spek2.Spek

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/I18nSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/I18nSpec.kt
@@ -8,6 +8,7 @@ import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.*
 //snippet-import-logic-end
 //@formatter:on
+
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt
@@ -1,8 +1,13 @@
 package readme.examples
 
+//@formatter:off
+//snippet-mapArguments-start
+import ch.tutteli.atrium.logic.utils.mapArguments
+//snippet-mapArguments-end
+//@formatter:on
+
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.logic.utils.mapArguments
 import ch.tutteli.atrium.reporting.Text
 import org.spekframework.spek2.Spek
 import readme.examples.utils.expect

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationVerbSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationVerbSpec.kt
@@ -1,0 +1,67 @@
+package readme.examples
+
+//@formatter:off
+//snippet-own-expectation-verb-import-start
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.creating.build
+//snippet-own-expectation-verb-import-end
+//@formatter:on
+
+import ch.tutteli.atrium.api.fluent.en_GB.ExperimentalWithOptions
+import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.api.fluent.en_GB.withOptions
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.RootExpect
+import ch.tutteli.atrium.logic.creating.RootExpectBuilder
+import ch.tutteli.atrium.reporting.ObjectFormatter
+import ch.tutteli.atrium.reporting.text.TextAssertionPairFormatter
+import org.spekframework.spek2.Spek
+import readme.examples.utils.ReadmeObjectFormatter
+import readme.examples.expect as expectWithNewLine
+
+/**
+ * The tests and error message are written here and automatically placed into the README via generation.
+ * The generation is done during the project built. To trigger it manually, you have to run:
+ * ```
+ * ./gradlew :readme-examples:build
+ * ```
+ *
+ * There are currently three kind of tags supported:
+ * - <ex-xy> => places code and output into the tag
+ * - <exs-xy> => places code into the tag, output will be put into a tag named <exs-xy-output>
+ * - <code> => is not supposed to fail and only the code is put into the code
+ *
+ * Moreover, all tags can reuse snippets defined in this file with corresponding markers
+ */
+
+object OwnExpectationVerbSpec : Spek({
+    test("code-own-expectation-verb") {
+        //snippet-own-expectation-verb-import-insert
+
+        //snippet-own-expectation-verb-insert
+    }
+
+    @OptIn(ExperimentalWithOptions::class, ExperimentalComponentFactoryContainer::class)
+    fun <T> expect(subject: T): Expect<T> =
+        expectWithNewLine(subject).withOptions {
+            withComponent(ObjectFormatter::class) { c -> ReadmeObjectFormatter(c.build()) }
+        }
+
+    test("ex-own-expectation-verb") {
+        expect(10).toBe(9)
+    }
+})
+
+//snippet-own-expectation-verb-start
+@OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
+fun <T> expect(subject: T): RootExpect<T> =
+    RootExpectBuilder.forSubject(subject)
+        .withVerb("expected the subject")
+        .withOptions {
+            withComponent(TextAssertionPairFormatter::class) { c ->
+                TextAssertionPairFormatter.newNextLine(c.build(), c.build())
+            }
+        }
+        .build()
+//snippet-own-expectation-verb-end

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/utils/expect.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/utils/expect.kt
@@ -5,14 +5,14 @@ import ch.tutteli.atrium.api.fluent.en_GB.withOptions
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.creating.build
-import ch.tutteli.atrium.reporting.ObjectFormatter
+import ch.tutteli.atrium.reporting.text.TextObjectFormatter
 import ch.tutteli.atrium.reporting.text.impl.AbstractTextObjectFormatter
 import ch.tutteli.atrium.reporting.translating.Translator
 
 @OptIn(ExperimentalWithOptions::class, ExperimentalComponentFactoryContainer::class)
 fun <T> expect(t: T): Expect<T> =
     ch.tutteli.atrium.api.verbs.expect(t).withOptions {
-        withComponent(ObjectFormatter::class) { c -> ReadmeObjectFormatter(c.build()) }
+        withSingletonComponent(TextObjectFormatter::class) { c -> ReadmeObjectFormatter(c.build()) }
     }
 
 fun <T> expect(t: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =

--- a/misc/verbs-internal/atrium-verbs-internal-common/src/main/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/verbs-internal/atrium-verbs-internal-common/src/main/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -26,7 +26,6 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
 fun <T> expect(subject: T): RootExpect<T> =
-
     RootExpectBuilder.forSubject(subject)
         .withVerb(EXPECT)
         .withOptions {


### PR DESCRIPTION
moreover:
- fix the broken link for mapArguments snippet
- let TextObjectFormatterCommon extend TextObjectFormatter



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
