### PR TITLE
show max 10 dir entries (with ellipsis) for isEmptyDirectory

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -81,6 +81,31 @@ fun <T : Path> Expect<T>.existsNot(): Expect<T> =
     _logicAppend { existsNot() }
 
 /**
+ * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect] for the extracted feature.
+ *
+ * @since 0.9.0
+ */
+val <T : Path> Expect<T>.extension: Expect<String>
+    get() = _logic.extension().transform()
+
+/**
+ * Expects that the property [Path.extension][ch.tutteli.niok.extension]
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of `this` expectation.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.9.0
+ */
+fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
+    _logic.extension().collectAndAppend(assertionCreator)
+
+/**
  * Creates an [Expect] for the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
@@ -281,11 +306,10 @@ fun <T : Path> Expect<T>.isDirectory(): Expect<T> =
  *
  * @since 0.16.0
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathAssertionSamples.isASymbolicLink
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathAssertionSamples.isNotASymbolicLink
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.PathAssertionSamples.isASymbolicLink
  */
-fun <T : Path> Expect<T>.toBeASymbolicLink(): Expect<T> =
-    _logicAppend { toBeASymbolicLink() }
+fun <T : Path> Expect<T>.isSymbolicLink(): Expect<T> =
+    _logicAppend { isSymbolicLink() }
 
 /**
  * Expects that the subject of `this` expectation (a [Path]) is an absolute path;
@@ -310,6 +334,19 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
     _logicAppend { isRelative() }
 
 /**
+ * Expects that the subject of `this` expectation (a [Path]) is an empty directory;
+ * meaning that there is a file system entry at the location the [Path] points to and that is an empty directory.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.16.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.PathAssertionSamples.isEmptyDirectory
+ */
+fun <T : Path> Expect<T>.isEmptyDirectory(): Expect<T> =
+    _logicAppend { isEmptyDirectory() }
+
+/**
  * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided entries.
  * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
  * Furthermore, every argument string resolved against the subject yields an existing file system entry.
@@ -330,30 +367,6 @@ fun <T : Path> Expect<T>.isRelative(): Expect<T> =
 fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String, vararg otherEntries: String): Expect<T> =
     _logicAppend { hasDirectoryEntry(entry glue otherEntries) }
 
-/**
- * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
- * so that further fluent calls are assertions about it.
- *
- * @return The newly created [Expect] for the extracted feature.
- *
- * @since 0.9.0
- */
-val <T : Path> Expect<T>.extension: Expect<String>
-    get() = _logic.extension().transform()
-
-/**
- * Expects that the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
- * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of `this` expectation.
- *
- * @return an [Expect] for the subject of `this` expectation.
- *
- * @since 0.9.0
- */
-fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.extension().collectAndAppend(assertionCreator)
 
 /**
  * Expects that the subject of `this` expectation (a [Path]) has the same textual content
@@ -382,17 +395,3 @@ fun <T : Path> Expect<T>.hasSameTextualContentAs(
  */
 fun <T : Path> Expect<T>.hasSameBinaryContentAs(targetPath: Path): Expect<T> =
     _logicAppend { hasSameBinaryContentAs(targetPath) }
-
-/**
- * Expects that the subject of `this` expectation (a [Path]) is an empty directory;
- * meaning that there is a file system entry at the location the [Path] points to and that is an empty directory.
- *
- * @return an [Expect] for the subject of `this` expectation.
- *
- * @since 0.16.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathAssertionSamples.isEmptyDirectory
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathAssertionSamples.isNotEmptyDirectory
- */
-fun <T : Path> Expect<T>.isEmptyDirectory(): Expect<T> =
-    _logicAppend { isEmptyDirectory() }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/PathExpectationsSpec.kt
@@ -17,7 +17,7 @@ class PathExpectationsSpec : ch.tutteli.atrium.specs.integration.PathExpectation
     fun0(Expect<Path>::isExecutable),
     fun0(Expect<Path>::isRegularFile),
     fun0(Expect<Path>::isDirectory),
-    fun0(Expect<Path>::toBeASymbolicLink),
+    fun0(Expect<Path>::isSymbolicLink),
     fun0(Expect<Path>::isAbsolute),
     fun0(Expect<Path>::isRelative),
     fun0(Expect<Path>::isEmptyDirectory),
