### PR TITLE
add notToBeGreaterThan and notToBeLessThan

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyExpectations.kt
@@ -9,7 +9,10 @@ import ch.tutteli.kbox.glue
 import kotlin.reflect.KClass
 
 /**
- * Expects that the subject of `this` expectation is equal to [expected].
+ * Expects that the subject of `this` expectation is equal to [expected]
+ * where the comparison is carried out based on [Any.equals].
+ *
+ * Use [toBeEqualComparingTo] if you want a comparison based on [Comparable.compareTo].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
 
 /**
- * Expects that the subject of `this` expectation is less than [expected].
+ * Expects that the subject of `this` expectation is less than (`<`) [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -17,8 +17,10 @@ fun <T : Comparable<T>> Expect<T>.toBeLessThan(expected: T): Expect<T> =
     _logicAppend { isLessThan(expected) }
 
 /**
- * Expects that the subject of `this` expectation is less than or equal [expected].
+ * Expects that the subject of `this` expectation is less than or equal (`<=`) [expected].
  * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [notToBeGreaterThan] which is logically equivalent.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -30,30 +32,19 @@ fun <T : Comparable<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Expect<T> 
     _logicAppend { isLessThanOrEqual(expected) }
 
 /**
- * Expects that the subject of `this` expectation is greater than [expected].
+ * Expects that the subject of `this` expectation is not greater than [expected].
  * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [toBeLessThanOrEqualTo] which is logically equivalent.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeGreaterThan
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.notToBeGreaterThan
  *
  * @since 0.17.0
  */
-fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> =
-    _logicAppend { isGreaterThan(expected) }
-
-/**
- * Expects that the subject of `this` expectation is greater than or equal [expected].
- * The comparison is carried out with [Comparable.compareTo].
- *
- * @return an [Expect] for the subject of `this` expectation.
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeGreaterThanOrEqualTo
- *
- * @since 0.17.0
- */
-fun <T : Comparable<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Expect<T> =
-    _logicAppend { isGreaterThanOrEqual(expected) }
+fun <T : Comparable<T>> Expect<T>.notToBeGreaterThan(expected: T): Expect<T> =
+    _logicAppend { isNotGreaterThan(expected) }
 
 /**
  * Expects that the subject of `this` expectation is equal to [expected]
@@ -69,3 +60,47 @@ fun <T : Comparable<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Expect<
  */
 fun <T : Comparable<T>> Expect<T>.toBeEqualComparingTo(expected: T): Expect<T> =
     _logicAppend { isEqualComparingTo(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is greater than or equal (`>=`) [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [notToBeLessThan] which is logically equivalent.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeGreaterThanOrEqualTo
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Expect<T> =
+    _logicAppend { isGreaterThanOrEqual(expected) }
+
+/**
+ * Expects that the subject of `this` expectation is not less than [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [toBeGreaterThanOrEqualTo] which is logically equivalent.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.notToBeLessThan
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.notToBeLessThan(expected: T): Expect<T> =
+    _logicAppend { isNotLessThan(expected) }
+
+
+/**
+ * Expects that the subject of `this` expectation is greater than (`>`) [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ComparableExpectationSamples.toBeGreaterThan
+ *
+ * @since 0.17.0
+ */
+fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> =
+    _logicAppend { isGreaterThan(expected) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsSpec.kt
@@ -3,12 +3,38 @@ package ch.tutteli.atrium.api.fluent.en_GB
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.integration.DiffEqualsCompareTo
+import ch.tutteli.atrium.translations.DescriptionComparableAssertion
+import org.spekframework.spek2.Spek
 
-object ComparableExpectationsSpec : ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
-    fun1(Expect<Int>::toBeLessThan),
-    fun1(Expect<Int>::toBeLessThanOrEqualTo),
-    fun1(Expect<Int>::toBeGreaterThan),
-    fun1(Expect<Int>::toBeGreaterThanOrEqualTo),
-    fun1(Expect<Int>::toBeEqualComparingTo),
-    fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo)
-)
+object ComparableExpectationsSpec : Spek({
+
+    include(object : ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
+        fun1(Expect<Int>::toBeLessThan),
+        fun1(Expect<Int>::toBeLessThanOrEqualTo),
+        fun1(Expect<Int>::toBeEqualComparingTo),
+        fun1(Expect<Int>::toBeGreaterThanOrEqualTo),
+        fun1(Expect<Int>::toBeGreaterThan),
+
+        fun1(Expect<DiffEqualsCompareTo>::toBeLessThanOrEqualTo),
+        fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo),
+        fun1(Expect<DiffEqualsCompareTo>::toBeGreaterThanOrEqualTo),
+        describePrefix = "[Atrium][<=] "
+    ) {})
+
+    include(object : ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
+        fun1(Expect<Int>::toBeLessThan),
+        fun1(Expect<Int>::notToBeGreaterThan),
+        fun1(Expect<Int>::toBeEqualComparingTo),
+        fun1(Expect<Int>::notToBeLessThan),
+        fun1(Expect<Int>::toBeGreaterThan),
+
+        fun1(Expect<DiffEqualsCompareTo>::notToBeGreaterThan),
+        fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo),
+        fun1(Expect<DiffEqualsCompareTo>::notToBeLessThan),
+
+        DescriptionComparableAssertion.IS_NOT_GREATER_THAN.getDefault(),
+        DescriptionComparableAssertion.IS_NOT_LESS_THAN.getDefault(),
+        describePrefix = "[Atrium][!>] "
+    ) {})
+
+})

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ComparableExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ComparableExpectationSamples.kt
@@ -26,11 +26,22 @@ class ComparableExpectationSamples {
     }
 
     @Test
