### PR TITLE
renaming comparableAssertions to consistent `to + infitinive` naming schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The next section shows how you can define multiple assertions for the same subje
 
 ```kotlin
 // two single assertions, only first evaluated
-expect(4 + 6).isLessThan(5).isGreaterThan(10)
+expect(4 + 6).toBeLessThan(5).toBeGreaterThan(10)
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L24)</sub> ↓ <sub>[Output](#ex-single)</sub>
 <a name="ex-single"></a>
@@ -319,8 +319,8 @@ If you want that both assertions are evaluated together, then use the assertion 
 ```kotlin
 // assertion group with two assertions, both evaluated
 expect(4 + 6) {
-    isLessThan(5)
-    isGreaterThan(10)
+    toBeLessThan(5)
+    toBeGreaterThan(10)
 }
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L29)</sub> ↓ <sub>[Output](#ex-group)</sub>
@@ -1020,8 +1020,8 @@ Following an example:
 
 ```kotlin
 expect(listOf(1, 2, 2, 4)).contains(
-    { isLessThan(0) },
-    { isGreaterThan(2).isLessThan(4) }
+    { toBeLessThan(0) },
+    { toBeGreaterThan(2).toBeLessThan(4) }
 )
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L101)</sub> ↓ <sub>[Output](#ex-collection-short-2)</sub>
@@ -1062,7 +1062,7 @@ Following each in action:
 <ex-collection-any>
 
 ```kotlin
-expect(listOf(1, 2, 3, 4)).any { isLessThan(0) }
+expect(listOf(1, 2, 3, 4)).any { toBeLessThan(0) }
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L108)</sub> ↓ <sub>[Output](#ex-collection-any)</sub>
 <a name="ex-collection-any"></a>
@@ -1079,7 +1079,7 @@ expected that subject: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>
 <ex-collection-none>
 
 ```kotlin
-expect(listOf(1, 2, 3, 4)).none { isGreaterThan(2) }
+expect(listOf(1, 2, 3, 4)).none { toBeGreaterThan(2) }
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L111)</sub> ↓ <sub>[Output](#ex-collection-none)</sub>
 <a name="ex-collection-none"></a>
@@ -1098,7 +1098,7 @@ expected that subject: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>
 <ex-collection-all>
 
 ```kotlin
-expect(listOf(1, 2, 3, 4)).all { isGreaterThan(2) }
+expect(listOf(1, 2, 3, 4)).all { toBeGreaterThan(2) }
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L114)</sub> ↓ <sub>[Output](#ex-collection-all)</sub>
 <a name="ex-collection-all"></a>
@@ -1128,7 +1128,7 @@ Following on the last section we will start with an `inOrder` example:
 <ex-collection-builder-1>
 
 ```kotlin
-expect(listOf(1, 2, 2, 4)).contains.inOrder.only.entries({ isLessThan(3) }, { isLessThan(2) })
+expect(listOf(1, 2, 2, 4)).contains.inOrder.only.entries({ toBeLessThan(3) }, { toBeLessThan(2) })
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L118)</sub> ↓ <sub>[Output](#ex-collection-builder-1)</sub>
 <a name="ex-collection-builder-1"></a>
@@ -1201,7 +1201,7 @@ expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>
 <ex-collection-builder-3>
 
 ```kotlin
-expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.atLeast(1).butAtMost(2).entries({ isLessThan(3) })
+expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.atLeast(1).butAtMost(2).entries({ toBeLessThan(3) })
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L124)</sub> ↓ <sub>[Output](#ex-collection-builder-3)</sub>
 <a name="ex-collection-builder-3"></a>
@@ -1289,8 +1289,8 @@ the help of the parameter object `KeyValue`:
 ```kotlin
 expect(mapOf("a" to 1, "b" to 2)).contains(
     KeyValue("c") { toEqual(2) },
-    KeyValue("a") { isGreaterThan(2) },
-    KeyValue("b") { isLessThan(2) }
+    KeyValue("a") { toBeGreaterThan(2) },
+    KeyValue("b") { toBeLessThan(2) }
 )
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L137)</sub> ↓ <sub>[Output](#ex-map-2)</sub>
@@ -1336,8 +1336,8 @@ And the other overload which expects a `KeyValue` and allows to define sub asert
 ```kotlin
 expect(mapOf("a" to 1, "b" to 2)).containsOnly(
     KeyValue("c") { toEqual(2) },
-    KeyValue("a") { isLessThan(2) },
-    KeyValue("b") { isLessThan(2) }
+    KeyValue("a") { toBeLessThan(2) },
+    KeyValue("b") { toBeLessThan(2) }
 )
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L148)</sub> ↓ <sub>[Output](#ex-map-only-2)</sub>
@@ -1392,8 +1392,8 @@ And the other expecting `KeyValue`s which allow to specify sub assertions for th
 
 ```kotlin
 expect(mapOf("a" to 1, "b" to 2)).contains.inOrder.only.entries(
-    KeyValue("a") { isLessThan(2) },
-    KeyValue("b") { isLessThan(2) })
+    KeyValue("a") { toBeLessThan(2) },
+    KeyValue("b") { toBeLessThan(2) })
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L159)</sub> ↓ <sub>[Output](#ex-map-builder-2)</sub>
 <a name="ex-map-builder-2"></a>
@@ -1449,7 +1449,7 @@ In case you want to make an assertion only about the keys or values of the `Map`
 ```kotlin
 expect(mapOf("a" to 1, "b" to 2)) {
     keys { all { toStartWith("a") } }
-    values { none { isGreaterThan(1) } }
+    values { none { toBeGreaterThan(1) } }
 }
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/master/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L181)</sub> ↓ <sub>[Output](#ex-map-4)</sub>
@@ -1486,7 +1486,7 @@ expect(linkedMapOf("a" to 1, "b" to 2)).asEntries().contains.inOrder.only.entrie
     { isKeyValue("a", 1) },
     {
         key.toStartWith("a")
-        value.isGreaterThan(2)
+        value.toBeGreaterThan(2)
     }
 )
 ```
@@ -1668,9 +1668,9 @@ import ch.tutteli.atrium.logic.utils.expectLambda
 
 expect("calling myFun with ...") {
     mapOf(
-        1 to expectLambda<Char> { isLessThan('f') },
+        1 to expectLambda<Char> { toBeLessThan('f') },
         2 to expectLambda { toEqual('c') },
-        3 to expectLambda { isGreaterThan('e') }
+        3 to expectLambda { toBeGreaterThan('e') }
     ).forEach { (arg, assertionCreator) ->
         feature({ f(::myFun, arg) }, assertionCreator)
     }
@@ -2075,7 +2075,7 @@ Say you want to build a `isBetween` assertion function for `java.util.Date`, you
 
 ```kotlin
 fun <T : Date> Expect<T>.isBetween(lowerBoundInclusive: T, upperBoundExclusive: T) =
-    isGreaterThanOrEqual(lowerBoundInclusive).and.isLessThan(upperBoundExclusive)
+    toBeGreaterThanOrEqual(lowerBoundInclusive).and.toBeLessThan(upperBoundExclusive)
 ```
 </code-own-compose-1>
 
@@ -2092,8 +2092,8 @@ import ch.tutteli.atrium.logic._logic
 
 fun <T : Date> Expect<T>.isBetween(lowerBoundInclusive: T, upperBoundExclusive: T) =
     _logic.appendAssertionsCreatedBy {
-        isGreaterThanOrEqual(lowerBoundInclusive)
-        isLessThan(upperBoundExclusive)
+        toBeGreaterThanOrEqual(lowerBoundInclusive)
+        toBeLessThan(upperBoundExclusive)
     }
 ```
 </code-own-compose-2>
@@ -2173,7 +2173,7 @@ Another example: assert the person has children which are all adults (assuming 1
 ```kotlin
 fun Expect<Person>.hasAdultChildren(): Expect<Person> =
     feature(Person::children) {
-        all { feature(Person::age).isGreaterThanOrEqual(18) }
+        all { feature(Person::age).toBeGreaterThanOrEqual(18) }
     }
 
 ```
@@ -2227,7 +2227,7 @@ expect(Person("Susanne", "Whitley", 43, listOf(Person("Petra", "Whitley", 12, li
     .apply { // only evaluated because the previous assertion group holds
         children  // using the val -> subsequent assertions are about children and fail fast
             .toHaveSize(2)
-            .any { feature { f(it::age) }.isGreaterThan(18) }
+            .any { feature { f(it::age) }.toBeGreaterThan(18) }
     } // subject is still Person here due to the `apply`
     .children // using the val -> subsequent assertions are about children and fail fast
     .toHaveSize(2)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceContainsCreators.kt
@@ -224,7 +224,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(
  *
  * @since 0.9.0
  */
-//TODO rename to `matchFor` with 1.0.0
+//TODO rename to `matchFor` with 0.18.0
 fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.regex(
     pattern: Regex,
     vararg otherPatterns: Regex

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableAssertions.kt
@@ -11,6 +11,7 @@ import ch.tutteli.atrium.logic.*
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isLessThan
  */
+@Deprecated("Use toBeLessThan; will be removed with 1.0.0 at the latest", ReplaceWith("this.toBeLessThan<T>(expected)"))
 fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T): Expect<T> =
     _logicAppend { isLessThan(expected) }
 
@@ -22,6 +23,10 @@ fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T): Expect<T> =
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isLessThanOrEqual
  */
+@Deprecated(
+    "Use toBeLessThanOrEqual; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeLessThanOrEqual<T>(expected)")
+)
 fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isLessThanOrEqual(expected) }
 
@@ -33,6 +38,10 @@ fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T): Expect<T> =
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isGreaterThan
  */
+@Deprecated(
+    "Use toBeGreaterThan; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeGreaterThan<T>(expected)")
+)
 fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T): Expect<T> =
     _logicAppend { isGreaterThan(expected) }
 
@@ -44,6 +53,10 @@ fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T): Expect<T> =
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.ComparableAssertionSamples.isGreaterThanOrEqual
  */
+@Deprecated(
+    "Use toBeGreaterThanOrEqual; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeGreaterThanOrEqual<T>(expected)")
+)
 fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isGreaterThanOrEqual(expected) }
 
@@ -57,5 +70,9 @@ fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T): Expect<T> =
  *
  * @since 0.13.0
  */
