### PR TITLE
Make notToContain less verbose and show mismatched indices

### DIFF
--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
@@ -42,11 +42,20 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
             }
         }
         val description = searchBehaviour.decorateDescription(descriptionContains)
-        return assertionBuilder.list
+        val inAnyOrderAssertion = assertionBuilder.list
             .withDescriptionAndEmptyRepresentation(description)
             .withAssertions(assertions)
             .build()
+        return decorateInAnyOrderAssertion(inAnyOrderAssertion, multiConsumableContainer)
     }
+
+    /**
+     * Override in a subclass if you want to decorate the assertion.
+     */
+    protected open fun decorateInAnyOrderAssertion(
+        inAnyOrderAssertion: AssertionGroup,
+        multiConsumableContainer: AssertionContainer<TT>
+    ): AssertionGroup = inAnyOrderAssertion
 
     /**
      * Make the underlying subject multiple times consumable.

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
@@ -5,7 +5,6 @@ import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.Contains
-import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.reporting.translating.Translatable
 
 /**

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
@@ -2,10 +2,10 @@ package ch.tutteli.atrium.logic.creating.basic.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
-import ch.tutteli.atrium.assertions.AssertionGroupType
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.Contains
+import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.reporting.translating.Translatable
 
 /**
@@ -32,7 +32,7 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
     checkers: List<C>
 ) : ContainsAssertionCreator<T, TT, SC, C>(searchBehaviour, checkers) {
 
-    final override fun searchAndCreateAssertion(
+    override fun searchAndCreateAssertion(
         multiConsumableContainer: AssertionContainer<TT>,
         searchCriterion: SC,
         featureFactory: (Int, Translatable) -> AssertionGroup
@@ -40,11 +40,10 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
         val count = search(multiConsumableContainer, searchCriterion)
         val featureAssertion = featureFactory(count, descriptionNumberOfOccurrences)
 
-        val inAnyOrderAssertion =  assertionBuilder.list
+        return assertionBuilder.list
             .withDescriptionAndRepresentation(groupDescription, searchCriterion)
             .withAssertion(featureAssertion)
             .build()
-        return decorateInAnyOrderAssertion(inAnyOrderAssertion, multiConsumableContainer)
     }
 
     /**

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
@@ -40,10 +40,11 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
         val count = search(multiConsumableContainer, searchCriterion)
         val featureAssertion = featureFactory(count, descriptionNumberOfOccurrences)
 
-        return assertionBuilder.customType(getAssertionGroupType())
+        val inAnyOrderAssertion =  assertionBuilder.list
             .withDescriptionAndRepresentation(groupDescription, searchCriterion)
-            .withAssertions(decorateAssertion(multiConsumableContainer, featureAssertion))
+            .withAssertion(featureAssertion)
             .build()
+        return decorateInAnyOrderAssertion(inAnyOrderAssertion, multiConsumableContainer)
     }
 
     /**
@@ -55,11 +56,6 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
      * Provides the translation for [AssertionGroup.description]
      */
     protected abstract val groupDescription: Translatable
-
-    /**
-     * Provides the [AssertionGroupType] for the resulting [AssertionGroup].
-     */
-    protected abstract fun getAssertionGroupType(): AssertionGroupType
 
 
     /**
@@ -73,9 +69,4 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
      * @return The number of times the [searchCriterion] matched in the subject of this expectation.
      */
     protected abstract fun search(multiConsumableContainer: AssertionContainer<TT>, searchCriterion: SC): Int
-
-    /**
-     * Either return the given [featureAssertion] as [List] or add further assertions.
-     */
-    abstract fun decorateAssertion(container: AssertionContainer<TT>, featureAssertion: Assertion): List<Assertion>
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator.kt
@@ -2,8 +2,6 @@ package ch.tutteli.atrium.logic.creating.charsequence.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
-import ch.tutteli.atrium.assertions.AssertionGroupType
-import ch.tutteli.atrium.assertions.DefaultListAssertionGroupType
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.changeSubject
 import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains.*
@@ -40,8 +38,6 @@ class CharSequenceContainsAssertionCreator<T : CharSequence, in SC : Any, S : Se
     override val descriptionContains: Translatable = DescriptionCharSequenceAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionCharSequenceAssertion.NUMBER_OF_OCCURRENCES
 
