### PR TITLE
Issue/path expectations sample 919

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -97,7 +97,7 @@ fun <T : Path> Expect<T>.existsNot(): Expect<T> =
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testPathExtensionFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.pathExtensionFeature
  *
  * @since 0.9.0
  */
@@ -113,7 +113,7 @@ val <T : Path> Expect<T>.extension: Expect<String>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testPathExtension
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.pathExtension
  *
  * @since 0.9.0
  */
@@ -128,7 +128,7 @@ fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit):
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileNameFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.fileNameFeature
  *
  * @since 0.9.0
  */
@@ -144,7 +144,7 @@ val <T : Path> Expect<T>.fileName: Expect<String>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileName
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.fileName
  *
  * @since 0.9.0
  */
@@ -159,7 +159,7 @@ fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): 
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileNameWithoutExtensionFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.fileNameWithoutExtensionFeature
  *
  * @since 0.9.0
  */
@@ -175,7 +175,7 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileNameWithoutExtension
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.fileNameWithoutExtension
  *
  * @since 0.9.0
  */
@@ -189,7 +189,7 @@ fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<Strin
  *
  * @return The newly created [Expect] for the extracted feature.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testParentFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.parentFeature
  *
  * @since 0.9.0
  */
@@ -203,7 +203,7 @@ val <T : Path> Expect<T>.parent: Expect<Path>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testParent
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.parent
  *
  * @since 0.9.0
  */
@@ -217,6 +217,8 @@ fun <T : Path> Expect<T>.parent(assertionCreator: Expect<Path>.() -> Unit): Expe
  *
  * @return The newly created [Expect] for the extracted feature.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.resolveFeature
+ *
  * @since 0.10.0
  */
 fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
@@ -228,6 +230,8 @@ fun <T : Path> Expect<T>.resolve(other: String): Expect<Path> =
  * given [assertionCreator] creates for it and returns an [Expect] for the current subject of `this` expectation.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.resolve
  *
  * @since 0.10.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathAssertions.kt
@@ -97,6 +97,8 @@ fun <T : Path> Expect<T>.existsNot(): Expect<T> =
  *
  * @return The newly created [Expect] for the extracted feature.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testPathExtensionFeature
+ *
  * @since 0.9.0
  */
 val <T : Path> Expect<T>.extension: Expect<String>
@@ -111,6 +113,8 @@ val <T : Path> Expect<T>.extension: Expect<String>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testPathExtension
+ *
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
@@ -123,6 +127,8 @@ fun <T : Path> Expect<T>.extension(assertionCreator: Expect<String>.() -> Unit):
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileNameFeature
  *
  * @since 0.9.0
  */
@@ -138,6 +144,8 @@ val <T : Path> Expect<T>.fileName: Expect<String>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileName
+ *
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
@@ -150,6 +158,8 @@ fun <T : Path> Expect<T>.fileName(assertionCreator: Expect<String>.() -> Unit): 
  * so that further fluent calls are assertions about it.
  *
  * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileNameWithoutExtensionFeature
  *
  * @since 0.9.0
  */
@@ -165,6 +175,8 @@ val <T : Path> Expect<T>.fileNameWithoutExtension: Expect<String>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testFileNameWithoutExtension
+ *
  * @since 0.9.0
  */
 fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<String>.() -> Unit): Expect<T> =