+@Deprecated(
+    "Use toBeEqualComparingTo; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeEqualComparingTo<T>(expected)")
+)
 fun <T : Comparable<T>> Expect<T>.isEqualComparingTo(expected: T): Expect<T> =
     _logicAppend { isEqualComparingTo(expected) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
@@ -1,0 +1,71 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.*
+
+/**
+ * Expects that the subject of `this` expectation is less than [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeLessThan
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeLessThan(expected: T): Expect<T> =
+    _logicAppend { isLessThan(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is less than or equal [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeLessThanOrEqual
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeLessThanOrEqual(expected: T): Expect<T> =
+    _logicAppend { isLessThanOrEqual(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is greater than [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeGreaterThan
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> =
+    _logicAppend { isGreaterThan(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is greater than or equal [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeGreaterThanOrEqual
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeGreaterThanOrEqual(expected: T): Expect<T> =
+    _logicAppend { isGreaterThanOrEqual(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is equal to [expected]
+ * where the comparison is carried out based on [Comparable.compareTo].
+ *
+ * Use [toEqual] if you want a comparison based on [Any.equals].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeEqualComparingTo
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeEqualComparingTo(expected: T): Expect<T> =
+    _logicAppend { isEqualComparingTo(expected) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsSpec.kt
@@ -5,10 +5,10 @@ import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.integration.DiffEqualsCompareTo
 
 object ComparableExpectationsSpec : ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
-    fun1(Expect<Int>::isLessThan),
-    fun1(Expect<Int>::isLessThanOrEqual),
-    fun1(Expect<Int>::isGreaterThan),
-    fun1(Expect<Int>::isGreaterThanOrEqual),
-    fun1(Expect<Int>::isEqualComparingTo),
-    fun1(Expect<DiffEqualsCompareTo>::isEqualComparingTo)
+    fun1(Expect<Int>::toBeLessThan),
+    fun1(Expect<Int>::toBeLessThanOrEqual),
+    fun1(Expect<Int>::toBeGreaterThan),
+    fun1(Expect<Int>::toBeGreaterThanOrEqual),
+    fun1(Expect<Int>::toBeEqualComparingTo),
+    fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo)
 )

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/AnyExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/AnyExpectationSamples.kt
@@ -63,12 +63,12 @@ class AnyExpectationSamples {
         expect<Int?>(null).toEqualNullIfNullGivenElse(null)
 
         expect<Int?>(1).toEqualNullIfNullGivenElse { // subject inside this block is of type Int
-            isLessThan(2)
+            toBeLessThan(2)
         }  // subject here is back to type Int?
 
         fails { // because sub-expectation fails
             expect<Int?>(1).toEqualNullIfNullGivenElse {
-                isLessThan(0)
+                toBeLessThan(0)
             }
         }
     }
@@ -77,12 +77,12 @@ class AnyExpectationSamples {
     fun notToEqualNullFeature() {
         expect<Int?>(1)
             .notToEqualNull() // subject is now of type Int
-            .isLessThan(2)
+            .toBeLessThan(2)
 
         fails {
             expect<Int?>(null)
                 .notToEqualNull() // fails
-                .isLessThan(2) // not reported because `notToEqualNull` already fails
+                .toBeLessThan(2) // not reported because `notToEqualNull` already fails
         }
     }
 
@@ -90,8 +90,8 @@ class AnyExpectationSamples {
     fun notToEqualNull() {
         expect<Int?>(1)
             .notToEqualNull { // subject is now of type Int
-                isGreaterThan(0)
-                isLessThan(10)
+                toBeGreaterThan(0)
+                toBeLessThan(10)
             } // subject remains type Int also after the block
             .toEqual(1)
 
@@ -104,13 +104,13 @@ class AnyExpectationSamples {
 
         fails { // because subject is null, but since we use a block...
             expect<Int?>(null).notToEqualNull {
-                isGreaterThan(2) // ...reporting mentions that subject was expected `to be greater than: 2`
+                toBeGreaterThan(2) // ...reporting mentions that subject was expected `to be greater than: 2`
             }
         }
 
         fails { // because sub-expectation fails
             expect<Int?>(1).notToEqualNull {
-                isLessThan(0)
+                toBeLessThan(0)
             }
         }
     }
@@ -120,12 +120,12 @@ class AnyExpectationSamples {
         val n: Number = 1
         expect(n)
             .toBeAnInstanceOf<Int>() // subject is now of type Int
-            .isGreaterThan(0)
+            .toBeGreaterThan(0)
 
         fails {
             expect("A")
                 .toBeAnInstanceOf<Long>()
-                .isLessThan(2L) // not shown in reporting as `toBeA<Long>()` already fails
+                .toBeLessThan(2L) // not shown in reporting as `toBeA<Long>()` already fails
 
         }
     }
@@ -135,9 +135,9 @@ class AnyExpectationSamples {
         val n: Number = 16
         expect(n)
             .toBeAnInstanceOf<Int> { // subject is now of type Int
-                isGreaterThanOrEqual(15)
+                toBeGreaterThanOrEqual(15)
             } // subject remains type Int also after the block
-            .isLessThan(20)
+            .toBeLessThan(20)
 
         fails { // because wrong type expected (Long instead of String), but since we use a block...
             expect("A").toBeAnInstanceOf<Long> {
@@ -155,17 +155,17 @@ class AnyExpectationSamples {
     @Test
     fun andFeature() {
         // `and` is just a filler word; does not have any behaviour
-        expect(13).isGreaterThan(5).and.isLessThan(20)
+        expect(13).toBeGreaterThan(5).and.toBeLessThan(20)
 
         // i.e. the above is equivalent to:
-        expect(13).isGreaterThan(5).isLessThan(20)
+        expect(13).toBeGreaterThan(5).toBeLessThan(20)
     }
 
     @Test
     fun and() {
         expect(13).toBeAnInstanceOf<Int>().and {
-            isGreaterThan(5)
-            isLessThan(20)
+            toBeGreaterThan(5)
+            toBeLessThan(20)
         }
 
         fails {
@@ -176,7 +176,7 @@ class AnyExpectationSamples {
                 // use `.and.` if you want fail fast behaviour
 
                 notToEqualOneOf(1, 2, 13) // fails
-                isLessThan(10)            // still evaluated and included in the error report
+                toBeLessThan(10)          // still evaluated and included in the error report
             }
         }
     }
@@ -212,7 +212,7 @@ class AnyExpectationSamples {
 
         expect(customers).all {
             because("the legal age of maturity in Switzerland is 18") {
-                feature { f(it::age) }.isGreaterThanOrEqual(18)
+                feature { f(it::age) }.toBeGreaterThanOrEqual(18)
             }
         }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CollectionExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CollectionExpectationSamples.kt
@@ -36,19 +36,19 @@ class CollectionExpectationSamples {
     @Test
     fun sizeFeature() {
         expect(listOf(1, 2, 3))
-            .size             // subject is now of type Int (actually 3)
-            .isGreaterThan(1) // subject is still of type Int (still 3)
-            .isLessThan(4)
+            .size               // subject is now of type Int (actually 3)
+            .toBeGreaterThan(1) // subject is still of type Int (still 3)
+            .toBeLessThan(4)
 
         fails {
             expect(listOf(1, 2, 3))
                 .size
-                .isLessThan(1)    // fails
-                .isGreaterThan(4) // not reported because `isLessThan(1)` already fails
-                                  // use `size { ... }` if you want that all assertions are evaluated
+                .toBeLessThan(1)    // fails
+                .toBeGreaterThan(4) // not reported because `isLessThan(1)` already fails
+            //                         use `size { ... }` if you want that all assertions are evaluated
         }.message {
-            toContain("is less than: 1" )
-            notToContain("is greater than: 4" )
+            toContain("is less than: 1")
+            notToContain("is greater than: 4")
         }
     }
 
@@ -56,10 +56,10 @@ class CollectionExpectationSamples {
     fun size() {
         expect(listOf(1, 2, 3))
             .size { // subject inside this block is of type Int (actually 3)
-                isGreaterThan(1)
+                toBeGreaterThan(1)
             } // subject here is back to type List<Int, String>
             .size {
-                isLessThan(4)
+                toBeLessThan(4)
             }
 
         fails {
@@ -68,9 +68,9 @@ class CollectionExpectationSamples {
 
             expect(listOf(1, 2, 3))
                 .size {
-                    isLessThan(1)    // fails
-                    isGreaterThan(4) // still evaluated even though `isLessThan(1)` already fails,
-                                     // use `.size.` if you want a fail fast behaviour
+                    toBeLessThan(1)    // fails
+                    toBeGreaterThan(4) // still evaluated even though `isLessThan(1)` already fails,
+                    //                    use `.size.` if you want a fail fast behaviour
                 }
         }.messageContains(
             "is less than: 1",

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ComparableExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ComparableExpectationSamples.kt
@@ -1,0 +1,56 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class ComparableExpectationSamples {
+
+    @Test
+    fun toBeLessThan() {
+        expect(1).toBeLessThan(2)
+
+        fails {
+            expect(2).toBeLessThan(1)
+        }
+    }
+
+    @Test
+    fun toBeLessThanOrEqual() {
+        expect(1).toBeLessThanOrEqual(2)
+        expect(2).toBeLessThanOrEqual(2)
+
+        fails {
+            expect(2).toBeLessThanOrEqual(1)
+        }
+    }
+
+    @Test
+    fun toBeGreaterThan() {
+        expect(2).toBeGreaterThan(1)
+
+        fails {
+            expect(1).toBeGreaterThan(2)
+        }
+    }
+
+    @Test
+    fun toBeGreaterThanOrEqual() {
+        expect(2).toBeGreaterThanOrEqual(1)
+        expect(2).toBeGreaterThanOrEqual(2)
+
+        fails {
+            expect(1).toBeGreaterThanOrEqual(2)
+        }
+    }
+
+    @Test
+    fun toBeEqualComparingTo() {
+        expect(2).toBeEqualComparingTo(2)
+
+        fails {
+            expect(1).toBeEqualComparingTo(2)
+            expect(2).toBeEqualComparingTo(1)
+        }
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableAssertions.kt
@@ -11,6 +11,7 @@ import ch.tutteli.atrium.logic.*
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ComparableAssertionSamples.isLessThan
  */
+@Deprecated("Use toBeLessThan; will be removed with 1.0.0 at the latest", ReplaceWith("this.toBeLessThan<T>(expected)"))
 infix fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T): Expect<T> =
     _logicAppend { isLessThan(expected) }
 
@@ -22,6 +23,10 @@ infix fun <T : Comparable<T>> Expect<T>.isLessThan(expected: T): Expect<T> =
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ComparableAssertionSamples.isLessThanOrEqual
  */
+@Deprecated(
+    "Use toBeLessThanOrEqual; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeLessThanOrEqual<T>(expected)")
+)
 infix fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isLessThanOrEqual(expected) }
 
@@ -33,6 +38,10 @@ infix fun <T : Comparable<T>> Expect<T>.isLessThanOrEqual(expected: T): Expect<T
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ComparableAssertionSamples.isGreaterThan
  */
+@Deprecated(
+    "Use toBeGreaterThan; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeGreaterThan<T>(expected)")
+)
 infix fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T): Expect<T> =
     _logicAppend { isGreaterThan(expected) }
 
@@ -44,6 +53,10 @@ infix fun <T : Comparable<T>> Expect<T>.isGreaterThan(expected: T): Expect<T> =
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.deprecated.ComparableAssertionSamples.isGreaterThanOrEqual
  */
+@Deprecated(
+    "Use toBeGreaterThanOrEqual; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeGreaterThanOrEqual<T>(expected)")
+)
 infix fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T): Expect<T> =
     _logicAppend { isGreaterThanOrEqual(expected) }
 
@@ -57,5 +70,9 @@ infix fun <T : Comparable<T>> Expect<T>.isGreaterThanOrEqual(expected: T): Expec
  *
  * @since 0.13.0
  */
