### PR TITLE
rename appendAssertion/CreatedBy to append and appendAsGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2010,7 +2010,7 @@ This is kind of the simplest way of defining assertion functions. Following an e
 import ch.tutteli.atrium.logic._logic
 
 fun Expect<Int>.toBeAMultipleOf(base: Int) =
-    _logic.createAndAppendAssertion("is multiple of", base) { it % base == 0 }
+    _logic.createAndAppend("is multiple of", base) { it % base == 0 }
 ```
 </code-own-boolean-1>
 
@@ -2060,7 +2060,7 @@ Consider the following assertion function:
 import ch.tutteli.atrium.logic._logic
 
 fun Expect<Int>.toBeEven() =
-    _logic.createAndAppendAssertion("is", Text("an even number")) { it % 2 == 0 }
+    _logic.createAndAppend("is", Text("an even number")) { it % 2 == 0 }
 ```
 </code-own-boolean-2>
 
@@ -2109,7 +2109,7 @@ if you want that both are evaluated:
 import ch.tutteli.atrium.logic._logic
 
 fun <T : Date> Expect<T>.toBeBetween(lowerBoundInclusive: T, upperBoundExclusive: T) =
-    _logic.appendAssertionsCreatedBy {
+    _logic.appendAsGroup {
         toBeGreaterThanOrEqualTo(lowerBoundInclusive)
         toBeLessThan(upperBoundExclusive)
     }
@@ -2481,7 +2481,7 @@ we do no longer use a `String` but a proper `Translatable`.
 import ch.tutteli.atrium.logic.*
 
 fun Expect<Int>.toBeAMultipleOf(base: Int): Expect<Int> = _logic.run {
-    appendAssertion(
+    append(
         createDescriptiveAssertion(DescriptionIntAssertion.TO_BE_A_MULTIPLE_OF, base) { it % base == 0 }
     )
 }
@@ -2533,7 +2533,7 @@ as second example:
 import ch.tutteli.atrium.logic.*
 
 fun Expect<Int>.toBeEven(): Expect<Int> = _logic.run {
-    appendAssertion(
+    append(
         createDescriptiveAssertion(DescriptionBasic.IS, DescriptionIntAssertions.EVEN) { it % 2 == 0 }
     )
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/anyAssertions.kt
@@ -216,7 +216,7 @@ inline val <T> Expect<T>.and: Expect<T> get() = this
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.AnyExpectationSamples.and
  */
 infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    _logic.appendAssertionsCreatedBy(assertionCreator)
+    _logic.appendAsGroup(assertionCreator)
 
 /**
  * Expects that the subject of `this` expectation is not (equal to) [expected] and [otherValues].

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arrayAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arrayAssertions.kt
@@ -35,7 +35,7 @@ fun <E> Expect<out Array<out E>>.asList(): Expect<List<E>> =
  * @since 0.9.0
  */
 fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<E>> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
@@ -52,7 +52,7 @@ fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): E
  */
 @JvmName("asListEOut")
 fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<out E>> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Turns `Expect<CharArray>` into `Expect<List<Byte>>`.
@@ -85,7 +85,7 @@ fun Expect<ByteArray>.asList(): Expect<List<Byte>> =
  */
 @JvmName("byteArrAsList")
 fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Unit): Expect<ByteArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -119,7 +119,7 @@ fun Expect<CharArray>.asList(): Expect<List<Char>> =
  */
 @JvmName("charArrAsList")
 fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Unit): Expect<CharArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -153,7 +153,7 @@ fun Expect<ShortArray>.asList(): Expect<List<Short>> =
  */
 @JvmName("shortArrAsList")
 fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> Unit): Expect<ShortArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -187,7 +187,7 @@ fun Expect<IntArray>.asList(): Expect<List<Int>> =
  */
 @JvmName("intArrAsList")
 fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit): Expect<IntArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -221,7 +221,7 @@ fun Expect<LongArray>.asList(): Expect<List<Long>> =
  */
 @JvmName("longArrAsList")
 fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Unit): Expect<LongArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -255,7 +255,7 @@ fun Expect<FloatArray>.asList(): Expect<List<Float>> =
  */
 @JvmName("floatArrAsList")
 fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> Unit): Expect<FloatArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -289,7 +289,7 @@ fun Expect<DoubleArray>.asList(): Expect<List<Double>> =
  */
 @JvmName("doubleArrAsList")
 fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -> Unit): Expect<DoubleArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -323,4 +323,4 @@ fun Expect<BooleanArray>.asList(): Expect<List<Boolean>> =
  */
 @JvmName("boolArrAsList")
 fun Expect<BooleanArray>.asList(assertionCreator: Expect<List<Boolean>>.() -> Unit): Expect<BooleanArray> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableAssertions.kt
@@ -404,4 +404,4 @@ fun <E, T : Iterable<E>> Expect<T>.asList(): Expect<List<E>> = _logic.changeSubj
  * @since 0.14.0
  */
 fun <E, T : Iterable<E>> Expect<T>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<T> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapAssertions.kt
@@ -277,7 +277,7 @@ fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(): Expect<Set<Map.Entry<K, V>>
  */
 fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit
-): Expect<T> = apply { asEntries()._logic.appendAssertionsCreatedBy(assertionCreator) }
+): Expect<T> = apply { asEntries()._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Expects that the subject of `this` expectation (a [Map]) is an empty [Map].

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceAssertions.kt
@@ -26,7 +26,7 @@ fun <E, T : Sequence<E>> Expect<T>.asIterable(): Expect<Iterable<E>> =
  * @return an [Expect] for the subject of `this` expectation.
  */
 fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
-    apply { asIterable()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asIterable()._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Turns `Expect<E, T : Sequence<E>>` into `Expect<List<E>`.
@@ -52,4 +52,4 @@ fun <E, T : Sequence<E>> Expect<T>.asList(): Expect<List<E>> = _logic.changeSubj
  * @since 0.14.0
  */
 fun <E, T : Sequence<E>> Expect<T>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<T> =
-    apply { asList()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fileAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fileAssertions.kt
@@ -37,4 +37,4 @@ fun <T : File> Expect<T>.asPath(): Expect<Path> =
  * @since 0.9.0
  */
 fun <T : File> Expect<T>.asPath(assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
-    apply { asPath()._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asPath()._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
@@ -246,7 +246,7 @@ inline infix fun <T> Expect<T>.and(@Suppress("UNUSED_PARAMETER") o: o): Expect<T
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.AnyExpectationSamples.and
  */
 infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    _logic.appendAssertionsCreatedBy(assertionCreator)
+    _logic.appendAsGroup(assertionCreator)
 
 //TODO 0.17.0 deprecate?
 /**

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/arrayAssertions.kt
@@ -35,7 +35,7 @@ infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o
  * @since 0.12.0
  */
 infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<E>> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
@@ -52,7 +52,7 @@ infix fun <E> Expect<Array<E>>.asList(assertionCreator: Expect<List<E>>.() -> Un
  */
 @JvmName("asListEOut")
 infix fun <E> Expect<Array<out E>>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<Array<out E>> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Turns `Expect<CharArray>` into `Expect<List<Byte>>`.
@@ -85,7 +85,7 @@ infix fun Expect<ByteArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  */
 @JvmName("byteArrAsList")
 infix fun Expect<ByteArray>.asList(assertionCreator: Expect<List<Byte>>.() -> Unit): Expect<ByteArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -119,7 +119,7 @@ infix fun Expect<CharArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  */
 @JvmName("charArrAsList")
 infix fun Expect<CharArray>.asList(assertionCreator: Expect<List<Char>>.() -> Unit): Expect<CharArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -153,7 +153,7 @@ infix fun Expect<ShortArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
  */
 @JvmName("shortArrAsList")
 infix fun Expect<ShortArray>.asList(assertionCreator: Expect<List<Short>>.() -> Unit): Expect<ShortArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -187,7 +187,7 @@ infix fun Expect<IntArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<Li
  */
 @JvmName("intArrAsList")
 infix fun Expect<IntArray>.asList(assertionCreator: Expect<List<Int>>.() -> Unit): Expect<IntArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -221,7 +221,7 @@ infix fun Expect<LongArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<L
  */
 @JvmName("longArrAsList")
 infix fun Expect<LongArray>.asList(assertionCreator: Expect<List<Long>>.() -> Unit): Expect<LongArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -255,7 +255,7 @@ infix fun Expect<FloatArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<
  */
 @JvmName("floatArrAsList")
 infix fun Expect<FloatArray>.asList(assertionCreator: Expect<List<Float>>.() -> Unit): Expect<FloatArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -289,7 +289,7 @@ infix fun Expect<DoubleArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect
  */
 @JvmName("doubleArrAsList")
 infix fun Expect<DoubleArray>.asList(assertionCreator: Expect<List<Double>>.() -> Unit): Expect<DoubleArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }
 
 
 /**
@@ -323,4 +323,4 @@ infix fun Expect<BooleanArray>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expec
  */
 @JvmName("boolArrAsList")
 infix fun Expect<BooleanArray>.asList(assertionCreator: Expect<List<Boolean>>.() -> Unit): Expect<BooleanArray> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableAssertions.kt
@@ -454,4 +454,4 @@ infix fun <E, T : Iterable<E>> Expect<T>.asList(
  * @since 0.14.0
  */
 infix fun <E, T : Iterable<E>> Expect<T>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<T> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapAssertions.kt
@@ -351,7 +351,7 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
  */
 infix fun <K, V, T : Map<out K, V>> Expect<T>.asEntries(
     assertionCreator: Expect<Set<Map.Entry<K, V>>>.() -> Unit
-): Expect<T> = apply { asEntries(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+): Expect<T> = apply { asEntries(o)._logic.appendAsGroup(assertionCreator) }
 
 //TODO move to mapExpectations.kt with 0.18.0
 /**

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceAssertions.kt
@@ -27,7 +27,7 @@ infix fun <E, T : Sequence<E>> Expect<T>.asIterable(
  * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
-    apply { asIterable(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asIterable(o)._logic.appendAsGroup(assertionCreator) }
 
 /**
  * Turns `Expect<E, T : Sequence<E>>` into `Expect<List<E>`.
@@ -55,4 +55,4 @@ infix fun <E, T : Sequence<E>> Expect<T>.asList(
  * @since 0.14.0
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<T> =
-    apply { asList(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asList(o)._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fileAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/fileAssertions.kt
@@ -37,4 +37,4 @@ infix fun <T : File> Expect<T>.asPath(@Suppress("UNUSED_PARAMETER") o: o): Expec
  * @since 0.12.0
  */
 infix fun <T : File> Expect<T>.asPath(assertionCreator: Expect<Path>.() -> Unit): Expect<T> =
-    apply { asPath(o)._logic.appendAssertionsCreatedBy(assertionCreator) }
+    apply { asPath(o)._logic.appendAsGroup(assertionCreator) }

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB-common/src/test/kotlin/SmokeTest.kt
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB-common/src/test/kotlin/SmokeTest.kt
@@ -108,10 +108,10 @@ class SmokeTest {
 }
 
 fun Expect<Int>.toBeEven() =
-    _logic.createAndAppendAssertion("is", Text("an even number")) { it % 2 == 0 }
+    _logic.createAndAppend("is", Text("an even number")) { it % 2 == 0 }
 
 fun Expect<Int>.toBeOdd() =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(IS, Text("an odd number")) { it % 2 == 1 })
+    _logic.append(_logic.createDescriptiveAssertion(IS, Text("an odd number")) { it % 2 == 1 })
 
 fun Expect<Int>.toBeAMultipleOf(base: Int): Expect<Int> = _logicAppend { toBeAMultipleOf(base) }
 

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB-jvm/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB-jvm/src/test/kotlin/custom/SmokeSpec.kt
@@ -35,10 +35,10 @@ object SmokeSpec : Spek({
 })
 
 fun Expect<Int>.toBeEven() =
-    _logic.createAndAppendAssertion("is", Text("an even number")) { it % 2 == 0 }
+    _logic.createAndAppend("is", Text("an even number")) { it % 2 == 0 }
 
 fun Expect<Int>.toBeOdd() =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
+    _logic.append(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
 
 fun Expect<Int>.toBeAMultipleOf(base: Int) = _logicAppend { toBeAMultipleOf(base) }
 

--- a/bundles/fluent-en_GB/extensions/atrium-fluent-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/fluent-en_GB/extensions/atrium-fluent-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
@@ -39,10 +39,10 @@ object SmokeSpec : Spek({
 })
 
 fun Expect<Int>.isEven() =
-    _logic.createAndAppendAssertion("is", Text("an even number")) { it % 2 == 0 }
+    _logic.createAndAppend("is", Text("an even number")) { it % 2 == 0 }
 
 fun Expect<Int>.isOdd() =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
+    _logic.append(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
 
 fun Expect<Int>.isMultipleOf(base: Int): Expect<Int> = _logicAppend { isMultipleOf(base) }
 

--- a/bundles/infix-en_GB/atrium-infix-en_GB-common/src/test/kotlin/SmokeTest.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-common/src/test/kotlin/SmokeTest.kt
@@ -59,10 +59,10 @@ object even
 object odd
 
 infix fun Expect<Int>.toBe(@Suppress("UNUSED_PARAMETER") even: even) =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(IS, Text("an even number")) { it % 2 == 0 })
+    _logic.append(_logic.createDescriptiveAssertion(IS, Text("an even number")) { it % 2 == 0 })
 
 infix fun Expect<Int>.toBe(@Suppress("UNUSED_PARAMETER") odd: odd) =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(IS, Text("an odd number")) { it % 2 == 1})
+    _logic.append(_logic.createDescriptiveAssertion(IS, Text("an odd number")) { it % 2 == 1})
 
 infix fun Expect<Int>.toBeAMultipleOf(base: Int): Expect<Int> = _logicAppend { toBeAMultipleOf(base) }
 

--- a/bundles/infix-en_GB/atrium-infix-en_GB-jvm/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/infix-en_GB/atrium-infix-en_GB-jvm/src/test/kotlin/custom/SmokeSpec.kt
@@ -34,10 +34,10 @@ object even
 object odd
 
 infix fun Expect<Int>.tobe(@Suppress("UNUSED_PARAMETER") even: even) =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an even number")) { it % 2 == 0 })
+    _logic.append(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an even number")) { it % 2 == 0 })
 
 infix fun Expect<Int>.tobe(@Suppress("UNUSED_PARAMETER") odd: odd) =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
+    _logic.append(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
 
 infix fun Expect<Int>.isMultipleOf(base: Int): Expect<Int> = _logicAppend { isMultipleOf(base) }
 

--- a/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/infix-en_GB/extensions/atrium-infix-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
@@ -45,10 +45,10 @@ object even
 object odd
 
 infix fun Expect<Int>.toBe(@Suppress("UNUSED_PARAMETER") even: even) =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an even number")) { it % 2 == 0 })
+    _logic.append(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an even number")) { it % 2 == 0 })
 
 infix fun Expect<Int>.toBe(@Suppress("UNUSED_PARAMETER") odd: odd) =
-    _logic.appendAssertion(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
+    _logic.append(_logic.createDescriptiveAssertion(DescriptionBasic.IS, Text("an odd number")) { it % 2 == 1 })
 
 infix fun Expect<Int>.isMultipleOf(base: Int): Expect<Int> = _logicAppend { isMultipleOf(base) }
 

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
@@ -33,6 +33,7 @@ interface AssertionContainer<T> : @kotlin.Suppress("DEPRECATION") SubjectProvide
      * Might be we completely remove it without prior notice.
      */
     //TODO 0.18.0/0.19.0 maybe it would be better to have proofFactories as val like we have components?
+    //TODO 0.18.0 I guess it would make sense to get rid of getImpl and only use the ComponentFactoryContainer approach
     @ExperimentalNewExpectTypes
     fun <I : Any> getImpl(kClass: KClass<I>, defaultFactory: () -> I): I
 
@@ -55,8 +56,7 @@ interface AssertionContainer<T> : @kotlin.Suppress("DEPRECATION") SubjectProvide
      *
      * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately evaluated.
      */
-    //TODO 0.17.0 rename to append - this way we can use it also on ProofContainer and users won't notice anything as long as they recompile
-    fun appendAssertion(assertion: Assertion): Expect<T>
+    fun append(assertion: Assertion): Expect<T>
 
     /**
      * Appends the [Assertion]s the given [assertionCreator] creates to this container and
@@ -72,12 +72,11 @@ interface AssertionContainer<T> : @kotlin.Suppress("DEPRECATION") SubjectProvide
      *
      * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately evaluated.
      */
-    //TODO 0.17.0  rename to append - this way we can use it also on ProofContainer and users won't notice anything as long as they recompile
-    fun appendAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): Expect<T>
+    fun appendAsGroup(assertionCreator: Expect<T>.() -> Unit): Expect<T>
 
     /**
      * Creates a [DescriptiveAssertion] based on the given [description], [expected] and [test]
-     * and [appends][appendAssertion] it to the container.
+     * and [append]s it to the container.
      *
      * @param description The description of the assertion, e.g., `is less than`.
      * @param expected The expected value, e.g., `5`
@@ -86,8 +85,7 @@ interface AssertionContainer<T> : @kotlin.Suppress("DEPRECATION") SubjectProvide
      * @return an [Expect] for the subject of `this` expectation.
      */
     //TODO remove SUPPRESS with 0.18.0
-    //TODO 0.17.0  rename to append - this way we can use it also on ProofContainer and users won't notice anything as long as they recompile
     @Suppress("UNCHECKED_CAST", "DEPRECATION")
-    fun createAndAppendAssertion(description: String, expected: Any?, test: (T) -> Boolean): Expect<T> =
-        appendAssertion(assertionBuilder.createDescriptive(this as Expect<T>, Untranslatable(description),expected, test))
+    fun createAndAppend(description: String, expected: Any?, test: (T) -> Boolean): Expect<T> =
+        append(assertionBuilder.createDescriptive(this as Expect<T>, Untranslatable(description),expected, test))
 }

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/CollectingExpect.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/CollectingExpect.kt
@@ -22,8 +22,8 @@ interface CollectingExpect<T> : Expect<T> {
     fun getAssertions(): List<Assertion>
 
     @Deprecated(
-        "use appendAssertionsCreatedBy; will be removed with 0.18.0",
-        ReplaceWith("this.appendAssertionsCreatedBy(assertionCreator)")
+        "use appendAsGroup; will be removed with 0.18.0",
+        ReplaceWith("this.appendAsGroup(assertionCreator)")
     )
     override fun addAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): CollectingExpect<T>
 
@@ -41,7 +41,7 @@ interface CollectingExpect<T> : Expect<T> {
      *
      * @throws AssertionError Might throw an [AssertionError] in case [Assertion]s are immediately evaluated.
     */
-    fun appendAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): CollectingExpect<T>
+    fun appendAsGroup(assertionCreator: Expect<T>.() -> Unit): CollectingExpect<T>
 
     companion object {
         @Suppress(

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
@@ -63,8 +63,8 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      * @return an [Expect] for the subject of `this` expectation.
      */
     @Deprecated(
-        "use _logic.appendAssertionsCreatedBy; will be removed with 0.18.0",
-        ReplaceWith("this._logic.appendAssertionsCreatedBy(assertionCreator)", "ch.tutteli.atrium.logic._logic")
+        "use _logic.appendAsGroup; will be removed with 0.18.0",
+        ReplaceWith("this._logic.appendAsGroup(assertionCreator)", "ch.tutteli.atrium.logic._logic")
     )
     fun addAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): Expect<T>
 
@@ -76,8 +76,8 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      * @return an [Expect] for the subject of `this` expectation.
      */
     @Deprecated(
-        "use _logic.appendAssertion; will be removed with 0.18.0",
-        ReplaceWith("this._logic.appendAssertion(assertion)", "ch.tutteli.atrium.logic._logic")
+        "use _logic.append; will be removed with 0.18.0",
+        ReplaceWith("this._logic.append(assertion)", "ch.tutteli.atrium.logic._logic")
     )
     override fun addAssertion(assertion: Assertion): Expect<T>
 
@@ -92,9 +92,9 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      * @return an [Expect] for the subject of `this` expectation.
      */
     @Deprecated(
-        "use _logic.createAndAppendAssertion; will be removed with 0.18.0",
+        "use _logic.createAndAppend; will be removed with 0.18.0",
         ReplaceWith(
-            "this._logic.createAndAppendAssertion(description, expected, test)",
+            "this._logic.createAndAppend(description, expected, test)",
             "ch.tutteli.atrium.logic._logic"
         )
     )
@@ -112,9 +112,9 @@ interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
      * @return an [Expect] for the subject of `this` expectation.
      */
     @Deprecated(
-        "use _logic.createAndAppendAssertion; will be removed with 0.18.0",
+        "use _logic.createAndAppend; will be removed with 0.18.0",
         ReplaceWith(
-            "this._logic.appendAssertion(this._logic.createDescriptiveAssertion(description, expected, test))",
+            "this._logic.append(this._logic.createDescriptiveAssertion(description, expected, test))",
             "ch.tutteli.atrium.logic._logic",
             "ch.tutteli.atrium.logic.createDescriptiveAssertion"
         )

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/BaseExpectImpl.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/BaseExpectImpl.kt
@@ -43,21 +43,21 @@ abstract class BaseExpectImpl<T>(
 
     //TODO remove with 0.18.0
     override fun addAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-        appendAssertionsCreatedBy(assertionCreator)
+        appendAsGroup(assertionCreator)
 
-    override fun appendAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): Expect<T> {
+    override fun appendAsGroup(assertionCreator: Expect<T>.() -> Unit): Expect<T> {
         val assertions = CollectingExpect(maybeSubject, components)
-            .appendAssertionsCreatedBy(assertionCreator)
+            .appendAsGroup(assertionCreator)
             .getAssertions()
-        return addAssertions(assertions)
+        return appendAsGroup(assertions)
     }
 
 
-    protected fun addAssertions(assertions: List<Assertion>): Expect<T> {
+    protected fun appendAsGroup(assertions: List<Assertion>): Expect<T> {
         return when (assertions.size) {
             0 -> this
-            1 -> appendAssertion(assertions.first())
-            else -> appendAssertion(assertionBuilder.invisibleGroup.withAssertions(assertions).build())
+            1 -> append(assertions.first())
+            else -> append(assertionBuilder.invisibleGroup.withAssertions(assertions).build())
         }
     }
 

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/CollectingExpectImpl.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/CollectingExpectImpl.kt
@@ -16,15 +16,15 @@ internal class CollectingExpectImpl<T>(
 
     override fun getAssertions(): List<Assertion> = assertions.toList()
 
-    override fun addAssertion(assertion: Assertion): Expect<T> = appendAssertion(assertion)
+    override fun addAssertion(assertion: Assertion): Expect<T> = append(assertion)
 
-    override fun appendAssertion(assertion: Assertion): Expect<T> =
+    override fun append(assertion: Assertion): Expect<T> =
         apply { assertions.add(assertion) }
 
     override fun addAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): CollectingExpect<T> =
-        appendAssertionsCreatedBy(assertionCreator)
+        appendAsGroup(assertionCreator)
 
-    override fun appendAssertionsCreatedBy(assertionCreator: Expect<T>.() -> Unit): CollectingExpect<T> {
+    override fun appendAsGroup(assertionCreator: Expect<T>.() -> Unit): CollectingExpect<T> {
         // in case we run into performance problems, the code below is certainly not ideal
         val allAssertions = mutableListOf<Assertion>()
         allAssertions.addAll(getAssertions())
@@ -56,7 +56,7 @@ internal class CollectingExpectImpl<T>(
                 .build()
             )
         }
-        allAssertions.forEach { appendAssertion(it) }
+        allAssertions.forEach { append(it) }
         return this
     }
 

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/DelegatingExpectImpl.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/DelegatingExpectImpl.kt
@@ -14,8 +14,8 @@ internal class DelegatingExpectImpl<T>(private val container: AssertionContainer
         get() = container.components
 
     override fun addAssertion(assertion: Assertion): Expect<T> =
-        appendAssertion(assertion)
+        append(assertion)
 
-    override fun appendAssertion(assertion: Assertion): Expect<T> =
+    override fun append(assertion: Assertion): Expect<T> =
         apply { container.addAssertion(assertion) }
 }

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/FeatureExpectImpl.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/FeatureExpectImpl.kt
@@ -49,7 +49,7 @@ internal class FeatureExpectImpl<T, R>(
     private val assertions: MutableList<Assertion> = mutableListOf()
 
     init {
-        addAssertions(assertions)
+        appendAsGroup(assertions)
     }
 
     override val components: ComponentFactoryContainer
@@ -58,9 +58,9 @@ internal class FeatureExpectImpl<T, R>(
 
 
     override fun addAssertion(assertion: Assertion): Expect<R> =
-        appendAssertion(assertion)
+        append(assertion)
 
-    override fun appendAssertion(assertion: Assertion): Expect<R> {
+    override fun append(assertion: Assertion): Expect<R> {
         assertions.add(assertion)
         //Would be nice if we don't have to add it immediately to the previousExpect but only:
         //if (!assertion.holds()) {
@@ -76,7 +76,7 @@ internal class FeatureExpectImpl<T, R>(
         //
         //However, for this to work we would need to know when no more assertion is defined. This would be possible
         //for CollectingExpectImpl
-        (previousExpect as AssertionContainer<*>).appendAssertion(
+        (previousExpect as AssertionContainer<*>).append(
             assertionBuilder.feature
                 .withDescriptionAndRepresentation(description, representation)
                 .withAssertions(ArrayList(assertions))

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/RootExpectImpl.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/RootExpectImpl.kt
@@ -55,9 +55,9 @@ internal class RootExpectImpl<T>(
     private val assertions: MutableList<Assertion> = mutableListOf()
 
     override fun addAssertion(assertion: Assertion): Expect<T> =
-        appendAssertion(assertion)
+        append(assertion)
 
-    override fun appendAssertion(assertion: Assertion): Expect<T> {
+    override fun append(assertion: Assertion): Expect<T> {
         assertions.add(assertion)
         if (!assertion.holds()) {
             val assertionGroup = assertionBuilder.root

--- a/core/atrium-core-common/src/test/kotlin/ch/tutteli/atrium/assertions/builders/DescriptiveWithBasedOnSubjectSpec.kt
+++ b/core/atrium-core-common/src/test/kotlin/ch/tutteli/atrium/assertions/builders/DescriptiveWithBasedOnSubjectSpec.kt
@@ -11,7 +11,7 @@ import org.spekframework.spek2.Spek
 class DescriptiveWithBasedOnSubjectSpec : Spek({
 
     fun addDescriptive(f: (Expect<Int>, Descriptive.HoldsOption) -> Assertion) = expectLambda<Int> {
-        _logic.appendAssertion(f(this, assertionBuilder.descriptive))
+        _logic.append(f(this, assertionBuilder.descriptive))
     }
 
     include(object : SubjectLessSpec<Int>("",

--- a/core/atrium-core-common/src/test/kotlin/ch/tutteli/atrium/reporting/text/BulletPointProviderSpec.kt
+++ b/core/atrium-core-common/src/test/kotlin/ch/tutteli/atrium/reporting/text/BulletPointProviderSpec.kt
@@ -33,8 +33,8 @@ class BulletPointProviderSpec : Spek({
                     expectWitNewBulletPoint(p, "a") toEqual "b"
                 }),
                 ListAssertionGroupType::class to ("- " to { p ->
-                    expectWitNewBulletPoint(p, "a")._logic.appendAssertionsCreatedBy {
-                        _logic.appendAssertion(
+                    expectWitNewBulletPoint(p, "a")._logic.appendAsGroup {
+                        _logic.append(
                             assertionBuilder.list
                                 .withDescriptionAndEmptyRepresentation("hello")
                                 .withAssertion(_logic.toBe("b")).build()
@@ -54,8 +54,8 @@ class BulletPointProviderSpec : Spek({
                     expectWitNewBulletPoint(p, listOf(1)) toContainExactly 2
                 }),
                 ExplanatoryAssertionGroupType::class to (">> " to { p ->
-                    expectWitNewBulletPoint(p, "a")._logic.appendAssertionsCreatedBy {
-                        _logic.appendAssertion(
+                    expectWitNewBulletPoint(p, "a")._logic.appendAsGroup {
+                        _logic.append(
                             assertionBuilder.explanatoryGroup
                                 .withDefaultType
                                 .withAssertion(_logic.toBe("b"))
@@ -65,8 +65,8 @@ class BulletPointProviderSpec : Spek({
                     }
                 }),
                 WarningAssertionGroupType::class to ("(!) " to { p ->
-                    expectWitNewBulletPoint(p, "a")._logic.appendAssertionsCreatedBy {
-                        _logic.appendAssertion(
+                    expectWitNewBulletPoint(p, "a")._logic.appendAsGroup {
+                        _logic.append(
                             assertionBuilder.explanatoryGroup
                                 .withWarningType
                                 .withAssertion(_logic.toBe("b"))
@@ -76,8 +76,8 @@ class BulletPointProviderSpec : Spek({
                     }
                 }),
                 InformationAssertionGroupType::class to ("(i) " to { p ->
-                    expectWitNewBulletPoint(p, "a")._logic.appendAssertionsCreatedBy {
-                        _logic.appendAssertion(
+                    expectWitNewBulletPoint(p, "a")._logic.appendAsGroup {
+                        _logic.append(
                             assertionBuilder.explanatoryGroup
                                 .withInformationType(false)
                                 .withAssertion(_logic.toBe("b"))

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
@@ -46,7 +46,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
                     { emptyList() }
                 )
                 if (list.size > index) {
-                    _logic.appendAssertion(
+                    _logic.append(
                         createAdditionalElementsAssertion(
                             container,
                             index,
@@ -81,7 +81,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
         itr: Iterator<E?>
     ): Assertion {
         return container.collectBasedOnSubject(Some(iterableAsList)) {
-            _logic.appendAssertion(LazyThreadUnsafeAssertionGroup {
+            _logic.append(LazyThreadUnsafeAssertionGroup {
                 val additionalEntries = itr.mapRemainingWithCounter { counter, it ->
                     val description = TranslatableWithArgs(
                         DescriptionIterableAssertion.ELEMENT_WITH_INDEX,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep.kt
@@ -6,7 +6,6 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.collect
 import ch.tutteli.atrium.logic.creating.transformers.TransformationExecutionStep
-import ch.tutteli.atrium.logic.toExpect
 
 /**
  * Step which has all necessary information to perform a subject transformation (subject change/feature extraction etc.)
@@ -37,7 +36,7 @@ abstract class BaseTransformationExecutionStep<T, R, E : Expect<R>>(
      * @return an [Expect] for the subject of this expectation.
      */
     final override fun collectAndAppend(assertionCreator: Expect<R>.() -> Unit): Expect<T> =
-        container.appendAssertion(collect(assertionCreator))
+        container.append(collect(assertionCreator))
 
     /**
      * Finishes the transformation process by collecting the assertions the given [assertionCreator] creates

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultSubjectChanger.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultSubjectChanger.kt
@@ -47,13 +47,13 @@ class DefaultSubjectChanger : SubjectChanger {
             .build()
 
         return if (shallTransform) {
-            val e = expect._logic.appendAssertion(descriptiveAssertion)
+            val e = expect._logic.append(descriptiveAssertion)
             maybeSubAssertions.fold({ e }) { assertionCreator ->
-                expect._logic.appendAssertionsCreatedBy(assertionCreator)
+                expect._logic.appendAsGroup(assertionCreator)
             }
         } else {
             val assertion = failureHandler.createAssertion(container, descriptiveAssertion, maybeSubAssertions)
-            expect._logic.appendAssertion(assertion)
+            expect._logic.append(assertion)
         }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
@@ -36,7 +36,7 @@ class DefaultAnyAssertions : AnyAssertions {
         } else {
             val collectSubject = container.maybeSubject.flatMap { if (it != null) Some(it) else None }
             val assertion = container.collectBasedOnSubject(collectSubject) {
-                _logic.appendAssertionsCreatedBy(assertionCreatorOrNull)
+                _logic.appendAsGroup(assertionCreatorOrNull)
             }
             //TODO 0.18.0 this is a pattern which occurs over and over again, maybe incorporate into collect?
             container.maybeSubject.fold(

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logic.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logic.kt
@@ -12,7 +12,7 @@ import ch.tutteli.atrium.creating.Expect
  * Use [_logic] for more sophisticated scenarios, like feature extraction.
  */
 inline fun <T> Expect<T>._logicAppend(assertionCreator: AssertionContainer<T>.() -> Assertion): Expect<T> =
-    _logic.run { appendAssertion(assertionCreator()) }
+    _logic.run { append(assertionCreator()) }
 
 /**
  * Entry point to the logic level of Atrium -- which is one level deeper than the API --

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logicCharSequenceContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logicCharSequenceContains.kt
@@ -40,7 +40,7 @@ inline val <T : CharSequence, S : CharSequenceContains.SearchBehaviour>
 inline fun <T : CharSequence, S : CharSequenceContains.SearchBehaviour>
     CharSequenceContains.CheckerStep<T, S>._logicAppend(
     factory: CharSequenceContains.CheckerStepLogic<T, S>.() -> Assertion
-): Expect<T> = _logic.let { l -> l.entryPointStepLogic.container.appendAssertion(l.factory()) }
+): Expect<T> = _logic.let { l -> l.entryPointStepLogic.container.append(l.factory()) }
 
 /**
  * Entry point to the logic level of Atrium -- which is one level deeper than the API --

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logicIterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logicIterableLikeContains.kt
@@ -18,7 +18,7 @@ import ch.tutteli.atrium.reporting.BUG_REPORT_URL
 inline fun <E, T : Any, S : IterableLikeContains.SearchBehaviour>
     IterableLikeContains.EntryPointStep<E, T, S>._logicAppend(
     factory: IterableLikeContains.EntryPointStepLogic<E, T, S>.() -> Assertion
-): Expect<T> = _logic.let { l -> l.container.appendAssertion(l.factory()) }
+): Expect<T> = _logic.let { l -> l.container.append(l.factory()) }
 
 /**
  * Entry point to the logic level of Atrium -- which is one level deeper than the API --
@@ -52,7 +52,7 @@ inline val <E, T : Any, S : IterableLikeContains.SearchBehaviour>
 inline fun <E, T : Any, S : IterableLikeContains.SearchBehaviour>
     IterableLikeContains.CheckerStep<E, T, S>._logicAppend(
     factory: IterableLikeContains.CheckerStepLogic<E, T, S>.() -> Assertion
-): Expect<T> = _logic.let { l -> l.entryPointStepLogic.container.appendAssertion(l.factory()) }
+): Expect<T> = _logic.let { l -> l.entryPointStepLogic.container.append(l.factory()) }
 
 /**
  * Entry point to the logic level of Atrium -- which is one level deeper than the API --

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logicMapLikeContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/logicMapLikeContains.kt
@@ -15,7 +15,7 @@ import ch.tutteli.atrium.reporting.BUG_REPORT_URL
 inline fun <K, V, T : Any, S : MapLikeContains.SearchBehaviour>
     MapLikeContains.EntryPointStep<K, V, T, S>._logicAppend(
     factory: MapLikeContains.EntryPointStepLogic<K, V, T, S>.() -> Assertion
-): Expect<T> = _logic.let { l -> l.container.appendAssertion(l.factory()) }
+): Expect<T> = _logic.let { l -> l.container.append(l.factory()) }
 
 /**
  * Entry point to the logic level of Atrium -- which is one level deeper than the API --

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/SubjectLessSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/SubjectLessSpec.kt
@@ -50,7 +50,7 @@ abstract class SubjectLessSpec<T>(
                     .withDefaultType
                     .withAssertions(assertions)
                     .build()
-                expect._logic.appendAssertion(explanatoryGroup)
+                expect._logic.append(explanatoryGroup)
             }
         }
     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
@@ -170,7 +170,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                 val nameWithArrow = "${featureArrow}name"
                 it("${toContain.name} 'treboR' and 'llotS' - error message toContain '$nameWithArrow' exactly once") {
                     expect {
-                        expect(person)._logic.appendAssertionsCreatedBy {
+                        expect(person)._logic.appendAsGroup {
                             feature(Person::name).toContainFun("treboR", "llotS")
                         }
                     }.toThrow<AssertionError> {
@@ -179,7 +179,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                 }
                 it("${notToContain.name} 'Robert' and 'Stoll' - error message toContain '$nameWithArrow' exactly once") {
                     expect {
-                        expect(person)._logic.appendAssertionsCreatedBy {
+                        expect(person)._logic.appendAsGroup {
                             feature(Person::name).notToContainFun("Robert", "Stoll")
                         }
                     }.toThrow<AssertionError> {

--- a/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslatorIntSpec.kt
+++ b/misc/specs/atrium-specs-jvm/src/main/kotlin/ch/tutteli/atrium/specs/reporting/translating/TranslatorIntSpec.kt
@@ -191,7 +191,7 @@ abstract class TranslatorIntSpec(
                 it("uses the translation form 'fr' but the primary Locale to format the date") {
                     expect {
                         val assertwithdechFr = assertWithDeCh_Fr(1)
-                        assertwithdechFr._logic.appendAssertion(assertwithdechFr._logic.createDescriptiveAssertion(
+                        assertwithdechFr._logic.append(assertwithdechFr._logic.createDescriptiveAssertion(
                             TranslatableWithArgs(
                                 TestTranslatable.DATE_KNOWN,
                                 firstOfFeb2017,
@@ -206,7 +206,7 @@ abstract class TranslatorIntSpec(
                 it("uses default translation but the primary Locale to format the date") {
                     expect {
                         val assertwithdechFr = assertWithDeCh_Fr(1)
-                        assertwithdechFr._logic.appendAssertion(assertwithdechFr._logic.createDescriptiveAssertion(
+                        assertwithdechFr._logic.append(assertwithdechFr._logic.createDescriptiveAssertion(
                             TranslatableWithArgs(
                                 TestTranslatable.DATE_UNKNOWN,
                                 firstOfFeb2017
@@ -226,7 +226,7 @@ abstract class TranslatorIntSpec(
                 ) {
                     expect {
                         val assertwithdechFr = assertWithDeCh_Fr(1)
-                        assertwithdechFr._logic.appendAssertion(assertwithdechFr._logic.createDescriptiveAssertion(
+                        assertwithdechFr._logic.append(assertwithdechFr._logic.createDescriptiveAssertion(
                             TranslatableWithArgs(
                                 TestTranslatable.PLACEHOLDER,
                                 toBe
@@ -251,7 +251,7 @@ abstract class TranslatorIntSpec(
                 it("uses the translation form 'fr' but the primary Locale to format the date") {
                     expect {
                         val assertwithdechFrchItch = assertWithDeCh_FrCh_ItCh(1)
-                        assertwithdechFrchItch._logic.appendAssertion(assertwithdechFrchItch._logic.createDescriptiveAssertion(
+                        assertwithdechFrchItch._logic.append(assertwithdechFrchItch._logic.createDescriptiveAssertion(
                             TranslatableWithArgs(
                                 TestTranslatable.DATE_KNOWN,
                                 firstOfFeb2017,
@@ -266,7 +266,7 @@ abstract class TranslatorIntSpec(
                 it("uses 'it' but the primary Locale to format the date") {
                     expect {
                         val assertwithdechFrchItch = assertWithDeCh_FrCh_ItCh(1)
-                        assertwithdechFrchItch._logic.appendAssertion(assertwithdechFrchItch._logic.createDescriptiveAssertion(
+                        assertwithdechFrchItch._logic.append(assertwithdechFrchItch._logic.createDescriptiveAssertion(
                             TranslatableWithArgs(
                                 TestTranslatable.DATE_UNKNOWN,
                                 firstOfFeb2017

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/Between2Spec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/Between2Spec.kt
@@ -30,7 +30,7 @@ object Between2Spec : Spek({
         //snippet-own-compose-import-insert
 
         fun <T : Date> Expect<T>.toBeBetween(lowerBoundInclusive: T, upperBoundExclusive: T) =
-            _logic.appendAssertionsCreatedBy {
+            _logic.appendAsGroup {
                 toBeGreaterThanOrEqualTo(lowerBoundInclusive)
                 toBeLessThan(upperBoundExclusive)
             }

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/I18nSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/I18nSpec.kt
@@ -38,7 +38,7 @@ object I18nSpec : Spek({
         //snippet-import-logic-insert
 
         fun Expect<Int>.toBeAMultipleOf(base: Int): Expect<Int> = _logic.run {
-            appendAssertion(
+            append(
                 createDescriptiveAssertion(DescriptionIntAssertion.TO_BE_A_MULTIPLE_OF, base) { it % base == 0 }
             )
         }
@@ -50,7 +50,7 @@ object I18nSpec : Spek({
         //snippet-import-logic-insert
 
         fun Expect<Int>.toBeEven(): Expect<Int> = _logic.run {
-            appendAssertion(
+            append(
                 createDescriptiveAssertion(DescriptionBasic.IS, DescriptionIntAssertions.EVEN) { it % 2 == 0 }
             )
         }

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/OwnExpectationFunctionsSpec.kt
@@ -34,7 +34,7 @@ object OwnExpectationFunctionsSpec : Spek({
 
     //snippet-own-boolean-1-start
     fun Expect<Int>.toBeAMultipleOf(base: Int) =
-        _logic.createAndAppendAssertion("is multiple of", base) { it % base == 0 }
+        _logic.createAndAppend("is multiple of", base) { it % base == 0 }
     //snippet-own-boolean-1-end
     test("code-own-boolean-1") {
         //snippet-own-boolean-import-insert
@@ -47,7 +47,7 @@ object OwnExpectationFunctionsSpec : Spek({
 
     //snippet-own-boolean-2-start
     fun Expect<Int>.toBeEven() =
-        _logic.createAndAppendAssertion("is", Text("an even number")) { it % 2 == 0 }
+        _logic.createAndAppend("is", Text("an even number")) { it % 2 == 0 }
     //snippet-own-boolean-2-end
     test("code-own-boolean-2") {
         //snippet-own-boolean-import-insert

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/utils/expect.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/utils/expect.kt
@@ -17,7 +17,7 @@ fun <T> expect(t: T): Expect<T> =
     }
 
 fun <T> expect(t: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    expect(t)._logic.appendAssertionsCreatedBy(assertionCreator)
+    expect(t)._logic.appendAsGroup(assertionCreator)
 
 class ReadmeObjectFormatter(translator: Translator) : AbstractTextObjectFormatter(translator) {
 

--- a/misc/verbs-internal/atrium-verbs-internal-common/src/main/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/verbs-internal/atrium-verbs-internal-common/src/main/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -41,7 +41,7 @@ fun <T> expect(subject: T): RootExpect<T> =
  * @throws AssertionError in case an assertion does not hold.
  */
 fun <T> expect(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    expect(subject)._logic.appendAssertionsCreatedBy(assertionCreator)
+    expect(subject)._logic.appendAsGroup(assertionCreator)
 
 /**
  * Defines the translation used for the assertion verbs used for internal purposes.

--- a/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assert.kt
+++ b/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assert.kt
@@ -44,7 +44,7 @@ fun <T> assert(subject: T): RootExpect<T> =
     ReplaceWith("expect<T>(subject, assertionCreator)", "ch.tutteli.atrium.api.verbs.expect")
 )
 fun <T> assert(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    assert(subject)._logic.appendAssertionsCreatedBy(assertionCreator)
+    assert(subject)._logic.appendAsGroup(assertionCreator)
 
 @Deprecated(
     "`assert` should not be nested, use `feature` instead.",

--- a/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assertThat.kt
+++ b/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/assertThat.kt
@@ -44,7 +44,7 @@ fun <T> assertThat(subject: T): RootExpect<T> =
     ReplaceWith("expect<T>(subject, assertionCreator)", "ch.tutteli.atrium.api.verbs.expect")
 )
 fun <T> assertThat(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    assertThat(subject)._logic.appendAssertionsCreatedBy(assertionCreator)
+    assertThat(subject)._logic.appendAsGroup(assertionCreator)
 
 @Deprecated(
     "`assertThat` should not be nested, use `feature` instead.",

--- a/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/expect.kt
+++ b/misc/verbs/atrium-verbs-common/src/main/kotlin/ch/tutteli/atrium/api.verbs/expect.kt
@@ -33,7 +33,7 @@ fun <T> expect(subject: T): RootExpect<T> =
  * @throws AssertionError in case an assertion does not hold.
  */
 fun <T> expect(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
-    expect(subject)._logic.appendAssertionsCreatedBy(assertionCreator)
+    expect(subject)._logic.appendAsGroup(assertionCreator)
 
 @Deprecated(
     "`expect` should not be nested, use `feature` instead.",


### PR DESCRIPTION
This way we can use it also on ProofContainer and users won't notice
anything as long as they recompile



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