-    fun toBeGreaterThan() {
-        expect(2).toBeGreaterThan(1)
+    fun notToBeGreaterThan() {
+        expect(1).notToBeGreaterThan(2)
+        expect(2).notToBeGreaterThan(2)
 
         fails {
-            expect(1).toBeGreaterThan(2)
+            expect(2).notToBeGreaterThan(1)
+        }
+    }
+
+    @Test
+    fun toBeEqualComparingTo() {
+        expect(2).toBeEqualComparingTo(2)
+
+        fails {
+            expect(1).toBeEqualComparingTo(2)
+            expect(2).toBeEqualComparingTo(1)
         }
     }
 
@@ -45,12 +56,22 @@ class ComparableExpectationSamples {
     }
 
     @Test
-    fun toBeEqualComparingTo() {
-        expect(2).toBeEqualComparingTo(2)
+    fun notToBeLessThan() {
+        expect(2).notToBeLessThan(1)
+        expect(2).notToBeLessThan(2)
 
         fails {
-            expect(1).toBeEqualComparingTo(2)
-            expect(2).toBeEqualComparingTo(1)
+            expect(1).notToBeLessThan(2)
         }
     }
+
+    @Test
+    fun toBeGreaterThan() {
+        expect(2).toBeGreaterThan(1)
+
+        fails {
+            expect(1).toBeGreaterThan(2)
+        }
+    }
+
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyExpectations.kt
@@ -9,7 +9,10 @@ import ch.tutteli.atrium.logic.utils.iterableLikeToIterable
 import kotlin.reflect.KClass
 
 /**
- * Expects that the subject of `this` expectation is (equal to) [expected].
+ * Expects that the subject of `this` expectation is (equal to) [expected]
+ * where the comparison is carried out based on [Any.equals].
+ *
+ * Use [toBeEqualComparingTo] if you want a comparison based on [Comparable.compareTo].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/comparableExpectations.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
 
 /**
- * Expects that the subject of `this` expectation is less than [expected].
+ * Expects that the subject of `this` expectation is less than (`<`) [expected].
  * The comparison is carried out with [Comparable.compareTo].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -17,8 +17,10 @@ infix fun <T : Comparable<T>> Expect<T>.toBeLessThan(expected: T): Expect<T> =
     _logicAppend { isLessThan(expected) }
 
 /**
- * Expects that the subject of `this` expectation is less than or equal [expected].
+ * Expects that the subject of `this` expectation is less than or equal (`<=`) [expected].
  * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [notToBeGreaterThan] which is logically equivalent.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -30,21 +32,41 @@ infix fun <T : Comparable<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Expe
     _logicAppend { isLessThanOrEqual(expected) }
 
 /**
- * Expects that the subject of `this` expectation is greater than [expected].
+ * Expects that the subject of `this` expectation is less than or equal [expected].
  * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [toBeLessThanOrEqualTo] which is logically equivalent.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeGreaterThan
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.notToBeGreaterThan
  *
  * @since 0.17.0
  */
-infix fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> =
-    _logicAppend { isGreaterThan(expected) }
+infix fun <T : Comparable<T>> Expect<T>.notToBeGreaterThan(expected: T): Expect<T> =
+    _logicAppend { isNotGreaterThan(expected) }
 
 /**
- * Expects that the subject of `this` expectation is greater than or equal [expected].
+ * Expects that the subject of `this` expectation is equal to [expected]
+ * where the comparison is carried out with [Comparable.compareTo].
+ *
+ * Use [toEqual] if you want a comparison based on [Any.equals].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeEqualComparingTo
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeEqualComparingTo(expected: T): Expect<T> =
+    _logicAppend { isEqualComparingTo(expected) }
+
+
+/**
+ * Expects that the subject of `this` expectation is greater than or equal (`>=`) [expected].
  * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [notToBeLessThan] which is logically equivalent.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -55,15 +77,32 @@ infix fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> 
 infix fun <T : Comparable<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Expect<T> =
     _logicAppend { isGreaterThanOrEqual(expected) }
 
+
 /**
- * Expects that the subject of `this` expectation is equal to [expected]
- * where the comparison is carried out with [Comparable.compareTo].
+ * Expects that the subject of `this` expectation is not less than [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * You could also use [toBeGreaterThanOrEqualTo] which is logically equivalent.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeEqualComparingTo
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.notToBeLessThan
  *
  * @since 0.17.0
  */
-infix fun <T : Comparable<T>> Expect<T>.toBeEqualComparingTo(expected: T): Expect<T> =
-    _logicAppend { isEqualComparingTo(expected) }
+infix fun <T : Comparable<T>> Expect<T>.notToBeLessThan(expected: T): Expect<T> =
+    _logicAppend { isNotLessThan(expected) }
+
+
+/**
+ * Expects that the subject of `this` expectation is greater than (`>`) [expected].
+ * The comparison is carried out with [Comparable.compareTo].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ComparableExpectationSamples.toBeGreaterThan
+ *
+ * @since 0.17.0
+ */
+infix fun <T : Comparable<T>> Expect<T>.toBeGreaterThan(expected: T): Expect<T> =
+    _logicAppend { isGreaterThan(expected) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsSpec.kt
@@ -4,15 +4,40 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.integration.DiffEqualsCompareTo
 import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.translations.DescriptionComparableAssertion
+import org.spekframework.spek2.Spek
 
-class ComparableExpectationsSpec : ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
-    fun1(Expect<Int>::toBeLessThan),
-    fun1(Expect<Int>::toBeLessThanOrEqualTo),
-    fun1(Expect<Int>::toBeGreaterThan),
-    fun1(Expect<Int>::toBeGreaterThanOrEqualTo),
-    fun1(Expect<Int>::toBeEqualComparingTo),
-    fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo)
-) {
+class ComparableExpectationsSpec: Spek({
+
+    include(object: ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
+        fun1(Expect<Int>::toBeLessThan),
+        fun1(Expect<Int>::toBeLessThanOrEqualTo),
+        fun1(Expect<Int>::toBeEqualComparingTo),
+        fun1(Expect<Int>::toBeGreaterThanOrEqualTo),
+        fun1(Expect<Int>::toBeGreaterThan),
+
+        fun1(Expect<DiffEqualsCompareTo>::toBeLessThanOrEqualTo),
+        fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo),
+        fun1(Expect<DiffEqualsCompareTo>::toBeGreaterThanOrEqualTo),
+        describePrefix = "[Atrium][<=] "
+    ){})
+
+    include(object: ch.tutteli.atrium.specs.integration.ComparableExpectationsSpec(
+        fun1(Expect<Int>::toBeLessThan),
+        fun1(Expect<Int>::notToBeGreaterThan),
+        fun1(Expect<Int>::toBeEqualComparingTo),
+        fun1(Expect<Int>::notToBeLessThan),
+        fun1(Expect<Int>::toBeGreaterThan),
+
+        fun1(Expect<DiffEqualsCompareTo>::notToBeGreaterThan),
+        fun1(Expect<DiffEqualsCompareTo>::toBeEqualComparingTo),
+        fun1(Expect<DiffEqualsCompareTo>::notToBeLessThan),
+
+        DescriptionComparableAssertion.IS_NOT_GREATER_THAN.getDefault(),
+        DescriptionComparableAssertion.IS_NOT_LESS_THAN.getDefault(),
+        describePrefix = "[Atrium][!>] "
+    ){})
+})  {
 
     @Suppress("unused")
     fun ambiguityTest() {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ComparableExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ComparableExpectationSamples.kt
@@ -1,9 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
-import ch.tutteli.atrium.api.infix.en_GB.toBeEqualComparingTo
-import ch.tutteli.atrium.api.infix.en_GB.toBeGreaterThan
-import ch.tutteli.atrium.api.infix.en_GB.toBeLessThan
-import ch.tutteli.atrium.api.infix.en_GB.toBeLessThanOrEqualTo
+import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import kotlin.test.Test
 
@@ -29,6 +26,16 @@ class ComparableExpectationSamples {
     }
 
     @Test
+    fun notToBeGreaterThan() {
+        expect(1) notToBeGreaterThan 2
+        expect(2) notToBeGreaterThan 2
+
+        fails {
+            expect(2) notToBeGreaterThan 1
+        }
+    }
+
+    @Test
     fun toBeGreaterThan() {
         expect(2) toBeGreaterThan 1
 
@@ -39,11 +46,21 @@ class ComparableExpectationSamples {
 
     @Test
     fun toBeGreaterThanOrEqualTo() {
-        expect(2) toBeEqualComparingTo 2
+        expect(2) toBeGreaterThanOrEqualTo 1
+        expect(2) toBeGreaterThanOrEqualTo 2
 
         fails {
-            expect(1) toBeEqualComparingTo 2
-            expect(2) toBeEqualComparingTo 1
+            expect(1) toBeGreaterThanOrEqualTo 2
+        }
+    }
+
+    @Test
+    fun notToBeLessThan() {
+        expect(2) notToBeLessThan 1
+        expect(2) notToBeLessThan 2
+
+        fails {
+            expect(1) notToBeLessThan 2
         }
     }
 

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/comparable.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/comparable.kt
@@ -16,11 +16,15 @@ fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isLessThan(expected:
 
 fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isLessThanOrEqual(expected: T2): Assertion = impl.isLessThanOrEqual(this, expected)
 
-fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isGreaterThan(expected: T2): Assertion = impl.isGreaterThan(this, expected)
+fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isNotGreaterThan(expected: T2): Assertion = impl.isNotGreaterThan(this, expected)
+
+fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isEqualComparingTo(expected: T2): Assertion = impl.isEqualComparingTo(this, expected)
 
 fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isGreaterThanOrEqual(expected: T2): Assertion = impl.isGreaterThanOrEqual(this, expected)
 
-fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isEqualComparingTo(expected: T2): Assertion = impl.isEqualComparingTo(this, expected)
+fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isNotLessThan(expected: T2): Assertion = impl.isNotLessThan(this, expected)
+
+fun <T1 : Comparable<T2>, T2 : Any?> AssertionContainer<T1>.isGreaterThan(expected: T2): Assertion = impl.isGreaterThan(this, expected)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/ComparableAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/ComparableAssertions.kt
@@ -11,15 +11,19 @@ interface ComparableAssertions {
 
     fun <T1 : Comparable<T2>, T2 : Any?> isLessThanOrEqual(container: AssertionContainer<T1>, expected: T2): Assertion
 
-    fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThan(container: AssertionContainer<T1>, expected: T2): Assertion
+    fun <T1 : Comparable<T2>, T2 : Any?> isNotGreaterThan(container: AssertionContainer<T1>, expected: T2): Assertion
+
+    fun <T1 : Comparable<T2>, T2 : Any?> isEqualComparingTo(
+        container: AssertionContainer<T1>,
+        expected: T2
+    ): Assertion
 
     fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThanOrEqual(
         container: AssertionContainer<T1>,
         expected: T2
     ): Assertion
 
-    fun <T1 : Comparable<T2>, T2 : Any?> isEqualComparingTo(
-        container: AssertionContainer<T1>,
-        expected: T2
-    ): Assertion
+    fun <T1 : Comparable<T2>, T2 : Any?> isNotLessThan(container: AssertionContainer<T1>, expected: T2): Assertion
+
+    fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThan(container: AssertionContainer<T1>, expected: T2): Assertion
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultComparableAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultComparableAssertions.kt
@@ -18,18 +18,31 @@ class DefaultComparableAssertions : ComparableAssertions {
         expected: T2
     ): Assertion = container.createDescriptiveAssertion(IS_LESS_THAN_OR_EQUAL, expected) { it <= expected }
 
-    override fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThan(
+    override fun <T1 : Comparable<T2>, T2 : Any?> isNotGreaterThan(
         container: AssertionContainer<T1>,
         expected: T2
-    ): Assertion = container.createDescriptiveAssertion(IS_GREATER_THAN, expected) { it > expected }
+    ): Assertion = container.createDescriptiveAssertion(IS_NOT_GREATER_THAN, expected) { it <= expected }
+
+    override fun <T1 : Comparable<T2>, T2 : Any?> isEqualComparingTo(
+        container: AssertionContainer<T1>,
+        expected: T2
+    ): Assertion = container.createDescriptiveAssertion(IS_EQUAL, expected) { it.compareTo(expected) == 0 }
+
 
     override fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThanOrEqual(
         container: AssertionContainer<T1>,
         expected: T2
     ): Assertion = container.createDescriptiveAssertion(IS_GREATER_THAN_OR_EQUAL, expected) { it >= expected }
 
-    override fun <T1 : Comparable<T2>, T2 : Any?> isEqualComparingTo(
+    override fun <T1 : Comparable<T2>, T2 : Any?> isNotLessThan(
         container: AssertionContainer<T1>,
         expected: T2
-    ): Assertion = container.createDescriptiveAssertion(IS_EQUAL, expected) { it.compareTo(expected) == 0 }
+    ): Assertion = container.createDescriptiveAssertion(IS_NOT_LESS_THAN, expected) { it >= expected }
+
+
+    override fun <T1 : Comparable<T2>, T2 : Any?> isGreaterThan(
+        container: AssertionContainer<T1>,
+        expected: T2
+    ): Assertion = container.createDescriptiveAssertion(IS_GREATER_THAN, expected) { it > expected }
+
 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ComparableExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ComparableExpectationsSpec.kt
@@ -10,135 +10,180 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 abstract class ComparableExpectationsSpec(
-    isLessThan: Fun1<Int, Int>,
-    isLessOrEquals: Fun1<Int, Int>,
-    isGreaterThan: Fun1<Int, Int>,
-    isGreaterOrEquals: Fun1<Int, Int>,
-    isEqualComparingTo: Fun1<Int, Int>,
-    isEqualComparingTo2: Fun1<DiffEqualsCompareTo, DiffEqualsCompareTo>,
+    toBeLessThan: Fun1<Int, Int>,
+    toBeLessThanOrEqualTo: Fun1<Int, Int>,
+    toBeEqualComparingTo: Fun1<Int, Int>,
+    toBeGreaterThanOrEqualTo: Fun1<Int, Int>,
+    toBeGreaterThan: Fun1<Int, Int>,
+
+    toBeLessThan2: Fun1<DiffEqualsCompareTo, DiffEqualsCompareTo>,
+    toBeEqualComparingTo2: Fun1<DiffEqualsCompareTo, DiffEqualsCompareTo>,
+    toBeGreaterThanOrEqualTo2: Fun1<DiffEqualsCompareTo, DiffEqualsCompareTo>,
+
+    toBeLessThanOrEqualToDescr: String = IS_LESS_THAN_OR_EQUAL.getDefault(),
+    toBeGreaterThanOrEqualToDescr: String = IS_GREATER_THAN_OR_EQUAL.getDefault(),
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
     include(object : SubjectLessSpec<Int>(
         describePrefix,
-        isLessThan.forSubjectLess(1),
-        isLessOrEquals.forSubjectLess(1),
-        isGreaterThan.forSubjectLess(1),
-        isGreaterOrEquals.forSubjectLess(1),
-        isEqualComparingTo.forSubjectLess(1)
+        toBeLessThan.forSubjectLess(1),
+        toBeLessThanOrEqualTo.forSubjectLess(1),
+        toBeEqualComparingTo.forSubjectLess(1),
+        toBeGreaterThanOrEqualTo.forSubjectLess(1),
+        toBeGreaterThan.forSubjectLess(1)
     ) {})
 
-    val isLessThanDescr = IS_LESS_THAN.getDefault()
-    val isLessOrEqualsDescr = IS_LESS_THAN_OR_EQUAL.getDefault()
-    val isGreaterThanDescr = IS_GREATER_THAN.getDefault()
-    val isGreaterOrEqualsDescr = IS_GREATER_THAN_OR_EQUAL.getDefault()
-    val isEqualComparingToDescr = IS_EQUAL.getDefault()
+    val toBeLessThanDescr = IS_LESS_THAN.getDefault()
+    val toBeGreaterThanDescr = IS_GREATER_THAN.getDefault()
+    val toBeEqualComparingToDescr = IS_EQUAL.getDefault()
 
-    val fluent = expect(10)
+
     describe("$describePrefix context subject is 10") {
-        context("${isLessThan.name} ...") {
-            val isLessThanFun = isLessThan.lambda
+        val fluent = expect(10)
+
+        context("${toBeLessThan.name} ...") {
+            val toBeLessThanFun = toBeLessThan.lambda
 
             it("... 11 does not throw") {
-                fluent.isLessThanFun(11)
+                fluent.toBeLessThanFun(11)
             }
             it("... 10 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_LESS_THAN and `: 10`") {
                 expect {
-                    fluent.isLessThanFun(10)
-                }.toThrow<AssertionError> { messageContains("$isLessThanDescr: 10") }
+                    fluent.toBeLessThanFun(10)
+                }.toThrow<AssertionError> { messageContains("$toBeLessThanDescr: 10") }
             }
             it("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_LESS_THAN and `: 10`") {
                 expect {
-                    fluent.isLessThanFun(9)
-                }.toThrow<AssertionError> { messageContains("$isLessThanDescr: 9") }
+                    fluent.toBeLessThanFun(9)
+                }.toThrow<AssertionError> { messageContains("$toBeLessThanDescr: 9") }
             }
         }
 
-        describe("${isLessOrEquals.name} ...") {
-            val isLessOrEqualsFun = isLessOrEquals.lambda
+        describe("${toBeLessThanOrEqualTo.name} ...") {
+            val toBeLessThanOrEqualToFun = toBeLessThanOrEqualTo.lambda
 
             it("... 11 does not throw") {
-                fluent.isLessOrEqualsFun(11)
+                fluent.toBeLessThanOrEqualToFun(11)
             }
             it("... 10 does not throw") {
-                fluent.isLessOrEqualsFun(10)
+                fluent.toBeLessThanOrEqualToFun(10)
             }
             it("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_LESS_THAN_OR_EQUAL and `: 10`") {
                 expect {
-                    fluent.isLessOrEqualsFun(9)
-                }.toThrow<AssertionError> { messageContains("$isLessOrEqualsDescr: 9") }
+                    fluent.toBeLessThanOrEqualToFun(9)
+                }.toThrow<AssertionError> { messageContains("$toBeLessThanOrEqualToDescr: 9") }
             }
         }
 
-        describe("${isGreaterThan.name} ...") {
-            val isGreaterThanFun = isGreaterThan.lambda
-
-            it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN and `: 11`") {
-                expect {
-                    fluent.isGreaterThanFun(11)
-                }.toThrow<AssertionError> { messageContains("$isGreaterThanDescr: 11") }
-            }
-            it("... 10 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN and `: 10`") {
-                expect {
-                    fluent.isGreaterThanFun(10)
-                }.toThrow<AssertionError> { messageContains("$isGreaterThanDescr: 10") }
-            }
-            it("... 9 does not throw") {
-                fluent.isGreaterThanFun(9)
-            }
-        }
-
-        describe("${isGreaterOrEquals.name} ...") {
-            val isGreaterOrEqualsFun = isGreaterOrEquals.lambda
-
-            it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN_OR_EQUAL and `: 11`") {
-                expect {
-                    fluent.isGreaterOrEqualsFun(11)
-                }.toThrow<AssertionError> { messageContains("$isGreaterOrEqualsDescr: 11") }
-            }
-            it("... 10 does not throw") {
-                fluent.isGreaterOrEqualsFun(10)
-            }
-            it("... 9 does not throw") {
-                fluent.isGreaterOrEqualsFun(9)
-            }
-        }
-
-        describe("${isEqualComparingTo.name} ...") {
-            val isEqualComparingToFun = isEqualComparingTo.lambda
+        describe("${toBeEqualComparingTo.name} ...") {
+            val toBeEqualComparingToFun = toBeEqualComparingTo.lambda
 
             it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_EQUAL and `: 11`") {
                 expect {
-                    fluent.isEqualComparingToFun(11)
-                }.toThrow<AssertionError> { messageContains("$isEqualComparingToDescr: 11") }
+                    fluent.toBeEqualComparingToFun(11)
+                }.toThrow<AssertionError> { messageContains("$toBeEqualComparingToDescr: 11") }
             }
             it("... 10 does not throw") {
-                fluent.isEqualComparingToFun(10)
+                fluent.toBeEqualComparingToFun(10)
             }
             it("... 9 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_EQUAL and `: 9`") {
                 expect {
-                    fluent.isEqualComparingToFun(9)
-                }.toThrow<AssertionError> { messageContains("$isEqualComparingToDescr: 9") }
+                    fluent.toBeEqualComparingToFun(9)
+                }.toThrow<AssertionError> { messageContains("$toBeEqualComparingToDescr: 9") }
+            }
+        }
+
+        describe("${toBeGreaterThanOrEqualTo.name} ...") {
+            val toBeGreaterThanOrEqualFun = toBeGreaterThanOrEqualTo.lambda
+
+            it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN_OR_EQUAL and `: 11`") {
+                expect {
+                    fluent.toBeGreaterThanOrEqualFun(11)
+                }.toThrow<AssertionError> { messageContains("$toBeGreaterThanOrEqualToDescr: 11") }
+            }
+            it("... 10 does not throw") {
+                fluent.toBeGreaterThanOrEqualFun(10)
+            }
+            it("... 9 does not throw") {
+                fluent.toBeGreaterThanOrEqualFun(9)
+            }
+        }
+
+        describe("${toBeGreaterThan.name} ...") {
+            val toBeGreaterThanFun = toBeGreaterThan.lambda
+
+            it("... 11 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN and `: 11`") {
+                expect {
+                    fluent.toBeGreaterThanFun(11)
+                }.toThrow<AssertionError> { messageContains("$toBeGreaterThanDescr: 11") }
+            }
+            it("... 10 throws an AssertionError containing ${DescriptionComparableAssertion::class.simpleName}.$IS_GREATER_THAN and `: 10`") {
+                expect {
+                    fluent.toBeGreaterThanFun(10)
+                }.toThrow<AssertionError> { messageContains("$toBeGreaterThanDescr: 10") }
+            }
+            it("... 9 does not throw") {
+                fluent.toBeGreaterThanFun(9)
             }
         }
     }
     describe("$describePrefix context subject is a class where equals is different from compareTo") {
-        describe("${isEqualComparingTo2.name} ...") {
-            val isEqualComparingToFun = isEqualComparingTo2.lambda
-            it("expected is same instance but compareTo returns false - throws AssertionError") {
+        context("${toBeLessThan2.name} ...") {
+            val toBeLessThanFun = toBeLessThan2.lambda
+
+            it("expected is same instance but compareTo does not return 0 but 1 - throws AssertionError") {
                 expect {
                     val subject = DiffEqualsCompareTo("welcome")
-                    expect(subject).isEqualComparingToFun(subject)
-                }.toThrow<AssertionError> { messageContains("$isEqualComparingToDescr: DiffEqualsCompareTo(s=welcome)") }
+                    expect(subject).toBeLessThanFun(subject)
+                }.toThrow<AssertionError> { messageContains("$toBeLessThanOrEqualToDescr: DiffEqualsCompareTo(s=welcome)") }
             }
 
-            it("expected equals but compareTo returns false - throws AssertionError") {
+            it("expected equals but compareTo does not return 0 but 1- throws AssertionError") {
                 expect {
-                    expect(DiffEqualsCompareTo("welcome")).isEqualComparingToFun(DiffEqualsCompareTo("welcome"))
-                }.toThrow<AssertionError> { messageContains("$isEqualComparingToDescr: DiffEqualsCompareTo(s=welcome)") }
+                    expect(DiffEqualsCompareTo("welcome")).toBeLessThanFun(DiffEqualsCompareTo("welcome"))
+                }.toThrow<AssertionError> { messageContains("$toBeLessThanOrEqualToDescr: DiffEqualsCompareTo(s=welcome)") }
             }
-            it("expected does not equal but compareTo = 0 - does not throw") {
-                expect(DiffEqualsCompareTo("welcome")).isEqualComparingToFun(DiffEqualsCompareTo("hello"))
+            it("expected does not equal but compareTo returns 0 - does not throw") {
+                expect(DiffEqualsCompareTo("welcome")).toBeLessThanFun(DiffEqualsCompareTo("hello"))
+            }
+        }
+
+        describe("${toBeEqualComparingTo2.name} ...") {
+            val toBeEqualComparingToFun = toBeEqualComparingTo2.lambda
+            it("expected is same instance but compareTo does not return 0 but 1 - throws AssertionError") {
+                expect {
+                    val subject = DiffEqualsCompareTo("welcome")
+                    expect(subject).toBeEqualComparingToFun(subject)
+                }.toThrow<AssertionError> { messageContains("$toBeEqualComparingToDescr: DiffEqualsCompareTo(s=welcome)") }
+            }
+
+            it("expected equals but compareTo does not return 0 but 1 - throws AssertionError") {
+                expect {
+                    expect(DiffEqualsCompareTo("welcome")).toBeEqualComparingToFun(DiffEqualsCompareTo("welcome"))
+                }.toThrow<AssertionError> { messageContains("$toBeEqualComparingToDescr: DiffEqualsCompareTo(s=welcome)") }
+            }
+            it("expected does not equal but compareTo returns 0 - does not throw") {
+                expect(DiffEqualsCompareTo("welcome")).toBeEqualComparingToFun(DiffEqualsCompareTo("hello"))
+            }
+        }
+
+        describe("${toBeGreaterThanOrEqualTo2.name} ...") {
+            val toBeGreaterThanOrEqualFun = toBeGreaterThanOrEqualTo2.lambda
+            it("expected is same instance but compareTo does not return 0 but -1 - throws AssertionError") {
+                expect {
+                    val subject = DiffEqualsCompareTo("allo")
+                    expect(subject).toBeGreaterThanOrEqualFun(subject)
+                }.toThrow<AssertionError> { messageContains("$toBeGreaterThanOrEqualToDescr: DiffEqualsCompareTo(s=allo)") }
+            }
+
+            it("expected equals but compareTo does not return 0 but -1 - throws AssertionError") {
+                expect {
+                    expect(DiffEqualsCompareTo("allo")).toBeGreaterThanOrEqualFun(DiffEqualsCompareTo("allo"))
+                }.toThrow<AssertionError> { messageContains("$toBeGreaterThanOrEqualToDescr: DiffEqualsCompareTo(s=allo)") }
+            }
+            it("expected does not equal but compareTo returns 0 - does not throw") {
+                expect(DiffEqualsCompareTo("welcome")).toBeGreaterThanOrEqualFun(DiffEqualsCompareTo("hello"))
             }
         }
     }

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
@@ -8,14 +8,23 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class DescriptionComparableAssertion(override val value: String) : StringBasedTranslatable {
     IS_LESS_THAN("ist weniger als"),
-    @Deprecated("Use IS_LESS_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL"))
-    IS_LESS_OR_EQUALS("ist weniger oder gleich"),
-    IS_GREATER_THAN("ist grösser als"),
-    @Deprecated("Use IS_GREATER_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL"))
-    IS_GREATER_OR_EQUALS("ist grösser oder gleich"),
-    IS_EQUAL("ist gleich wie"),
+
     /** @since 0.13.0 */
     IS_LESS_THAN_OR_EQUAL("ist weniger als oder gleich wie"),
+    /** @since 0.17.0 */
+    IS_NOT_GREATER_THAN("ist nicht grösser als"),
+
+    IS_EQUAL("ist gleich wie"),
+
     /** @since 0.13.0 */
     IS_GREATER_THAN_OR_EQUAL("ist grösser als oder gleich wie"),
+    /** @since 0.17.0 */
+    IS_NOT_LESS_THAN("ist nicht weniger als"),
+
+    IS_GREATER_THAN("ist grösser als"),
+
+    @Deprecated("Use IS_LESS_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL"))
+    IS_LESS_OR_EQUALS("ist weniger oder gleich"),
+    @Deprecated("Use IS_GREATER_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL"))
+    IS_GREATER_OR_EQUALS("ist grösser oder gleich"),
 }

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionComparableAssertion.kt
@@ -8,14 +8,24 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class DescriptionComparableAssertion(override val value: String) : StringBasedTranslatable {
     IS_LESS_THAN("is less than"),
-    @Deprecated("Use IS_LESS_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL"))
-    IS_LESS_OR_EQUALS("is less or equals"),
-    IS_GREATER_THAN("is greater than"),
-    @Deprecated("Use IS_GREATER_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL"))
-    IS_GREATER_OR_EQUALS("is greater or equals"),
-    IS_EQUAL("is equal comparing to"),
+
     /** @since 0.13.0 */
     IS_LESS_THAN_OR_EQUAL("is less than or equal to"),