@@ -177,6 +189,8 @@ fun <T : Path> Expect<T>.fileNameWithoutExtension(assertionCreator: Expect<Strin
  *
  * @return The newly created [Expect] for the extracted feature.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testParentFeature
+ *
  * @since 0.9.0
  */
 val <T : Path> Expect<T>.parent: Expect<Path>
@@ -188,6 +202,8 @@ val <T : Path> Expect<T>.parent: Expect<Path>
  * given [assertionCreator] creates for it and returns an [Expect] for the current subject of `this` expectation.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.testParent
  *
  * @since 0.9.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/pathExpectations.kt
@@ -16,6 +16,8 @@ import java.nio.file.Path
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toStartWith
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toStartWith(expected: Path): Expect<T> =
@@ -25,6 +27,8 @@ fun <T : Path> Expect<T>.toStartWith(expected: Path): Expect<T> =
  * Expects that the subject of `this` expectation (a [Path]) does not start with the [expected] [Path].
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.notToStartWith
  *
  * @since 0.17.0
  */
@@ -36,6 +40,8 @@ fun <T : Path> Expect<T>.notToStartWith(expected: Path): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toEndWith
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toEndWith(expected: Path): Expect<T> =
@@ -46,6 +52,8 @@ fun <T : Path> Expect<T>.toEndWith(expected: Path): Expect<T> =
  *
  * @param expected The [Path] provided to the assertion
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.notToEndWith
  *
  * @since 0.17.0
  */
@@ -61,6 +69,8 @@ fun <T : Path> Expect<T>.notToEndWith(expected: Path): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toExist
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toExist(): Expect<T> =
@@ -74,6 +84,8 @@ fun <T : Path> Expect<T>.toExist(): Expect<T> =
  * then the search will continue at that location.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.notToExist
  *
  * @since 0.17.0
  */
@@ -96,6 +108,8 @@ fun <T : Path> Expect<T>.notToExist(): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeReadable
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toBeReadable(): Expect<T> =
@@ -111,6 +125,8 @@ fun <T : Path> Expect<T>.toBeReadable(): Expect<T> =
  * at the location the link points at.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeWritable
  *
  * @since 0.17.0
  */
@@ -133,6 +149,8 @@ fun <T : Path> Expect<T>.toBeWritable(): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeExecutable
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toBeExecutable(): Expect<T> =
@@ -152,6 +170,8 @@ fun <T : Path> Expect<T>.toBeExecutable(): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeARegularFile
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toBeARegularFile(): Expect<T> =
@@ -170,6 +190,8 @@ fun <T : Path> Expect<T>.toBeARegularFile(): Expect<T> =
  * take place.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeADirectory
  *
  * @since 0.17.0
  */
@@ -213,6 +235,8 @@ fun <T : Path> Expect<T>.toBeASymbolicLink(): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeAbsolute
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toBeAbsolute(): Expect<T> =
@@ -223,6 +247,8 @@ fun <T : Path> Expect<T>.toBeAbsolute(): Expect<T> =
  * meaning that the [Path] specified in this instance does not start at the file system root.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toBeRelative
  *
  * @since 0.17.0
  */
@@ -245,6 +271,8 @@ fun <T : Path> Expect<T>.toBeRelative(): Expect<T> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toHaveTheDirectoryEntries
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toHaveTheDirectoryEntries(entry: String, vararg otherEntries: String): Expect<T> =
@@ -260,6 +288,8 @@ fun <T : Path> Expect<T>.toHaveTheDirectoryEntries(entry: String, vararg otherEn
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toHaveTheSameTextualContentAs
+ *
  * @since 0.17.0
  */
 fun <T : Path> Expect<T>.toHaveTheSameTextualContentAs(
@@ -274,7 +304,10 @@ fun <T : Path> Expect<T>.toHaveTheSameTextualContentAs(
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.PathExpectationSamples.toHaveTheSameBinaryContentAs
+ *
  * @since 0.17.0
+ *
  */
 fun <T : Path> Expect<T>.toHaveTheSameBinaryContentAs(targetPath: Path): Expect<T> =
     _logicAppend { hasSameBinaryContentAs(targetPath) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -6,7 +6,6 @@ import ch.tutteli.niok.*
 import java.nio.file.Files
 import java.nio.file.Paths
 import kotlin.test.Test
-import kotlin.test.fail
 
 class PathExpectationSamples {
 
@@ -32,14 +31,14 @@ class PathExpectationSamples {
         val dir = tempDir.newDirectory(TEST_DIR)
         expect(dir).toBeAnEmptyDirectory()
 
-        dir.newFile("test.txt")
+        dir.newFile("$TEST_FILE.txt")
         fails {
             expect(dir).toBeAnEmptyDirectory()
         }
     }
 
     @Test
-    fun toStartWithTestDir() {
+    fun toStartWith() {
         val dir = tempDir.newDirectory(TEST_DIR)
 
         expect(dir.last()).toStartWith(Paths.get(TEST_DIR))
@@ -50,7 +49,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun notToStartWithTestDir() {
+    fun notToStartWith() {
         val dir = tempDir.newDirectory(TEST_DIR)
 
         expect(dir.last()).notToStartWith(Paths.get(INVALID_DIR))
@@ -61,7 +60,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun toEndWithTestDir() {
+    fun toEndWith() {
         val dir = tempDir.newDirectory(TEST_DIR)
 
         expect(dir).toEndWith(Paths.get(TEST_DIR))
@@ -72,7 +71,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun notToEndWithTestDir() {
+    fun notToEndWith() {
         val dir = tempDir.newDirectory(TEST_DIR)
 
         expect(dir).notToEndWith(Paths.get(INVALID_DIR))
@@ -83,7 +82,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun toExistTestDir() {
+    fun toExist() {
         val dir = tempDir.newDirectory(TEST_DIR)
 
         expect(dir).toExist()
@@ -94,7 +93,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun notToExistTestDir() {
+    fun notToExist() {
         val dir = tempDir.newDirectory(TEST_DIR)
 
         expect(Paths.get(INVALID_DIR)).notToExist()
@@ -184,7 +183,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun toHaveDirectoryEntries() {
+    fun toHaveTheDirectoryEntries() {
         val dir = tempDir.newDirectory(TEST_DIR)
         val file = dir.newFile(TEST_FILE)
 
@@ -199,12 +198,14 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun toHaveSameTextualContentAs() {
+    fun toHaveTheSameTextualContentAs() {
+        val writtenTextInFile = "test_test"
+
         val notEmptyFilePath = tempDir.newFile("${TEST_FILE}_1")
-        notEmptyFilePath.toFile().writeText("test_test")
+        notEmptyFilePath.toFile().writeText(writtenTextInFile)
 
         val expectedFilePath = tempDir.newFile("${TEST_FILE}_2")
-        expectedFilePath.toFile().writeText("test_test")
+        expectedFilePath.toFile().writeText(writtenTextInFile)
 
         val emptyFilePath = tempDir.newFile("${TEST_FILE}_3")
 
@@ -234,28 +235,30 @@ class PathExpectationSamples {
 
     @Test
     fun testPathExtensionFeature() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val extension = "txt"
+        val dir = tempDir.newFile("$TEST_FILE.$extension")
 
-        expect(dir).extension.notToBeEmpty().toEndWith(TEST_DIR)
+        expect(dir).extension.notToBeEmpty().toEqual(extension)
 
         fails {
-            expect(dir).extension.toBeEmpty().toEndWith(INVALID_DIR)
+            val invalidExtension = "txtt"
+            expect(dir).extension.toEqual(invalidExtension)
         }
     }
 
     @Test
     fun testPathExtension() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val extension = "txt"
+        val dir = tempDir.newDirectory("test.$extension")
 
         expect(dir).extension {
             notToBeEmpty()
-            toEndWith(TEST_DIR)
+            toEqual(extension)
         }
 
         fails {
             expect(dir).extension {
-                toBeEmpty()
-                toEndWith(INVALID_DIR)
+                toEqual("txtt")
             }
         }
     }
@@ -319,20 +322,20 @@ class PathExpectationSamples {
 
     @Test
     fun testParentFeature() {
-        val dir = tempDir.newFile("${TEST_DIR}_1")
-        val dir2 = tempDir.newFile("${TEST_DIR}_2")
+        val dir = tempDir.newDirectory("${TEST_DIR}_1")
+        val dir2 = tempDir.newDirectory("${TEST_DIR}_2")
 
         expect(dir).parent.toEqual(dir2.parent)
 
         fails {
-            expect(dir).parent.toEqual(dir2.newFile(TEST_DIR))
+            expect(dir).parent.toEqual(dir2.newDirectory(TEST_DIR))
         }
     }
 
     @Test
     fun testParent() {
-        val dir = tempDir.newFile("${TEST_DIR}_1")
-        val dir2 = tempDir.newFile("${TEST_DIR}_2")
+        val dir = tempDir.newDirectory("${TEST_DIR}_1")
+        val dir2 = tempDir.newDirectory("${TEST_DIR}_2")
 
         expect(dir).parent {
             toEqual(dir2.parent)
@@ -340,7 +343,36 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).parent {
-                toEqual(dir2.newFile(TEST_DIR))
+                toEqual(dir2.newDirectory(TEST_DIR))
+            }
+        }
+    }
+
+    @Test
+    fun testResolveFeature() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+        val fileInDir = dir.newFile("$TEST_FILE.txt")
+
+        expect(dir).resolve("$TEST_FILE.txt").toEqual(fileInDir)
+
+        fails {
+            expect(dir).resolve("$TEST_FILE.ttt").toEqual(fileInDir)
+        }
+    }
+
+    @Test
+    fun testResolve() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+        val fileInDir = dir.newFile("$TEST_FILE.txt")
+
+        expect(dir).resolve("$TEST_FILE.txt") {
+            toEqual(fileInDir)
+            toExist()
+        }
+
+        fails {
+            expect(dir).resolve("$TEST_FILE.ttt") {
+                toEqual(fileInDir)
             }
         }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -1,12 +1,12 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
-import ch.tutteli.atrium.api.fluent.en_GB.toBeASymbolicLink
-import ch.tutteli.atrium.api.fluent.en_GB.toBeAnEmptyDirectory
+import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
-import ch.tutteli.niok.newDirectory
-import ch.tutteli.niok.newFile
+import ch.tutteli.niok.*
 import java.nio.file.Files
+import java.nio.file.Paths
 import kotlin.test.Test
+import kotlin.test.fail
 
 class PathExpectationSamples {
 
@@ -29,7 +29,7 @@ class PathExpectationSamples {
 
     @Test
     fun toBeAnEmptyDirectory() {
-        val dir = tempDir.newDirectory("dir")
+        val dir = tempDir.newDirectory(TEST_DIR)
         expect(dir).toBeAnEmptyDirectory()
 
         dir.newFile("test.txt")
@@ -37,4 +37,321 @@ class PathExpectationSamples {
             expect(dir).toBeAnEmptyDirectory()
         }
     }
+
+    @Test
+    fun toStartWithTestDir() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir.last()).toStartWith(Paths.get(TEST_DIR))
+
+        fails {
+            expect(dir.last()).toStartWith(Paths.get(INVALID_DIR))
+        }
+    }
+
+    @Test
+    fun notToStartWithTestDir() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir.last()).notToStartWith(Paths.get(INVALID_DIR))
+
+        fails {
+            expect(dir.last()).notToStartWith(Paths.get(TEST_DIR))
+        }
+    }
+
+    @Test
+    fun toEndWithTestDir() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).toEndWith(Paths.get(TEST_DIR))
+
+        fails {
+            expect(dir).toEndWith(Paths.get(INVALID_DIR))
+        }
+    }
+
+    @Test
+    fun notToEndWithTestDir() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).notToEndWith(Paths.get(INVALID_DIR))
+
+        fails {
+            expect(dir).notToEndWith(Paths.get(TEST_DIR))
+        }
+    }
+
+    @Test
+    fun toExistTestDir() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).toExist()
+
+        fails {
+            expect(Paths.get(INVALID_DIR)).toExist()
+        }
+    }
+
+    @Test
+    fun notToExistTestDir() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(Paths.get(INVALID_DIR)).notToExist()
+
+        fails {
+            expect(dir).notToExist()
+        }
+
+    }
+
+    @Test
+    fun toBeReadable() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).toBeReadable()
+
+        fails {
+            expect(Paths.get(INVALID_DIR)).toBeReadable()
+        }
+    }
+
+    @Test
+    fun toBeWritable() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).toBeWritable()
+
+        fails {
+            expect(Paths.get(INVALID_DIR)).toBeWritable()
+        }
+    }
+
+    @Test
+    fun toBeExecutable() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).toBeExecutable()
+
+        fails {
+            expect(Paths.get(INVALID_DIR)).toBeExecutable()
+        }
+    }
+
+    @Test
+    fun toBeARegularFile() {
+        val file = tempDir.newFile(TEST_FILE)
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(file).toBeARegularFile()
+
+        fails {
+            expect(dir).toBeARegularFile()
+        }
+    }
+
+
+    @Test
+    fun toBeADirectory() {
+        val file = tempDir.newFile(TEST_FILE)
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).toBeADirectory()
+
+        fails {
+            expect(file).toBeADirectory()
+        }
+    }
+
+    @Test
+    fun toBeAbsolute() {
+        val dir = tempDir.newDirectory(ABSOLUTE_DIR)
+
+        expect(dir).toBeAbsolute()
+
+        fails {
+            expect(Paths.get(RELATIVE_DIR)).toBeAbsolute()
+        }
+    }
+
+    @Test
+    fun toBeRelative() {
+        expect(Paths.get(RELATIVE_DIR)).toBeRelative()
+
+        fails {
+            expect(tempDir.newDirectory(ABSOLUTE_DIR)).toBeRelative()
+        }
+    }
+
+    @Test
+    fun toHaveDirectoryEntries() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+        val file = dir.newFile(TEST_FILE)
+
+        expect(dir).toHaveTheDirectoryEntries(TEST_FILE)
+
+        file.delete()
+
+        fails {
+            expect(dir).toHaveTheDirectoryEntries(TEST_FILE)
+        }
+
+    }
+
+    @Test
+    fun toHaveSameTextualContentAs() {
+        val notEmptyFilePath = tempDir.newFile("${TEST_FILE}_1")
+        notEmptyFilePath.toFile().writeText("test_test")
+
+        val expectedFilePath = tempDir.newFile("${TEST_FILE}_2")
+        expectedFilePath.toFile().writeText("test_test")
+
+        val emptyFilePath = tempDir.newFile("${TEST_FILE}_3")
+
+        expect(notEmptyFilePath).toHaveTheSameTextualContentAs(expectedFilePath)
+
+        fails {
+            expect(emptyFilePath).toHaveTheSameTextualContentAs(expectedFilePath)
+        }
+    }
+
+    @Test
+    fun toHaveTheSameBinaryContentAs() {
+        val notEmptyFilePath = tempDir.newFile("${TEST_FILE}_1")
+        notEmptyFilePath.toFile().writeBytes(byteArrayOf(1, 2, 3))
+
+        val expectedFilePath = tempDir.newFile("${TEST_FILE}_2")
+        expectedFilePath.toFile().writeBytes(byteArrayOf(1, 2, 3))
+
+        val emptyFilePath = tempDir.newFile("${TEST_FILE}_3")
+
+        expect(notEmptyFilePath).toHaveTheSameBinaryContentAs(expectedFilePath)
+
+        fails {
+            expect(emptyFilePath).toHaveTheSameBinaryContentAs(expectedFilePath)
+        }
+    }
+
+    @Test
+    fun testPathExtensionFeature() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).extension.notToBeEmpty().toEndWith(TEST_DIR)
+
+        fails {
+            expect(dir).extension.toBeEmpty().toEndWith(INVALID_DIR)
+        }
+    }
+
+    @Test
+    fun testPathExtension() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).extension {
+            notToBeEmpty()
+            toEndWith(TEST_DIR)
+        }
+
+        fails {
+            expect(dir).extension {
+                toBeEmpty()
+                toEndWith(INVALID_DIR)
+            }
+        }
+    }
+
+    @Test
+    fun testFileNameFeature() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).fileName.toEndWith(TEST_DIR).notToStartWith(INVALID_DIR).notToBeBlank()
+
+        fails {
+            expect(dir).fileName.toEndWith(INVALID_DIR).toStartWith(TEST_DIR)
+        }
+    }
+
+    @Test
+    fun testFileName() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).fileName {
+            toEndWith(TEST_DIR)
+            notToStartWith(INVALID_DIR)
+            notToBeBlank()
+        }
+
+        fails {
+            expect(dir).fileName {
+                toEndWith(INVALID_DIR)
+                toStartWith(TEST_DIR)
+            }
+        }
+    }
+
+    @Test
+    fun testFileNameWithoutExtensionFeature() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).fileNameWithoutExtension.notToBeEmpty().toEqual(TEST_DIR)
+
+        fails {
+            expect(dir).fileNameWithoutExtension.toBeEmpty().notToEqual(TEST_DIR)
+        }
+    }
+
+    @Test
+    fun testFileNameWithoutExtension() {
+        val dir = tempDir.newDirectory(TEST_DIR)
+
+        expect(dir).fileNameWithoutExtension {
+            notToBeEmpty()
+            toEqual(TEST_DIR)
+        }
+
+        fails {
+            expect(dir).fileNameWithoutExtension {
+                toBeEmpty()
+                notToEqual(TEST_DIR)
+            }
+        }
+    }
+
+    @Test
+    fun testParentFeature() {
+        val dir = tempDir.newFile("${TEST_DIR}_1")
+        val dir2 = tempDir.newFile("${TEST_DIR}_2")
+
+        expect(dir).parent.toEqual(dir2.parent)
+
+        fails {
+            expect(dir).parent.toEqual(dir2.newFile(TEST_DIR))
+        }
+    }
+
+    @Test
+    fun testParent() {
+        val dir = tempDir.newFile("${TEST_DIR}_1")
+        val dir2 = tempDir.newFile("${TEST_DIR}_2")
+
+        expect(dir).parent {
+            toEqual(dir2.parent)
+        }
+
+        fails {
+            expect(dir).parent {
+                toEqual(dir2.newFile(TEST_DIR))
+            }
+        }
+    }
+
+    private companion object {
+        private const val TEST_DIR = "test_dir"
+        private const val TEST_FILE = "test_file"
+        private const val INVALID_DIR = "invalid_dir"
+
+        private const val RELATIVE_DIR = "relative_dir"
+        private const val ABSOLUTE_DIR = "absolute_dir"
+    }
+
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -252,10 +252,10 @@ class PathExpectationSamples {
             .notToEndWith("jpg")
 
         fails {
-            expect(dir).extension         // subject is now of type String (actually "txt")
+            expect(dir).extension // subject is now of type String (actually "txt")
                 .toEqual("txtt")  // fails because it doesn't equal to "txtt"
                 .toEndWith("jpg") // not reported
-            //                               use `.extension` if you want that all expectations are evaluated
+            //                       use `.extension` if you want that all expectations are evaluated
         }
     }
 