+@Deprecated(
+    "Use toBeEqualComparingTo; will be removed with 1.0.0 at the latest",
+    ReplaceWith("this.toBeEqualComparingTo<T>(expected)")
+)
 infix fun <T : Comparable<T>> Expect<T>.isEqualComparingTo(expected: T): Expect<T> =
     _logicAppend { isEqualComparingTo(expected) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableExpectations.kt
@@ -1,0 +1,69 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.*
+
+/**
+ * Expects that the subject of `this` expectation is less than [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeLessThan
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeLessThan(expected: T): Expect<T> =
+    _logicAppend { isLessThan(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is less than or equal [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeLessThanOrEqual
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeLessThanOrEqual(expected: T): Expect<T> =
+    _logicAppend { isLessThanOrEqual(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is greater than [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeGreaterThan
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> =
+    _logicAppend { isGreaterThan(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is greater than or equal [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeGreaterThanOrEqual
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeGreaterThanOrEqual(expected: T): Expect<T> =
+    _logicAppend { isGreaterThanOrEqual(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is equal to [expected]
+ * where the comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeEqualComparingTo
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeEqualComparingTo(expected: T): Expect<T> =
+    _logicAppend { isEqualComparingTo(expected) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsSpec.kt
@@ -6,21 +6,21 @@ import ch.tutteli.atrium.specs.integration.DiffEqualsCompareTo
 import ch.tutteli.atrium.specs.notImplemented
 
 class ComparableExpectationsSpec : ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
-    fun1(Expect<Int>::isLessThan),
-    fun1(Expect<Int>::isLessThanOrEqual),
-    fun1(Expect<Int>::isGreaterThan),
-    fun1(Expect<Int>::isGreaterThanOrEqual),
-    fun1(Expect<Int>::isEqualComparingTo),
-    fun1(Expect<DiffEqualsCompareTo>::isEqualComparingTo)
+    fun1(Expect<Int>::toBeLessThan),
+    fun1(Expect<Int>::toBeLessThanOrEqual),
+    fun1(Expect<Int>::toBeGreaterThan),
+    fun1(Expect<Int>::toBeGreaterThanOrEqual),
+    fun1(Expect<Int>::toBeEqualComparingTo),
+    fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo)
 ) {
 
     @Suppress("unused")
     fun ambiguityTest() {
         val a1: Expect<Int> = notImplemented()
-        a1 isLessThan 1
-        a1 isLessThanOrEqual 1
-        a1 isGreaterThan 1
-        a1 isGreaterThanOrEqual 1
-        a1 isEqualComparingTo 1
+        a1 toBeLessThan 1
+        a1 toBeLessThanOrEqual 1
+        a1 toBeGreaterThan 1
+        a1 toBeGreaterThanOrEqual 1
+        a1 toBeEqualComparingTo 1
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/AnyExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/AnyExpectationSamples.kt
@@ -64,23 +64,23 @@ class AnyExpectationSamples {
         expect<Int?>(null) toEqualNullIfNullGivenElse null
 
         expect<Int?>(1) toEqualNullIfNullGivenElse { // subject inside this block is of type Int (actually 1)
-            it isLessThan 2
+            it toBeLessThan 2
         } // subject here is back to type Int?
 
         fails { // because sub-expectation fails
             expect<Int?>(1) toEqualNullIfNullGivenElse {
-                it isLessThan 0
+                it toBeLessThan 0
             }
         }
     }
 
     @Test
     fun notToEqualNullFeature() {
-        expect<Int?>(1) notToEqualNull o isLessThan 2
+        expect<Int?>(1) notToEqualNull o toBeLessThan 2
         //                             | subject is now of type Int
 
         fails {
-            expect<Int?>(null) notToEqualNull o isLessThan 2
+            expect<Int?>(null) notToEqualNull o toBeLessThan 2
             //                      |             | not reported because `notToEqualNull` already fails
             //                      | fails
         }
@@ -89,8 +89,8 @@ class AnyExpectationSamples {
     @Test
     fun notToEqualNull() {
         expect<Int?>(1) notToEqualNull { // subject is now of type Int
-            it isGreaterThan 0
-            it isLessThan 10
+            it toBeGreaterThan 0
+            it toBeLessThan 10
         } /* subject remains type Int also after the block
         */ toEqual 1
 
@@ -102,13 +102,13 @@ class AnyExpectationSamples {
 
         fails { // because subject is null, but since we use a block...
             expect<Int?>(null) notToEqualNull {
-                it isGreaterThan 2  // ...reporting mentions that subject was expected `to be greater than: 2`
+                it toBeGreaterThan 2  // ...reporting mentions that subject was expected `to be greater than: 2`
             }
         }
 
         fails { // because sub-expectation fails
             expect<Int?>(1) notToEqualNull {
-                it isLessThan 0
+                it toBeLessThan 0
             }
         }
     }
@@ -116,11 +116,11 @@ class AnyExpectationSamples {
     @Test
     fun toBeAnInstanceOfFeature() {
         val n: Number = 1
-        expect(n).toBeAnInstanceOf<Int>() isGreaterThan 0
+        expect(n).toBeAnInstanceOf<Int>() toBeGreaterThan 0
         //                   | subject is now of type Int
 
         fails {
-            expect("A").toBeAnInstanceOf<Long>() isLessThan 2L
+            expect("A").toBeAnInstanceOf<Long>() toBeLessThan 2L
             //                        | not shown in reporting as `toBeA<Long>()` already fails
         }
     }
@@ -129,9 +129,9 @@ class AnyExpectationSamples {
     fun toBeAnInstanceOf() {
         val n: Number = 16
         expect(n).toBeAnInstanceOf<Int> { // subject is now of type Int
-            it isGreaterThanOrEqual 15
+            it toBeGreaterThanOrEqual 15
         } /* subject remains type Int also after the block
-        */ isLessThan 20
+        */ toBeLessThan 20
 
         fails { // because wrong type expected (Long instead of String), but since we use a block...
             expect("A").toBeAnInstanceOf<Long> {
@@ -149,17 +149,17 @@ class AnyExpectationSamples {
     @Test
     fun andFeature() {
         // `and` is just a filler word does not have any behaviour
-        expect(13) isGreaterThan 5 and o isLessThan 20
+        expect(13) toBeGreaterThan 5 and o toBeLessThan 20
 
         // i.e. the above is equivalent to:
-        expect(13) isGreaterThan 5 isLessThan 20
+        expect(13) toBeGreaterThan 5 toBeLessThan 20
     }
 
     @Test
     fun and() {
         expect(13).toBeAnInstanceOf<Int>() and {
-            it isGreaterThan 5
-            it isLessThan 20
+            it toBeGreaterThan 5
+            it toBeLessThan 20
         }
 
         fails {
@@ -167,9 +167,9 @@ class AnyExpectationSamples {
                 // introduces an expectation group block
                 // all expectations are evaluated inside an expectations group block; for more details:
                 // https://github.com/robstoll/atrium#define-single-expectations-or-expectation-groups
-                it notToEqualOneOf values(1, 2, 13)  // fails
-                it isLessThan 10              // still evaluated and included in the error report
-                // use `.and.` if you want fail fast behaviour
+                it notToEqualOneOf values(1, 2, 13) // fails
+                it toBeLessThan 10                  // still evaluated and included in the error report
+                //                                     use `.and.` if you want fail fast behaviour
             }
         }
     }
@@ -204,7 +204,7 @@ class AnyExpectationSamples {
 
         expect(customers) all {
             it because of("the legal age of maturity in Switzerland is 18") {
-                feature { f(it::age) } isGreaterThanOrEqual 18
+                feature { f(it::age) } toBeGreaterThanOrEqual 18
             }
         }
     }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CollectionExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CollectionExpectationSamples.kt
@@ -39,17 +39,17 @@ class CollectionExpectationSamples {
     @Test
     fun sizeFeature() {
         expect(listOf(1, 2, 3))
-            .size isGreaterThan 1 isLessThan 4
-            //|         |             | subject is still of type Int (still 3)
-            //|         | subject is still of type Int (still 3)
-            //| subject is now of type Int (actually 3)
+            .size toBeGreaterThan 1 toBeLessThan 4
+        //       |                 |             | subject is still of type Int (still 3)
+        //       |                 | subject is still of type Int (still 3)
+        //       | subject is now of type Int (actually 3)
 
         fails {
             expect(listOf(1, 2, 3))
-                .size isLessThan 1 isGreaterThan 4
-                //|       |              | not reported because `isLessThan 1` already fails
-                //|       | fails
-                //| subject is now of type Int (actually 3)
+                .size toBeLessThan 1 toBeGreaterThan 4
+            //       |              |         | not reported because `isLessThan 1` already fails
+            //       |              | fails
+            //       | subject is now of type Int (actually 3)
         } message {
             toContain("${isLessThanDescr}: 1")
             notToContain("${isGreaterThanDescr}: 4")
@@ -60,19 +60,19 @@ class CollectionExpectationSamples {
     fun size() {
         expect(listOf(1, 2, 3))
             .size { // subject inside this block is of type Int (actually 3)
-                it isGreaterThan 1
+                it toBeGreaterThan 1
             } // subject here is back to type List<Int>
             .size { // subject inside this block is of type Int (actually 3)
-                it isLessThan 4
+                it toBeLessThan 4
             }
 
         fails {
             // all assertions are evaluated inside an assertion group block; for more details:
             // https://github.com/robstoll/atrium#define-single-assertions-or-assertion-groups
             expect(listOf(1, 2, 3)) size { // subject inside this block is of type Int (actually 3)
-                it isLessThan 1     // fails
-                it isGreaterThan 4  // isLessThan 1 fails, but isGreaterThan 4 still evaluated
-                                    // use `.size.` if you want a fail fast behaviour
+                it toBeLessThan 1     // fails
+                it toBeGreaterThan 4  // isLessThan 1 fails, but isGreaterThan 4 still evaluated
+                //                       use `.size.` if you want a fail fast behaviour
             }
         } messageContains values(
             "${isLessThanDescr}: 1",

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ComparableExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ComparableExpectationSamples.kt
@@ -1,0 +1,60 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.toBeEqualComparingTo
+import ch.tutteli.atrium.api.infix.en_GB.toBeGreaterThan
+import ch.tutteli.atrium.api.infix.en_GB.toBeLessThan
+import ch.tutteli.atrium.api.infix.en_GB.toBeLessThanOrEqual
+import ch.tutteli.atrium.api.infix.en_GB.samples.fails
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class ComparableExpectationSamples {
+
+    @Test
+    fun toBeLessThan() {
+        expect(1) toBeLessThan 2
+
+        fails {
+            expect(2) toBeLessThan 1
+        }
+    }
+
+    @Test
+    fun toBeLessThanOrEqual() {
+        expect(1) toBeLessThanOrEqual 2
+        expect(2) toBeLessThanOrEqual 2
+
+        fails {
+            expect(2) toBeLessThanOrEqual 1
+        }
+    }
+
+    @Test
+    fun toBeGreaterThan() {
+        expect(2) toBeGreaterThan 1
+
+        fails {
+            expect(2) toBeGreaterThan 2
+        }
+    }
+
+    @Test
+    fun toBeGreaterThanOrEqual() {
+        expect(2) toBeEqualComparingTo 2
+
+        fails {
+            expect(1) toBeEqualComparingTo 2
+            expect(2) toBeEqualComparingTo 1
+        }
+    }
+
+    @Test
+    fun toBeEqualComparingTo() {
+        expect(2) toBeEqualComparingTo 2
+
+        fails {
+            expect(1) toBeEqualComparingTo 2
+            expect(2) toBeEqualComparingTo 1
+        }
+    }
+}

--- a/logic/atrium-logic-common/src/test/kotlin/ch/tutteli/atrium/logic/creating/EitherSpec.kt
+++ b/logic/atrium-logic-common/src/test/kotlin/ch/tutteli/atrium/logic/creating/EitherSpec.kt
@@ -27,7 +27,7 @@ object EitherSpec : Spek({
         }
         it("isRight throws AssertionError containing explanation") {
             expect {
-                expect(either).isRight { isLessThan(2) }
+                expect(either).isRight { toBeLessThan(2) }
             }.toThrow<AssertionError> {
                 messageContains(
                     "value of Right: ❗❗ is not a Right",
@@ -51,7 +51,7 @@ object EitherSpec : Spek({
             }
         }
         it("isRight throws AssertionError containing explanation") {
-            expect(either).isRight { isLessThan(2) }
+            expect(either).isRight { toBeLessThan(2) }
         }
     }
 })

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/AnyExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/AnyExpectationsSpec.kt
@@ -559,11 +559,11 @@ abstract class AnyExpectationsSpec(
         context("subject is not null") {
             val subject: Int? = 1
             it("does not throw if sub assertion holds") {
-                expect(subject).toBeNullIfNullElseFun { isLessThan(2) }
+                expect(subject).toBeNullIfNullElseFun { toBeLessThan(2) }
             }
             it("throws an AssertionError if sub assertion does not hold") {
                 expect {
-                    expect(subject).toBeNullIfNullElseFun { isGreaterThan(1) }
+                    expect(subject).toBeNullIfNullElseFun { toBeGreaterThan(1) }
                 }.toThrow<AssertionError> {
                     messageContains(": 1", "${IS_GREATER_THAN.getDefault()}: 1")
                 }
@@ -602,12 +602,12 @@ abstract class AnyExpectationsSpec(
                 notToBeNullFunctions.forEach { (name, notToBeNullFun, _) ->
 
                     it("$name - does not throw if the assertion holds") {
-                        expect(1 as Int?).notToBeNullFun { isLessThan(2) }
+                        expect(1 as Int?).notToBeNullFun { toBeLessThan(2) }
                     }
 
                     it("$name - throws an AssertionError if the assertion does not hold") {
                         expect {
-                            expect(1 as Int?).notToBeNullFun { isLessThan(0) }
+                            expect(1 as Int?).notToBeNullFun { toBeLessThan(0) }
                         }.toThrow<AssertionError> {
                             messageContains("${IS_LESS_THAN.getDefault()}: 0")
                         }
@@ -617,13 +617,13 @@ abstract class AnyExpectationsSpec(
             context("it allows to define multiple assertions for the subject") {
                 notToBeNullFunctions.forEach { (name, notToBeNullFun, hasExtraHint) ->
                     it("$name - does not throw if the assertions hold") {
-                        expect(1 as Int?).notToBeNullFun { isGreaterThan(0); isLessThan(2) }
+                        expect(1 as Int?).notToBeNullFun { toBeGreaterThan(0); toBeLessThan(2) }
                     }
 
                     it("$name - throws an AssertionError if one assertion does not hold") {
                         expect {
                             val i: Int? = 1
-                            expect(i).notToBeNullFun { isGreaterThan(2); isLessThan(5) }
+                            expect(i).notToBeNullFun { toBeGreaterThan(2); toBeLessThan(5) }
                         }.toThrow<AssertionError> {
                             message {
                                 toContain(IS_GREATER_THAN.getDefault())
@@ -635,7 +635,7 @@ abstract class AnyExpectationsSpec(
                     it("$name - throws an AssertionError if both assertions do not hold " + (if (hasExtraHint) "and contains both messages" else "and contains only first message")) {
                         expect {
                             val i: Int? = 1
-                            expect(i).notToBeNullFun { isGreaterThan(2); isLessThan(0) }
+                            expect(i).notToBeNullFun { toBeGreaterThan(2); toBeLessThan(0) }
                         }.toThrow<AssertionError> {
                             messageContains(IS_GREATER_THAN.getDefault())
                             if (hasExtraHint) messageContains(IS_LESS_THAN.getDefault())
@@ -663,7 +663,7 @@ abstract class AnyExpectationsSpec(
                 it("$name - throws an AssertionError which contains subsequent assertions") {
                     class A(val i: Int? = null)
                     expect {
-                        expect(A()).feature(A::i).notToEqualNull { isLessThan(1) }
+                        expect(A()).feature(A::i).notToEqualNull { toBeLessThan(1) }
                     }.toThrow<AssertionError> {
                         messageContains(
                             A::class.simpleName!!,
@@ -698,14 +698,14 @@ abstract class AnyExpectationsSpec(
             context("it allows to perform sub assertions") {
                 toBeAnInstanceOfIntFunctions.forEach { (name, toBeAnInstanceOfInt, _) ->
                     it("$name - does not throw if it holds") {
-                        expect(1 as Any?).toBeAnInstanceOfInt { isLessThan(2) }
+                        expect(1 as Any?).toBeAnInstanceOfInt { toBeLessThan(2) }
                     }
 
                     val expectedLessThan = 2
                     val actualValue: Any? = 5
                     it("$name - throws if it does not hold") {
                         expect {
-                            expect(actualValue).toBeAnInstanceOfInt { isLessThan(expectedLessThan) }
+                            expect(actualValue).toBeAnInstanceOfInt { toBeLessThan(expectedLessThan) }
                         }.toThrow<AssertionError> {
                             messageContains(actualValue as Any, IS_LESS_THAN.getDefault(), expectedLessThan)
                         }
@@ -801,8 +801,8 @@ abstract class AnyExpectationsSpec(
             expect {
                 expect(21)
                     .becauseFunForInt("we use the definition that teens are between 12 and 18 years old") {
-                        isGreaterThanOrEqual(12)
-                        isLessThan(18)
+                        toBeGreaterThanOrEqual(12)
+                        toBeLessThan(18)
                         notToEqualOneOf(21)
                     }
             }.toThrow<AssertionError> {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CollectionExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CollectionExpectationsSpec.kt
@@ -22,7 +22,7 @@ abstract class CollectionExpectationsSpec(
         isEmpty.forSubjectLess(),
         isNotEmpty.forSubjectLess(),
         sizeFeature.forSubjectLess().adjustName { "$it feature" },
-        size.forSubjectLess { isGreaterThan(2) }
+        size.forSubjectLess { toBeGreaterThan(2) }
     ) {})
 
     include(object : AssertionCreatorSpec<Collection<Int>>(
@@ -72,11 +72,11 @@ abstract class CollectionExpectationsSpec(
         context("list with two entries") {
             sizeFunctions.forEach { (name, sizeFun, _) ->
                 it("$name - is greater than 1 holds") {
-                    fluent.sizeFun { isGreaterThan(1) }
+                    fluent.sizeFun { toBeGreaterThan(1) }
                 }
                 it("$name - is less than 1 fails") {
                     expect {
-                        fluent.sizeFun { isLessThan(1) }
+                        fluent.sizeFun { toBeLessThan(1) }
                     }.toThrow<AssertionError> {
                         messageContains("$sizeDescr: 2")
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableAllExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableAllExpectationsSpec.kt
@@ -22,11 +22,11 @@ abstract class IterableAllExpectationsSpec(
 
     include(object : AssertionCreatorSpec<Iterable<Double>>(
         describePrefix, oneToSeven().toList().asIterable(),
-        all.forAssertionCreatorSpec("$isGreaterThanDescr: 0.0") { isGreaterThan(0.0) }
+        all.forAssertionCreatorSpec("$isGreaterThanDescr: 0.0") { toBeGreaterThan(0.0) }
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
         "$describePrefix[nullable Element] ", oneToSeven().toList().asIterable(),
-        allNullable.forAssertionCreatorSpec("$isGreaterThanDescr: 0.0") { isGreaterThan(0.0) }
+        allNullable.forAssertionCreatorSpec("$isGreaterThanDescr: 0.0") { toBeGreaterThan(0.0) }
     ) {})
 
     val allDescr = DescriptionIterableAssertion.ALL.getDefault()
@@ -45,7 +45,7 @@ abstract class IterableAllExpectationsSpec(
         context("empty collection") {
             it("throws AssertionError as there needs to be at least one element") {
                 expect {
-                    expect(fluentEmpty()).allFun { isLessThan(1.0) }
+                    expect(fluentEmpty()).allFun { toBeLessThan(1.0) }
                 }.toThrow<AssertionError> {
                     messageContains(
                         "$rootBulletPoint$featureArrow$hasElement: false$separator" +
@@ -59,7 +59,7 @@ abstract class IterableAllExpectationsSpec(
             context("all are $isGreaterThanFun(2.5) and $isLessThanFun(7.0)") {
                 it("throws AssertionError containing both assumptions in one assertion") {
                     expect {
-                        expect(oneToSeven()).allFun { isGreaterThan(2.5); isLessThan(7.0) }
+                        expect(oneToSeven()).allFun { toBeGreaterThan(2.5); toBeLessThan(7.0) }
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(1).values(
@@ -78,7 +78,7 @@ abstract class IterableAllExpectationsSpec(
 
             context("all are $isGreaterThanFun(0.5) and $isLessThanFun(7.5)") {
                 it("does not throw an exception") {
-                    expect(oneToSeven()).allFun { isGreaterThan(0.5); isLessThan(7.5) }
+                    expect(oneToSeven()).allFun { toBeGreaterThan(0.5); toBeLessThan(7.5) }
                 }
             }
         }
@@ -99,7 +99,7 @@ abstract class IterableAllExpectationsSpec(
             context("iterable ${oneToSevenNullable().toList()}") {
                 it("$isGreaterThanDescr(0.5) throws because two are `null`") {
                     expect {
-                        expect(oneToSevenNullable()).allNullableFun { isGreaterThan(0.5) }
+                        expect(oneToSevenNullable()).allNullableFun { toBeGreaterThan(0.5) }
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(1).values(

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableAnyExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableAnyExpectationsSpec.kt
@@ -24,11 +24,11 @@ abstract class IterableAnyExpectationsSpec(
 
     include(object : AssertionCreatorSpec<Iterable<Double>>(
         describePrefix, oneToSeven().toList().asIterable(),
-        any.forAssertionCreatorSpec("$isGreaterThanDescr: 1.0") { isGreaterThan(1.0) }
+        any.forAssertionCreatorSpec("$isGreaterThanDescr: 1.0") { toBeGreaterThan(1.0) }
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
         "$describePrefix[nullable Element] ", oneToSeven().toList().asIterable(),
-        anyNullable.forAssertionCreatorSpec("$isGreaterThanDescr: 1.0") { isGreaterThan(1.0) }
+        anyNullable.forAssertionCreatorSpec("$isGreaterThanDescr: 1.0") { toBeGreaterThan(1.0) }
     ) {})
 
     nonNullableCases(
@@ -40,7 +40,7 @@ abstract class IterableAnyExpectationsSpec(
         context("empty collection") {
             it("throws AssertionError as there needs to be at least one element") {
                 expect {
-                    expect(fluentEmpty()).anyFun { isLessThan(1.0) }
+                    expect(fluentEmpty()).anyFun { toBeLessThan(1.0) }
                 }.toThrow<AssertionError> {
                     messageContains(
                         "$rootBulletPoint$containsInAnyOrder: $separator",
@@ -58,7 +58,7 @@ abstract class IterableAnyExpectationsSpec(
             context("search for entry which $isGreaterThanFun(1.0) and $isLessThanFun(2.0)") {
                 it("throws AssertionError containing both assumptions in one assertion") {
                     expect {
-                        expect(oneToSeven()).anyFun { isGreaterThan(1.0); isLessThan(2.0) }
+                        expect(oneToSeven()).anyFun { toBeGreaterThan(1.0); toBeLessThan(2.0) }
                     }.toThrow<AssertionError> {
                         messageContains(
                             "$rootBulletPoint$containsInAnyOrder: $separator",
@@ -74,7 +74,7 @@ abstract class IterableAnyExpectationsSpec(
 
             context("search for entry which $isGreaterThanFun(1.0) and $isLessThanFun(2.1)") {
                 it("does not throw an exception") {
-                    expect(oneToSeven()).anyFun { isGreaterThan(1.0); isLessThan(2.1) }
+                    expect(oneToSeven()).anyFun { toBeGreaterThan(1.0); toBeLessThan(2.1) }
                 }
             }
         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsEntriesSpecBase.kt
@@ -1,7 +1,6 @@
 package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.fluent.en_GB.isLessThan
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionComparableAssertion
@@ -12,8 +11,8 @@ abstract class IterableContainsEntriesSpecBase(
     spec: Root.() -> Unit
 ) : IterableContainsSpecBase(spec) {
     init {
-        isLessThanFun = Expect<Double>::isLessThan.name
-        isGreaterThanFun = Expect<Double>::isGreaterThan.name
+        isLessThanFun = Expect<Double>::toBeLessThan.name
+        isGreaterThanFun = Expect<Double>::toBeGreaterThan.name
         toBeFun = fun1<Double, Double>(Expect<Double>::toEqual).name
     }
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec.kt
@@ -55,7 +55,7 @@ abstract class IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec(
         context("empty collection") {
             it("$isLessThanFun(1.0) throws AssertionError") {
                 expect {
-                    expect(fluentEmpty()).containsEntriesFun({ isLessThan(1.0) })
+                    expect(fluentEmpty()).containsEntriesFun({ toBeLessThan(1.0) })
                 }.toThrow<AssertionError> {
                     message {
                         toContain.exactly(1).values(
@@ -70,7 +70,7 @@ abstract class IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec(
             }
             it("$isLessThanFun(1.0) and $isGreaterThanFun(2.0) throws AssertionError") {
                 expect {
-                    expect(fluentEmpty()).containsEntriesFun({ isLessThan(1.0) }, { isGreaterThan(2.0) })
+                    expect(fluentEmpty()).containsEntriesFun({ toBeLessThan(1.0) }, { toBeGreaterThan(2.0) })
                 }.toThrow<AssertionError> {
                     message {
                         toContain.exactly(2).values(
@@ -92,7 +92,7 @@ abstract class IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec(
             context("search for entry which $isGreaterThanFun(1.0) and $isLessThanFun(2.0)") {
                 it("throws AssertionError containing both assumptions in one assertion") {
                     expect {
-                        expect(oneToSeven()).containsEntriesFun({ isGreaterThan(1.0); isLessThan(2.0) })
+                        expect(oneToSeven()).containsEntriesFun({ toBeGreaterThan(1.0); toBeLessThan(2.0) })
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(1).values(
@@ -110,14 +110,16 @@ abstract class IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec(
 
             context("search for entry which $isGreaterThanFun(1.0) and $isLessThanFun(2.1)") {
                 it("does not throw an exception") {
-                    expect(oneToSeven()).containsEntriesFun({ isGreaterThan(1.0); isLessThan(2.1) })
+                    expect(oneToSeven()).containsEntriesFun({ toBeGreaterThan(1.0); toBeLessThan(2.1) })
                 }
             }
 
             context("search for entry which $isGreaterThanFun(1.0) and $isLessThanFun(2.1) and another entry which is $isLessThanFun(2.0)") {
                 it("does not throw an exception") {
                     //finds twice the entry 1.0 but that is fine since we do not search for unique entries in this case
-                    expect(oneToSeven()).containsEntriesFun({ isGreaterThan(1.0).isLessThan(2.1) }, { isLessThan(2.0) })
+                    expect(oneToSeven()).containsEntriesFun(
+                        { toBeGreaterThan(1.0).toBeLessThan(2.1) },
+                        { toBeLessThan(2.0) })
                 }
             }
 
@@ -168,8 +170,8 @@ abstract class IterableContainsInAnyOrderAtLeast1EntriesExpectationsSpec(
                     it("$isLessThanFun(1.0) and $isGreaterThanDescr(7.0)") {
                         expect {
                             expect(oneToSevenNullable()).containsInAnyOrderNullableEntriesFun(
-                                { isLessThan(1.0) },
-                                { isGreaterThan(7.0) }
+                                { toBeLessThan(1.0) },
+                                { toBeGreaterThan(7.0) }
                             )
                         }.toThrow<AssertionError> {
                             message {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInAnyOrderOnlyEntriesExpectationsSpec.kt
@@ -59,7 +59,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
         context("empty collection") {
             it("$isLessThanFun(1.0) throws AssertionError") {
                 expect {
-                    expect(fluentEmpty()).containsEntriesFun({ isLessThan(1.0) })
+                    expect(fluentEmpty()).containsEntriesFun({ toBeLessThan(1.0) })
                 }.toThrow<AssertionError> {
                     message {
                         toContain(
@@ -73,7 +73,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
             }
             it("$isLessThanFun(1.0) and $isGreaterThanFun(4.0) throws AssertionError") {
                 expect {
-                    expect(fluentEmpty()).containsEntriesFun({ isLessThan(1.0) }, { isGreaterThan(4.0) })
+                    expect(fluentEmpty()).containsEntriesFun({ toBeLessThan(1.0) }, { toBeGreaterThan(4.0) })
                 }.toThrow<AssertionError> {
                     message {
                         toContain.exactly(1).values(
@@ -114,11 +114,11 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                         { toEqual(2.0) },
                         { toEqual(3.0) },
                         { toEqual(4.0) },
-                        { isGreaterThan(0.0) })
+                        { toBeGreaterThan(0.0) })
                 }
                 it(" $isLessThanFun(3.0), 2.0, 3.0, 4.0 and 4.0") {
                     expect(oneToFour()).containsEntriesFun(
-                        { isLessThan(3.0) },
+                        { toBeLessThan(3.0) },
                         { toEqual(2.0) },
                         { toEqual(3.0) },
                         { toEqual(4.0) },
@@ -127,7 +127,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                 it("2.0, $isLessThanFun(5.0), 3.0, 4.0 and 4.0") {
                     expect(oneToFour()).containsEntriesFun(
                         { toEqual(2.0) },
-                        { isLessThan(5.0) },
+                        { toBeLessThan(5.0) },
                         { toEqual(3.0) },
                         { toEqual(4.0) },
                         { toEqual(4.0) })
@@ -162,7 +162,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
 
                     it("$isLessThanFun(3.0), isGreaterThan(3.0) -- 2.0, 3.0 and 4.0 was missing") {
                         expect {
-                            expect(oneToFour()).containsEntriesFun({ isLessThan(3.0) }, { isGreaterThan(3.0) })
+                            expect(oneToFour()).containsEntriesFun({ toBeLessThan(3.0) }, { toBeGreaterThan(3.0) })
                         }.toThrow<AssertionError> {
                             message {
                                 toContain.exactly(1).values(
@@ -184,7 +184,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                     it("first wins: $isLessThanFun(5.0), 1.0, 2.0, 3.0, 4.0") {
                         expect {
                             expect(oneToFour()).containsEntriesFun(
-                                { isLessThan(5.0) },
+                                { toBeLessThan(5.0) },
                                 { toEqual(1.0) },
                                 { toEqual(2.0) },
                                 { toEqual(3.0) },
@@ -212,8 +212,8 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                         expect {
                             expect(oneToFour()).containsEntriesFun(
                                 { toEqual(1.0) },
-                                { isGreaterThan(3.0) },
-                                { isGreaterThan(4.0) })
+                                { toBeGreaterThan(3.0) },
+                                { toBeGreaterThan(4.0) })
                         }.toThrow<AssertionError> {
                             message {
                                 toContain.exactly(1).values(
@@ -316,7 +316,7 @@ abstract class IterableContainsInAnyOrderOnlyEntriesExpectationsSpec(
                     it("first wins: $isLessThanFun(4.0), null, null, $toBeDescr(1.0)") {
                         expect {
                             expect(null1null3()).containsInAnyOrderOnlyNullableEntriesFun(
-                                { isLessThan(4.0) },
+                                { toBeLessThan(4.0) },
                                 null,
                                 null,
                                 { toEqual(1.0) })

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyEntriesExpectationsSpec.kt
@@ -77,7 +77,7 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
         context("empty collection") {
             it("$isLessThanFun(1.0) throws AssertionError") {
                 expect {
-                    expect(fluentEmpty()).containsEntriesFun({ isLessThan(1.0) })
+                    expect(fluentEmpty()).containsEntriesFun({ toBeLessThan(1.0) })
                 }.toThrow<AssertionError> {
                     message {
                         toContain("$rootBulletPoint$containsInOrderOnly:")
@@ -89,7 +89,7 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
             }
             it("$isLessThanFun(1.0) and $isGreaterThanFun(4.0) throws AssertionError") {
                 expect {
-                    expect(fluentEmpty()).containsEntriesFun({ isLessThan(1.0) }, { isGreaterThan(4.0) })
+                    expect(fluentEmpty()).containsEntriesFun({ toBeLessThan(1.0) }, { toBeGreaterThan(4.0) })
                 }.toThrow<AssertionError> {
                     message {
                         toContain.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
@@ -115,11 +115,11 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                 }
                 it("$isLessThanFun(5.0), $isLessThanFun(5.0), $isLessThanFun(5.0), $isLessThanFun(5.0), $isLessThanFun(5.0)") {
                     expect(oneToFour()).containsEntriesFun(
-                        { isLessThan(5.0) },
-                        { isLessThan(5.0) },
-                        { isLessThan(5.0) },
-                        { isLessThan(5.0) },
-                        { isLessThan(5.0) })
+                        { toBeLessThan(5.0) },
+                        { toBeLessThan(5.0) },
+                        { toBeLessThan(5.0) },
+                        { toBeLessThan(5.0) },
+                        { toBeLessThan(5.0) })
                 }
             }
 
@@ -128,10 +128,10 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                 it("$isLessThanFun(5.0), 1.0, 2.0, $isGreaterThanFun(2.0), 4.0 -- wrong order") {
                     expect {
                         expect(oneToFour()).containsEntriesFun(
-                            { isLessThan(5.0) },
+                            { toBeLessThan(5.0) },
                             { toEqual(1.0) },
                             { toEqual(2.0) },
-                            { isGreaterThan(2.0) },
+                            { toBeGreaterThan(2.0) },
                             { toEqual(4.0) })
                     }.toThrow<AssertionError> {
                         message {
@@ -190,7 +190,7 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                 it("1.0, 3.0, $isGreaterThanFun(4.0) -- $isGreaterThanFun(4.0) is wrong and 4.0 and 4.0 are missing") {
                     expect {
                         expect(oneToFour()).containsEntriesFun({ toEqual(1.0) },
-                            { toEqual(3.0) }, { isGreaterThan(4.0) })
+                            { toEqual(3.0) }, { toBeGreaterThan(4.0) })
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(1).value("$rootBulletPoint$containsInOrderOnly:")
@@ -251,9 +251,9 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                     it("null, $isLessThanFun(5.0), null, $isLessThanFun(5.0)") {
                         expect(null1null3()).containsInOrderOnlyNullableEntriesFun(
                             null,
-                            { isLessThan(5.0) },
+                            { toBeLessThan(5.0) },
                             null,
-                            { isLessThan(5.0) }
+                            { toBeLessThan(5.0) }
                         )
                     }
                 }
@@ -265,8 +265,8 @@ abstract class IterableContainsInOrderOnlyEntriesExpectationsSpec(
                             expect(null1null3()).containsInOrderOnlyNullableEntriesFun(
                                 null,
                                 null,
-                                { isLessThan(5.0) },
-                                { isGreaterThan(2.0) }
+                                { toBeLessThan(5.0) },
+                                { toBeGreaterThan(2.0) }
                             )
                         }.toThrow<AssertionError> {
                             message {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -237,10 +237,11 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec(
                     }
                     it("[$isLessThanFun(2.1) && $isGreaterThanFun(1.0), $isLessThanFun(2.0)], [$isGreaterThanFun(3.0), $isGreaterThanFun(2.0), $isGreaterThanFun(1.0) && $isLessThanFun(5.0)]") {
                         expect(oneToFour() as Iterable<Double?>).containsInOrderOnlyGroupedEntriesFun(
-                            context({ isLessThan(2.1).and.isGreaterThan(1.0) }, { isLessThan(2.0) }),
-                            context({ isGreaterThan(3.0) },
-                                { isGreaterThan(2.0) },
-                                { isGreaterThan(1.0); isLessThan(5.0) })
+                            context({ toBeLessThan(2.1).and.toBeGreaterThan(1.0) }, { toBeLessThan(2.0) }),
+                            context(
+                                { toBeGreaterThan(3.0) },
+                                { toBeGreaterThan(2.0) },
+                                { toBeGreaterThan(1.0); toBeLessThan(5.0) })
                         )
                     }
                 }
@@ -280,7 +281,7 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec(
                     it("[$isLessThanFun(2.1), $isLessThanFun(2.0)], (4.0, 3.0, 4.0) -- first win also applies here, $isLessThanFun(2.1) matches 1.0 and not 2.0") {
                         expect {
                             expect(oneToFour() as Iterable<Double?>).containsInOrderOnlyGroupedEntriesFun(
-                                context({ isLessThan(2.1) }, { isLessThan(2.0) }),
+                                context({ toBeLessThan(2.1) }, { toBeLessThan(2.0) }),
                                 context({ toEqual(4.0) }, { toEqual(3.0) }, { toEqual(4.0) })
                             )
                         }.toThrow<AssertionError> {
@@ -413,7 +414,7 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec(
                     it("[null], [null, $isGreaterThanFun(2.0), $isLessThanFun(5.0)]") {
                         expect(null1null3()).containsInOrderOnlyGroupedEntriesFun(
                             context(null),
-                            context(null, { isGreaterThan(2.0) }, { isLessThan(5.0) })
+                            context(null, { toBeGreaterThan(2.0) }, { toBeLessThan(5.0) })
                         )
                     }
                 }
@@ -424,7 +425,7 @@ abstract class IterableContainsInOrderOnlyGroupedEntriesExpectationsSpec(
                         expect {
                             expect(null1null3()).containsInOrderOnlyGroupedEntriesFun(
                                 context(null, null),
-                                context({ isLessThan(5.0) }, { isGreaterThan(2.0) })
+                                context({ toBeLessThan(5.0) }, { toBeGreaterThan(2.0) })
                             )
                         }.toThrow<AssertionError> {
                             message {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsNotEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsNotEntriesExpectationsSpec.kt
@@ -27,7 +27,7 @@ abstract class IterableContainsNotEntriesExpectationsSpec(
         *containsNotEntries.forAssertionCreatorSpec(
             "$isGreaterThanDescr: 8.0",
             "$isGreaterThanDescr: 10.0",
-            { isGreaterThan(8.0) }, arrayOf(expectLambda { isGreaterThan(10.0) })
+            { toBeGreaterThan(8.0) }, arrayOf(expectLambda { toBeGreaterThan(10.0) })
         )
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
@@ -35,7 +35,7 @@ abstract class IterableContainsNotEntriesExpectationsSpec(
         *containsNotNullableEntries.forAssertionCreatorSpec(
             "$isGreaterThanDescr: 8.0",
             "$isGreaterThanDescr: 10.0",
-            { isGreaterThan(8.0) }, arrayOf(expectLambda { isGreaterThan(10.0) })
+            { toBeGreaterThan(8.0) }, arrayOf(expectLambda { toBeGreaterThan(10.0) })
         )
     ) {})
 
@@ -84,7 +84,7 @@ abstract class IterableContainsNotEntriesExpectationsSpec(
 
             context("happy case") {
                 it("$isGreaterThanFun(1.0) and $isLessThanFun(2.0) does not throw") {
-                    expect(oneToSeven()).containsNotFun({ isGreaterThan(1.0); isLessThan(2.0) })
+                    expect(oneToSeven()).containsNotFun({ toBeGreaterThan(1.0); toBeLessThan(2.0) })
                 }
                 it("$toBeFun(1.1), $toBeFun(2.2), $toBeFun(3.3) does not throw") {
                     expect(oneToSeven()).containsNotFun({ toEqual(1.1) }, { toEqual(2.2) }, { toEqual(3.3) })
@@ -97,7 +97,7 @@ abstract class IterableContainsNotEntriesExpectationsSpec(
             context("failing cases; search string at different positions") {
                 it("$isLessThanFun(4.0) throws AssertionError") {
                     expect {
-                        expect(oneToSeven()).containsNotFun({ isLessThan(4.0) })
+                        expect(oneToSeven()).containsNotFun({ toBeLessThan(4.0) })
                     }.toThrow<AssertionError> {
                         message {
                             toContainRegex(

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableContainsSpecBase.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.specs.integration
 
-import ch.tutteli.atrium.api.fluent.en_GB.contains
 import ch.tutteli.atrium.api.fluent.en_GB.exactly
 import ch.tutteli.atrium.api.fluent.en_GB.regex
 import ch.tutteli.atrium.api.fluent.en_GB.toContain

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableExpectationsSpec.kt
@@ -25,7 +25,7 @@ abstract class IterableExpectationsSpec(
         describePrefix,
         hasNext.forSubjectLess(),
         minFeature.forSubjectLess(),
-        min.forSubjectLess { isGreaterThan(-100) },
+        min.forSubjectLess { toBeGreaterThan(-100) },
         maxFeature.forSubjectLess(),
         max.forSubjectLess { toEqual(1) }
     ) {})
@@ -80,11 +80,11 @@ abstract class IterableExpectationsSpec(
             val fluent = expect(listOf(4, 3) as Iterable<Int>)
             minFunctions.forEach { (name, minFun, _) ->
                 it("$name - is greater than 2 holds") {
-                    fluent.minFun { isGreaterThan(2) }
+                    fluent.minFun { toBeGreaterThan(2) }
                 }
                 it("$name - is less than 2 fails") {
                     expect {
-                        fluent.minFun { isLessThan(2) }
+                        fluent.minFun { toBeLessThan(2) }
                     }.toThrow<AssertionError> {
                         messageContains("min(): 3")
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNoneExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNoneExpectationsSpec.kt
@@ -21,11 +21,11 @@ abstract class IterableNoneExpectationsSpec(
 
     include(object : AssertionCreatorSpec<Iterable<Double>>(
         describePrefix, oneToSeven().toList().asIterable(),
-        none.forAssertionCreatorSpec("$isGreaterThanDescr: 10.0") { isGreaterThan(10.0) }
+        none.forAssertionCreatorSpec("$isGreaterThanDescr: 10.0") { toBeGreaterThan(10.0) }
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
         "$describePrefix[nullable Element] ", oneToSeven().toList().asIterable(),
-        noneNullable.forAssertionCreatorSpec("$isGreaterThanDescr: 10.0") { isGreaterThan(10.0) }
+        noneNullable.forAssertionCreatorSpec("$isGreaterThanDescr: 10.0") { toBeGreaterThan(10.0) }
     ) {})
 
     val containsNotDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
@@ -40,7 +40,7 @@ abstract class IterableNoneExpectationsSpec(
         context("empty collection") {
             it("throws AssertionError as there needs to be at least one element") {
                 expect {
-                    expect(fluentEmpty()).noneFun { isLessThan(1.0) }
+                    expect(fluentEmpty()).noneFun { toBeLessThan(1.0) }
                 }.toThrow<AssertionError> {
                     messageContains("$featureArrow$hasElement: false")
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/KeyValueLikeExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/KeyValueLikeExpectationsSpec.kt
@@ -32,7 +32,7 @@ abstract class KeyValueLikeExpectationsSpec<T : Any, TNullable : Any>(
         keyFeature.forSubjectLess(),
         key.forSubjectLess { toEndWith("a") },
         valueFeature.forSubjectLess(),
-        value.forSubjectLess { isGreaterThan(2) }
+        value.forSubjectLess { toBeGreaterThan(2) }
     ) {})
     include(object : SubjectLessSpec<TNullable>(
         "$describePrefix[nullable] ",
@@ -88,11 +88,11 @@ abstract class KeyValueLikeExpectationsSpec<T : Any, TNullable : Any>(
 
             valueFunctions.forEach { (name, valueFun, _) ->
                 it("$name - isGreaterThan(0) holds") {
-                    fluent.valueFun { isGreaterThan(0) }
+                    fluent.valueFun { toBeGreaterThan(0) }
                 }
                 it("$name - isGreaterThan(1) fails") {
                     expect {
-                        fluent.valueFun { isGreaterThan(1) }
+                        fluent.valueFun { toBeGreaterThan(1) }
                     }.toThrow<AssertionError> {
                         messageContains(
                             "$valueName: 1",
@@ -124,7 +124,7 @@ abstract class KeyValueLikeExpectationsSpec<T : Any, TNullable : Any>(
             }
             valueFunctions.forEach { (name, nullableValueFun, _) ->
                 it("$name - isGreaterThan(0) holds") {
-                    nullableFluent.nullableValueFun { notToEqualNull { isGreaterThan(0) } }
+                    nullableFluent.nullableValueFun { notToEqualNull { toBeGreaterThan(0) } }
                 }
                 it("$name - toBe(null) throws AssertionError") {
                     expect {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapAsEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapAsEntriesExpectationsSpec.kt
@@ -32,7 +32,7 @@ abstract class MapAsEntriesExpectationsSpec(
                         { isKeyValue("b", 2) },
                         {
                             key { toStartWith("a") }
-                            value.isGreaterThanOrEqual(1)
+                            value.toBeGreaterThanOrEqual(1)
                         }
                     )
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapContainsInAnyOrderKeyValueExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapContainsInAnyOrderKeyValueExpectationsSpec.kt
@@ -24,7 +24,7 @@ abstract class MapContainsInAnyOrderKeyValueExpectationsSpec(
         describePrefix,
         keyWithValueAssertions.forSubjectLess(
             keyValue("a") { toEqual(1) },
-            arrayOf(keyValue("a") { isLessThanOrEqual(2) })
+            arrayOf(keyValue("a") { toBeLessThanOrEqual(2) })
         )
     ) {})
 
@@ -77,16 +77,16 @@ abstract class MapContainsInAnyOrderKeyValueExpectationsSpec(
 
                 it("$name - a { isLessThan(2) } and a { isGreaterThan(0) } does not throw (no unique match)") {
                     fluent.containsKeyWithValueAssertionsFun(
-                        keyValue("a") { isLessThan(2) },
-                        arrayOf(keyValue("a") { isGreaterThan(0) })
+                        keyValue("a") { toBeLessThan(2) },
+                        arrayOf(keyValue("a") { toBeGreaterThan(0) })
                     )
                 }
 
                 it("$name - a { isLessThan(3) }, b { isLessThan(2) }, c { isLessThan(1) }} throws AssertionError, reports b and c") {
                     expect {
                         fluent.containsKeyWithValueAssertionsFun(
-                            keyValue("a") { isLessThan(3) },
-                            arrayOf(keyValue("b") { isLessThan(2) }, keyValue("c") { isLessThan(1) })
+                            keyValue("a") { toBeLessThan(3) },
+                            arrayOf(keyValue("b") { toBeLessThan(2) }, keyValue("c") { toBeLessThan(1) })
                         )
                     }.toThrow<AssertionError> {
                         message {
@@ -143,8 +143,8 @@ abstract class MapContainsInAnyOrderKeyValueExpectationsSpec(
                 expect {
                     nullableFluent.containsFun(
                         keyNullableValue("a", null), arrayOf(
-                            keyNullableValue("b") { isLessThan(2) },
-                            keyNullableValue("c") { isLessThan(1) }
+                            keyNullableValue("b") { toBeLessThan(2) },
+                            keyNullableValue("c") { toBeLessThan(1) }
                         )
                     )
                 }.toThrow<AssertionError> {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapContainsInAnyOrderOnlyKeyValueExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapContainsInAnyOrderOnlyKeyValueExpectationsSpec.kt
@@ -17,7 +17,7 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
         describePrefix,
         keyWithValueAssertions.forSubjectLess(
             keyValue("a") { toEqual(1) },
-            arrayOf(keyValue("a") { isLessThanOrEqual(2) })
+            arrayOf(keyValue("a") { toBeLessThanOrEqual(2) })
         )
     ) {})
 
@@ -37,8 +37,8 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
             {
                 keyWithValueAssertions(
                     this,
-                    keyValue("a") { isLessThan(2) },
-                    arrayOf(keyValue("b") { isLessThan(3) })
+                    keyValue("a") { toBeLessThan(2) },
+                    arrayOf(keyValue("b") { toBeLessThan(3) })
                 )
             },
             { keyWithValueAssertions(this, keyValue("a") { }, arrayOf(keyValue("a") { })) }
@@ -52,7 +52,7 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
             {
                 keyWithNullableValueAssertions(
                     this,
-                    keyNullableValue("a") { isLessThan(2) },
+                    keyNullableValue("a") { toBeLessThan(2) },
                     arrayOf(keyNullableValue("b", null))
                 )
             },
@@ -88,10 +88,10 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
                 it("$name - a to { isLessThan(1) }, b to { toBe(3) }, c to { isLessThan(4) } } throws AssertionError, reports a, b and c") {
                     expect {
                         expect(emptyMap).containsFun(
-                            keyValue("a") { isLessThan(1) },
+                            keyValue("a") { toBeLessThan(1) },
                             arrayOf(
                                 keyValue("b") { toEqual(3) },
-                                keyValue("c") { isLessThan(4) }
+                                keyValue("c") { toBeLessThan(4) }
                             ))
                     }.toThrow<AssertionError> {
                         message {
@@ -117,11 +117,11 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
                         keyValue("b") { toEqual(2) },
                         keyValue("a") { toEqual(1) }),
                     "b to { isGreaterThan(1) }, a to { isLessThan(2) }" to listOf(
-                        keyValue("b") { isGreaterThan(1) },
-                        keyValue("a") { isLessThan(2) }),
+                        keyValue("b") { toBeGreaterThan(1) },
+                        keyValue("a") { toBeLessThan(2) }),
                     "a to { isGreaterThan(0) }, b to { isLessThan(3) }" to listOf(
-                        keyValue("a") { isGreaterThan(0) },
-                        keyValue("b") { isLessThan(3) })
+                        keyValue("a") { toBeGreaterThan(0) },
+                        keyValue("b") { toBeLessThan(3) })
                 ).forEach { (description, list) ->
                     it("$name - $description does not throw") {
                         expect(map).containsFun(list.first(), list.drop(1).toTypedArray())
@@ -130,7 +130,7 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
 
                 it("$name - a to { isLessThan(2) } throws AssertionError, reports second a and missing b") {
                     expect {
-                        expect(map).containsFun(keyValue("a") { isLessThan(2) }, arrayOf())
+                        expect(map).containsFun(keyValue("a") { toBeLessThan(2) }, arrayOf())
                     }.toThrow<AssertionError> {
                         message {
                             containsInAnyOrderOnlyDescr()
@@ -143,7 +143,7 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
 
                 it("$name - a to { isLessThan(2) }, a to { toBe(1) } throws AssertionError, reports second a and missing b") {
                     expect {
-                        expect(map).containsFun(keyValue("a") { isLessThan(2) }, arrayOf(keyValue("a") { toEqual(1) }))
+                        expect(map).containsFun(keyValue("a") { toBeLessThan(2) }, arrayOf(keyValue("a") { toEqual(1) }))
                     }.toThrow<AssertionError> {
                         message {
                             containsInAnyOrderOnlyDescr()
@@ -159,9 +159,9 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
                 it("$name - a to { isLessThan(3), b to { isLessThan(1), c to { toBe(4) } throws AssertionError, reports b and c") {
                     expect {
                         expect(map).containsFun(
-                            keyValue("a") { isLessThan(3) },
+                            keyValue("a") { toBeLessThan(3) },
                             arrayOf(
-                                keyValue("b") { isLessThan(1) },
+                                keyValue("b") { toBeLessThan(1) },
                                 keyValue("c") { toEqual(4) }
                             )
                         )
@@ -226,9 +226,9 @@ abstract class MapContainsInAnyOrderOnlyKeyValueExpectationsSpec(
                     expect(nullableMap).containsKeyWithNullableValueAssertionsFun(
                         keyNullableValue("a") { toEqual(1) },
                         arrayOf(
-                            keyNullableValue("c") { isLessThan(3) },
+                            keyNullableValue("c") { toBeLessThan(3) },
                             keyNullableValue(null, null),
-                            keyNullableValue("b") { isLessThan(3) }
+                            keyNullableValue("b") { toBeLessThan(3) }
                         )
                     )
                 }.toThrow<AssertionError> {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapContainsInOrderOnlyKeyValueExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapContainsInOrderOnlyKeyValueExpectationsSpec.kt
@@ -16,7 +16,7 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
         describePrefix,
         keyWithValueAssertions.forSubjectLess(
             keyValue("a") { toEqual(1) },
-            arrayOf(keyValue("a") { isLessThanOrEqual(2) })
+            arrayOf(keyValue("a") { toBeLessThanOrEqual(2) })
         )
     ) {})
 
@@ -34,8 +34,8 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
             {
                 keyWithValueAssertions(
                     this,
-                    keyValue("a") { isLessThan(2) },
-                    arrayOf(keyValue("b") { isLessThan(3) })
+                    keyValue("a") { toBeLessThan(2) },
+                    arrayOf(keyValue("b") { toBeLessThan(3) })
                 )
             },
             { keyWithValueAssertions(this, keyValue("a") { }, arrayOf(keyValue("b") { })) }
@@ -48,7 +48,7 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
             {
                 keyWithNullableValueAssertions(
                     this,
-                    keyNullableValue("a") { isLessThan(2) },
+                    keyNullableValue("a") { toBeLessThan(2) },
                     arrayOf(keyNullableValue("b", null))
                 )
             },
@@ -152,10 +152,10 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
                 it("$name - a to { isLessThan(1) }, b to { toBe(3) }, c to { isLessThan(4) } } throws AssertionError, reports a, b and c") {
                     expect {
                         expect(emptyMap).containsFun(
-                            keyValue("a") { isLessThan(1) },
+                            keyValue("a") { toBeLessThan(1) },
                             arrayOf(
                                 keyValue("b") { toEqual(3) },
-                                keyValue("c") { isLessThan(4) }
+                                keyValue("c") { toBeLessThan(4) }
                             ))
                     }.toThrow<AssertionError> {
                         message {
@@ -180,8 +180,8 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
                         keyValue("a") { toEqual(1) },
                         keyValue("b") { toEqual(2) }),
                     "a to { isGreaterThan(0) }, b to { isLessThan(3) }" to listOf(
-                        keyValue("a") { isGreaterThan(0) },
-                        keyValue("b") { isLessThan(3) })
+                        keyValue("a") { toBeGreaterThan(0) },
+                        keyValue("b") { toBeLessThan(3) })
                 ).forEach { (description, list) ->
                     it("$name - $description does not throw") {
                         expect(map).containsFun(list.first(), list.drop(1).toTypedArray())
@@ -225,8 +225,8 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
                 it("$name - a { isLessThan(3) }, b { isLessThan(2) }, c { isLessThan(1) }} throws AssertionError, reports b and c") {
                     expect {
                         fluent.containsFun(
-                            keyValue("a") { isLessThan(3) },
-                            arrayOf(keyValue("b") { isLessThan(2) }, keyValue("c") { isLessThan(1) })
+                            keyValue("a") { toBeLessThan(3) },
+                            arrayOf(keyValue("b") { toBeLessThan(2) }, keyValue("c") { toBeLessThan(1) })
                         )
                     }.toThrow<AssertionError> {
                         message {
@@ -256,8 +256,8 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
                 "(a, null), null { isLessThan(2) }, b { isGreaterThan(1) }" to
                     listOf(
                         keyNullableValue("a", null),
-                        keyNullableValue(null) { isLessThan(2) },
-                        keyNullableValue("b") { isGreaterThan(1) }
+                        keyNullableValue(null) { toBeLessThan(2) },
+                        keyNullableValue("b") { toBeGreaterThan(1) }
                     )
             ).forEach { (description, keyValues) ->
                 it("$description does not throw") {
@@ -309,8 +309,8 @@ abstract class MapContainsInOrderOnlyKeyValueExpectationsSpec(
                 expect {
                     nullableFluent.containsFun(
                         keyNullableValue("a", null), arrayOf(
-                            keyNullableValue("c") { isLessThan(1) },
-                            keyNullableValue("b") { isLessThan(2) }
+                            keyNullableValue("c") { toBeLessThan(1) },
+                            keyNullableValue("b") { toBeLessThan(2) }
                         )
                     )
                 }.toThrow<AssertionError> {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapExpectationsSpec.kt
@@ -42,7 +42,7 @@ abstract class MapExpectationsSpec(
         valuesFeature.forSubjectLess(),
         values.forSubjectLess { this.toBeEmpty() },
         getExistingFeature.forSubjectLess("a"),
-        getExisting.forSubjectLess("a") { isGreaterThan(1) }
+        getExisting.forSubjectLess("a") { toBeGreaterThan(1) }
     ) {})
 
     include(object : SubjectLessSpec<Map<out String?, Int?>>(

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/verbs/VerbSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/verbs/VerbSpec.kt
@@ -43,18 +43,18 @@ abstract class VerbSpec(
             }
             context("a subsequent assertion holds") {
                 it("does not throw an exception") {
-                    assertionVerb(1) { toEqual(1) }.isLessThan(2)
+                    assertionVerb(1) { toEqual(1) }.toBeLessThan(2)
                 }
             }
             context("a subsequent group of assertions hold") {
                 it("does not throw an exception") {
-                    assertionVerb(1) { toEqual(1) }.and { isLessThan(2) }
+                    assertionVerb(1) { toEqual(1) }.and { toBeLessThan(2) }
                 }
             }
             context("a subsequent assertion fails") {
                 it("throws an AssertionError") {
                     assert {
-                        assertionVerb(1) { toEqual(1) }.isLessThan(1)
+                        assertionVerb(1) { toEqual(1) }.toBeLessThan(1)
                     }.toThrow<AssertionError> {
                         message {
                             toContain("${DescriptionComparableAssertion.IS_LESS_THAN.getDefault()}: 1")
@@ -67,7 +67,7 @@ abstract class VerbSpec(
             context("multiple assertions of a subsequent group of assertion fails") {
                 it("evaluates all assertions and then throws an AssertionError, reporting only failing") {
                     assert {
-                        assertionVerb(1) { toEqual(1) }.and { isLessThan(0); toEqual(1); isGreaterThan(2) }
+                        assertionVerb(1) { toEqual(1) }.and { toBeLessThan(0); toEqual(1); toBeGreaterThan(2) }
                     }.toThrow<AssertionError> {
                         message {
                             toContain(
@@ -86,8 +86,8 @@ abstract class VerbSpec(
             it("evaluates all assertions and then throws an AssertionError") {
                 assert {
                     assertionVerb(1) {
-                        isLessThan(0)
-                        isGreaterThan(2)
+                        toBeLessThan(0)
+                        toBeGreaterThan(2)
                     }
                 }.toThrow<AssertionError> {
                     message {
@@ -160,7 +160,7 @@ private fun Suite.testNonNullableSubject(assertionVerb: (Int) -> Expect<Int>) {
     }
     it("throws an AssertionError as soon as one assertion fails") {
         assert {
-            assertionVerb(1).isLessThanOrEqual(10).and.isLessThanOrEqual(0).and.isGreaterThanOrEqual(2)
+            assertionVerb(1).toBeLessThanOrEqual(10).and.toBeLessThanOrEqual(0).and.toBeGreaterThanOrEqual(2)
         }.toThrow<AssertionError> {
             message {
                 toContain(": 1")

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateExpectationsSpec.kt
@@ -25,13 +25,13 @@ abstract class LocalDateExpectationsSpec(
 
     include(object : SubjectLessSpec<LocalDate>(describePrefix,
         yearFeature.forSubjectLess().adjustName { "$it feature" },
-        year.forSubjectLess { isGreaterThan(2000) },
+        year.forSubjectLess { toBeGreaterThan(2000) },
         monthFeature.forSubjectLess().adjustName { "$it feature" },
-        month.forSubjectLess { isLessThan(12) },
+        month.forSubjectLess { toBeLessThan(12) },
         dayFeature.forSubjectLess().adjustName { "$it feature" },
-        day.forSubjectLess { isLessThanOrEqual(20) },
+        day.forSubjectLess { toBeLessThanOrEqual(20) },
         dayOfWeekFeature.forSubjectLess().adjustName { "$it feature" },
-        dayOfWeek.forSubjectLess { isLessThanOrEqual(DayOfWeek.SUNDAY) }
+        dayOfWeek.forSubjectLess { toBeLessThanOrEqual(DayOfWeek.SUNDAY) }
     ) {})
 
     include(object : AssertionCreatorSpec<LocalDate>(
@@ -57,11 +57,11 @@ abstract class LocalDateExpectationsSpec(
         context("LocalDate with year 2009") {
             yearFunctions.forEach { (name, yearFun, _) ->
                 it("$name - is greater than 2009 holds") {
-                    fluent.yearFun { isGreaterThan(2008) }
+                    fluent.yearFun { toBeGreaterThan(2008) }
                 }
                 it("$name - is less than 2009 fails") {
                     expect {
-                        fluent.yearFun { isLessThan(2009) }
+                        fluent.yearFun { toBeLessThan(2009) }
                     }.toThrow<AssertionError> {
                         messageContains("$yearDescr: 2009")
                     }
@@ -76,11 +76,11 @@ abstract class LocalDateExpectationsSpec(
         context("LocalDate with month March(3)") {
             monthFunctions.forEach { (name, monthFun, _) ->
                 it("$name - is greater than February(2) holds") {
-                    fluent.monthFun { isGreaterThan(2) }
+                    fluent.monthFun { toBeGreaterThan(2) }
                 }
                 it("$name - is less than March(3) fails") {
                     expect {
-                        fluent.monthFun { isLessThan(3) }
+                        fluent.monthFun { toBeLessThan(3) }
                     }.toThrow<AssertionError> {
                         messageContains("$monthDescr: 3")
                     }
@@ -95,11 +95,11 @@ abstract class LocalDateExpectationsSpec(
         context("LocalDate with day of month 13") {
             dayFunctions.forEach { (name, dayFun, _) ->
                 it("$name - is greater than 5 holds") {
-                    fluent.dayFun { isGreaterThan(5) }
+                    fluent.dayFun { toBeGreaterThan(5) }
                 }
                 it("$name - is less than 5 fails") {
                     expect {
-                        fluent.dayFun { isLessThan(5) }
+                        fluent.dayFun { toBeLessThan(5) }
                     }.toThrow<AssertionError> {
                         messageContains("$dayDescr: 13")
                     }
@@ -114,11 +114,11 @@ abstract class LocalDateExpectationsSpec(
         context("LocalDate with day of week Friday(5)") {
             dayOfWeekFunctions.forEach { (name, dayOfWeekFun, _) ->
                 it("$name - is greater than Monday(1) holds") {
-                    fluent.dayOfWeekFun { isGreaterThan(DayOfWeek.MONDAY) }
+                    fluent.dayOfWeekFun { toBeGreaterThan(DayOfWeek.MONDAY) }
                 }
                 it("$name - is less than Friday(5) fails") {
                     expect {
-                        fluent.dayOfWeekFun { isLessThan(DayOfWeek.FRIDAY) }
+                        fluent.dayOfWeekFun { toBeLessThan(DayOfWeek.FRIDAY) }
                     }.toThrow<AssertionError> {
                         messageContains("$dayOfWeekDescr: ${DayOfWeek.FRIDAY}")
                     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateTimeExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/LocalDateTimeExpectationsSpec.kt
@@ -24,13 +24,13 @@ abstract class LocalDateTimeExpectationsSpec(
 
     include(object : SubjectLessSpec<LocalDateTime>(describePrefix,
         yearFeature.forSubjectLess().adjustName { "$it feature" },
-        year.forSubjectLess { isGreaterThan(2000) },
+        year.forSubjectLess { toBeGreaterThan(2000) },
         monthFeature.forSubjectLess().adjustName { "$it feature" },
-        month.forSubjectLess { isLessThan(12) },
+        month.forSubjectLess { toBeLessThan(12) },
         dayFeature.forSubjectLess().adjustName { "$it feature" },
-        day.forSubjectLess { isLessThanOrEqual(20) },
+        day.forSubjectLess { toBeLessThanOrEqual(20) },
         dayOfWeekFeature.forSubjectLess().adjustName { "$it feature" },
-        dayOfWeek.forSubjectLess { isLessThanOrEqual(DayOfWeek.SUNDAY) }
+        dayOfWeek.forSubjectLess { toBeLessThanOrEqual(DayOfWeek.SUNDAY) }
     ) {})
 
     include(object : AssertionCreatorSpec<LocalDateTime>(
@@ -56,11 +56,11 @@ abstract class LocalDateTimeExpectationsSpec(
         context("LocalDateTime with year 2009") {
             yearFunctions.forEach { (name, yearFun, _) ->
                 it("$name - is greater than 2009 holds") {
-                    fluent.yearFun { isGreaterThan(2008) }
+                    fluent.yearFun { toBeGreaterThan(2008) }
                 }
                 it("$name - is less than 2009 fails") {
                     expect {
-                        fluent.yearFun { isLessThan(2009) }
+                        fluent.yearFun { toBeLessThan(2009) }
                     }.toThrow<AssertionError> {
                         messageContains("$yearDescr: 2009")
                     }
@@ -75,11 +75,11 @@ abstract class LocalDateTimeExpectationsSpec(
         context("LocalDateTime with month May(5)") {
             monthFunctions.forEach { (name, monthFun, _) ->
                 it("$name - is greater than February(2) holds") {
-                    fluent.monthFun { isGreaterThan(2) }
+                    fluent.monthFun { toBeGreaterThan(2) }
                 }
                 it("$name - is less than 5 fails") {
                     expect {
-                        fluent.monthFun { isLessThan(5) }
+                        fluent.monthFun { toBeLessThan(5) }
                     }.toThrow<AssertionError> {
                         messageContains("$monthDescr: 5")
                     }
@@ -94,11 +94,11 @@ abstract class LocalDateTimeExpectationsSpec(
         context("LocalDateTime with day of month 15") {
             dayFunctions.forEach { (name, dayFun, _) ->
                 it("$name - is greater than 5 holds") {
-                    fluent.dayFun { isGreaterThan(5) }
+                    fluent.dayFun { toBeGreaterThan(5) }
                 }
                 it("$name - is less than 5 fails") {
                     expect {
-                        fluent.dayFun { isLessThan(5) }
+                        fluent.dayFun { toBeLessThan(5) }
                     }.toThrow<AssertionError> {
                         messageContains("$dayDescr: 15")
                     }
@@ -113,11 +113,11 @@ abstract class LocalDateTimeExpectationsSpec(
         context("LocalDateTime with day of week Friday(5)") {
             dayOfWeekFunctions.forEach { (name, dayOfWeekFun, _) ->
                 it("$name - is greater than Monday(1) holds") {
-                    fluent.dayOfWeekFun { isGreaterThan(DayOfWeek.MONDAY) }
+                    fluent.dayOfWeekFun { toBeGreaterThan(DayOfWeek.MONDAY) }
                 }
                 it("$name - is less than Friday(5) fails") {
                     expect {
-                        fluent.dayOfWeekFun { isLessThan(DayOfWeek.FRIDAY) }
+                        fluent.dayOfWeekFun { toBeLessThan(DayOfWeek.FRIDAY) }
                     }.toThrow<AssertionError> {
                         messageContains("$dayOfWeekDescr: ${DayOfWeek.FRIDAY}")
                     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/ZonedDateTimeExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/ZonedDateTimeExpectationsSpec.kt
@@ -24,13 +24,13 @@ abstract class ZonedDateTimeExpectationsSpec(
 
     include(object : SubjectLessSpec<ZonedDateTime>(describePrefix,
         yearFeature.forSubjectLess().adjustName { "$it feature" },
-        year.forSubjectLess { isGreaterThan(2000) },
+        year.forSubjectLess { toBeGreaterThan(2000) },
         monthFeature.forSubjectLess().adjustName { "$it feature" },
-        month.forSubjectLess { isLessThan(12) },
+        month.forSubjectLess { toBeLessThan(12) },
         dayFeature.forSubjectLess().adjustName { "$it feature" },
-        day.forSubjectLess { isLessThanOrEqual(20) },
+        day.forSubjectLess { toBeLessThanOrEqual(20) },
         dayOfWeekFeature.forSubjectLess().adjustName { "$it feature" },
-        dayOfWeek.forSubjectLess { isLessThanOrEqual(DayOfWeek.SUNDAY) }
+        dayOfWeek.forSubjectLess { toBeLessThanOrEqual(DayOfWeek.SUNDAY) }
     ) {})
 
     include(object : AssertionCreatorSpec<ZonedDateTime>(
@@ -56,11 +56,11 @@ abstract class ZonedDateTimeExpectationsSpec(
         context("ZonedDateTime with year 2009") {
             yearFunctions.forEach { (name, yearFun, _) ->
                 it("$name - is greater than 2009 holds") {
-                    fluent.yearFun { isGreaterThan(2008) }
+                    fluent.yearFun { toBeGreaterThan(2008) }
                 }
                 it("$name - is less than 2009 fails") {
                     expect {
-                        fluent.yearFun { isLessThan(2009) }
+                        fluent.yearFun { toBeLessThan(2009) }
                     }.toThrow<AssertionError> {
                         messageContains("$yearDescr: 2009")
                     }
@@ -75,11 +75,11 @@ abstract class ZonedDateTimeExpectationsSpec(
         context("ZonedDateTime with month May(5)") {
             monthFunctions.forEach { (name, monthFun, _) ->
                 it("$name - is greater than February(2) holds") {
-                    fluent.monthFun { isGreaterThan(2) }
+                    fluent.monthFun { toBeGreaterThan(2) }
                 }
                 it("$name - is less than 5 fails") {
                     expect {
-                        fluent.monthFun { isLessThan(5) }
+                        fluent.monthFun { toBeLessThan(5) }
                     }.toThrow<AssertionError> {
                         messageContains("$monthDescr: 5")
                     }
@@ -95,11 +95,11 @@ abstract class ZonedDateTimeExpectationsSpec(
         context("LocalDate with day of month 15") {
             dayFunctions.forEach { (name, dayFun, _) ->
                 it("$name - is greater than 5 holds") {
-                    fluent.dayFun { isGreaterThan(5) }
+                    fluent.dayFun { toBeGreaterThan(5) }
                 }
                 it("$name - is less than 5 fails") {
                     expect {
-                        fluent.dayFun { isLessThan(5) }
+                        fluent.dayFun { toBeLessThan(5) }
                     }.toThrow<AssertionError> {
                         messageContains("$dayDescr: 15")
                     }
@@ -114,11 +114,11 @@ abstract class ZonedDateTimeExpectationsSpec(
         context("ZonedDateTime with day of week Friday(5)") {
             dayOfWeekFunctions.forEach { (name, dayOfWeekFun, _) ->
                 it("$name - is greater than Monday(1) holds") {
-                    fluent.dayOfWeekFun { isGreaterThan(DayOfWeek.MONDAY) }
+                    fluent.dayOfWeekFun { toBeGreaterThan(DayOfWeek.MONDAY) }
                 }
                 it("$name - is less than Friday(5) fails") {
                     expect {
-                        fluent.dayOfWeekFun { isLessThan(DayOfWeek.FRIDAY) }
+                        fluent.dayOfWeekFun { toBeLessThan(DayOfWeek.FRIDAY) }
                     }.toThrow<AssertionError> {
                         messageContains("$dayOfWeekDescr: ${DayOfWeek.FRIDAY}")
                     }

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslatorIntSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslatorIntSpec.kt
@@ -181,7 +181,7 @@ abstract class TranslatorIntSpec(
             describe("translation for $descriptionComparableAssertion.${DescriptionComparableAssertion.IS_LESS_THAN} is not provided for 'fr'") {
                 it("throws an AssertionError which message contains the default of $descriptionComparableAssertion.${DescriptionComparableAssertion.IS_LESS_THAN}") {
                     expect {
-                        assertWithDeCh_Fr(1).isLessThan(1)
+                        assertWithDeCh_Fr(1).toBeLessThan(1)
                     }.toThrow<AssertionError> { messageContains("${DescriptionComparableAssertion.IS_LESS_THAN.getDefault()}: 1") }
                 }
             }
@@ -243,7 +243,7 @@ abstract class TranslatorIntSpec(
             describe("translation for $descriptionComparableAssertion.${DescriptionComparableAssertion.IS_LESS_THAN} is not provided for 'fr' nor for 'it'") {
                 it("throws an AssertionError which message contains the default of $descriptionComparableAssertion.${DescriptionComparableAssertion.IS_LESS_THAN}") {
                     expect {
-                        assertWithDeCh_FrCh_ItCh(1).isLessThan(1)
+                        assertWithDeCh_FrCh_ItCh(1).toBeLessThan(1)
                     }.toThrow<AssertionError> { messageContains("${DescriptionComparableAssertion.IS_LESS_THAN.getDefault()}: 1") }
                 }
             }

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/Between1Spec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/Between1Spec.kt
@@ -1,8 +1,8 @@
 package readme.examples
 
 import ch.tutteli.atrium.api.fluent.en_GB.and
-import ch.tutteli.atrium.api.fluent.en_GB.isGreaterThanOrEqual
-import ch.tutteli.atrium.api.fluent.en_GB.isLessThan
+import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toBeLessThan
 import ch.tutteli.atrium.creating.Expect
 import org.spekframework.spek2.Spek
 import java.util.*
@@ -25,6 +25,6 @@ import java.util.*
 object Between1Spec : Spek({
     test("code-own-compose-1") {
         fun <T : Date> Expect<T>.isBetween(lowerBoundInclusive: T, upperBoundExclusive: T) =
-            isGreaterThanOrEqual(lowerBoundInclusive).and.isLessThan(upperBoundExclusive)
+            toBeGreaterThanOrEqual(lowerBoundInclusive).and.toBeLessThan(upperBoundExclusive)
     }
 })

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/Between2Spec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/Between2Spec.kt
@@ -1,7 +1,7 @@
 package readme.examples
 
-import ch.tutteli.atrium.api.fluent.en_GB.isGreaterThanOrEqual
-import ch.tutteli.atrium.api.fluent.en_GB.isLessThan
+import ch.tutteli.atrium.api.fluent.en_GB.toBeGreaterThanOrEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toBeLessThan
 import ch.tutteli.atrium.creating.Expect
 import org.spekframework.spek2.Spek
 import java.util.*
@@ -31,8 +31,8 @@ object Between2Spec : Spek({
 
         fun <T : Date> Expect<T>.isBetween(lowerBoundInclusive: T, upperBoundExclusive: T) =
             _logic.appendAssertionsCreatedBy {
-                isGreaterThanOrEqual(lowerBoundInclusive)
-                isLessThan(upperBoundExclusive)
+                toBeGreaterThanOrEqual(lowerBoundInclusive)
+                toBeLessThan(upperBoundExclusive)
             }
     }
 })

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/DataDrivenSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/DataDrivenSpec.kt
@@ -51,9 +51,9 @@ class DataDrivenSpec : Spek({
 
         expect("calling myFun with ...") {
             mapOf(
-                1 to expectLambda<Char> { isLessThan('f') },
+                1 to expectLambda<Char> { toBeLessThan('f') },
                 2 to expectLambda { toEqual('c') },
-                3 to expectLambda { isGreaterThan('e') }
+                3 to expectLambda { toBeGreaterThan('e') }
             ).forEach { (arg, assertionCreator) ->
                 feature({ f(::myFun, arg) }, assertionCreator)
             }

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
@@ -23,14 +23,14 @@ class MostExamplesSpec : Spek({
 
     test("ex-single") {
         // two single assertions, only first evaluated
-        expect(4 + 6).isLessThan(5).isGreaterThan(10)
+        expect(4 + 6).toBeLessThan(5).toBeGreaterThan(10)
     }
 
     test("ex-group") {
         // assertion group with two assertions, both evaluated
         expect(4 + 6) {
-            isLessThan(5)
-            isGreaterThan(10)
+            toBeLessThan(5)
+            toBeGreaterThan(10)
         }
     }
 
@@ -100,29 +100,29 @@ class MostExamplesSpec : Spek({
 
     test("ex-collection-short-2") {
         expect(listOf(1, 2, 2, 4)).contains(
-            { isLessThan(0) },
-            { isGreaterThan(2).isLessThan(4) }
+            { toBeLessThan(0) },
+            { toBeGreaterThan(2).toBeLessThan(4) }
         )
     }
 
     test("ex-collection-any") {
-        expect(listOf(1, 2, 3, 4)).any { isLessThan(0) }
+        expect(listOf(1, 2, 3, 4)).any { toBeLessThan(0) }
     }
     test("ex-collection-none") {
-        expect(listOf(1, 2, 3, 4)).none { isGreaterThan(2) }
+        expect(listOf(1, 2, 3, 4)).none { toBeGreaterThan(2) }
     }
     test("ex-collection-all") {
-        expect(listOf(1, 2, 3, 4)).all { isGreaterThan(2) }
+        expect(listOf(1, 2, 3, 4)).all { toBeGreaterThan(2) }
     }
 
     test("ex-collection-builder-1") {
-        expect(listOf(1, 2, 2, 4)).contains.inOrder.only.entries({ isLessThan(3) }, { isLessThan(2) })
+        expect(listOf(1, 2, 2, 4)).contains.inOrder.only.entries({ toBeLessThan(3) }, { toBeLessThan(2) })
     }
     test("ex-collection-builder-2") {
         expect(listOf(1, 2, 2, 4)).contains.inOrder.only.values(1, 2, 2, 3, 4)
     }
     test("ex-collection-builder-3") {
-        expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.atLeast(1).butAtMost(2).entries({ isLessThan(3) })
+        expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.atLeast(1).butAtMost(2).entries({ toBeLessThan(3) })
     }
     test("ex-collection-builder-4") {
         expect(listOf(1, 2, 2, 4)).contains.inAnyOrder.only.values(1, 2, 3, 4)
@@ -137,8 +137,8 @@ class MostExamplesSpec : Spek({
     test("ex-map-2") {
         expect(mapOf("a" to 1, "b" to 2)).contains(
             KeyValue("c") { toEqual(2) },
-            KeyValue("a") { isGreaterThan(2) },
-            KeyValue("b") { isLessThan(2) }
+            KeyValue("a") { toBeGreaterThan(2) },
+            KeyValue("b") { toBeLessThan(2) }
         )
     }
 
@@ -148,8 +148,8 @@ class MostExamplesSpec : Spek({
     test("ex-map-only-2") {
         expect(mapOf("a" to 1, "b" to 2)).containsOnly(
             KeyValue("c") { toEqual(2) },
-            KeyValue("a") { isLessThan(2) },
-            KeyValue("b") { isLessThan(2) }
+            KeyValue("a") { toBeLessThan(2) },
+            KeyValue("b") { toBeLessThan(2) }
         )
     }
 
@@ -158,8 +158,8 @@ class MostExamplesSpec : Spek({
     }
     test("ex-map-builder-2") {
         expect(mapOf("a" to 1, "b" to 2)).contains.inOrder.only.entries(
-            KeyValue("a") { isLessThan(2) },
-            KeyValue("b") { isLessThan(2) })
+            KeyValue("a") { toBeLessThan(2) },
+            KeyValue("b") { toBeLessThan(2) })
     }
 
     //snippet-SimplePerson-start
@@ -181,7 +181,7 @@ class MostExamplesSpec : Spek({
     test("ex-map-4") {
         expect(mapOf("a" to 1, "b" to 2)) {
             keys { all { toStartWith("a") } }
-            values { none { isGreaterThan(1) } }
+            values { none { toBeGreaterThan(1) } }
         }
     }
     test("ex-map-5") {
@@ -189,7 +189,7 @@ class MostExamplesSpec : Spek({
             { isKeyValue("a", 1) },
             {
                 key.toStartWith("a")
-                value.isGreaterThan(2)
+                value.toBeGreaterThan(2)
             }
         )
     }

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt
@@ -79,7 +79,7 @@ object OwnExpectationFunctionsSpec : Spek({
     //snippet-own-compose-4-start
     fun Expect<Person>.hasAdultChildren(): Expect<Person> =
         feature(Person::children) {
-            all { feature(Person::age).isGreaterThanOrEqual(18) }
+            all { feature(Person::age).toBeGreaterThanOrEqual(18) }
         }
 
     //snippet-own-compose-4-end
@@ -105,7 +105,7 @@ object OwnExpectationFunctionsSpec : Spek({
             .apply { // only evaluated because the previous assertion group holds
                 children  // using the val -> subsequent assertions are about children and fail fast
                     .toHaveSize(2)
-                    .any { feature { f(it::age) }.isGreaterThan(18) }
+                    .any { feature { f(it::age) }.toBeGreaterThan(18) }
             } // subject is still Person here due to the `apply`
             .children // using the val -> subsequent assertions are about children and fail fast
             .toHaveSize(2)


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