-    override fun getAssertionGroupType(): AssertionGroupType = DefaultListAssertionGroupType
-
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<String> =
         container.changeSubject.unreported { it.toString() }.toAssertionContainer()
 
@@ -49,9 +45,4 @@ class CharSequenceContainsAssertionCreator<T : CharSequence, in SC : Any, S : Se
         // if the maybeSubject is None it means we are in an explanation like context in which
         // it should not matter what this number is. Moreover, we check in the atMostChecker that times is >= 0
         multiConsumableContainer.maybeSubject.fold({ -1 }) { searcher.search(it, searchCriterion) }
-
-    override fun decorateAssertion(
-        container: AssertionContainer<String>,
-        featureAssertion: Assertion
-    ): List<Assertion> = listOf(featureAssertion)
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -62,7 +62,6 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
         inAnyOrderAssertion: AssertionGroup,
         multiConsumableContainer: AssertionContainer<List<E?>>
     ): AssertionGroup {
-        val list = multiConsumableContainer.maybeSubject.getOrElse { emptyList() }
         return if (searchBehaviour is NotSearchBehaviour) {
             assertionBuilder.invisibleGroup
                 .withAssertions(
@@ -119,29 +118,6 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
         val count = list.count { allCreatedAssertionsHold(container, it, assertionCreatorOrNull) }
         return group to count
     }
-
-//    //TODO 0.18.0 check if this is still state of the art to add a hint that no assertion was created
-//    // in the assertionCreator-lambda, maybe it is a special case and needs to be handled like this,
-//    // maybe it would be enough to collect
-//    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
-//    @UseExperimental(ExperimentalComponentFactoryContainer::class)
-//    private fun addEmptyAssertionCreatorLambdaIfNecessary(
-//        container: AssertionContainer<*>,
-//        assertions: MutableList<Assertion>,
-//        searchCriterion: (Expect<E>.() -> Unit)?,
-//        count: Int
-//    ) {
-//        if (searchCriterion != null && count == 0) {
-//            val collectingExpect = CollectingExpect<E>(None, container.components)
-//            // not using addAssertionsCreatedBy on purpose so that we don't append a failing assertion
-//            collectingExpect.searchCriterion()
-//            val collectedAssertions = collectingExpect.getAssertions()
-//            if (collectedAssertions.isEmpty()) {
-//                // no assertion created in the lambda, so lets add the failing assertion containing the hint
-//                assertions.add(container.collectBasedOnSubject(None, searchCriterion))
-//            }
-//        }
-//    }
 
     @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
     @UseExperimental(ExperimentalComponentFactoryContainer::class)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -95,11 +95,15 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
                 allCreatedAssertionsHold(multiConsumableContainer, element, searchCriterion)
             }
             assertions.add(createExplanatoryGroupForMismatches(mismatches))
+            val hasNext = multiConsumableContainer.hasNext(::identity).holds()
             return assertionBuilder.fixedClaimGroup
                 .withListType
-                .withClaim(mismatches.isEmpty() && emptyAssertionHint == null)
+                .withClaim(mismatches.isEmpty() && hasNext && emptyAssertionHint == null)
                 .withDescriptionAndEmptyRepresentation(AN_ELEMENT_WHICH)
-                .withAssertions(assertions)
+                .let {
+                    if (hasNext) it.withAssertions(assertions)
+                    else it.withAssertion(explanatoryGroup)
+                }
                 .build()
         } else {
             return assertionBuilder.list

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.*
+import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.assertions.builders.invisibleGroup
 import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.creators.impl.ContainsObjectsAssertionCreator
@@ -38,31 +40,26 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
     override val descriptionNumberOfOccurrences: Translatable = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES
     override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
 
-    override fun getAssertionGroupType(): AssertionGroupType {
-        return if (searchBehaviour is NotSearchBehaviour) {
-            DefaultSummaryAssertionGroupType
-        } else {
-            DefaultListAssertionGroupType
-        }
-    }
-
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<List<SC>> =
         turnSubjectToList(container, converter)
 
     override fun search(multiConsumableContainer: AssertionContainer<List<SC>>, searchCriterion: SC): Int =
         multiConsumableContainer.maybeSubject.fold({ -1 }) { subject -> subject.filter { it == searchCriterion }.size }
 
-    override fun decorateAssertion(
-        container: AssertionContainer<List<SC>>,
-        featureAssertion: Assertion
-    ): List<Assertion> {
+    /**
+     * Override in a subclass if you want to decorate the assertion.
+     */
+    override fun decorateInAnyOrderAssertion(
+        inAnyOrderAssertion: AssertionGroup,
+        multiConsumableContainer: AssertionContainer<List<SC>>
+    ): AssertionGroup {
         return if (searchBehaviour is NotSearchBehaviour) {
-            listOf(
-                featureAssertion,
-                createHasElementAssertion(container.maybeSubject.getOrElse { emptyList() })
-            )
+            assertionBuilder.invisibleGroup.withAssertions(
+                createHasElementAssertion(multiConsumableContainer.maybeSubject.getOrElse { emptyList() }),
+                inAnyOrderAssertion
+            ).build()
         } else {
-            listOf(featureAssertion)
+            inAnyOrderAssertion
         }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -3,7 +3,6 @@ package ch.tutteli.atrium.logic.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.builders.*
 import ch.tutteli.atrium.core.Option
-import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.IterableLikeAssertions
@@ -27,7 +26,6 @@ import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion.NEXT_ELEMENT
-import ch.tutteli.kbox.WithIndex
 import ch.tutteli.kbox.mapWithIndex
 
 class DefaultIterableLikeAssertions : IterableLikeAssertions {
@@ -101,17 +99,7 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
         val mismatches = createIndexAssertions(list) { (_, element) ->
             !allCreatedAssertionsHold(container, element, assertionCreatorOrNull)
         }
-        assertions.add(
-            assertionBuilder.explanatoryGroup
-                .withWarningType
-                .withAssertion(
-                    assertionBuilder.list
-                        .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.WARNING_MISMATCHES)
-                        .withAssertions(mismatches)
-                        .build()
-                )
-                .build()
-        )
+        assertions.add(createExplanatoryGroupForMismatches(mismatches))
 
         createHasElementPlusFixedClaimGroup(
             list,
@@ -133,22 +121,6 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
                 else -> iterable.toList()
             }
         }
-
-    private fun <E> createIndexAssertions(
-        list: List<E>,
-        predicate: (WithIndex<E>) -> Boolean
-    ) = list
-        .asSequence()
-        .mapWithIndex()
-        .filter { predicate(it) }
-        .map { (index, element) ->
-            assertionBuilder.createDescriptive(
-                TranslatableWithArgs(DescriptionIterableAssertion.INDEX, index),
-                element,
-                falseProvider
-            )
-        }
-        .toList()
 
     private fun <E> createHasElementPlusFixedClaimGroup(
         list: List<E>,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -85,5 +85,6 @@ internal fun createExplanatoryGroupForMismatches(
                 .withAssertions(mismatches)
                 .build()
         )
+        .failing
         .build()
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -5,14 +5,18 @@ import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Some
+import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.core.trueProvider
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.collectBasedOnSubject
 import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.reporting.Text
+import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
+import ch.tutteli.kbox.WithIndex
+import ch.tutteli.kbox.mapWithIndex
 
 internal fun createHasElementAssertion(list: List<*>): Assertion {
     return assertionBuilder.feature
@@ -51,5 +55,35 @@ internal fun <E : Any> createExplanatoryAssertionGroup(
                 )
             }
         }
+        .build()
+}
+
+internal fun <E> createIndexAssertions(
+    list: List<E>,
+    predicate: (WithIndex<E>) -> Boolean
+) = list
+    .asSequence()
+    .mapWithIndex()
+    .filter { predicate(it) }
+    .map { (index, element) ->
+        assertionBuilder.createDescriptive(
+            TranslatableWithArgs(DescriptionIterableAssertion.INDEX, index),
+            element,
+            falseProvider
+        )
+    }
+    .toList()
+
+internal fun createExplanatoryGroupForMismatches(
+    mismatches: List<Assertion>
+) : AssertionGroup {
+    return assertionBuilder.explanatoryGroup
+        .withWarningType
+        .withAssertion(
+            assertionBuilder.list
+                .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.WARNING_MISMATCHES)
+                .withAssertions(mismatches)
+                .build()
+        )
         .build()
 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
@@ -45,7 +45,6 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
     ) = notToContainNullableEntries(this, a, aX)
 
     val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
