### PR TITLE
Add samples for arrayAssertions of api-infix

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
@@ -13,6 +13,8 @@ import kotlin.jvm.JvmName
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.asListFeature
+ *
  * @since 0.12.0
  */
 infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<E>> =
@@ -26,6 +28,8 @@ infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o
  * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.asList
  *
  * @since 0.12.0
  */
@@ -41,6 +45,8 @@ infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Un
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.asListEOut
+ *
  * @since 0.12.0
  */
 @JvmName("asListEOut")
@@ -54,6 +60,8 @@ infix fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.byteArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -70,6 +78,8 @@ infix fun Expect<ByteArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.byteArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("byteArrAsList")
@@ -84,6 +94,8 @@ infix fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Un
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.charArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -100,6 +112,8 @@ infix fun Expect<CharArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.charArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("charArrAsList")
@@ -114,6 +128,8 @@ infix fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Un
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.shortArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -130,6 +146,8 @@ infix fun Expect<ShortArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.shortArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("shortArrAsList")
@@ -144,6 +162,8 @@ infix fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> 
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.intArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -160,6 +180,8 @@ infix fun Expect<IntArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<Li
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.intArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("intArrAsList")
@@ -174,6 +196,8 @@ infix fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.longArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -190,6 +214,8 @@ infix fun Expect<LongArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.longArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("longArrAsList")
@@ -204,6 +230,8 @@ infix fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Un
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.floatArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -220,6 +248,8 @@ infix fun Expect<FloatArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.floatArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("floatArrAsList")
@@ -234,6 +264,8 @@ infix fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> 
  * Use `feature { f(it::asList) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.doubleArrAsListFeature
  *
  * @since 0.12.0
  */
@@ -250,6 +282,8 @@ infix fun Expect<DoubleArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.doubleArrAsList
+ *
  * @since 0.12.0
  */
 @JvmName("doubleArrAsList")
@@ -265,6 +299,8 @@ infix fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.booleanArrAsListFeature
+ *
  * @since 0.12.0
  */
 @JvmName("boolArrAsList")
@@ -279,6 +315,8 @@ infix fun Expect<BooleanArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expec
  * Use `feature of({ f(it::asList) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ArrayAssertionSamples.booleanArrAsList
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/ArrayAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/ArrayAssertionSamples.kt
@@ -1,0 +1,256 @@
+//TODO remove file with 1.0.0
+@file:Suppress("DEPRECATION")
+
+package ch.tutteli.atrium.api.infix.en_GB.samples.deprecated
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.infix.en_GB.samples.fails
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class ArrayAssertionSamples {
+
+    @Test
+    fun asListFeature() {
+        expect(arrayOf("A", "B")) asList o toBe listOf("A", "B")
+        //                           | subject is now of type List<String>
+    }
+
+    @Test
+    fun asList() {
+        expect(arrayOf("A", "B"))
+            .asList { // subject within this block is of type List<String>
+                it toBe listOf("A", "B")
+            } // subject here is back to type Array<String>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(arrayOf("A", "B"))
+                .asList {
+                    it contains "C"  // fails
+                    it contains "D"  // still evaluated even though `contains "C"` already fails
+                    //                  use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun asListEOut() {
+        expect<Array<out String>>(arrayOf("A", "B"))
+            .asList { // subject within this block is of type List<String>
+                it toBe listOf("A", "B")
+            } // subject here is back to type Array<out String>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect<Array<out String>>(arrayOf("A", "B"))
+                .asList {
+                    it contains "C" // fails
+                    it contains "D" // still evaluated even though `contains "C"` already fails
+                    //                 use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun byteArrAsListFeature() {
+        expect(byteArrayOf(1, 2, 3)) asList o toBe listOf<Byte>(1, 2, 3)
+        //                              | subject is now of type List<Byte>
+    }
+
+    @Test
+    fun byteArrAsList() {
+        expect(byteArrayOf(1, 2, 3))
+            .asList { // subject within this block is of type List<Byte>
+                it toBe listOf<Byte>(1, 2, 3)
+            } // subject here is back to type Array<Byte>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(byteArrayOf(1, 2, 3))
+                .asList {
+                    it contains 98  // fails
+                    it contains 99  // still evaluated even though `contains 98` already fails
+                    //                 use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun charArrAsListFeature() {
+        expect(charArrayOf('A', 'B', 'C')) asList o toBe listOf('A', 'B', 'C')
+        //                                    | subject is now of type List<Char>
+    }
+
+    @Test
+    fun charArrAsList() {
+        expect(charArrayOf('A', 'B', 'C'))
+            .asList { // subject within this block is of type List<Char>
+                it toBe listOf('A', 'B', 'C')
+            } // subject here is back to type Array<Char>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(charArrayOf('A', 'B', 'C'))
+                .asList {
+                    it contains 'X'  // fails
+                    it contains 'Y'  // still evaluated even though `contains 'X'` already fails
+                    //                  use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun shortArrAsListFeature() {
+        expect(shortArrayOf(1, 2, 3)) asList o toBe listOf<Short>(1, 2, 3)
+        //                               | subject is now of type List<Short>
+    }
+
+    @Test
+    fun shortArrAsList() {
+        expect(shortArrayOf(1, 2, 3))
+            .asList { // subject within this block is of type List<Short>
+                it toBe listOf<Short>(1, 2, 3)
+            } // subject here is back to type Array<Short>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(shortArrayOf(1, 2, 3))
+                .asList {
+                    it contains 98  // fails
+                    it contains 99  // still evaluated even though `contains 98` already fails
+                    //                 use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun intArrAsListFeature() {
+        expect(intArrayOf(1, 2, 3)) asList o toBe listOf(1, 2, 3)
+        //                             | subject is now of type List<Int>
+    }
+
+    @Test
+    fun intArrAsList() {
+        expect(intArrayOf(1, 2, 3))
+            .asList { // subject within this block is of type List<Int>
+                it toBe listOf(1, 2, 3)
+            } // subject here is back to type Array<Int>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(intArrayOf(1, 2, 3))
+                .asList {
+                    it contains 98  // fails
+                    it contains 99  // still evaluated even though `contains 98` already fails
+                    //                 use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun longArrAsListFeature() {
+        expect(longArrayOf(1L, 2L, 3L)) asList o toBe listOf(1L, 2L, 3L)
+        //                                 | subject is now of type List<Long>
+    }
+
+    @Test
+    fun longArrAsList() {
+        expect(longArrayOf(1L, 2L, 3L))
+            .asList { // subject within this block is of type List<Long>
+                it toBe listOf(1L, 2L, 3L)
+            } // subject here is back to type Array<Long>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(longArrayOf(1L, 2L, 3L))
+                .asList {
+                    it contains 98L  // fails
+                    it contains 99L  // still evaluated even though `contains 98L` already fails
+                    //                  use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun floatArrAsListFeature() {
+        expect(floatArrayOf(1f, 2f, 3f)) asList o toBe listOf(1f, 2f, 3f)
+        //                                  | subject is now of type List<Float>
+    }
+
+    @Test
+    fun floatArrAsList() {
+        expect(floatArrayOf(1f, 2f, 3f))
+            .asList { // subject within this block is of type List<Float>
+                it toBe listOf(1f, 2f, 3f)
+            } // subject here is back to type Array<Float>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(floatArrayOf(1f, 2f, 3f))
+                .asList {
+                    it contains 98f  // fails
+                    it contains 99f  // still evaluated even though `contains 98f` already fails
+                    //                  use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun doubleArrAsListFeature() {
+        expect(doubleArrayOf(1.1, 2.2, 3.3)) asList o toBe listOf(1.1, 2.2, 3.3)
+        //                                      | subject is now of type List<Double>
+    }
+
+    @Test
+    fun doubleArrAsList() {
+        expect(doubleArrayOf(1.1, 2.2, 3.3))
+            .asList { // subject within this block is of type List<Double>
+                it toBe listOf(1.1, 2.2, 3.3)
+            } // subject here is back to type Array<Double>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(doubleArrayOf(1.1, 2.2, 3.3))
+                .asList {
+                    it contains 98.1  // fails
+                    it contains 99.2  // still evaluated even though `contains 98.1` already fails
+                    //                   use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+
+    @Test
+    fun booleanArrAsListFeature() {
+        expect(booleanArrayOf(true, false)) asList o toBe listOf(true, false)
+        //                                     | subject is now of type List<Boolean>
+    }
+
+    @Test
+    fun booleanArrAsList() {
+        expect(booleanArrayOf(true, false))
+            .asList { // subject within this block is of type List<Boolean>
+                it toBe listOf(true, false)
+            } // subject here is back to type Array<Boolean>
+
+        fails {
+            // all assertions are evaluated inside an assertion group block; for more details:
+            // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
+            expect(booleanArrayOf(true, true))
+                .asList {
+                    it contains false  //                              fails
+                    it contains o inAny order atLeast 3 value true  // still evaluated even though `contains false` already fails
+                    //                                                 use `.asList.` if you want a fail fast behaviour
+                }
+        }
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/ArrayAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/ArrayAssertionSamples.kt
@@ -30,7 +30,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains "C"  // fails
                     it contains "D"  // still evaluated even though `contains "C"` already fails
-                    //                  use `.asList.` if you want a fail fast behaviour
+                    //                  use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -49,7 +49,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains "C" // fails
                     it contains "D" // still evaluated even though `contains "C"` already fails
-                    //                 use `.asList.` if you want a fail fast behaviour
+                    //                 use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -74,7 +74,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 98  // fails
                     it contains 99  // still evaluated even though `contains 98` already fails
-                    //                 use `.asList.` if you want a fail fast behaviour
+                    //                 use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -99,7 +99,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 'X'  // fails
                     it contains 'Y'  // still evaluated even though `contains 'X'` already fails
-                    //                  use `.asList.` if you want a fail fast behaviour
+                    //                  use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -124,7 +124,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 98  // fails
                     it contains 99  // still evaluated even though `contains 98` already fails
-                    //                 use `.asList.` if you want a fail fast behaviour
+                    //                 use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -149,7 +149,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 98  // fails
                     it contains 99  // still evaluated even though `contains 98` already fails
-                    //                 use `.asList.` if you want a fail fast behaviour
+                    //                 use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -174,7 +174,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 98L  // fails
                     it contains 99L  // still evaluated even though `contains 98L` already fails
-                    //                  use `.asList.` if you want a fail fast behaviour
+                    //                  use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -199,7 +199,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 98f  // fails
                     it contains 99f  // still evaluated even though `contains 98f` already fails
-                    //                  use `.asList.` if you want a fail fast behaviour
+                    //                  use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -224,7 +224,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains 98.1  // fails
                     it contains 99.2  // still evaluated even though `contains 98.1` already fails
-                    //                   use `.asList.` if you want a fail fast behaviour
+                    //                   use `asList o` if you want a fail fast behaviour
                 }
         }
     }
@@ -249,7 +249,7 @@ class ArrayAssertionSamples {
                 .asList {
                     it contains false  //                              fails
                     it contains o inAny order atLeast 3 value true  // still evaluated even though `contains false` already fails
-                    //                                                 use `.asList.` if you want a fail fast behaviour
+                    //                                                 use `asList o` if you want a fail fast behaviour
                 }
         }
     }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
@@ -62,12 +62,13 @@ class CollectionAssertionSamples {
 
     @Test
     fun size() {
-        expect(listOf(1, 2, 3)) size { // subject inside this block is of type Int (actually 3)
-            it isGreaterThan 1
-        } /* // subject here is back to type List<Int>
-        */size { // subject inside this block is of type Int (actually 3)
-            it isLessThan 4
-        }
+        expect(listOf(1, 2, 3))
+            .size { // subject inside this block is of type Int (actually 3)
+                it isGreaterThan 1
+            } // subject here is back to type List<Int>
+            .size { // subject inside this block is of type Int (actually 3)
+                it isLessThan 4
+            }
 
         fails {
             // all assertions are evaluated inside an assertion group block; for more details:

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/deprecated/CollectionAssertionSamples.kt
@@ -64,7 +64,8 @@ class CollectionAssertionSamples {
     fun size() {
         expect(listOf(1, 2, 3)) size { // subject inside this block is of type Int (actually 3)
             it isGreaterThan 1
-        } size { // subject inside this block is of type Int (actually 3)
+        } /* // subject here is back to type List<Int>
+        */size { // subject inside this block is of type Int (actually 3)
             it isLessThan 4
         }
 


### PR DESCRIPTION
Add samples for arrayAssertions of api-infix.

Fix #675 