@@ -271,10 +271,10 @@ class PathExpectationSamples {
         }
 
         fails {
-            expect(dir).extension {      // subject is now of type String (actually "txt")
-                toEqual("txtt")  // fails because it doesn't equal to "txtt"
-                toEndWith("jpg") // fails because it doesn't end with "jpg"
-                //                          use `.extension` if you want fail fast behaviour
+            expect(dir).extension { // subject is now of type String (actually "txt")
+                toEqual("txtt")     // fails because it doesn't equal to "txtt"
+                toEndWith("jpg")    // fails because it doesn't end with "jpg"
+                //                     use `.extension` if you want fail fast behaviour
             }
         }
     }
@@ -289,10 +289,10 @@ class PathExpectationSamples {
             .notToBeBlank()
 
         fails {
-            expect(dir).fileName                // subject is now of type String (actually "test_dir")
+            expect(dir).fileName        // subject is now of type String (actually "test_dir")
                 .toEndWith("foo")       // fails because it does not end with "foo"
                 .toStartWith("invalid") // not reported
-            //                                     use `fileName {...}` if you want that all expectations are evaluated
+            //                             use `fileName {...}` if you want that all expectations are evaluated
         }
     }
 
@@ -307,10 +307,10 @@ class PathExpectationSamples {
         }
 
         fails {
-            expect(dir).fileName {              // subject is now of type String (actually "test_dir")
+            expect(dir).fileName {      // subject is now of type String (actually "test_dir")
                 toEndWith("foo")        // fails because it does not end with "foo"
                 toStartWith("invalid")  // still evaluated even though `toEndWith("foo")` already fails
-                //                                 use `.fileName` if you want fail fast behaviour
+                //                         use `.fileName` if you want fail fast behaviour
             }
         }
     }