@@ -59,7 +59,7 @@ class PathExpectationsSpec : ch.tutteli.atrium.specs.integration.PathExpectation
         a1.isWritable()
         a1.isRegularFile()
         a1.isDirectory()
-        a1.toBeASymbolicLink()
+        a1.isSymbolicLink()
         a1.hasSameBinaryContentAs(Paths.get("a"))
         a1.hasSameTextualContentAs(Paths.get("a"))
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/PathAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/PathAssertionSamples.kt
@@ -1,8 +1,8 @@
-package ch.tutteli.atrium.api.infix.en_GB.samples
+package ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated
 
-import ch.tutteli.atrium.api.infix.en_GB.aSymbolicLink
-import ch.tutteli.atrium.api.infix.en_GB.anEmptyDirectory
-import ch.tutteli.atrium.api.infix.en_GB.toBe
+import ch.tutteli.atrium.api.fluent.en_GB.isEmptyDirectory
+import ch.tutteli.atrium.api.fluent.en_GB.samples.fails
+import ch.tutteli.atrium.api.fluent.en_GB.isSymbolicLink
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.niok.newDirectory
 import ch.tutteli.niok.newFile
@@ -19,31 +19,24 @@ class PathAssertionSamples {
         val link = Files.createSymbolicLink(tempDir.resolve("link"), target)
 
         // Passes, as subject `link` is a symbolic link
-        expect(link) toBe aSymbolicLink
-    }
+        expect(link).isSymbolicLink()
 
-    @Test
-    fun isNotASymbolicLink() {
-        val path = tempDir.newFile("somePath")
+        val file = tempDir.newFile("somePath")
 
         // Fails, as subject `path` is a not a symbolic link
         fails {
-            expect(path) toBe aSymbolicLink
+            expect(file).isSymbolicLink()
         }
     }
 
     @Test
     fun isEmptyDirectory() {
-        val path = tempDir.newDirectory("dir")
-        expect(path) toBe anEmptyDirectory
-    }
+        val dir = tempDir.newDirectory("dir")
+        expect(dir).isEmptyDirectory()
 
-    @Test
-    fun isNotEmptyDirectory() {
-        tempDir.newFile("a")
-
+        dir.newFile("test.txt")
         fails {
-            expect(tempDir) toBe anEmptyDirectory
+            expect(dir).isEmptyDirectory()
         }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathAssertions.kt
@@ -83,6 +83,31 @@ infix fun <T : Path> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") existing: e
     _logicAppend { existsNot() }
 
 /**
+ * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect] for the extracted feature.
+ *
+ * @since 0.12.0
+ */
+val <T : Path> Expect<T>.extension: Expect<String>
+    get() = _logic.extension().transform()
+
+/**
+ * Expects that the property [Path.extension][ch.tutteli.niok.extension]
+ * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of `this` expectation.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.12.0
+ */
+infix fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
+    _logic.extension().collectAndAppend(assertionCreator)
+
+/**
  * Creates an [Expect] for the property [Path.fileNameAsString][ch.tutteli.niok.fileNameAsString]
  * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
@@ -164,58 +189,6 @@ infix fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit)
  */
 infix fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
     _logic.resolve(other).transform()
-
-/**
- * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided [entry].
- * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
- * Furthermore, the argument string resolved against the subject yields an existing file system entry.
- *
- * This assertion _resolves_ symbolic links for the subject, but not for the [entry].
- * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
- * the link points at. If a symbolic link exists at the [entry], this will fulfill the assertion and the entry’s
- * symbolic link will not be followed.
- *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
- * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
- * take place.
- *
- * @return an [Expect] for the subject of `this` expectation.
- * @see [has]
- *
- * @since 0.14.0
- */
-infix fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String) =
-    _logicAppend { hasDirectoryEntry(listOf(entry)) }
-
-/**
- * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided entries.
- * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
- * Furthermore, every argument string resolved against the subject yields an existing file system entry.
- *
- * This assertion _resolves_ symbolic links for the subject, but not for the entries.
- * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
- * the link points at. If a symbolic link exists at one of the entries, this will fulfill the respective assertion and
- * the entry’s symbolic link will not be followed.
- *
- * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
- * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
- * take place.
- *
- * @return an [Expect] for the subject of `this` expectation.
- * @see [directoryEntries]
- * @see [hasDirectoryEntry]
- *
- * @since 0.14.0
- */
-infix fun <T : Path> Expect<T>.has(directoryEntries: DirectoryEntries) =
-    _logicAppend { hasDirectoryEntry(directoryEntries.toList()) }
-
-/**
- * Helper function for [has] to create [DirectoryEntries] with the provided [entry] and the [otherEntries].
- *
- * @since 0.14.0
- */
-fun directoryEntries(entry: String, vararg otherEntries: String) = DirectoryEntries(entry, otherEntries)
 
 /**
  * Expects that [PathWithCreator.path] resolves against this [Path], that the resolved [Path] holds all assertions the
@@ -343,11 +316,10 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aDirectory: aD
  *
  * @since 0.16.0
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathAssertionSamples.isASymbolicLink
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathAssertionSamples.isNotASymbolicLink
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.PathAssertionSamples.toBeASymbolicLink
  */
 infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aSymbolicLink: aSymbolicLink): Expect<T> =