-    val hasElement = DescriptionIterableAssertion.HAS_ELEMENT.getDefault()
 
     nonNullableCases(
         describePrefix,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
@@ -67,9 +67,9 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                     message {
                         toContainRegex(
                             "$hasANextElement$separator" +
-                                "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
-                                "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
-                                "$afterExplanatory$toBeDescr: 4.0.*"
+                                "$indentRootBulletPoint\\Q$explanatoryBulletPoint\\E$notToContainDescr: $separator" +
+                                "$indentRootBulletPoint$indentListBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
+                                "$indentListBulletPoint$afterExplanatory$toBeDescr: 4.0.*"
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
@@ -66,11 +66,7 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                     fluent.notToContainFun({ toEqual(4.0) })
                 }.toThrow<AssertionError> {
                     message {
-                        toContainRegex(
-                            "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
-                                "$indentRootBulletPoint$hasElement: false$separator" +
-                                "$isDescr: true"
-                        )
+                        toContainRegex(hasANextElement)
                         notToContain(anElementWhich)
                     }
                 }
@@ -101,10 +97,10 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeLessThanDescr: 4.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 3$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(1, "2.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(5, "3.0")}.*"
                             )
                         }
                     }
@@ -118,16 +114,14 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeDescr: 1.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 1$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true$separator" +
+                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*$separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeDescr: 4.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 3$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(2, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(3, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(8, "4.0")}.*"
                             )
                         }
                     }