@@ -324,7 +324,7 @@ class PathExpectationSamples {
         fails {
             expect(dir).fileNameWithoutExtension // subject is now of type String (actually "test_dir")
                 .toBeEmpty()                     // fails because string is not empty
-                .notToEqual("test_dir")  // not reported toBeEmpty already fails
+                .notToEqual("test_dir")          // not reported toBeEmpty already fails
             //                                      use `.fileNameWithoutExtension { ... }` if you want that all expectations are evaluated
         }
     }
@@ -341,7 +341,7 @@ class PathExpectationSamples {
         fails {                                     // because fileNameWithoutExtension equals `test_dir`
             expect(dir).fileNameWithoutExtension {  // subject is now of type String (actually "test_dir")
                 toBeEmpty()                         // fails because string is not empty
-                notToEqual("test_dir")      // still evaluated even though `toBeEmpty()` already fails
+                notToEqual("test_dir")              // still evaluated even though `toBeEmpty()` already fails
                 //                                     use `.fileNameWithoutExtension` if you want a fail fast behaviour
             }
         }
@@ -394,9 +394,9 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).resolve("test_file.ttt")
-                .toEqual(fileInDir)               //fails because resolve returns *test_file.ttt and fileInDir equals *test_file.txt
+                .toEqual(fileInDir)          // fails because resolve returns *test_file.ttt and fileInDir equals *test_file.txt
                 .toEndWith(Paths.get("ttt")) // not reported `toEqual(fileInDir)` already fails