-    _logicAppend { toBeASymbolicLink() }
+    _logicAppend { isSymbolicLink() }
 
 /**
  * Expects that the subject of `this` expectation (a [Path]) is an absolute path;
@@ -373,29 +345,69 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") relative: rela
 
 
 /**
- * Creates an [Expect] for the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation,
- * so that further fluent calls are assertions about it.
+ * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided [entry].
+ * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
+ * Furthermore, the argument string resolved against the subject yields an existing file system entry.
  *
- * @return The newly created [Expect] for the extracted feature.
+ * This assertion _resolves_ symbolic links for the subject, but not for the [entry].
+ * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
+ * the link points at. If a symbolic link exists at the [entry], this will fulfill the assertion and the entry’s
+ * symbolic link will not be followed.
  *
- * @since 0.12.0
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
+ * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ * @see [has]
+ *
+ * @since 0.14.0
  */
-val <T : Path> Expect<T>.extension: Expect<String>
-    get() = _logic.extension().transform()
+infix fun <T : Path> Expect<T>.hasDirectoryEntry(entry: String) =
+    _logicAppend { hasDirectoryEntry(listOf(entry)) }
 
 /**
- * Expects that the property [Path.extension][ch.tutteli.niok.extension]
- * (provided via [niok](https://github.com/robstoll/niok)) of the subject of `this` expectation
- * holds all assertions the given [assertionCreator] creates for it and
- * returns an [Expect] for the current subject of `this` expectation.
+ * Expects that the subject of `this` expectation (a [Path]) is a directory having the provided entries.
+ * That means that there is a file system entry at the location the [Path] points to and that it is a directory.
+ * Furthermore, every argument string resolved against the subject yields an existing file system entry.
+ *
+ * This assertion _resolves_ symbolic links for the subject, but not for the entries.
+ * Therefore, if a symbolic link exists at the location the subject points to, the search will continue at the location
+ * the link points at. If a symbolic link exists at one of the entries, this will fulfill the respective assertion and
+ * the entry’s symbolic link will not be followed.
+ *
+ * This assertion is not atomic with respect to concurrent file system operations on the paths the assertions work on.
+ * The result, in particular its extended explanations, may be wrong if such concurrent file system operations
+ * take place.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ * @see [directoryEntries]
+ * @see [hasDirectoryEntry]
+ *
+ * @since 0.14.0
+ */
+infix fun <T : Path> Expect<T>.has(directoryEntries: DirectoryEntries) =
+    _logicAppend { hasDirectoryEntry(directoryEntries.toList()) }
+
+/**
+ * Helper function for [has] to create [DirectoryEntries] with the provided [entry] and the [otherEntries].
+ *
+ * @since 0.14.0
+ */
+fun directoryEntries(entry: String, vararg otherEntries: String) = DirectoryEntries(entry, otherEntries)
+
+/**
+ * Expects that the subject of `this` expectation (a [Path]) is an empty directory;
+ * meaning that there is a file system entry at the location the [Path] points to and that is an empty directory.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.12.0
+ * @since 0.16.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.PathAssertionSamples.toBeAnEmptyDirectory
  */