@@ -164,10 +158,9 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$isDescr: null$separator" +
-                                    "$featureFailing$numberOfOccurrences: 2$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(1, "null")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(5, "null")}.*"
                             )
                         }
                     }
@@ -182,10 +175,9 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$isDescr: null$separator" +
-                                    "$featureFailing$numberOfOccurrences: 2$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterMismatchedWarning${index(1)}: null.*$separator" +
+                                    "$afterMismatchedWarning${index(5)}: null.*"
                             )
                             this.notToContain("$notToContainDescr: 1.1")
                         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
@@ -65,8 +65,12 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                     fluent.notToContainFun({ toEqual(4.0) })
                 }.toThrow<AssertionError> {
                     message {
-                        toContainRegex(hasANextElement)
-                        notToContain(anElementWhich)
+                        toContainRegex(
+                            "$hasANextElement$separator" +
+                                "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
+                                "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
+                                "$afterExplanatory$toBeDescr: 4.0.*"
+                        )
                     }
                 }
             }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
@@ -68,13 +68,10 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                     message {
                         toContainRegex(
                             "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
-                                "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
-                                "$afterExplanatory$toBeDescr: 4.0.*$separator" +
-                                "$featureSuccess$numberOfOccurrences: 0$separator" +
-                                "$isAfterSuccess: 0.*$separator" +
-                                "$featureFailing$hasElement: false$separator" +
-                                "$isAfterFailing: true"
+                                "$indentRootBulletPoint$hasElement: false$separator" +
+                                "$isDescr: true"
                         )
+                        notToContain(anElementWhich)
                     }
                 }
             }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainEntriesExpectationsSpec.kt
@@ -100,7 +100,7 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeLessThanDescr: 4.0.*$separator" +
-                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*$separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(1, "2.0")}.*$separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(5, "3.0")}.*"
@@ -117,11 +117,11 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeDescr: 1.0.*$separator" +
-                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*$separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeDescr: 4.0.*$separator" +
-                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(2, "4.0")}.*$separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(3, "4.0")}.*$separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(8, "4.0")}.*"
@@ -161,7 +161,7 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$isDescr: null$separator" +
-                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(1, "null")}.*$separator" +
                                     "$afterMismatchedWarning${mismatchedIndex(5, "null")}.*"
                             )