-            //                                      use `.resolve(other) { ... }` if you want that all expectations are evaluated
+            //                                  use `.resolve(other) { ... }` if you want that all expectations are evaluated
         }
     }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -55,10 +55,10 @@ class PathExpectationSamples {
     fun notToStartWith() {
         val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir.last()).notToStartWith(Paths.get("invalid_dir"))
+        expect(dir).notToStartWith(Paths.get("invalid_dir"))
 
         fails {
-            expect(dir.last()).notToStartWith(Paths.get("test_dir"))
+            expect(dir).notToStartWith(dir.parent)
         }
     }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -252,10 +252,10 @@ class PathExpectationSamples {
             .notToEndWith("jpg")
 
         fails {
-            expect(dir).extension // subject is now of type String (actually "txt")
-                .toEqual("txtt") // fails because it doesn't equal to "txtt"
-                .toEndWith("jpg") // not reported
-            //                              use `.extension` if you want that all expectations are evaluated
+            expect(dir).extension //            subject is now of type String (actually "txt")
+                .toEqual("txtt") //     fails because it doesn't equal to "txtt"
+                .toEndWith("jpg") //    not reported
+            //                                  use `.extension` if you want that all expectations are evaluated
         }
     }
 
@@ -271,10 +271,10 @@ class PathExpectationSamples {
         }
 
         fails {
-            expect(dir).extension { // subject is now of type String (actually "txt")
-                toEqual("txtt") // fails because it doesn't equal to "txtt"
+            expect(dir).extension { //      subject is now of type String (actually "txt")
+                toEqual("txtt") //  fails because it doesn't equal to "txtt"
                 toEndWith("jpg") // fails because it doesn't end with "jpg"
-                //                          use `.extension` if you want fail fast behaviour
+            //                              use `.extension` if you want fail fast behaviour
             }
         }
     }
@@ -289,10 +289,10 @@ class PathExpectationSamples {
             .notToBeBlank()
 
         fails {
-            expect(dir).fileName // subject is now of type String (actually "test_dir")
-                .toEndWith("foo") // fails because it does not end with "foo"
-                .toStartWith("invalid") // not reported
-            //                      use `fileName {...}` if you want that all expectations are evaluated
+            expect(dir).fileName //                 subject is now of type String (actually "test_dir")
+                .toEndWith("foo") //        fails because it does not end with "foo"
+                .toStartWith("invalid") //  not reported
+            //                                      use `fileName {...}` if you want that all expectations are evaluated
         }
     }
 
@@ -307,10 +307,10 @@ class PathExpectationSamples {
         }
 
         fails {
-            expect(dir).fileName { // subject is now of type String (actually "test_dir")
-                toEndWith("foo") // fails because it does not end with "foo"
-                toStartWith("invalid") // still evaluated even though `toEndWith("foo")` already fails
-                //                           use `.fileName` if you want fail fast behaviour
+            expect(dir).fileName { //               subject is now of type String (actually "test_dir")
+                toEndWith("foo") //         fails because it does not end with "foo"
+                toStartWith("invalid") //   still evaluated even though `toEndWith("foo")` already fails
+            //                                      use `.fileName` if you want fail fast behaviour
             }
         }
     }
@@ -323,9 +323,9 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).fileNameWithoutExtension // subject is now of type String (actually "test_dir")
-                .toBeEmpty() // fails because string is not empty
-                .notToEqual("test_dir") // not reported toBeEmpty already fails
-            //                   use `.fileNameWithoutExtension { ... }` if you want that all expectations are evaluated
+                .toBeEmpty() //                     fails because string is not empty
+                .notToEqual("test_dir") //  not reported toBeEmpty already fails
+            //                                      use `.fileNameWithoutExtension { ... }` if you want that all expectations are evaluated
         }
     }
 
@@ -338,11 +338,11 @@ class PathExpectationSamples {
             toEqual("test_dir")
         }
 
-        fails { // because fileNameWithoutExtension equals `test_dir`
+        fails { //                                    because fileNameWithoutExtension equals `test_dir`
             expect(dir).fileNameWithoutExtension { // subject is now of type String (actually "test_dir")
-                toBeEmpty() // fails because string is not empty
-                notToEqual("test_dir")  // still evaluated even though `toBeEmpty()` already fails
-                // use `.fileNameWithoutExtension` if you want a fail fast behaviour
+                toBeEmpty() //                        fails because string is not empty
+                notToEqual("test_dir") //     still evaluated even though `toBeEmpty()` already fails
+            //                                        use `.fileNameWithoutExtension` if you want a fail fast behaviour
             }
         }
     }
@@ -358,8 +358,8 @@ class PathExpectationSamples {
             val dir3 = dir2.newDirectory("test_dir")
             expect(dir).parent
                 .toEqual(dir3) // fails because dir3 and dir does not have same parents
-                .notToExist() // not reported `toEqual(dir3)` already fails
-            //                   use `.parent { ... }` if you want that all expectations are evaluated
+                .notToExist() //  not reported `toEqual(dir3)` already fails
+            //                    use `.parent { ... }` if you want that all expectations are evaluated
         }
     }
 
@@ -377,8 +377,8 @@ class PathExpectationSamples {
             val dir3 = dir2.newDirectory("test_dir")
             expect(dir).parent {
                 toEqual(dir3) // fails because dir3 and dir does not have same parents
-                notToExist() // still evaluated even though `toEqual(dir3)` already fails
-                //              use `.parent` if you want a fail fast behaviour
+                notToExist() //  still evaluated even though `toEqual(dir3)` already fails
+                //               use `.parent` if you want a fail fast behaviour
             }
         }
     }
@@ -394,9 +394,9 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).resolve("test_file.ttt")
-                .toEqual(fileInDir) // fails because resolve returns *test_file.ttt and fileInDir equals *test_file.txt
+                .toEqual(fileInDir) //              fails because resolve returns *test_file.ttt and fileInDir equals *test_file.txt
                 .toEndWith(Paths.get("ttt")) // not reported `toEqual(fileInDir)` already fails
-            //                       use `.resolve(other) { ... }` if you want that all expectations are evaluated
+            //                                      use `.resolve(other) { ... }` if you want that all expectations are evaluated
         }
     }
 
