### PR TITLE
Add samples for collectionAssertions of api-infix

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/CollectionAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/CollectionAssertionSamples.kt
@@ -50,7 +50,7 @@ class CollectionAssertionSamples {
     fun sizeFeature() {
         expect(listOf(1, 2, 3))
             .size             // subject is now of type Int (actually 3)
-            .isGreaterThan(1) // subject is still of type Int (still 1)
+            .isGreaterThan(1) // subject is still of type Int (still 3)
             .isLessThan(4)
 
         fails {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
@@ -10,6 +10,8 @@ import ch.tutteli.kbox.identity
  * @param empty Use the pseudo-keyword `empty`.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.isEmpty
  */
 infix fun <T : Collection<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isEmpty(::identity) }
@@ -20,6 +22,8 @@ infix fun <T : Collection<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty
  * @param empty Use the pseudo-keyword `empty`.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.isNotEmpty
  */
 infix fun <T : Collection<*>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") empty: empty): Expect<T> =
     _logicAppend { isNotEmpty(::identity) }
@@ -30,6 +34,8 @@ infix fun <T : Collection<*>> Expect<T>.notToBe(@Suppress("UNUSED_PARAMETER") em
  * Shortcut for `size.toBe(expected)`.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.hasSize
  */
 infix fun <T : Collection<*>> Expect<T>.hasSize(expected: Int): Expect<T> =
     size { toBe(expected) }
@@ -50,6 +56,8 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
  * returns an [Expect] for the current subject of `this` expectation.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.sizeFeature
  */
 infix fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
     _logic.size(::identity).collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/collectionAssertions.kt
@@ -46,6 +46,8 @@ infix fun <T : Collection<*>> Expect<T>.hasSize(expected: Int): Expect<T> =
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.sizeFeature
  */
 val <T : Collection<*>> Expect<T>.size: Expect<Int>
     get() = _logic.size(::identity).transform()
@@ -57,7 +59,7 @@ val <T : Collection<*>> Expect<T>.size: Expect<Int>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.sizeFeature
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.CollectionAssertionSamples.size
  */
 infix fun <E, T : Collection<E>> Expect<T>.size(assertionCreator: Expect<Int>.() -> Unit): Expect<T> =
     _logic.size(::identity).collectAndAppend(assertionCreator)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
@@ -1,0 +1,83 @@
+//TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
+package ch.tutteli.atrium.api.infix.en_GB.samples.deprecated
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.infix.en_GB.samples.fails
+import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.translations.DescriptionComparableAssertion
+import kotlin.test.Test
+
+class CollectionAssertionSamples {
+    private val isLessThanDescr = DescriptionComparableAssertion.IS_LESS_THAN.getDefault()
+    private val isGreaterThanDescr = DescriptionComparableAssertion.IS_GREATER_THAN.getDefault()
+
+    @Test
+    fun isEmpty() {
+        expect(listOf<Int>()) toBe empty
+
+        fails {
+            expect(listOf(1, 2, 3)) toBe empty
+        }
+    }
+
+    @Test
+    fun isNotEmpty() {
+        expect(listOf(1, 2, 3)) notToBe empty
+
+        fails {
+            expect(listOf<Int>()) notToBe empty
+        }
+    }
+
+    @Test
+    fun hasSize() {
+        expect(listOf(1, 2, 3)) hasSize 3
+
+        fails {
+            expect(listOf(1, 2, 3)) hasSize 1
+        }
+    }
+
+    @Test
+    fun sizeFeature() {
+        expect(listOf(1, 2, 3)) size {
+            it isGreaterThan 1 // subject is now of type Int (actually 3)
+        } size {
+            it isLessThan 4 // subject is still of type Int (still 3)
+        }
+
+        fails {
+            expect(listOf(1, 2, 3)) size {
+                it isLessThan 1 // fails
+            } size {
+                it isGreaterThan 4 // not reported because `isLessThan(1)` already fails
+            }
+        } message {
+            contains("${isLessThanDescr}: 1")
+            containsNot("${isGreaterThanDescr}: 4")
+        }
+    }
+
+    @Test
+    fun size() {
+        expect(listOf(1, 2, 3)) size { // subject inside this block is of type Int (actually 3)
+            it isGreaterThan 1
+            it isLessThan 4
+        }
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(listOf(1, 2, 3)) size {
+                it isLessThan 1    // fails
+                it isGreaterThan 4 // still evaluated even though `isLessThan(1)` already fails,
+                // use `.size.` if you want a fail fast behaviour
+            }
+        } messageContains values(
+            "${isLessThanDescr}: 1",
+            "${isGreaterThanDescr}: 4"
+        )
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
@@ -42,18 +42,18 @@ class CollectionAssertionSamples {
 
     @Test
     fun sizeFeature() {
-        expect(listOf(1, 2, 3)) size {
-            it isGreaterThan 1 // subject is now of type Int (actually 3)
-        } size {
-            it isLessThan 4 // subject is still of type Int (still 3)
-        }
+        expect(listOf(1, 2, 3))
+            .size isGreaterThan 1 isLessThan 4
+            //|         |             | subject is still of type Int (still 3)
+            //|         | subject is still of type Int (still 3)
+            //| subject is now of type Int (actually 3)
 
         fails {
-            expect(listOf(1, 2, 3)) size {
-                it isLessThan 1 // fails
-            } size {
-                it isGreaterThan 4 // not reported because `isLessThan(1)` already fails
-            }
+            expect(listOf(1, 2, 3))
+                .size isLessThan 1 isGreaterThan 4
+                //|       |              | not reported because `isLessThan 1` already fails
+                //|       | fails
+                //| subject is now of type Int (actually 3)
         } message {
             contains("${isLessThanDescr}: 1")
             containsNot("${isGreaterThanDescr}: 4")
@@ -64,16 +64,17 @@ class CollectionAssertionSamples {
     fun size() {
         expect(listOf(1, 2, 3)) size { // subject inside this block is of type Int (actually 3)
             it isGreaterThan 1
+        } size { // subject inside this block is of type Int (actually 3)
             it isLessThan 4
         }
 
         fails {
             // all assertions are evaluated inside an assertion group block; for more details:
             // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
-            expect(listOf(1, 2, 3)) size {
-                it isLessThan 1    // fails
-                it isGreaterThan 4 // still evaluated even though `isLessThan(1)` already fails,
-                // use `.size.` if you want a fail fast behaviour
+            expect(listOf(1, 2, 3)) size { // subject inside this block is of type Int (actually 3)
+                it isLessThan 1     // fails
+                it isGreaterThan 4  // isLessThan 1 fails, but isGreaterThan 4 still evaluated
+                                    // use `.size.` if you want a fail fast behaviour
             }
         } messageContains values(
             "${isLessThanDescr}: 1",

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/ListAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/ListAssertionSamples.kt
@@ -29,7 +29,7 @@ class ListAssertionSamples {
             // use `get index(elementIndex) { ... }` if you want that all assertions are evaluated
         } message {
             contains("index out of bounds")
-            containsNot("is less than: 2")
+            containsNot("is less than: 0")
         }
 
         fails {


### PR DESCRIPTION
Add samples for collectionAssertions of api-infix.

Fix #680 .