@@ -178,7 +178,7 @@ abstract class IterableNotToContainEntriesExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$isDescr: null$separator" +
-                                    "$afterExplanatoryIndent$warningBulletPoint$mismatches: $separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
                                     "$afterMismatchedWarning${index(1)}: null.*$separator" +
                                     "$afterMismatchedWarning${index(5)}: null.*"
                             )

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainValuesExpectationsSpec.kt
@@ -46,12 +46,9 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                 }.toThrow<AssertionError> {
                     message {
                         toContainRegex(
-                            "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
-                                "$anElementWhichIsWithIndent: 4.0.*$separator" +
-                                "$featureSuccess$numberOfOccurrences: 0$separator" +
-                                "$isAfterSuccess: 0.*$separator" +
-                                "$featureFailing$hasElement: false$separator" +
-                                "$isAfterFailing: true"
+                            "$hasANextElement$separator" +
+                                    "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
+                                    "$anElementWhichIsWithIndent: 4.0.*"
                         )
                     }
                 }
@@ -81,10 +78,10 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                             toContainRegex(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$anElementWhichIsWithIndent: 4.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 3$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(2, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(3, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(8, "4.0")}.*"
                             )
                         }
                     }
@@ -97,15 +94,13 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                             toContainRegex(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$anElementWhichIsWithIndent: 1.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 1$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true$separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*$separator" +
                                     "$anElementWhichIsWithIndent: 4.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 3$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(2, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(3, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(8, "4.0")}.*"
                             )
                         }
                     }
@@ -118,15 +113,13 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                             toContainRegex(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$anElementWhichIsWithIndent: 4.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 3$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true$separator" +
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(2, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(3, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(8, "4.0")}.*$separator" +
                                     "$anElementWhichIsWithIndent: 1.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 1$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*"
                             )
                         }
                     }
@@ -152,10 +145,9 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                             toContainRegex(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$anElementWhichIsWithIndent: null$separator" +
-                                    "$featureFailing$numberOfOccurrences: 2$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(1, "null")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(5, "null")}.*"
                             )
                         }
                     }
@@ -169,10 +161,9 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                             toContainRegex(
                                 "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
                                     "$anElementWhichIsWithIndent: null$separator" +
-                                    "$featureFailing$numberOfOccurrences: 2$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(1, "null")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(5, "null")}.*"
                             )
                             notToContain("$notToContainDescr: 1.1")
                         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainValuesExpectationsSpec.kt