@@ -413,7 +413,7 @@ class PathExpectationSamples {
         fails {
             expect(dir).resolve("test_file.ttt") {
                 toEqual(fileInDir) // fails
-                toExist() // still evaluated even though `toEqual(fileInDir)` already fails
+                toExist()          // still evaluated even though `toEqual(fileInDir)` already fails
                 //                    use `.resolve(other).` if you want a fail fast behaviour
             }
         }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -3,8 +3,11 @@ package ch.tutteli.atrium.api.fluent.en_GB.samples
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.niok.*
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Paths
+import javax.swing.filechooser.FileSystemView
+import kotlin.test.AfterTest
 import kotlin.test.Test
 
 class PathExpectationSamples {
@@ -28,10 +31,10 @@ class PathExpectationSamples {
 
     @Test
     fun toBeAnEmptyDirectory() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
         expect(dir).toBeAnEmptyDirectory()
 
-        dir.newFile("$TEST_FILE.txt")
+        dir.newFile("test_file.txt")
         fails {
             expect(dir).toBeAnEmptyDirectory()
         }
@@ -39,64 +42,64 @@ class PathExpectationSamples {
 
     @Test
     fun toStartWith() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir.last()).toStartWith(Paths.get(TEST_DIR))
+        expect(dir).toStartWith(dir.parent)
 
         fails {
-            expect(dir.last()).toStartWith(Paths.get(INVALID_DIR))
+            expect(dir).toStartWith(Paths.get("invalid_dir"))
         }
     }
 
     @Test
     fun notToStartWith() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir.last()).notToStartWith(Paths.get(INVALID_DIR))
+        expect(dir.last()).notToStartWith(Paths.get("invalid_dir"))
 
         fails {
-            expect(dir.last()).notToStartWith(Paths.get(TEST_DIR))
+            expect(dir.last()).notToStartWith(Paths.get("test_dir"))
         }
     }
 
     @Test
     fun toEndWith() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir).toEndWith(Paths.get(TEST_DIR))
+        expect(dir).toEndWith(Paths.get("test_dir"))
 
         fails {
-            expect(dir).toEndWith(Paths.get(INVALID_DIR))
+            expect(dir).toEndWith(Paths.get("invalid_dir"))
         }
     }
 
     @Test
     fun notToEndWith() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir).notToEndWith(Paths.get(INVALID_DIR))
+        expect(dir).notToEndWith(Paths.get("invalid_dir"))
 
         fails {
-            expect(dir).notToEndWith(Paths.get(TEST_DIR))
+            expect(dir).notToEndWith(Paths.get("test_dir"))
         }
     }
 
     @Test
     fun toExist() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).toExist()
 
         fails {
-            expect(Paths.get(INVALID_DIR)).toExist()
+            expect(Paths.get("invalid_dir")).toExist()
         }
     }
 
     @Test
     fun notToExist() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(Paths.get(INVALID_DIR)).notToExist()
