### PR TITLE
renaming mapEntryAssertions to consistent to + infitinive naming schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,7 +1501,7 @@ then it will come in handy:
 
 ```kotlin
 expect(linkedMapOf("a" to 1, "b" to 2)).asEntries().toContain.inOrder.only.entries(
-    { isKeyValue("a", 1) },
+    { toEqualKeyValue("a", 1) },
     {
         key.toStartWith("a")
         value.toBeGreaterThan(2)
@@ -1526,7 +1526,7 @@ expected that subject: {a=1, b=2}        (java.util.LinkedHashMap <1234789>)
 ```
 </ex-map-5>
 
-`isKeyValue` as well as `key` and `value` are assertion functions defined for `Map.Entry<K, V>`.
+`toEqualKeyValue` as well as `key` and `value` are assertion functions defined for `Map.Entry<K, V>`.
 
 There are more assertion functions, a full list can be found in 
 [KDoc of atrium-api-fluent-en_GB](https://docs.atriumlib.org/latest#/doc/ch.tutteli.atrium.api.fluent.en_-g-b/index.html).

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
@@ -182,7 +182,7 @@ fun <K, T : Map<out K, *>> Expect<T>.containsNotKey(key: K): Expect<T> =
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.getExistingFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.getExistingFeature
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
     _logic.getExisting(::identity, key).transform()
@@ -194,7 +194,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K): Expect<V> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.getExisting
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.getExisting
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.getExisting(::identity, key).collectAndAppend(assertionCreator)
@@ -206,7 +206,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.getExisting(key: K, assertionCreator: Ex
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.keysFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.keysFeature
  */
 val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
     get() = _logic.property(Map<out K, *>::keys).transform()
@@ -219,7 +219,7 @@ val <K, T : Map<out K, *>> Expect<T>.keys: Expect<Set<K>>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.keys
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.keys
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.() -> Unit): Expect<T> =
     _logic.property(Map<out K, *>::keys).collectAndAppend(assertionCreator)