+    /** @since 0.17.0 */
+    IS_NOT_GREATER_THAN("is not greater than"),
+
+    //TODO use TO_BE_EQUAL_TO with 0.18.0
+    IS_EQUAL("is equal comparing to"),
+
     /** @since 0.13.0 */
     IS_GREATER_THAN_OR_EQUAL("is greater than or equal to"),
+    /** @since 0.17.0 */
+    IS_NOT_LESS_THAN("is not less than"),
+
+    IS_GREATER_THAN("is greater than"),
+
+    @Deprecated("Use IS_LESS_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_LESS_THAN_OR_EQUAL"))
+    IS_LESS_OR_EQUALS("is less or equals"),
+    @Deprecated("Use IS_GREATER_THAN_OR_EQUAL; will be removed with 1.0.0 at the latest", ReplaceWith("DescriptionComparableAssertion.IS_GREATER_THAN_OR_EQUAL"))
+    IS_GREATER_OR_EQUALS("is greater or equals"),
 }


### PR DESCRIPTION
moreover:
- make the distiction between toEqual and toBeEqualComparingTo clearer
- rewrite ComparableExpectationsSpec to new nameing and include test
  cases for toBeLessThanOrEqualTo and toBeGreaterThanOrEqualTo where
  the equals/compareTo contract is broken



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