@@ -4,7 +4,6 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
 abstract class IterableNotToContainValuesExpectationsSpec(
     notToContainValues: Fun2<Iterable<Double>, Double, Array<out Double>>,
@@ -23,8 +22,6 @@ abstract class IterableNotToContainValuesExpectationsSpec(
 
     fun Expect<Iterable<Double?>>.notToContainNullableFun(a: Double?, vararg aX: Double?) =
         notToContainNullableValues(this, a, aX)
-
-    val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
 
     val anElementWhichIsWithIndent = "$indentRootBulletPoint$listBulletPoint$anElementWhichIs"
 
@@ -46,8 +43,8 @@ abstract class IterableNotToContainValuesExpectationsSpec(
                     message {
                         toContainRegex(
                             "$hasANextElement$separator" +
-                                    "\\Q$rootBulletPoint\\E$notToContainDescr: $separator" +
-                                    "$anElementWhichIsWithIndent: 4.0.*"
+                                    "$indentRootBulletPoint\\Q$explanatoryBulletPoint\\E$notToContainDescr: $separator" +
+                                    "$indentListBulletPoint$anElementWhichIsWithIndent: 4.0.*"
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableNotToContainValuesExpectationsSpec.kt
@@ -25,7 +25,6 @@ abstract class IterableNotToContainValuesExpectationsSpec(
         notToContainNullableValues(this, a, aX)
 
     val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
-    val hasElement = DescriptionIterableAssertion.HAS_ELEMENT.getDefault()
 
     val anElementWhichIsWithIndent = "$indentRootBulletPoint$listBulletPoint$anElementWhichIs"
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -41,7 +41,7 @@ abstract class IterableToContainEntriesSpecBase(
         val isAfterSuccess = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow\\Q$featureBulletPoint\\E$isDescr"
         val afterExplanatory = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint\\Q$explanatoryBulletPoint\\E"
         val afterExplanatoryIndent = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint"
-        val afterMismatchedWarning = "$afterExplanatoryIndent$indentWarningBulletPoint$listBulletPoint"
+        val afterMismatchedWarning = "$afterExplanatoryIndent$indentWarningBulletPoint\\Q$listBulletPoint\\E"
         val hasANextElement = "\\Q$rootBulletPoint\\E$hasDescriptionBasic: $nextElement"
         //@formatter:on
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -3,7 +3,6 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
-import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionComparableAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import org.spekframework.spek2.dsl.Root
@@ -24,9 +23,6 @@ abstract class IterableToContainEntriesSpecBase(
         val anElementWhich = DescriptionIterableAssertion.AN_ELEMENT_WHICH.getDefault()
         val toBeLessThanDescr = DescriptionComparableAssertion.IS_LESS_THAN.getDefault()
         val toBeGreaterThanDescr = DescriptionComparableAssertion.IS_GREATER_THAN.getDefault()
-        val hasDescriptionBasic = DescriptionBasic.HAS.getDefault()
-        val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
-        val mismatches = DescriptionIterableAssertion.WARNING_MISMATCHES.getDefault()
         fun <T> mismatchedIndex(index: Int, value: T) : String {
             val indexDescr = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
             return "$indexDescr: ${value.toString()}"
@@ -35,10 +31,6 @@ abstract class IterableToContainEntriesSpecBase(
         fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
 
         //@formatter:off
-        val featureSuccess = "$indentRootBulletPoint$indentListBulletPoint\\Q$successfulBulletPoint$featureArrow\\E"
-        val featureFailing = "$indentRootBulletPoint$indentListBulletPoint\\Q$failingBulletPoint$featureArrow\\E"
-        val isAfterFailing = "$indentRootBulletPoint$indentListBulletPoint$indentFailingBulletPoint$indentFeatureArrow\\Q$featureBulletPoint\\E$isDescr"
-        val isAfterSuccess = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow\\Q$featureBulletPoint\\E$isDescr"
         val afterExplanatory = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint\\Q$explanatoryBulletPoint\\E"
         val afterExplanatoryIndent = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint"
         val afterMismatchedWarning = "$afterExplanatoryIndent$indentWarningBulletPoint\\Q$listBulletPoint\\E"

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -28,8 +28,8 @@ abstract class IterableToContainEntriesSpecBase(
         val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
         val mismatches = DescriptionIterableAssertion.WARNING_MISMATCHES.getDefault()
         fun <T> mismatchedIndex(index: Int, value: T) : String {
-            val index = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
-            return "$index: ${value.toString()}"
+            val indexDescr = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
+            return "$indexDescr: ${value.toString()}"
         }
 
         fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionComparableAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import org.spekframework.spek2.dsl.Root
@@ -23,7 +24,15 @@ abstract class IterableToContainEntriesSpecBase(
         val anElementWhich = DescriptionIterableAssertion.AN_ELEMENT_WHICH.getDefault()
         val toBeLessThanDescr = DescriptionComparableAssertion.IS_LESS_THAN.getDefault()
         val toBeGreaterThanDescr = DescriptionComparableAssertion.IS_GREATER_THAN.getDefault()
+        val hasDescriptionBasic = DescriptionBasic.HAS.getDefault()
+        val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
+        val mismatches = DescriptionIterableAssertion.WARNING_MISMATCHES.getDefault()
+        fun <T> mismatchedIndex(index: Int, value: T) : String {
+            val index = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
+            return "$index: ${value.toString()}"
+        }
 
+        fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
 
         //@formatter:off
         val featureSuccess = "$indentRootBulletPoint$indentListBulletPoint\\Q$successfulBulletPoint$featureArrow\\E"
@@ -31,6 +40,9 @@ abstract class IterableToContainEntriesSpecBase(
         val isAfterFailing = "$indentRootBulletPoint$indentListBulletPoint$indentFailingBulletPoint$indentFeatureArrow\\Q$featureBulletPoint\\E$isDescr"
         val isAfterSuccess = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow\\Q$featureBulletPoint\\E$isDescr"
         val afterExplanatory = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint\\Q$explanatoryBulletPoint\\E"
+        val afterExplanatoryIndent = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint"
+        val afterMismatchedWarning = "$afterExplanatoryIndent$indentWarningBulletPoint$listBulletPoint"
+        val hasANextElement = "\\Q$rootBulletPoint\\E$hasDescriptionBasic: $nextElement"
         //@formatter:on
 
     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.toContain
 import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import org.spekframework.spek2.Spek
@@ -43,6 +44,9 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val mismatchesAdditionalElements = DescriptionIterableAssertion.WARNING_MISMATCHES_ADDITIONAL_ELEMENTS.getDefault()
         val sizeExceeded = DescriptionIterableAssertion.SIZE_EXCEEDED.getDefault()
         val anElementWhichIs = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS.getDefault()
+        val hasDescriptionBasic = DescriptionBasic.HAS.getDefault()
+        val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
+        val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
 
         val sizeDescr = DescriptionCollectionAssertion.SIZE.getDefault()
         val atLeastDescr = DescriptionIterableAssertion.AT_LEAST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndNoneExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndNoneExpectationsSpec.kt
@@ -42,7 +42,14 @@ abstract class IterableToHaveElementsAndNoneExpectationsSpec(
                 expect {
                     expect(fluentEmpty()).toHaveElementsAndNoneFun { toBeLessThan(1.0) }
                 }.toThrow<AssertionError> {
-                    messageToContain("$featureArrow$hasElement: false")
+                    message {
+                        toContainRegex(
+                            "$hasANextElement$separator" +
+                                "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
+                                "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
+                                "$afterExplanatory$toBeLessThanDescr: 1.0.*"
+                        )
+                    }
                 }
             }
         }
@@ -66,10 +73,10 @@ abstract class IterableToHaveElementsAndNoneExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeDescr: 4.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 3$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(2, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(3, "4.0")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(8, "4.0")}.*"
                             )
                         }
                     }
@@ -96,10 +103,9 @@ abstract class IterableToHaveElementsAndNoneExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$isDescr: null$separator" +
-                                    "$featureFailing$numberOfOccurrences: 2$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(1, "null")}.*$separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(5, "null")}.*"
                             )
                         }
                     }
@@ -114,10 +120,8 @@ abstract class IterableToHaveElementsAndNoneExpectationsSpec(
                                 "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
                                     "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
                                     "$afterExplanatory$toBeDescr: 1.0.*$separator" +
-                                    "$featureFailing$numberOfOccurrences: 1$separator" +
-                                    "$isAfterFailing: 0.*$separator" +
-                                    "$featureSuccess$hasElement: true$separator" +
-                                    "$isAfterSuccess: true"
+                                    "$afterExplanatoryIndent\\Q$warningBulletPoint$mismatches:\\E $separator" +
+                                    "$afterMismatchedWarning${mismatchedIndex(0, "1.0")}.*"
                             )
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndNoneExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndNoneExpectationsSpec.kt
@@ -29,7 +29,6 @@ abstract class IterableToHaveElementsAndNoneExpectationsSpec(
     ) {})
 
     val containsNotDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
-    val hasElement = DescriptionIterableAssertion.HAS_ELEMENT.getDefault()
 
     nonNullableCases(
         describePrefix,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndNoneExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndNoneExpectationsSpec.kt
@@ -44,9 +44,9 @@ abstract class IterableToHaveElementsAndNoneExpectationsSpec(
                     message {
                         toContainRegex(
                             "$hasANextElement$separator" +
-                                "\\Q$rootBulletPoint\\E$containsNotDescr: $separator" +
-                                "$indentRootBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
-                                "$afterExplanatory$toBeLessThanDescr: 1.0.*"
+                                "$indentRootBulletPoint\\Q$explanatoryBulletPoint\\E$containsNotDescr: $separator" +
+                                "$indentRootBulletPoint$indentListBulletPoint\\Q$listBulletPoint\\E$anElementWhich: $separator" +
+                                "$indentListBulletPoint$afterExplanatory$toBeLessThanDescr: 1.0.*"
                         )
                     }
                 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -160,7 +160,7 @@ buildscript {
                 "IterableContains.*Spec.*points to containsNot",
                 // we improved reporting for containsNoDuplicates
                 "IterableExpectationsSpec.*`(containsNoDuplicates|contains noDuplicates)`",
-                // we improved reporting for notToContain
+                // we improved reporting for notToContain with 0.17.0
                 "IterableContainsNot(Entries|Values)ExpectationsSpec.*`containsNot.*`.*throws AssertionError",
                 "IterableNoneExpectationsSpec.*`(none|containsNot).*`.*throws AssertionError"
             ) + ".*)").let { commonPatterns ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,10 @@ buildscript {
                         "BigDecimalAssertionsSpec.*overload throws PleaseUseReplacementException",
                         // we renamed containsNot to notToContain with 0.17.0
                         "CharSequenceContains.*Spec.*points to containsNot",
-                        "IterableContains.*Spec.*points to containsNot"
+                        "IterableContains.*Spec.*points to containsNot",
+                        // we improved reporting for notToContain with 0.17.0
+                        "IterableContainsNot(Entries|Values)AssertionsSpec.*`containsNot( nullable)?`.*throws AssertionError",
+                        "IterableNoneAssertionsSpec.*`(none|containsNot)( nullable)?`.*throws AssertionError"
                     ) + ".*)",
                 // we don't use asci bullet points in reporting since 0.17.0
                 // but have own tests to assure that changing bullet points work
@@ -92,7 +95,10 @@ buildscript {
                         "BigDecimalAssertionsSpec.*overload throws PleaseUseReplacementException.*",
                         // we renamed containsNot to notToContain with 0.17.0
                         "CharSequenceContains.*Spec.*points to containsNot",
-                        "IterableContains.*Spec.*points to containsNot"
+                        "IterableContains.*Spec.*points to containsNot",
+                        // we improved reporting for notToContain with 0.17.0
+                        "IterableContainsNot(Entries|Values)AssertionsSpec.*`containsNot.*`.*throws AssertionError",
+                        "IterableNoneAssertionsSpec.*`(none|containsNot).*`.*throws AssertionError"
                     ) + ".*)",
                 // we don't use asci bullet points in reporting since 0.17.0
                 // but have own tests to assure that changing bullet points work
@@ -153,7 +159,10 @@ buildscript {
                 "CharSequenceContains.*Spec.*points to containsNot",
                 "IterableContains.*Spec.*points to containsNot",
                 // we improved reporting for containsNoDuplicates
-                "IterableExpectationsSpec.*`(containsNoDuplicates|contains noDuplicates)`"
+                "IterableExpectationsSpec.*`(containsNoDuplicates|contains noDuplicates)`",
+                // we improved reporting for notToContain
+                "IterableContainsNot(Entries|Values)ExpectationsSpec.*`containsNot.*`.*throws AssertionError",
+                "IterableNoneExpectationsSpec.*`(none|containsNot).*`.*throws AssertionError"
             ) + ".*)").let { commonPatterns ->
                 Pair(
                     // bc


### PR DESCRIPTION
Work in progress pull request. Resolves #722.

- [X] Modify `ContainsAssertionCreator` so that subclasses can decorate the assertion
- [X] Modify `InAnyOrderEntriesAssertionCreator` in the `NotSearchBehavior` case:
  - [X] Remove feature assertion about the number of occurrences
  - [X] Add explanatory group with the mismatches
  - [X] Use `_logic.hasNext` to decorate the parent assertion
  - [X] Modify specs
- [x] Refactor `expect(IterableLike).all` to use new methods in `containsHelpers`.
- [x] Modify `InAnyOrderValuesAssertionCreator` and/or `ContainsObjectsAssertionCreator` in the `NotSearchBehavior` case:
  - [x] Decorate parent assertion with `_logic.hasNext`
  - [x] Remove feature assertion about the number of occurrences
  - [x] Add explanatory group with mismatches
  - [x] Modify specs
- [x] Forgive backward compatability for changing specs

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