@@ -231,7 +231,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.keys(assertionCreator: Expect<Set<K>>.()
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.valuesFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.valuesFeature
  */
 val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
     get() = _logic.property(Map<out Any?, V>::values).transform()
@@ -244,7 +244,7 @@ val <V, T : Map<*, V>> Expect<T>.values: Expect<Collection<V>>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.values
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.values
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.values(assertionCreator: Expect<Collection<V>>.() -> Unit): Expect<T> =
     _logic.property(Map<out K, V>::values).collectAndAppend(assertionCreator)
@@ -258,7 +258,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.values(assertionCreator: Expect<Collecti
  *
  * @return The newly created [Expect] for the transformed subject.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.asEntriesFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.asEntriesFeature
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(): Expect<Set<Map.Entry<K, V>>> =
     _logic.changeSubject.unreported { it.entries }
@@ -273,7 +273,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(): Expect<Set<Map.Entry<K, V>>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapAssertionSamples.asEntries
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapExpectationSamples.asEntries
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapCollectionLikeAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapCollectionLikeAssertions.kt
@@ -1,3 +1,4 @@
+//TODO rename file with 0.18.0 to ...Expectations
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -18,17 +18,20 @@ import ch.tutteli.atrium.logic.*
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
     _logicAppend { isKeyValue(key, value) }
 
+
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Creates an [Expect] for the property [Map.Entry.key] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.keyFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryExpectationSamples.keyFeature
  */
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = _logic.key().transform()
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Expects that the property [Map.Entry.key] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
@@ -36,22 +39,24 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.key
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryExpectationSamples.key
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.key().collectAndAppend(assertionCreator)
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Creates an [Expect] for the property [Map.Entry.value] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.valueFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryExpectationSamples.valueFeature
  */
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = _logic.value().transform()
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Expects that the property [Map.Entry.value] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
@@ -59,7 +64,7 @@ val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.value
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryExpectationSamples.value
  */
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.value(assertionCreator: Expect<V>.() -> Unit): Expect<T> =
     _logic.value().collectAndAppend(assertionCreator)

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -15,6 +15,7 @@ import ch.tutteli.atrium.logic.*
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.isKeyValue
  */
+@Deprecated("Use toEqualKeyValue; will be removed with 1.0.0 at the latest", ReplaceWith("toEqualKeyValue(key, value)"))
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
     _logicAppend { isKeyValue(key, value) }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryAssertions.kt
@@ -15,7 +15,7 @@ import ch.tutteli.atrium.logic.*
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.deprecated.MapEntryAssertionSamples.isKeyValue
  */
-@Deprecated("Use toEqualKeyValue; will be removed with 1.0.0 at the latest", ReplaceWith("toEqualKeyValue(key, value)"))
+@Deprecated("Use toEqualKeyValue; will be removed with 1.0.0 at the latest", ReplaceWith("this.toEqualKeyValue<K, V, T>(key, value)"))
 fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(key: K, value: V): Expect<T> =
     _logicAppend { isKeyValue(key, value) }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapEntryExpectations.kt
@@ -1,0 +1,17 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.*
+
+/**
+ * Expects that the property [Map.Entry.key] of the subject of `this` expectation
+ * is equal to the given [key] and the property [Map.Entry.value] is equal to the given [value].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapEntryExpectationSamples.toEqualKeyValue
+ *
+ * @since 0.17.0
+ */
+fun <K, V, T : Map.Entry<K, V>> Expect<T>.toEqualKeyValue(key: K, value: V): Expect<T> =
+    _logicAppend { isKeyValue(key, value) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/MapEntryExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/MapEntryExpectationsSpec.kt
@@ -4,8 +4,8 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 
 object MapEntryExpectationsSpec : ch.tutteli.atrium.specs.integration.MapEntryExpectationsSpec(
-    fun2(Expect<Map.Entry<String, Int>>::isKeyValue),
-    fun2(Expect<Map.Entry<String?, Int?>>::isKeyValue).withNullableSuffix(),
+    fun2(Expect<Map.Entry<String, Int>>::toEqualKeyValue),
+    fun2(Expect<Map.Entry<String?, Int?>>::toEqualKeyValue).withNullableSuffix(),
     property<Map.Entry<String, Int>, String>(Expect<Map.Entry<String, Int>>::key),
     fun1<Map.Entry<String, Int>, Expect<String>.() -> Unit>(Expect<Map.Entry<String, Int>>::key),
     property<Map.Entry<String, Int>, Int>(Expect<Map.Entry<String, Int>>::value),

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/MapEntryExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/MapEntryExpectationsSpec.kt
@@ -24,16 +24,16 @@ object MapEntryExpectationsSpec : ch.tutteli.atrium.specs.integration.MapEntryEx
 
         var star: Expect<Map.Entry<*, *>> = notImplemented()
 
-        a1.isKeyValue("a", 1)
-        a2.isKeyValue("a", 1)
-        a3.isKeyValue("a", 1)
-        a4.isKeyValue("a", 1)
-        star.isKeyValue("a", 1)
+        a1.toEqualKeyValue("a", 1)
+        a2.toEqualKeyValue("a", 1)
+        a3.toEqualKeyValue("a", 1)
+        a4.toEqualKeyValue("a", 1)
+        star.toEqualKeyValue("a", 1)
 
-        a2.isKeyValue(null, 1)
-        a3.isKeyValue("a", null)
-        a4.isKeyValue(null, null)
-        star.isKeyValue(null, null)
+        a2.toEqualKeyValue(null, 1)
+        a3.toEqualKeyValue("a", null)
+        a4.toEqualKeyValue(null, null)
+        star.toEqualKeyValue(null, null)
 
         a1.key
         a2.key

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryExpectationSamples.kt
@@ -1,0 +1,73 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class MapEntryExpectationSamples {
+
+    @Test
+    fun toEqualKeyValue() {
+        expect(mapOf(1 to "a").entries.first()).toEqualKeyValue(1, "a")
+
+        fails {
+            expect(mapOf(1 to "a").entries.first()).toEqualKeyValue(1, "b")
+        }
+    }
+
+    @Test
+    fun keyFeature() {
+        expect(mapOf(1 to "a").entries.first())
+            .key    // subject here is of type Int (actually 1)
+            .toEqual(1)
+
+        fails {
+            expect(mapOf(1 to "a").entries.first())
+                .key    // subject here is of type Int (actually 1)
+                .toEqual(2)    // fails because 1 is not equal to 2
+        }
+    }
+
+    @Test
+    fun key() {
+        expect(mapOf(1 to "a").entries.first())
+            .key {  // subject inside this block is of type Int (actually 1)
+                toEqual(1)
+            }
+
+        fails {
+            expect(mapOf(1 to "a").entries.first())
+                .key {  // subject inside this block is of type Int (actually 1)
+                    toEqual(2) // fails because 1 is not equal to 2
+                }
+        }
+    }
+
+    @Test
+    fun valueFeature() {
+        expect(mapOf(1 to "a").entries.first())
+            .value  // subject here is of type String (actually "a")
+            .toEqual("a")
+
+        fails {
+            expect(mapOf(1 to "a").entries.first())
+                .value  // subject here is of type String (actually "a")
+                .toEqual("b")  // fails because "a" is not equal to "b"
+        }
+    }
+
+    @Test
+    fun value() {
+        expect(mapOf(1 to "a").entries.first())
+            .value {    // subject inside this block is of type String (actually "a")
+                toEqual("a")
+            }
+
+        fails {
+            expect(mapOf(1 to "a").entries.first())
+                .value {    // subject inside this block is of type String (actually "a")
+                    toEqual("b")   // fails because "a" is not equal to "b"
+                }
+        }
+    }
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/deprecated/MapEntryAssertionSamples.kt
@@ -12,10 +12,10 @@ class MapEntryAssertionSamples {
 
     @Test
     fun isKeyValue() {
-        expect(mapOf(1 to "a").entries.first()).isKeyValue(1, "a")
+        expect(mapOf(1 to "a").entries.first()).toEqualKeyValue(1, "a")
 
         fails {
-            expect(mapOf(1 to "a").entries.first()).isKeyValue(1, "b")
+            expect(mapOf(1 to "a").entries.first()).toEqualKeyValue(1, "b")
         }
     }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryAssertions.kt
@@ -13,9 +13,11 @@ import ch.tutteli.atrium.logic.*
  *
  * @return an [Expect] for the subject of `this` expectation.
  */
+@Deprecated("Use toEqualKeyValue; will be removed with 1.0.0 at the latest", ReplaceWith("this.toEqualKeyValue<K, V, T>(keyValuePair)"))
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K, V>): Expect<T> =
     _logicAppend { isKeyValue(keyValuePair.first, keyValuePair.second) }
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Creates an [Expect] for the property [Map.Entry.key] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
@@ -25,6 +27,7 @@ infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.isKeyValue(keyValuePair: Pair<K,
 val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
     get() = _logic.key().transform()
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Expects that the property [Map.Entry.key] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and
@@ -35,6 +38,7 @@ val <K, T : Map.Entry<K, *>> Expect<T>.key: Expect<K>
 infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.() -> Unit): Expect<T> =
     _logic.key().collectAndAppend(assertionCreator)
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Creates an [Expect] for the property [Map.Entry.value] of the subject of `this` expectation,
  * so that further fluent calls are assertions about it.
@@ -44,6 +48,7 @@ infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.key(assertionCreator: Expect<K>.
 val <V, T : Map.Entry<*, V>> Expect<T>.value: Expect<V>
     get() = _logic.value().transform()
 
+//TODO move to mapEntryExpectations with 0.18.0
 /**
  * Expects that the property [Map.Entry.value] of the subject of `this` expectation
  * holds all assertions the given [assertionCreator] creates for it and

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapEntryExpectations.kt
@@ -1,0 +1,15 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.*
+
+/**
+ * Expects that the property [Map.Entry.key] of the subject of `this` expectation
+ * is equal to the given [key] and the property [Map.Entry.value] is equal to the given [value].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.17.0
+ */
+infix fun <K, V, T : Map.Entry<K, V>> Expect<T>.toEqualKeyValue(keyValuePair: Pair<K, V>): Expect<T> =
+    _logicAppend { isKeyValue(keyValuePair.first, keyValuePair.second) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/MapEntryExpectationsSpec.kt
@@ -4,8 +4,8 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 
 class MapEntryExpectationsSpec : ch.tutteli.atrium.specs.integration.MapEntryExpectationsSpec(
-    fun1(Expect<Map.Entry<String, Int>>::isKeyValue).name to Companion::isKeyValue,
-    (fun1(Expect<Map.Entry<String?, Int?>>::isKeyValue).name to Companion::isKeyValueNullable).withNullableSuffix(),
+    fun1(Expect<Map.Entry<String, Int>>::toEqualKeyValue).name to Companion::toEqualKeyValue,
+    (fun1(Expect<Map.Entry<String?, Int?>>::toEqualKeyValue).name to Companion::toEqualKeyValueNullable).withNullableSuffix(),
     property<Map.Entry<String, Int>, String>(Expect<Map.Entry<String, Int>>::key),
     fun1<Map.Entry<String, Int>, Expect<String>.() -> Unit>(Expect<Map.Entry<String, Int>>::key),
     property<Map.Entry<String, Int>, Int>(Expect<Map.Entry<String, Int>>::value),
@@ -17,11 +17,11 @@ class MapEntryExpectationsSpec : ch.tutteli.atrium.specs.integration.MapEntryExp
 ) {
     companion object {
 
-        private fun isKeyValue(expect: Expect<Map.Entry<String, Int>>, key: String, value: Int) =
-            expect isKeyValue (key to value)
+        private fun toEqualKeyValue(expect: Expect<Map.Entry<String, Int>>, key: String, value: Int) =
+            expect toEqualKeyValue (key to value)
 
-        private fun isKeyValueNullable(expect: Expect<Map.Entry<String?, Int?>>, key: String?, value: Int?) =
-            expect isKeyValue (key to value)
+        private fun toEqualKeyValueNullable(expect: Expect<Map.Entry<String?, Int?>>, key: String?, value: Int?) =
+            expect toEqualKeyValue (key to value)
     }
 
     @Suppress("unused", "UNUSED_VALUE")
@@ -33,16 +33,16 @@ class MapEntryExpectationsSpec : ch.tutteli.atrium.specs.integration.MapEntryExp
 
         var star: Expect<Map.Entry<*, *>> = notImplemented()
 
-        a1 isKeyValue ("a" to 1)
-        a2 isKeyValue ("a" to 1)
-        a3 isKeyValue ("a" to 1)
-        a4 isKeyValue ("a" to 1)
-        star isKeyValue ("a" to 1)
+        a1 toEqualKeyValue ("a" to 1)
+        a2 toEqualKeyValue ("a" to 1)
+        a3 toEqualKeyValue ("a" to 1)
+        a4 toEqualKeyValue ("a" to 1)
+        star toEqualKeyValue ("a" to 1)
 
-        a2 isKeyValue (null to 1)
-        a3 isKeyValue ("a" to null)
-        a4 isKeyValue (null to null)
-        star isKeyValue (null to null)
+        a2 toEqualKeyValue (null to 1)
+        a3 toEqualKeyValue ("a" to null)
+        a4 toEqualKeyValue (null to null)
+        star toEqualKeyValue (null to null)
 
         a1.key
         a2.key

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB-js/src/test/kotlin/ch/tutteli/atrium/fluent/en_GB/JsNameAmbiguityTest.kt
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB-js/src/test/kotlin/ch/tutteli/atrium/fluent/en_GB/JsNameAmbiguityTest.kt
@@ -19,7 +19,7 @@ class JsNameAmbiguityTest {
     @Test
     fun isKeyValueNullable() {
         expect(mapOf(1 to null as Int?)).asEntries().toContainExactly {
-            isKeyValue(1, null)
+            toEqualKeyValue(1, null)
         }
     }
 }

--- a/bundles/infix-en_GB/atrium-infix-en_GB-js/src/test/kotlin/ch/tutteli/atrium/infix/en_GB/JsNameAmbiguityTest.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-js/src/test/kotlin/ch/tutteli/atrium/infix/en_GB/JsNameAmbiguityTest.kt
@@ -20,7 +20,7 @@ class JsNameAmbiguityTest {
     @Test
     fun isKeyValueNullable() {
         expect(mapOf(1 to null as Int?)).asEntries(o).toContainExactly(fun Expect<Map.Entry<Int, Int?>>.() {
-            it isKeyValue (1 to null)
+            it toEqualKeyValue (1 to null)
         })
     }
 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapAsEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapAsEntriesExpectationsSpec.kt
@@ -29,7 +29,7 @@ abstract class MapAsEntriesExpectationsSpec(
             it("$name - transformation can be applied and an assertion made") {
                 expect(mapOf("a" to 1, "b" to 2)).asEntriesFun {
                     toContain.inAnyOrder.only.entries(
-                        { isKeyValue("b", 2) },
+                        { toEqualKeyValue("b", 2) },
                         {
                             key.toStartWith("a")
                             value.toBeGreaterThanOrEqualTo(1)

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapEntryExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapEntryExpectationsSpec.kt
@@ -8,8 +8,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.Suite
 
 abstract class MapEntryExpectationsSpec(
-    isKeyValue: Fun2<Map.Entry<String, Int>, String, Int>,
-    isKeyValueNullable: Fun2<Map.Entry<String?, Int?>, String?, Int?>,
+    toEqualKeyValue: Fun2<Map.Entry<String, Int>, String, Int>,
+    toEqualKeyValueNullable: Fun2<Map.Entry<String?, Int?>, String?, Int?>,
     keyFeature: Feature0<Map.Entry<String, Int>, String>,
     key: Fun1<Map.Entry<String, Int>, Expect<String>.() -> Unit>,
     valueFeature: Feature0<Map.Entry<String, Int>, Int>,
@@ -23,12 +23,12 @@ abstract class MapEntryExpectationsSpec(
 
     include(object : SubjectLessSpec<Map.Entry<String, Int>>(
         describePrefix,
-        isKeyValue.forSubjectLess("key", 1)
+        toEqualKeyValue.forSubjectLess("key", 1)
     ) {})
 
     include(object : SubjectLessSpec<Map.Entry<String?, Int?>>(
         "$describePrefix[nullable] ",
-        isKeyValueNullable.forSubjectLess("key", 1)
+        toEqualKeyValueNullable.forSubjectLess("key", 1)
     ) {})
 
     include(object : KeyValueLikeExpectationsSpec<Map.Entry<String, Int>, Map.Entry<String?, Int?>>(
@@ -53,18 +53,18 @@ abstract class MapEntryExpectationsSpec(
     val mapEntry = mapEntry("hello", 1)
     val fluent = expect(mapEntry)
 
-    describeFun(isKeyValue, isKeyValueNullable) {
-        val isKeyValueFunctions = uncheckedToNonNullable(isKeyValue, isKeyValueNullable)
+    describeFun(toEqualKeyValue, toEqualKeyValueNullable) {
+        val toEqualKeyValueFunctions = uncheckedToNonNullable(toEqualKeyValue, toEqualKeyValueNullable)
 
         context("map $mapEntry") {
-            isKeyValueFunctions.forEach { (name, isKeyValueFun) ->
+            toEqualKeyValueFunctions.forEach { (name, toEqualKeyValueFun) ->
                 it("$name - hello to 1 does not throw") {
-                    fluent.isKeyValueFun("hello", 1)
+                    fluent.toEqualKeyValueFun("hello", 1)
                 }
 
                 it("$name - hello to 2 throws AssertionError") {
                     expect {
-                        fluent.isKeyValueFun("hello", 2)
+                        fluent.toEqualKeyValueFun("hello", 2)
                     }.toThrow<AssertionError> {
                         message {
                             toContain("value: 1", "$toBeDescr: 2")
@@ -74,7 +74,7 @@ abstract class MapEntryExpectationsSpec(
                 }
                 it("$name - b to 1 throws AssertionError") {
                     expect {
-                        fluent.isKeyValueFun("b", 1)
+                        fluent.toEqualKeyValueFun("b", 1)
                     }.toThrow<AssertionError> {
                         message {
                             toContain("key: \"hello\"", "$toBeDescr: \"b\"")
@@ -86,19 +86,19 @@ abstract class MapEntryExpectationsSpec(
         }
     }
 
-    describeFun(isKeyValueNullable) {
-        val isKeyValueFun = isKeyValueNullable.lambda
+    describeFun(toEqualKeyValueNullable) {
+        val toEqualKeyValueFun = toEqualKeyValueNullable.lambda
         val mapEntryNullable2 = mapEntry(null as String?, null as Int?)
         val fluentNullable = expect(mapEntryNullable2)
 
         context("map $mapEntryNullable2") {
             it("null to null does not throw") {
-                fluentNullable.isKeyValueFun(null, null)
+                fluentNullable.toEqualKeyValueFun(null, null)
             }
 
             it("null to 2 throws AssertionError") {
                 expect {
-                    fluentNullable.isKeyValueFun(null, 2)
+                    fluentNullable.toEqualKeyValueFun(null, 2)
                 }.toThrow<AssertionError> {
                     message {
                         toContain("value: null", "$toBeDescr: 2")
@@ -108,7 +108,7 @@ abstract class MapEntryExpectationsSpec(
             }
             it("b to null throws AssertionError") {
                 expect {
-                    fluentNullable.isKeyValueFun("b", null)
+                    fluentNullable.toEqualKeyValueFun("b", null)
                 }.toThrow<AssertionError> {
                     message {
                         toContain("key: null", "$toBeDescr: \"b\"")

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
@@ -219,7 +219,7 @@ class MostExamplesSpec : Spek({
     }
     test("ex-map-5") {
         expect(linkedMapOf("a" to 1, "b" to 2)).asEntries().toContain.inOrder.only.entries(
-            { isKeyValue("a", 1) },
+            { toEqualKeyValue("a", 1) },
             {
                 key.toStartWith("a")
                 value.toBeGreaterThan(2)


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