+        expect(Paths.get("invalid_dir")).notToExist()
 
         fails {
             expect(dir).notToExist()
@@ -106,41 +109,41 @@ class PathExpectationSamples {
 
     @Test
     fun toBeReadable() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).toBeReadable()
 
         fails {
-            expect(Paths.get(INVALID_DIR)).toBeReadable()
+            expect(Paths.get("invalid_dir")).toBeReadable()
         }
     }
 
     @Test
     fun toBeWritable() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).toBeWritable()
 
         fails {
-            expect(Paths.get(INVALID_DIR)).toBeWritable()
+            expect(Paths.get("invalid_dir")).toBeWritable()
         }
     }
 
     @Test
     fun toBeExecutable() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).toBeExecutable()
 
         fails {
-            expect(Paths.get(INVALID_DIR)).toBeExecutable()
+            expect(Paths.get("invalid_dir")).toBeExecutable()
         }
     }
 
     @Test
     fun toBeARegularFile() {
-        val file = tempDir.newFile(TEST_FILE)
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val file = tempDir.newFile("test_file")
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(file).toBeARegularFile()
 
@@ -152,8 +155,8 @@ class PathExpectationSamples {
 
     @Test
     fun toBeADirectory() {
-        val file = tempDir.newFile(TEST_FILE)
-        val dir = tempDir.newDirectory(TEST_DIR)
+        val file = tempDir.newFile("test_file")
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).toBeADirectory()
 
@@ -164,35 +167,38 @@ class PathExpectationSamples {
 
     @Test
     fun toBeAbsolute() {
-        val dir = tempDir.newDirectory(ABSOLUTE_DIR)
-
-        expect(dir).toBeAbsolute()
+        val fooAbsolutePath = FileSystemView.getFileSystemView().homeDirectory.toPath().resolve("foo")
+        expect(fooAbsolutePath).toBeAbsolute()
 
         fails {
-            expect(Paths.get(RELATIVE_DIR)).toBeAbsolute()
+            expect(Paths.get("relative/path")).toBeAbsolute()
         }
     }
 
     @Test
     fun toBeRelative() {
-        expect(Paths.get(RELATIVE_DIR)).toBeRelative()
+        expect(Paths.get("relative/path")).toBeRelative()
 
         fails {
-            expect(tempDir.newDirectory(ABSOLUTE_DIR)).toBeRelative()
+            val fooAbsolutePath = FileSystemView.getFileSystemView().homeDirectory.toPath().resolve("foo")
+            expect(fooAbsolutePath).toBeRelative()
         }
     }
 
     @Test
     fun toHaveTheDirectoryEntries() {
-        val dir = tempDir.newDirectory(TEST_DIR)
-        val file = dir.newFile(TEST_FILE)
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir).toHaveTheDirectoryEntries(TEST_FILE)
+        val file1 = dir.newFile("test_file1")
+        val file2 = dir.newFile("test_file2")
 
-        file.delete()
+        expect(dir).toHaveTheDirectoryEntries("test_file1", "test_file2")
+
+        file1.delete()
+        file2.delete()
 
         fails {
-            expect(dir).toHaveTheDirectoryEntries(TEST_FILE)
+            expect(dir).toHaveTheDirectoryEntries("test_file1", "test_file2")
         }
 
     }
@@ -201,13 +207,13 @@ class PathExpectationSamples {
     fun toHaveTheSameTextualContentAs() {
         val writtenTextInFile = "test_test"
 
-        val notEmptyFilePath = tempDir.newFile("${TEST_FILE}_1")
-        notEmptyFilePath.toFile().writeText(writtenTextInFile)
+        val notEmptyFilePath = tempDir.newFile("${"test_file"}_1")
+        notEmptyFilePath.writeText(writtenTextInFile)
 
-        val expectedFilePath = tempDir.newFile("${TEST_FILE}_2")
-        expectedFilePath.toFile().writeText(writtenTextInFile)
+        val expectedFilePath = tempDir.newFile("${"test_file"}_2")
+        expectedFilePath.writeText(writtenTextInFile)
 
-        val emptyFilePath = tempDir.newFile("${TEST_FILE}_3")
+        val emptyFilePath = tempDir.newFile("${"test_file"}_3")
 
         expect(notEmptyFilePath).toHaveTheSameTextualContentAs(expectedFilePath)
 
@@ -218,13 +224,13 @@ class PathExpectationSamples {
 
     @Test
     fun toHaveTheSameBinaryContentAs() {
-        val notEmptyFilePath = tempDir.newFile("${TEST_FILE}_1")
-        notEmptyFilePath.toFile().writeBytes(byteArrayOf(1, 2, 3))
+        val notEmptyFilePath = tempDir.newFile("${"test_file"}_1")
+        notEmptyFilePath.writeBytes(byteArrayOf(1, 2, 3))
 
-        val expectedFilePath = tempDir.newFile("${TEST_FILE}_2")
-        expectedFilePath.toFile().writeBytes(byteArrayOf(1, 2, 3))
+        val expectedFilePath = tempDir.newFile("${"test_file"}_2")
+        expectedFilePath.writeBytes(byteArrayOf(1, 2, 3))
 
-        val emptyFilePath = tempDir.newFile("${TEST_FILE}_3")
+        val emptyFilePath = tempDir.newFile("${"test_file"}_3")
 
         expect(notEmptyFilePath).toHaveTheSameBinaryContentAs(expectedFilePath)
 
@@ -234,9 +240,9 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun testPathExtensionFeature() {
+    fun pathExtensionFeature() {
         val extension = "txt"
-        val dir = tempDir.newFile("$TEST_FILE.$extension")
+        val dir = tempDir.newFile("test_file.$extension")
 
         expect(dir).extension.notToBeEmpty().toEqual(extension)
 
@@ -247,7 +253,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun testPathExtension() {
+    fun pathExtension() {
         val extension = "txt"
         val dir = tempDir.newDirectory("test.$extension")
 
@@ -264,78 +270,78 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun testFileNameFeature() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+    fun fileNameFeature() {
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir).fileName.toEndWith(TEST_DIR).notToStartWith(INVALID_DIR).notToBeBlank()
+        expect(dir).fileName.toEndWith("test_dir").notToStartWith("invalid_dir").notToBeBlank()
 
         fails {
-            expect(dir).fileName.toEndWith(INVALID_DIR).toStartWith(TEST_DIR)
+            expect(dir).fileName.toEndWith("invalid_dir").toStartWith("test_dir")
         }
     }
 
     @Test
-    fun testFileName() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+    fun fileName() {
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).fileName {
-            toEndWith(TEST_DIR)
-            notToStartWith(INVALID_DIR)
+            toEndWith("test_dir")
+            notToStartWith("invalid_dir")
             notToBeBlank()
         }
 
         fails {
             expect(dir).fileName {
-                toEndWith(INVALID_DIR)
-                toStartWith(TEST_DIR)
+                toEndWith("invalid_dir")
+                toStartWith("test_dir")
             }
         }
     }
 
     @Test
-    fun testFileNameWithoutExtensionFeature() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+    fun fileNameWithoutExtensionFeature() {
+        val dir = tempDir.newDirectory("test_dir")
 
-        expect(dir).fileNameWithoutExtension.notToBeEmpty().toEqual(TEST_DIR)
+        expect(dir).fileNameWithoutExtension.notToBeEmpty().toEqual("test_dir")
 
         fails {
-            expect(dir).fileNameWithoutExtension.toBeEmpty().notToEqual(TEST_DIR)
+            expect(dir).fileNameWithoutExtension.toBeEmpty().notToEqual("test_dir")
         }
     }
 
     @Test
-    fun testFileNameWithoutExtension() {
-        val dir = tempDir.newDirectory(TEST_DIR)
+    fun fileNameWithoutExtension() {
+        val dir = tempDir.newDirectory("test_dir")
 
         expect(dir).fileNameWithoutExtension {
             notToBeEmpty()
-            toEqual(TEST_DIR)
+            toEqual("test_dir")
         }
 
         fails {
             expect(dir).fileNameWithoutExtension {
                 toBeEmpty()
-                notToEqual(TEST_DIR)
+                notToEqual("test_dir")
             }
         }
     }
 
     @Test
-    fun testParentFeature() {
-        val dir = tempDir.newDirectory("${TEST_DIR}_1")
-        val dir2 = tempDir.newDirectory("${TEST_DIR}_2")
+    fun parentFeature() {
+        val dir = tempDir.newDirectory("${"test_dir"}_1")
+        val dir2 = tempDir.newDirectory("${"test_dir"}_2")
 
         expect(dir).parent.toEqual(dir2.parent)
 
         fails {
-            expect(dir).parent.toEqual(dir2.newDirectory(TEST_DIR))
+            expect(dir).parent.toEqual(dir2.newDirectory("test_dir"))
         }
     }
 
     @Test
-    fun testParent() {
-        val dir = tempDir.newDirectory("${TEST_DIR}_1")
-        val dir2 = tempDir.newDirectory("${TEST_DIR}_2")
+    fun parent() {
+        val dir = tempDir.newDirectory("${"test_dir"}_1")
+        val dir2 = tempDir.newDirectory("${"test_dir"}_2")
 
         expect(dir).parent {
             toEqual(dir2.parent)
@@ -343,47 +349,38 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).parent {
-                toEqual(dir2.newDirectory(TEST_DIR))
+                toEqual(dir2.newDirectory("test_dir"))
             }
         }
     }
 
     @Test
-    fun testResolveFeature() {
-        val dir = tempDir.newDirectory(TEST_DIR)
-        val fileInDir = dir.newFile("$TEST_FILE.txt")
+    fun resolveFeature() {
+        val dir = tempDir.newDirectory("test_dir")
+        val fileInDir = dir.newFile("test_file.txt")
 
-        expect(dir).resolve("$TEST_FILE.txt").toEqual(fileInDir)
+        expect(dir).resolve("test_file.txt").toEqual(fileInDir)
 
         fails {
-            expect(dir).resolve("$TEST_FILE.ttt").toEqual(fileInDir)
+            expect(dir).resolve("test_file.ttt").toEqual(fileInDir)
         }
     }
 
     @Test
-    fun testResolve() {
-        val dir = tempDir.newDirectory(TEST_DIR)
-        val fileInDir = dir.newFile("$TEST_FILE.txt")
+    fun resolve() {
+        val dir = tempDir.newDirectory("test_dir")
+        val fileInDir = dir.newFile("test_file.txt")
 
-        expect(dir).resolve("$TEST_FILE.txt") {
+        expect(dir).resolve("test_file.txt") {
             toEqual(fileInDir)
             toExist()
         }
 
         fails {
-            expect(dir).resolve("$TEST_FILE.ttt") {
+            expect(dir).resolve("test_file.ttt") {
                 toEqual(fileInDir)
             }
         }
-    }
-
-    private companion object {
-        private const val TEST_DIR = "test_dir"
-        private const val TEST_FILE = "test_file"
-        private const val INVALID_DIR = "invalid_dir"
-
-        private const val RELATIVE_DIR = "relative_dir"
-        private const val ABSOLUTE_DIR = "absolute_dir"
     }
 
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -252,10 +252,10 @@ class PathExpectationSamples {
             .notToEndWith("jpg")
 
         fails {
-            expect(dir).extension //            subject is now of type String (actually "txt")
-                .toEqual("txtt") //     fails because it doesn't equal to "txtt"
-                .toEndWith("jpg") //    not reported
-            //                                  use `.extension` if you want that all expectations are evaluated
+            expect(dir).extension         // subject is now of type String (actually "txt")
+                .toEqual("txtt")  // fails because it doesn't equal to "txtt"
+                .toEndWith("jpg") // not reported
+            //                               use `.extension` if you want that all expectations are evaluated
         }
     }
 
@@ -271,10 +271,10 @@ class PathExpectationSamples {
         }
 
         fails {
-            expect(dir).extension { //      subject is now of type String (actually "txt")
-                toEqual("txtt") //  fails because it doesn't equal to "txtt"
+            expect(dir).extension {      // subject is now of type String (actually "txt")
+                toEqual("txtt")  // fails because it doesn't equal to "txtt"
                 toEndWith("jpg") // fails because it doesn't end with "jpg"
-            //                              use `.extension` if you want fail fast behaviour
+                //                          use `.extension` if you want fail fast behaviour
             }
         }
     }
@@ -289,10 +289,10 @@ class PathExpectationSamples {
             .notToBeBlank()
 
         fails {
-            expect(dir).fileName //                 subject is now of type String (actually "test_dir")
-                .toEndWith("foo") //        fails because it does not end with "foo"
-                .toStartWith("invalid") //  not reported
-            //                                      use `fileName {...}` if you want that all expectations are evaluated
+            expect(dir).fileName                // subject is now of type String (actually "test_dir")
+                .toEndWith("foo")       // fails because it does not end with "foo"
+                .toStartWith("invalid") // not reported
+            //                                     use `fileName {...}` if you want that all expectations are evaluated
         }
     }
 
@@ -307,10 +307,10 @@ class PathExpectationSamples {
         }
 
         fails {
-            expect(dir).fileName { //               subject is now of type String (actually "test_dir")
-                toEndWith("foo") //         fails because it does not end with "foo"
-                toStartWith("invalid") //   still evaluated even though `toEndWith("foo")` already fails
-            //                                      use `.fileName` if you want fail fast behaviour
+            expect(dir).fileName {              // subject is now of type String (actually "test_dir")
+                toEndWith("foo")        // fails because it does not end with "foo"
+                toStartWith("invalid")  // still evaluated even though `toEndWith("foo")` already fails
+                //                                 use `.fileName` if you want fail fast behaviour
             }
         }
     }
@@ -323,8 +323,8 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).fileNameWithoutExtension // subject is now of type String (actually "test_dir")
-                .toBeEmpty() //                     fails because string is not empty
-                .notToEqual("test_dir") //  not reported toBeEmpty already fails
+                .toBeEmpty()                     // fails because string is not empty
+                .notToEqual("test_dir")  // not reported toBeEmpty already fails
             //                                      use `.fileNameWithoutExtension { ... }` if you want that all expectations are evaluated
         }
     }
@@ -338,11 +338,11 @@ class PathExpectationSamples {
             toEqual("test_dir")
         }
 
-        fails { //                                    because fileNameWithoutExtension equals `test_dir`
-            expect(dir).fileNameWithoutExtension { // subject is now of type String (actually "test_dir")
-                toBeEmpty() //                        fails because string is not empty
-                notToEqual("test_dir") //     still evaluated even though `toBeEmpty()` already fails
-            //                                        use `.fileNameWithoutExtension` if you want a fail fast behaviour
+        fails {                                     // because fileNameWithoutExtension equals `test_dir`
+            expect(dir).fileNameWithoutExtension {  // subject is now of type String (actually "test_dir")
+                toBeEmpty()                         // fails because string is not empty
+                notToEqual("test_dir")      // still evaluated even though `toBeEmpty()` already fails
+                //                                     use `.fileNameWithoutExtension` if you want a fail fast behaviour
             }
         }
     }
@@ -358,7 +358,7 @@ class PathExpectationSamples {
             val dir3 = dir2.newDirectory("test_dir")
             expect(dir).parent
                 .toEqual(dir3) // fails because dir3 and dir does not have same parents
-                .notToExist() //  not reported `toEqual(dir3)` already fails
+                .notToExist()  // not reported `toEqual(dir3)` already fails
             //                    use `.parent { ... }` if you want that all expectations are evaluated
         }
     }
@@ -377,7 +377,7 @@ class PathExpectationSamples {
             val dir3 = dir2.newDirectory("test_dir")
             expect(dir).parent {
                 toEqual(dir3) // fails because dir3 and dir does not have same parents
-                notToExist() //  still evaluated even though `toEqual(dir3)` already fails
+                notToExist()  // still evaluated even though `toEqual(dir3)` already fails
                 //               use `.parent` if you want a fail fast behaviour
             }
         }
@@ -394,7 +394,7 @@ class PathExpectationSamples {
 
         fails {
             expect(dir).resolve("test_file.ttt")
-                .toEqual(fileInDir) //              fails because resolve returns *test_file.ttt and fileInDir equals *test_file.txt
+                .toEqual(fileInDir)               //fails because resolve returns *test_file.ttt and fileInDir equals *test_file.txt
                 .toEndWith(Paths.get("ttt")) // not reported `toEqual(fileInDir)` already fails
             //                                      use `.resolve(other) { ... }` if you want that all expectations are evaluated
         }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-jvm/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -240,7 +240,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun pathExtensionFeature() {
+    fun extensionFeature() {
         val extension = "txt"
         val dir = tempDir.newFile("test_file.$extension")
 
@@ -253,7 +253,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun pathExtension() {
+    fun extension() {
         val extension = "txt"
         val dir = tempDir.newDirectory("test.$extension")
 


### PR DESCRIPTION
- [x]  add one function per function in pathExpectations.kt and non deprectated function in pathAssertions to PathExpectationSamples (see PathExpectationSamples)

- [x] for functions having two overloads where one expects an assertionCreator in addition -- add the suffix Feature to the function name of the one not expecting assertionCreator (see ListExpectationSamples)

- [x]  refer to the sample in the KDoc of the corresponding function in pathExpectations and pathAssertions via @sample (check out toEqual in anyExpectations.kt to see how you have to refer to the sample)

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