-infix fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
-    _logic.extension().collectAndAppend(assertionCreator)
+infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") anEmptyDirectory: anEmptyDirectory): Expect<T> =
+    _logicAppend { isEmptyDirectory() }
 
 /**
  * Expects that the subject of `this` expectation (a [Path]) has the same textual content
@@ -449,17 +461,3 @@ infix fun <T : Path> Expect<T>.hasSameTextualContentAs(pathWithEncoding: PathWit
  */
 infix fun <T : Path> Expect<T>.hasSameBinaryContentAs(targetPath: Path): Expect<T> =
     _logicAppend { hasSameBinaryContentAs(targetPath) }
-
-/**
- * Expects that the subject of `this` expectation (a [Path]) is an empty directory;
- * meaning that there is a file system entry at the location the [Path] points to and that is an empty directory.
- *
- * @return an [Expect] for the subject of `this` expectation.
- *
- * @since 0.16.0
- *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathAssertionSamples.isEmptyDirectory
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathAssertionSamples.isNotEmptyDirectory
- */
-infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") anEmptyDirectory: anEmptyDirectory): Expect<T> =
-    _logicAppend { isEmptyDirectory() }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/PathAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/PathAssertionSamples.kt
@@ -1,7 +1,9 @@
-package ch.tutteli.atrium.api.fluent.en_GB.samples
+package ch.tutteli.atrium.api.infix.en_GB.samples.deprecated
 
-import ch.tutteli.atrium.api.fluent.en_GB.isEmptyDirectory
-import ch.tutteli.atrium.api.fluent.en_GB.toBeASymbolicLink
+import ch.tutteli.atrium.api.infix.en_GB.aSymbolicLink
+import ch.tutteli.atrium.api.infix.en_GB.anEmptyDirectory
+import ch.tutteli.atrium.api.infix.en_GB.samples.fails
+import ch.tutteli.atrium.api.infix.en_GB.toBe
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.niok.newDirectory
 import ch.tutteli.niok.newFile
