### PR TITLE
renaming floatingPointAssertions to consistent `to + infitinive` naming schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1830,7 +1830,7 @@ Let us have a look at another example.
 <exs-add-info-2>
 
 ```kotlin
-expect(9.99f).toBeWithErrorTolerance(10.0f, 0.01f)
+expect(9.99f).toEqualWithErrorTolerance(10.0f, 0.01f)
 ```
 </exs-add-info-2>
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointAssertions.kt
@@ -23,6 +23,7 @@ import kotlin.jvm.JvmName
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.FloatingPointAssertionSamples.toBeWithErrorToleranceFloat
  */
+@Deprecated("Use toEqualWithErrorTolerance; will be removed with 1.0.0 at the latest", ReplaceWith("this.toEqualWithErrorTolerance<T>(expected, tolerance)"))
 fun Expect<Float>.toBeWithErrorTolerance(expected: Float, tolerance: Float): Expect<Float> =
     _logicAppend { toBeWithErrorTolerance(expected, tolerance) }
 
@@ -40,5 +41,6 @@ fun Expect<Float>.toBeWithErrorTolerance(expected: Float, tolerance: Float): Exp
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.FloatingPointAssertionSamples.toBeWithErrorToleranceDouble
  */
+@Deprecated("Use toEqualWithErrorTolerance; will be removed with 1.0.0 at the latest", ReplaceWith("this.toEqualWithErrorTolerance<T>(expected, tolerance)"))
 fun Expect<Double>.toBeWithErrorTolerance(expected: Double, tolerance: Double): Expect<Double> =
     _logicAppend { toBeWithErrorTolerance(expected, tolerance) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointExpectations.kt
@@ -1,0 +1,43 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.toBeWithErrorTolerance
+
+/**
+ * Expects that the subject of `this` expectation (a [Float]) is equal to [expected] with an error [tolerance]
+ * (range including bounds).
+ *
+ * In detail, It compares the absolute difference between the subject and [expected];
+ * as long as it is less than or equal the [tolerance] the expectation holds; otherwise it fails.
+ * A more mathematical way of expressing the expectation is the following inequality:
+ *
+ * | `subject of `this` expectation` - [expected] | ≤ [tolerance]
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.FloatingPointExpectationSamples.toEqualWithErrorToleranceFloat
+ *
+ * @since 0.17.0
+ */
+fun Expect<Float>.toEqualWithErrorTolerance(expected: Float, tolerance: Float): Expect<Float> =
+    _logicAppend { toBeWithErrorTolerance(expected, tolerance) }
+
+/**
+ * Expects that the subject of `this` expectation  (a [Double]) is equal to [expected] with an error [tolerance]
+ * (range including bounds).
+ *
+ * In detail, It compares the absolute difference between the subject and [expected];
+ * as long as it is less than or equal the [tolerance] the expectation holds; otherwise it fails.
+ * A more mathematical way of expressing the expectation is the following inequality:
+ *
+ * | `subject of `this` expectation` - [expected] | ≤ [tolerance]
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.FloatingPointExpectationSamples.toEqualWithErrorToleranceDouble
+ *
+ * @since 0.17.0
+ */
+fun Expect<Double>.toEqualWithErrorTolerance(expected: Double, tolerance: Double): Expect<Double> =
+    _logicAppend { toBeWithErrorTolerance(expected, tolerance) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/FloatingPointWithErrorToleranceExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/FloatingPointWithErrorToleranceExpectationsSpec.kt
@@ -6,6 +6,6 @@ import ch.tutteli.atrium.specs.fun2
 
 class FloatingPointWithErrorToleranceExpectationsSpec :
     ch.tutteli.atrium.specs.integration.FloatingPointWithErrorToleranceExpectationsSpec(
-        fun2(Expect<Float>::toBeWithErrorTolerance).adjustName { "$it for Float" },
-        fun2(Expect<Double>::toBeWithErrorTolerance).adjustName { "$it for Double" }
+        fun2(Expect<Float>::toEqualWithErrorTolerance).adjustName { "$it for Float" },
+        fun2(Expect<Double>::toEqualWithErrorTolerance).adjustName { "$it for Double" }
     )

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FloatingPointExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FloatingPointExpectationSamples.kt
@@ -1,0 +1,26 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqualWithErrorTolerance
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class FloatingPointExpectationSamples {
+
+    @Test
+    fun toEqualWithErrorToleranceFloat() {
+        expect(12.001F).toEqualWithErrorTolerance(12.0F, 0.01F)
+
+        fails {
+            expect(12.1F).toEqualWithErrorTolerance(12.0F, 0.01F)
+        }
+    }
+
+    @Test
+    fun toEqualWithErrorToleranceDouble() {
+        expect(12.001).toEqualWithErrorTolerance(12.0, 0.01)
+
+        fails {
+            expect(12.1).toEqualWithErrorTolerance(12.0, 0.01)
+        }
+    }
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
@@ -23,6 +23,8 @@ import java.math.BigDecimal
  *
  * @return an [Expect] for the subject of `this` expectation.
  */
-@Deprecated("Will be removed without replacement with 0.18.0 - there shouldn't be a need for this function as BigDecimal takes care of the problems float/double have."))
+@Suppress("DeprecatedCallableAddReplaceWith")
+//TODO remove with 0.18.0 - search also for other "will be removed.*0.18.0"
+@Deprecated("Will be removed without replacement with 0.18.0 - there shouldn't be a need for this function as BigDecimal takes care of the problems float/double have.")
 fun <T : BigDecimal> Expect<T>.toBeWithErrorTolerance(expected: BigDecimal, tolerance: BigDecimal): Expect<T> =
     _logicAppend { toBeWithErrorTolerance(expected, tolerance) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/floatingPointJvmAssertions.kt
@@ -23,5 +23,6 @@ import java.math.BigDecimal
  *
  * @return an [Expect] for the subject of `this` expectation.
  */
+@Deprecated("Will be removed without replacement with 0.18.0 - there shouldn't be a need for this function as BigDecimal takes care of the problems float/double have."))
 fun <T : BigDecimal> Expect<T>.toBeWithErrorTolerance(expected: BigDecimal, tolerance: BigDecimal): Expect<T> =
     _logicAppend { toBeWithErrorTolerance(expected, tolerance) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/FloatingPointWithErrorToleranceExpectationsJvmSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/FloatingPointWithErrorToleranceExpectationsJvmSpec.kt
@@ -1,3 +1,5 @@
+//TODO remove file with 0.18.0
+@file:Suppress("DEPRECATION")
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions.kt
@@ -84,5 +84,5 @@ internal fun <T : Comparable<T>> toBeWithErrorTolerance(
             .withAssertions(explanatoryAssertionCreator(subject))
             .build()
     }
-    .withDescriptionAndRepresentation(TranslatableWithArgs(TO_BE_WITH_ERROR_TOLERANCE, tolerance), expected)
+    .withDescriptionAndRepresentation(TranslatableWithArgs(TO_EQUAL_WITH_ERROR_TOLERANCE, tolerance), expected)
     .build()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsSpec.kt
@@ -76,7 +76,7 @@ fun <T : Number> Root.checkFloatingPoint(
                 }
 
                 val toEqualInclErrorToleranceDescr =
-                    String.format(DescriptionFloatingPointAssertion.TO_BE_WITH_ERROR_TOLERANCE.getDefault(), tolerance)
+                    String.format(DescriptionFloatingPointAssertion.TO_EQUAL_WITH_ERROR_TOLERANCE.getDefault(), tolerance)
                 val failureNotice = String.format(
                     DescriptionFloatingPointAssertion.FAILURE_DUE_TO_FLOATING_POINT_NUMBER.getDefault(),
                     subject::class.fullName

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsSpec.kt
@@ -12,18 +12,18 @@ import org.spekframework.spek2.style.specification.describe
 import kotlin.math.absoluteValue
 
 abstract class FloatingPointWithErrorToleranceExpectationsSpec(
-    toBeWithErrorToleranceFloat: Fun2<Float, Float, Float>,
-    toBeWithErrorToleranceDouble: Fun2<Double, Double, Double>,
+    toEqualWithErrorToleranceFloat: Fun2<Float, Float, Float>,
+    toEqualWithErrorToleranceDouble: Fun2<Double, Double, Double>,
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
     include(object : SubjectLessSpec<Float>(
         "$describePrefix[Float] ",
-        toBeWithErrorToleranceFloat.forSubjectLess(1.0f, 0.01f)
+        toEqualWithErrorToleranceFloat.forSubjectLess(1.0f, 0.01f)
     ) {})
     include(object : SubjectLessSpec<Double>(
         "$describePrefix[Double] ",
-        toBeWithErrorToleranceDouble.forSubjectLess(1.0, 0.01)
+        toEqualWithErrorToleranceDouble.forSubjectLess(1.0, 0.01)
     ) {})
 
     fun <T : Number> Root.describeFun(
@@ -34,13 +34,13 @@ abstract class FloatingPointWithErrorToleranceExpectationsSpec(
     ) = checkFloatingPoint(describePrefix, pair, withFailureNotice, absDiff, testData)
 
     //@formatter:off
-    describeFun(toBeWithErrorToleranceFloat, true, { a: Float, b: Float -> (a - b).absoluteValue }, listOf(
+    describeFun(toEqualWithErrorToleranceFloat, true, { a: Float, b: Float -> (a - b).absoluteValue }, listOf(
         TestData(0.001f, 0.001f, listOf(0.002f, 0.0f, -0.0f, 0.00001f), listOf(0.0021f, -0.0000001f)),
         TestData(9.999f, 0.001f, listOf(9.998f, 9.9989f, 9.9988f), listOf(1.1f, 1.001f, 1.001f, 9.997f, /* due to precision */ 10.0f)),
         //should give out scientific notation
         TestData(0.000_000_01f, 0.000_000_002f, listOf(0.000_000_011f, 0.000_000_009f), listOf(0.000_000_013f, 0.000_000_007f, /* due to precision */ 0.000_000_012f, 0.000_000_008f))
     ))
-    describeFun(toBeWithErrorToleranceDouble, true, { a, b -> (a - b).absoluteValue }, listOf(
+    describeFun(toEqualWithErrorToleranceDouble, true, { a, b -> (a - b).absoluteValue }, listOf(
         TestData(1.0, 0.01, listOf(1.009), listOf(0.98, 1.02, 1.011, /* due to precision */ 1.01, 0.99)),
         TestData(0.001, 0.001, listOf(0.002, 0.0, -0.0, 0.00001), listOf(0.0021, -0.0000001)),
         TestData(9.99999, 0.00001, listOf(10.0, 9.99998), listOf(1.1, 1.001, 1.001, 9.99997)),
@@ -60,22 +60,22 @@ fun <T : Number> Root.checkFloatingPoint(
     absDiff: (T, T) -> T,
     testData: List<FloatingPointWithErrorToleranceExpectationsSpec.TestData<T>>
 ) {
-    val (name, toBeWithErrorTolerance) = pair
+    val (name, toEqualWithErrorTolerance) = pair
 
     describe("$describePrefix $name") {
         testData.forEach { (subject, tolerance, holding, failing) ->
             context("tolerance is $tolerance and subject is $subject ...") {
                 it("... compare to $subject does not throw") {
-                    expect(subject).toBeWithErrorTolerance(subject, tolerance)
+                    expect(subject).toEqualWithErrorTolerance(subject, tolerance)
                 }
 
                 holding.forEach { num ->
                     it("... compare to $num does not throw") {
-                        expect(subject).toBeWithErrorTolerance(num, tolerance)
+                        expect(subject).toEqualWithErrorTolerance(num, tolerance)
                     }
                 }
 
-                val toBeInclErrorTolerance =
+                val toEqualInclErrorToleranceDescr =
                     String.format(DescriptionFloatingPointAssertion.TO_BE_WITH_ERROR_TOLERANCE.getDefault(), tolerance)
                 val failureNotice = String.format(
                     DescriptionFloatingPointAssertion.FAILURE_DUE_TO_FLOATING_POINT_NUMBER.getDefault(),
@@ -84,7 +84,7 @@ fun <T : Number> Root.checkFloatingPoint(
                 failing.forEach { num ->
                     it("... compare to $num throws AssertionError") {
                         expect {
-                            expect(subject).toBeWithErrorTolerance(num, tolerance)
+                            expect(subject).toEqualWithErrorTolerance(num, tolerance)
                         }.toThrow<AssertionError> {
                             message {
                                 @Suppress("DEPRECATION")
@@ -97,7 +97,7 @@ fun <T : Number> Root.checkFloatingPoint(
                                 )
                                 toContain(
                                     subject,
-                                    "$toBeInclErrorTolerance: $num",
+                                    "$toEqualInclErrorToleranceDescr: $num",
                                     exactCheck
                                 )
                                 if (withFailureNotice) {

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsJvmSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsJvmSpec.kt
@@ -1,3 +1,4 @@
+//TODO remove file with 0.18.0
 package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.specs.Fun2

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
@@ -205,7 +205,7 @@ class MostExamplesSpec : Spek({
         expect(listOf(1, 2, 3)).contains.inOrder.only.values(1, 3)
     }
     test("exs-add-info-2") {
-        expect(9.99f).toBeWithErrorTolerance(10.0f, 0.01f)
+        expect(9.99f).toEqualWithErrorTolerance(10.0f, 0.01f)
     }
     test("ex-add-info-3") {
         expect {

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionFloatingPointAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionFloatingPointAssertion.kt
@@ -8,7 +8,10 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  * and maybe other platform specific floating point types (such as `BigDecimal` in JVM).
  */
 enum class DescriptionFloatingPointAssertion(override val value: String) : StringBasedTranslatable {
-    TO_BE_WITH_ERROR_TOLERANCE("to be (error ± %s)"),
+    TO_EQUAL_WITH_ERROR_TOLERANCE("to equal (error ± %s)"),
     FAILURE_DUE_TO_FLOATING_POINT_NUMBER("failure might be due to using %s, see exact check on the next line"),
     TO_BE_WITH_ERROR_TOLERANCE_EXPLAINED("exact check is |%s - %s| = %s ≤ %s"),
+
+    @Deprecated("Use TO_EQUAL_WITH_ERROR_TOLERANCE; will be removed with 0.18.0", ReplaceWith("TO_EQUAL_WITH_ERROR_TOLERANCE"))
+    TO_BE_WITH_ERROR_TOLERANCE(TO_EQUAL_WITH_ERROR_TOLERANCE.getDefault()),
 }


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
