### PR TITLE
Improve reporting for containsNoDuplicates

### DIFF
--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -189,7 +189,7 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
                 }
             }
 
-        val duplicates = duplicateIndices.asSequence()
+        val duplicates = duplicateIndices
             .map { (index, pair) ->
                 pair.let { (element, duplicateIndices) ->
                     assertionBuilder.descriptive
@@ -213,7 +213,6 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
                         .build()
                 }
             }
-            .toList()
 
         createHasElementPlusFixedClaimGroup(
             list,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableExpectationsSpec.kt
@@ -138,14 +138,18 @@ abstract class IterableExpectationsSpec(
 
         it("list with duplicates") {
             fun index(i: Int, element: Int) = DescriptionIterableAssertion.INDEX.getDefault().format("$i: $element")
+            fun duplicatedBy(vararg elements: Int) =
+                DescriptionIterableAssertion.DUPLICATED_BY.getDefault().format(elements.joinToString(", "))
 
             val input = listOf(1, 2, 1, 2, 3, 4, 4, 4).asIterable()
+
             expect {
                 expect(input).notToContainDuplicatesFun()
             }.toThrow<AssertionError> {
                 message {
                     toContain("$hasNotDescr: $duplicateElements")
-                    toContain(index(2, 1), index(3, 2), index(6, 4), index(7, 4))
+                    toContain(index(0, 1), index(1, 2), index(5, 4))
+                    toContain(duplicatedBy(2), duplicatedBy(3), duplicatedBy(6, 7))
                 }
             }
         }

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -45,7 +45,8 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     WARNING_MISMATCHES_ADDITIONAL_ENTRIES(WARNING_MISMATCHES_ADDITIONAL_ELEMENTS.getDefault()),
     NEXT_ELEMENT("ein nächstes Element"),
     NO_ELEMENTS("❗❗ kann nicht eruiert werden, leeres Iterable"),
-    DUPLICATE_ELEMENTS("doppelte Elemente")
+    DUPLICATE_ELEMENTS("doppelte Elemente"),
+    DUPLICATED_BY("(translation needed) duplicated by index: %s")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS =

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -46,7 +46,7 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NEXT_ELEMENT("ein nächstes Element"),
     NO_ELEMENTS("❗❗ kann nicht eruiert werden, leeres Iterable"),
     DUPLICATE_ELEMENTS("doppelte Elemente"),
-    DUPLICATED_BY("(translation needed) duplicated by index: %s")
+    DUPLICATED_BY("(dupliziert von Index: %s")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS =

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -45,7 +45,8 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     WARNING_MISMATCHES_ADDITIONAL_ENTRIES(WARNING_MISMATCHES_ADDITIONAL_ELEMENTS.getDefault()),
     NEXT_ELEMENT("a next element"),
     NO_ELEMENTS("❗❗ cannot be determined, empty Iterable"),
-    DUPLICATE_ELEMENTS("duplicate elements")
+    DUPLICATE_ELEMENTS("duplicate elements"),
+    DUPLICATED_BY("duplicated by index: %s")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS = "Could not evaluate the defined assertion(s)"


### PR DESCRIPTION
Resolves #813. I modified containsNoDuplicates from DefaultIterableLikeAssertions to describe which indices the first occurrence of an element is duplicated by.

    expect(listOf(1,2,1,2,3,4,4,4)).containsNoDuplicates()

displays the message
```
expected that subject: [1, 2, 1, 2, 3, 4, 4, 4]        (java.util.Arrays.ArrayList <1577752735>)
◆ has not: duplicate elements
  ⚬ index 0: 1        (kotlin.Int <370557051>)
      » duplicated by index: 2
  ⚬ index 1: 2        (kotlin.Int <628175509>)
      » duplicated by index: 3
  ⚬ index 5: 4        (kotlin.Int <2036589020>)
      » duplicated by index: 6, 7
```

I created a new translatable `DescriptionIterableAssertion.DUPLICATED_BY` but did not translate that into German, since I don't know any!
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