@@ -13,28 +15,23 @@ class PathAssertionSamples {
     private val tempDir = Files.createTempDirectory("PathAssertionSamples")
 
     @Test
-    fun isASymbolicLink() {
+    fun toBeASymbolicLink() {
         val target = tempDir.newFile("target")
         val link = Files.createSymbolicLink(tempDir.resolve("link"), target)
 
         // Passes, as subject `link` is a symbolic link
-        expect(link).toBeASymbolicLink()
-    }
+        expect(link) toBe aSymbolicLink
 
-    @Test
-    fun isNotASymbolicLink() {
-        val path = tempDir.newFile("somePath")
-
-        // Fails, as subject `path` is a not a symbolic link
-        fails {
-            expect(path).toBeASymbolicLink()
+        val file = tempDir.newFile("somePath")
+        fails { // Fails, as subject `path` is a not a symbolic link
+            expect(file) toBe aSymbolicLink
         }
     }
 
     @Test
-    fun isEmptyDirectory() {
+    fun toBeAnEmptyDirectory() {
         val path = tempDir.newDirectory("dir")
-        expect(path).isEmptyDirectory()
+        expect(path) toBe anEmptyDirectory
     }
 
     @Test
@@ -42,7 +39,7 @@ class PathAssertionSamples {
         tempDir.newFile("a")
 
         fails {
-            expect(tempDir).isEmptyDirectory()
+            expect(tempDir) toBe anEmptyDirectory
         }
     }
 }

--- a/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
+++ b/logic/atrium-logic-jvm/src/generated/kotlin/ch/tutteli/atrium/logic/path.kt
@@ -34,9 +34,12 @@ fun <T : Path> AssertionContainer<T>.isWritable(): Assertion = impl.isWritable(t
 fun <T : Path> AssertionContainer<T>.isExecutable(): Assertion = impl.isExecutable(this)
 fun <T : Path> AssertionContainer<T>.isRegularFile(): Assertion = impl.isRegularFile(this)
 fun <T : Path> AssertionContainer<T>.isDirectory(): Assertion = impl.isDirectory(this)
-fun <T : Path> AssertionContainer<T>.toBeASymbolicLink(): Assertion = impl.toBeASymbolicLink(this)
+fun <T : Path> AssertionContainer<T>.isSymbolicLink(): Assertion = impl.isSymbolicLink(this)
 fun <T : Path> AssertionContainer<T>.isAbsolute(): Assertion = impl.isAbsolute(this)
 fun <T : Path> AssertionContainer<T>.isRelative(): Assertion = impl.isRelative(this)
+
+fun <T : Path> AssertionContainer<T>.hasDirectoryEntry(entries: List<String>): Assertion = impl.hasDirectoryEntry(this, entries)
+fun <T : Path> AssertionContainer<T>.isEmptyDirectory(): Assertion = impl.isEmptyDirectory(this)
 
 fun <T : Path> AssertionContainer<T>.hasSameTextualContentAs(targetPath: Path, sourceCharset: Charset, targetCharset: Charset): Assertion =
     impl.hasSameTextualContentAs(this, targetPath, sourceCharset, targetCharset)
@@ -48,9 +51,6 @@ fun <T : Path> AssertionContainer<T>.extension(): FeatureExtractorBuilder.Execut
 fun <T : Path> AssertionContainer<T>.fileNameWithoutExtension(): FeatureExtractorBuilder.ExecutionStep<T, String> = impl.fileNameWithoutExtension(this)
 fun <T : Path> AssertionContainer<T>.parent(): FeatureExtractorBuilder.ExecutionStep<T, Path> = impl.parent(this)
 fun <T : Path> AssertionContainer<T>.resolve(other: String): FeatureExtractorBuilder.ExecutionStep<T, Path> = impl.resolve(this, other)
-
-fun <T : Path> AssertionContainer<T>.hasDirectoryEntry(entries: List<String>): Assertion = impl.hasDirectoryEntry(this, entries)
-fun <T : Path> AssertionContainer<T>.isEmptyDirectory(): Assertion = impl.isEmptyDirectory(this)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/PathAssertions.kt
@@ -29,9 +29,12 @@ interface PathAssertions {
     fun <T : Path> isExecutable(container: AssertionContainer<T>): Assertion
     fun <T : Path> isRegularFile(container: AssertionContainer<T>): Assertion
     fun <T : Path> isDirectory(container: AssertionContainer<T>): Assertion
-    fun <T : Path> toBeASymbolicLink(container: AssertionContainer<T>): Assertion
+    fun <T : Path> isSymbolicLink(container: AssertionContainer<T>): Assertion
     fun <T : Path> isAbsolute(container: AssertionContainer<T>): Assertion
     fun <T : Path> isRelative(container: AssertionContainer<T>): Assertion
+
+    fun <T : Path> hasDirectoryEntry(container: AssertionContainer<T>, entries: List<String>): Assertion
+    fun <T : Path> isEmptyDirectory(container: AssertionContainer<T>): Assertion
 
     fun <T : Path> hasSameTextualContentAs(
         container: AssertionContainer<T>,
@@ -50,7 +53,4 @@ interface PathAssertions {
         container: AssertionContainer<T>,
         other: String
     ): FeatureExtractorBuilder.ExecutionStep<T, Path>
-
-    fun <T : Path> hasDirectoryEntry(container: AssertionContainer<T>, entries: List<String>): Assertion
-    fun <T : Path> isEmptyDirectory(container: AssertionContainer<T>): Assertion
 }

--- a/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/creating/filesystem/hints/hints.kt
+++ b/logic/atrium-logic-jvm/src/main/kotlin/ch/tutteli/atrium/logic/creating/filesystem/hints/hints.kt
@@ -57,7 +57,7 @@ fun explainForResolvedLink(
     val resolvedPathAssertion = resolvedPathAssertionProvider(realPath)
     return if (hintList.isNotEmpty()) {
         when (resolvedPathAssertion) {
-            //TODO this should be done differently
+            //TODO 0.17.0 this should be done differently - see isEmptyDirectory !! directory contains is suddenly >> directory contains.
             is AssertionGroup -> hintList.addAll(resolvedPathAssertion.assertions)
             else -> hintList.add(resolvedPathAssertion)
         }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathExpectationsSpec.kt
@@ -179,7 +179,10 @@ abstract class PathExpectationsSpec(
     }
 
     fun Suite.itPrintsFileAccessProblemDetails(forceNoLinks: Skip = No, block: (Path) -> Unit) {
-        it("prints the closest existing parent if it is a directory", forceNoLink = forceNoLinks) withAndWithoutSymlink { maybeLink ->
+        it(
+            "prints the closest existing parent if it is a directory",
+            forceNoLink = forceNoLinks
+        ) withAndWithoutSymlink { maybeLink ->
             val start = tempFolder.newDirectory("startDir").toRealPath()
             val doesNotExist = maybeLink.create(start.resolve("i").resolve("dont").resolve("exist"))
             val existingParentHintMessage =
@@ -984,7 +987,7 @@ abstract class PathExpectationsSpec(
         it("throws an AssertionError for a non-empty directory") withAndWithoutSymlink { maybeLink ->
             val dir = tempFolder.newDirectory("notEmpty")
             val showMax = 10
-            (0 until showMax+1).forEach {
+            (0 until showMax + 1).forEach {
                 dir.newFile("f$it")
             }
             val folder = maybeLink.create(dir)
@@ -993,10 +996,14 @@ abstract class PathExpectationsSpec(
             }.toThrow<AssertionError>().message {
                 contains(expectedEmptyMessage)
                 containsExplanationFor(maybeLink)
-                (0 until showMax).forEach {
-                    contains("${listBulletPoint}f$it")
+                val sb = StringBuilder()
+                // entries should be sorted but not naturally, i.e. f10 comes before f2
+                val files = ((0..1) + (10..showMax) + (2 until 10)).take(showMax)
+                files.forEach {
+                    sb.append(".*${listBulletPoint}f$it.*$lineSeperator")
                 }
-                contains("$listBulletPoint...")
+                sb.append(".*${listBulletPoint}\\.\\.\\.")
+                containsRegex(sb.toString())
                 containsNot("f${showMax + 1}")
             }
         }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/PathExpectationsSpec.kt
@@ -833,7 +833,7 @@ abstract class PathExpectationsSpec(
             it("throws an AssertionError for a non-existent path") {
                 val path = tempFolder.resolve("nonExistent")
                 expect {
-                    expect(path).toBeASymbolicLink()
+                    expect(path).isSymbolicLink()
                 }.toThrow<AssertionError>().message {
                     contains(
                         expectedMessage,
@@ -983,14 +983,21 @@ abstract class PathExpectationsSpec(
 
         it("throws an AssertionError for a non-empty directory") withAndWithoutSymlink { maybeLink ->
             val dir = tempFolder.newDirectory("notEmpty")
-            dir.newFile("a")
+            val showMax = 10
+            (0 until showMax+1).forEach {
+                dir.newFile("f$it")
+            }
             val folder = maybeLink.create(dir)
             expect {
                 expect(folder).isEmptyDirectoryFun()
             }.toThrow<AssertionError>().message {
                 contains(expectedEmptyMessage)
                 containsExplanationFor(maybeLink)
-                contains("a")
+                (0 until showMax).forEach {
+                    contains("${listBulletPoint}f$it")
+                }
+                contains("$listBulletPoint...")
+                containsNot("f${showMax + 1}")
             }
         }
 
@@ -1005,6 +1012,7 @@ abstract class PathExpectationsSpec(
                     contains(expectedEmptyMessage)
                     containsExplanationFor(maybeLink)
                     contains("a")
+                    containsNot("$listBulletPoint...")
                 }
             }
 


### PR DESCRIPTION
instead of only one. Moreover, use an explanatory assertion group with
a warning group type. Looks then as follows:
```
expected that subject: /tmp/spek16789805802838758490/notEmpty        (sun.nio.fs.UnixPath <1842823132>)
◆ is: an empty directory
    ❗❗ directory contains:
       ⚬ f5        (sun.nio.fs.UnixPath <1295966993>)
       ⚬ f2        (sun.nio.fs.UnixPath <878629898>)
       ⚬ f3        (sun.nio.fs.UnixPath <1318008636>)
       ⚬ f0        (sun.nio.fs.UnixPath <452118766>)
       ⚬ f1        (sun.nio.fs.UnixPath <552502986>)
       ⚬ f8        (sun.nio.fs.UnixPath <1657993305>)
       ⚬ f9        (sun.nio.fs.UnixPath <1439892968>)
       ⚬ f4        (sun.nio.fs.UnixPath <1508512260>)
       ⚬ f6        (sun.nio.fs.UnixPath <224794405>)
       ⚬ f7        (sun.nio.fs.UnixPath <2013476576>)
       ⚬ ...
```
moreover:
- cleanup samples, isNotEmptyDirectory should actually be in
  isEmptyDirectory because we might have a isNotEmptyDirectory in the
  future. Same same for isSymbolicLink.
- move PathAssertionSamples also to deprecated package
- rename toBeASymbolicLink to isSymbolicLink for now. Will do the rename
  once we rename all
-



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
