### PR TITLE
More consise reporting for contains.atLeast(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,8 +999,7 @@ expect(listOf(1, 2, 2, 4)).toContain(2, 3)
 expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>)
 ◆ contains, in any order: 
   ⚬ an element which equals: 3        (kotlin.Int <1234789>)
-    ⚬ ▶ number of such entries: 0
-        ◾ is at least: 1
+      » but no such element was found
 ```
 </ex-collection-short-1>
  
@@ -1039,13 +1038,11 @@ expected that subject: [1, 2, 2, 4]        (java.util.Arrays.ArrayList <1234789>
 ◆ contains, in any order: 
   ⚬ an element which: 
       » is less than: 0        (kotlin.Int <1234789>)
-    ⚬ ▶ number of such entries: 0
-        ◾ is at least: 1
+      » but no such element was found
   ⚬ an element which: 
       » is greater than: 2        (kotlin.Int <1234789>)
       » is less than: 4        (kotlin.Int <1234789>)
-    ⚬ ▶ number of such entries: 0
-        ◾ is at least: 1
+      » but no such element was found
 ```
 </ex-collection-short-2>
 
@@ -1085,8 +1082,7 @@ expected that subject: [1, 2, 3, 4]        (java.util.Arrays.ArrayList <1234789>
 ◆ contains, in any order: 
   ⚬ an element which: 
       » is less than: 0        (kotlin.Int <1234789>)
-    ⚬ ▶ number of such entries: 0
-        ◾ is at least: 1
+      » but no such element was found
 ```
 </ex-collection-any>
 <hr/>
@@ -1739,8 +1735,7 @@ expected that subject: "calling myNullableFun with ..."        <1234789>
 ◆ ▶ myNullableFun(-2147483648): null
       » contains: 
         ⚬ value: "min"        <1234789>
-          ⚬ ▶ number of matches: 
-              ◾ is at least: 1
+            » but no match was found
 ◆ ▶ myNullableFun(2147483647): "2147483647"        <1234789>
     ◾ equals: "max"        <1234789>
 ```
@@ -1888,8 +1883,7 @@ expected that subject: () -> kotlin.Nothing        (readme.examples.MostExamples
           ◾ is instance of type: String (kotlin.String) -- Class: java.lang.String
           ◾ contains: 
             ⚬ value: "no no no"        <1234789>
-              ⚬ ▶ number of matches: 
-                  ◾ is at least: 1
+                » but no match was found
     ℹ Properties of the unexpected IllegalArgumentException
       » message: "no no no..."        <1234789>
       » stacktrace: 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
@@ -33,7 +33,7 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
     protected abstract val descriptionContains: Translatable
 
     /**
-     * Provides the translation for `but no such item was found`.
+     * Provides the translation for when an item is not found in a `contains.atLeast(1)` check.
      */
     protected abstract val descriptionNotFound: Translatable
 
@@ -101,9 +101,11 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
                     if (checker.createAssertion(count).holds()) it
                     else it.failing
                 }.build()
-        } else assertionBuilder.feature
-            .withDescriptionAndRepresentation(numberOfOccurrences, Text(count.toString()))
-            .withAssertions(assertions)
-            .build()
+        } else {
+            assertionBuilder.feature
+                .withDescriptionAndRepresentation(numberOfOccurrences, Text(count.toString()))
+                .withAssertions(assertions)
+                .build()
+        }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
@@ -6,10 +6,8 @@ import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.Contains
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
 import ch.tutteli.atrium.logic.creating.basic.contains.checkers.AtLeastChecker
-import ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl.DefaultIterableLikeContainsAssertions
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
-import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
 /**
  * Represents the base class for [Contains.Creator]s, providing a template to fulfill its job.

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
@@ -5,8 +5,11 @@ import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.Contains
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
+import ch.tutteli.atrium.logic.creating.basic.contains.checkers.AtLeastChecker
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl.DefaultIterableLikeContainsAssertions
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
 /**
  * Represents the base class for [Contains.Creator]s, providing a template to fulfill its job.
@@ -30,6 +33,11 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
      * Provides the translation for `contains`.
      */
     protected abstract val descriptionContains: Translatable
+
+    /**
+     * Provides the translation for `but no such item was found`.
+     */
+    protected abstract val descriptionNotFound: Translatable
 
     final override fun createAssertionGroup(
         container: AssertionContainer<T>,
@@ -83,7 +91,19 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
 
     private fun featureFactory(count: Int, numberOfOccurrences: Translatable): AssertionGroup {
         val assertions = checkers.map { it.createAssertion(count) }
-        return assertionBuilder.feature
+        val checker = checkers.firstOrNull()
+        return if (checkers.size == 1 && checker is AtLeastChecker && checker.times == 1) {
+            assertionBuilder.explanatoryGroup
+                .withDefaultType
+                .withAssertion(
+                    assertionBuilder.explanatory
+                        .withExplanation(descriptionNotFound)
+                        .build()
+                ).let {
+                    if (checker.createAssertion(count).holds()) it
+                    else it.failing
+                }.build()
+        } else assertionBuilder.feature
             .withDescriptionAndRepresentation(numberOfOccurrences, Text(count.toString()))
             .withAssertions(assertions)
             .build()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator.kt
@@ -2,12 +2,14 @@ package ch.tutteli.atrium.logic.creating.basic.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.assertions.builders.withExplanatoryAssertion
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.Contains
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
 import ch.tutteli.atrium.logic.creating.basic.contains.checkers.AtLeastChecker
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 
 /**
  * Represents the base class for [Contains.Creator]s, providing a template to fulfill its job.
@@ -36,6 +38,12 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
      * Provides the translation for when an item is not found in a `contains.atLeast(1)` check.
      */
     protected abstract val descriptionNotFound: Translatable
+
+    /**
+     * Provides the translation for `and N such elements were found` when an item is not found in a
+     * `contains.atLeast(1)` check.
+     */
+    protected abstract val descriptionNumberOfElementsFound: Translatable
 
     final override fun createAssertionGroup(
         container: AssertionContainer<T>,
@@ -91,16 +99,20 @@ abstract class ContainsAssertionCreator<T : Any, TT : Any, in SC, C : Contains.C
         val assertions = checkers.map { it.createAssertion(count) }
         val checker = checkers.firstOrNull()
         return if (checkers.size == 1 && checker is AtLeastChecker && checker.times == 1) {
-            assertionBuilder.explanatoryGroup
-                .withDefaultType
-                .withAssertion(
-                    assertionBuilder.explanatory
-                        .withExplanation(descriptionNotFound)
-                        .build()
-                ).let {
-                    if (checker.createAssertion(count).holds()) it
-                    else it.failing
-                }.build()
+            if (checker.createAssertion(count).holds()) {
+                assertionBuilder.explanatoryGroup
+                    .withDefaultType
+                    .withExplanatoryAssertion(
+                        TranslatableWithArgs(descriptionNumberOfElementsFound, count.toString())
+                    )
+                    .build()
+            } else {
+                assertionBuilder.explanatoryGroup
+                    .withDefaultType
+                    .withExplanatoryAssertion(descriptionNotFound)
+                    .failing
+                    .build()
+            }
         } else {
             assertionBuilder.feature
                 .withDescriptionAndRepresentation(numberOfOccurrences, Text(count.toString()))

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator.kt
@@ -38,6 +38,7 @@ class CharSequenceContainsAssertionCreator<T : CharSequence, in SC : Any, S : Se
     override val descriptionContains: Translatable = DescriptionCharSequenceAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionCharSequenceAssertion.NUMBER_OF_OCCURRENCES
     override val descriptionNotFound: Translatable = DescriptionCharSequenceAssertion.NOT_FOUND
+    override val descriptionNumberOfElementsFound: Translatable = DescriptionCharSequenceAssertion.NUMBER_OF_MATCHES_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<String> =
         container.changeSubject.unreported { it.toString() }.toAssertionContainer()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator.kt
@@ -37,6 +37,7 @@ class CharSequenceContainsAssertionCreator<T : CharSequence, in SC : Any, S : Se
 
     override val descriptionContains: Translatable = DescriptionCharSequenceAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionCharSequenceAssertion.NUMBER_OF_OCCURRENCES
+    override val descriptionNotFound: Translatable = DescriptionCharSequenceAssertion.NOT_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<String> =
         container.changeSubject.unreported { it.toString() }.toAssertionContainer()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -53,6 +53,7 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
     IterableLikeContains.Creator<T, (Expect<E>.() -> Unit)?> {
 
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
+    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.ENTRY_NOT_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<List<E?>> =
         turnSubjectToList(container, converter)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -53,7 +53,8 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
     IterableLikeContains.Creator<T, (Expect<E>.() -> Unit)?> {
 
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
-    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.ENTRY_NOT_FOUND
+    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.ELEMENT_NOT_FOUND
+    override val descriptionNumberOfElementsFound: Translatable = DescriptionIterableAssertion.NUMBER_OF_ELEMENTS_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<List<E?>> =
         turnSubjectToList(container, converter)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -51,23 +51,16 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
     override fun search(multiConsumableContainer: AssertionContainer<List<SC>>, searchCriterion: SC): Int =
         multiConsumableContainer.maybeSubject.fold({ -1 }) { subject -> subject.filter { it == searchCriterion }.size }
 
-    override fun searchAndCreateAssertion(
+    /**
+     * Override in any subclass that wants to report mismatched elements individually when the [searchBehaviour]
+     * is [NotSearchBehaviour]
+     */
+    override fun mismatchesForNotSearchBehaviour(
         multiConsumableContainer: AssertionContainer<List<SC>>,
-        searchCriterion: SC,
-        featureFactory: (Int, Translatable) -> AssertionGroup
-    ): AssertionGroup {
-        return if (searchBehaviour is NotSearchBehaviour) {
-            val list = multiConsumableContainer.maybeSubject.getOrElse { emptyList() }
-            val mismatches = createIndexAssertions(list) { (_, element) -> element == searchCriterion }
-            val assertions = mutableListOf<Assertion>()
-            if (mismatches.isNotEmpty()) assertions.add(createExplanatoryGroupForMismatches(mismatches))
-            assertionBuilder.list
-                .withDescriptionAndRepresentation(groupDescription, searchCriterion)
-                .withAssertions(assertions)
-                .build()
-        } else {
-            super.searchAndCreateAssertion(multiConsumableContainer, searchCriterion, featureFactory)
-        }
+        searchCriterion: SC
+    ): List<Assertion> {
+        val list = multiConsumableContainer.maybeSubject.getOrElse { emptyList() }
+        return createIndexAssertions(list) { (_, element) -> element == searchCriterion }
     }
 
     /**

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -15,7 +15,6 @@ import ch.tutteli.atrium.logic.hasNext
 import ch.tutteli.atrium.logic.impl.createExplanatoryGroupForMismatches
 import ch.tutteli.atrium.logic.impl.createIndexAssertions
 import ch.tutteli.atrium.reporting.translating.Translatable
-import ch.tutteli.atrium.translations.DescriptionCharSequenceAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.kbox.identity
 
@@ -44,7 +43,7 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES
     override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
-    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.ITEM_NOT_FOUND
+    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.VALUE_NOT_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<List<SC>> =
         turnSubjectToList(container, converter)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -43,7 +43,8 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES
     override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
-    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.VALUE_NOT_FOUND
+    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.ELEMENT_NOT_FOUND
+    override val descriptionNumberOfElementsFound: Translatable = DescriptionIterableAssertion.NUMBER_OF_ELEMENTS_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<List<SC>> =
         turnSubjectToList(container, converter)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -15,6 +15,7 @@ import ch.tutteli.atrium.logic.hasNext
 import ch.tutteli.atrium.logic.impl.createExplanatoryGroupForMismatches
 import ch.tutteli.atrium.logic.impl.createIndexAssertions
 import ch.tutteli.atrium.reporting.translating.Translatable
+import ch.tutteli.atrium.translations.DescriptionCharSequenceAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.kbox.identity
 
@@ -43,6 +44,7 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
     override val descriptionContains: Translatable = DescriptionIterableAssertion.CONTAINS
     override val descriptionNumberOfOccurrences: Translatable = DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES
     override val groupDescription: Translatable = DescriptionIterableAssertion.AN_ELEMENT_WHICH_EQUALS
+    override val descriptionNotFound: Translatable = DescriptionIterableAssertion.ITEM_NOT_FOUND
 
     override fun makeSubjectMultipleTimesConsumable(container: AssertionContainer<T>): AssertionContainer<List<SC>> =
         turnSubjectToList(container, converter)

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainAtLeastExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainAtLeastExpectationsSpec.kt
@@ -142,7 +142,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                 it("${toContainAtLeastPair.first("'h'", "once")} throws AssertionError") {
                     expect {
                         fluentHelloWorld.toContainAtLeastFun(1, 'h')
-                    }.toThrow<AssertionError> { messageToContain(noSuchItemFoundDescr, "$valueWithIndent: 'h'") }
+                    }.toThrow<AssertionError> { messageToContain(noSuchItemDescr, "$valueWithIndent: 'h'") }
                 }
                 it("${toContainAtLeastIgnoringCasePair.first("'h'", "once")} does not throw") {
                     fluentHelloWorld.toContainAtLeastIgnoringCaseFun(1, 'h')
@@ -151,7 +151,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                 it("${toContainAtLeastPair.first("'H', 'E'", "once")} throws AssertionError") {
                     expect {
                         fluentHelloWorld.toContainAtLeastFun(1, 'H', 'E')
-                    }.toThrow<AssertionError> { messageToContain(noSuchItemFoundDescr, 'E') }
+                    }.toThrow<AssertionError> { messageToContain(noSuchItemDescr, 'E') }
                 }
                 it("${toContainAtLeastIgnoringCasePair.first("'H', 'E'", "once")} does not throw") {
                     fluentHelloWorld.toContainAtLeastIgnoringCaseFun(1, 'H', 'E')
@@ -162,7 +162,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                         fluentHelloWorld.toContainAtLeastFun(1, 'E', 'H')
                     }.toThrow<AssertionError> {
                         message {
-                            toContain(noSuchItemFoundDescr, "$valueWithIndent: 'E'")
+                            toContain(noSuchItemDescr, "$valueWithIndent: 'E'")
                             notToContain("$valueWithIndent: 'H'")
                         }
                     }
@@ -181,7 +181,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                         fluentHelloWorld.toContainAtLeastFun(1, 'H', 'E', 'w', 'r')
                     }.toThrow<AssertionError> {
                         message {
-                            toContain(noSuchItemFoundDescr, "$valueWithIndent: 'E'", "$valueWithIndent: 'w'")
+                            toContain(noSuchItemDescr, "$valueWithIndent: 'E'", "$valueWithIndent: 'w'")
                             notToContain("$valueWithIndent: 'H'", "$valueWithIndent: 'r'")
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainAtLeastExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainAtLeastExpectationsSpec.kt
@@ -142,7 +142,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                 it("${toContainAtLeastPair.first("'h'", "once")} throws AssertionError") {
                     expect {
                         fluentHelloWorld.toContainAtLeastFun(1, 'h')
-                    }.toThrow<AssertionError> { messageToContain("$atLeast: 1", "$valueWithIndent: 'h'") }
+                    }.toThrow<AssertionError> { messageToContain(noSuchItemFoundDescr, "$valueWithIndent: 'h'") }
                 }
                 it("${toContainAtLeastIgnoringCasePair.first("'h'", "once")} does not throw") {
                     fluentHelloWorld.toContainAtLeastIgnoringCaseFun(1, 'h')
@@ -151,7 +151,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                 it("${toContainAtLeastPair.first("'H', 'E'", "once")} throws AssertionError") {
                     expect {
                         fluentHelloWorld.toContainAtLeastFun(1, 'H', 'E')
-                    }.toThrow<AssertionError> { messageToContain(atLeast, 'E') }
+                    }.toThrow<AssertionError> { messageToContain(noSuchItemFoundDescr, 'E') }
                 }
                 it("${toContainAtLeastIgnoringCasePair.first("'H', 'E'", "once")} does not throw") {
                     fluentHelloWorld.toContainAtLeastIgnoringCaseFun(1, 'H', 'E')
@@ -162,7 +162,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                         fluentHelloWorld.toContainAtLeastFun(1, 'E', 'H')
                     }.toThrow<AssertionError> {
                         message {
-                            toContain("$atLeast: 1", "$valueWithIndent: 'E'")
+                            toContain(noSuchItemFoundDescr, "$valueWithIndent: 'E'")
                             notToContain("$valueWithIndent: 'H'")
                         }
                     }
@@ -181,7 +181,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                         fluentHelloWorld.toContainAtLeastFun(1, 'H', 'E', 'w', 'r')
                     }.toThrow<AssertionError> {
                         message {
-                            toContain("$atLeast: 1", "$valueWithIndent: 'E'", "$valueWithIndent: 'w'")
+                            toContain(noSuchItemFoundDescr, "$valueWithIndent: 'E'", "$valueWithIndent: 'w'")
                             notToContain("$valueWithIndent: 'H'", "$valueWithIndent: 'r'")
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainAtLeastExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainAtLeastExpectationsSpec.kt
@@ -142,7 +142,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                 it("${toContainAtLeastPair.first("'h'", "once")} throws AssertionError") {
                     expect {
                         fluentHelloWorld.toContainAtLeastFun(1, 'h')
-                    }.toThrow<AssertionError> { messageToContain(noSuchItemDescr, "$valueWithIndent: 'h'") }
+                    }.toThrow<AssertionError> { messageToContain(noMatchFoundDescr, "$valueWithIndent: 'h'") }
                 }
                 it("${toContainAtLeastIgnoringCasePair.first("'h'", "once")} does not throw") {
                     fluentHelloWorld.toContainAtLeastIgnoringCaseFun(1, 'h')
@@ -151,7 +151,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                 it("${toContainAtLeastPair.first("'H', 'E'", "once")} throws AssertionError") {
                     expect {
                         fluentHelloWorld.toContainAtLeastFun(1, 'H', 'E')
-                    }.toThrow<AssertionError> { messageToContain(noSuchItemDescr, 'E') }
+                    }.toThrow<AssertionError> { messageToContain(noMatchFoundDescr, 'E') }
                 }
                 it("${toContainAtLeastIgnoringCasePair.first("'H', 'E'", "once")} does not throw") {
                     fluentHelloWorld.toContainAtLeastIgnoringCaseFun(1, 'H', 'E')
@@ -162,7 +162,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                         fluentHelloWorld.toContainAtLeastFun(1, 'E', 'H')
                     }.toThrow<AssertionError> {
                         message {
-                            toContain(noSuchItemDescr, "$valueWithIndent: 'E'")
+                            toContain(noMatchFoundDescr, "$valueWithIndent: 'E'")
                             notToContain("$valueWithIndent: 'H'")
                         }
                     }
@@ -181,7 +181,7 @@ abstract class CharSequenceToContainAtLeastExpectationsSpec(
                         fluentHelloWorld.toContainAtLeastFun(1, 'H', 'E', 'w', 'r')
                     }.toThrow<AssertionError> {
                         message {
-                            toContain(noSuchItemDescr, "$valueWithIndent: 'E'", "$valueWithIndent: 'w'")
+                            toContain(noMatchFoundDescr, "$valueWithIndent: 'E'", "$valueWithIndent: 'w'")
                             notToContain("$valueWithIndent: 'H'", "$valueWithIndent: 'r'")
                         }
                     }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
@@ -42,8 +42,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                     messageToContain(
                         "$rootBulletPoint$toContainDescr: $separator" +
                             "$valueWithIndent: \"Hello\"",
-                        "$numberOfOccurrences: 0",
-                        "$atLeast: 1"
+                            noSuchItemFoundDescr
                     )
                 }
             }
@@ -104,8 +103,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             this.toContain.exactly(2).values(
-                                "$numberOfOccurrences: 0",
-                                "$atLeast: 1"
+                                noSuchItemFoundDescr
                             )
                             this.toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainDescr: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
@@ -42,7 +42,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                     messageToContain(
                         "$rootBulletPoint$toContainDescr: $separator" +
                             "$valueWithIndent: \"Hello\"",
-                            noSuchItemFoundDescr
+                            noSuchItemDescr
                     )
                 }
             }
@@ -103,7 +103,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             this.toContain.exactly(2).value(
-                                noSuchItemFoundDescr
+                                noSuchItemDescr
                             )
                             this.toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainDescr: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
@@ -102,7 +102,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                         fluent.toContainFun("hello", "robert")
                     }.toThrow<AssertionError> {
                         message {
-                            this.toContain.exactly(2).values(
+                            this.toContain.exactly(2).value(
                                 noSuchItemFoundDescr
                             )
                             this.toContain.exactly(1).values(

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainNotToContainExpectationsSpec.kt
@@ -42,7 +42,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                     messageToContain(
                         "$rootBulletPoint$toContainDescr: $separator" +
                             "$valueWithIndent: \"Hello\"",
-                            noSuchItemDescr
+                            noMatchFoundDescr
                     )
                 }
             }
@@ -103,7 +103,7 @@ abstract class CharSequenceToContainNotToContainExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             this.toContain.exactly(2).value(
-                                noSuchItemDescr
+                                noMatchFoundDescr
                             )
                             this.toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainDescr: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.specs.integration
 
-import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.fluent.en_GB.message
+import ch.tutteli.atrium.api.fluent.en_GB.toContain
+import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
@@ -134,8 +136,7 @@ abstract class CharSequenceToContainRegexExpectationsSpec(
                         toContain(
                             "$rootBulletPoint$toContainDescr: $separator" +
                                 "$regexWithIndent: ${roberto.toLowerCase()}",
-                            "$numberOfOccurrences: 0",
-                            "$atLeast: 1"
+                            noSuchItemFoundDescr
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
@@ -134,7 +134,7 @@ abstract class CharSequenceToContainRegexExpectationsSpec(
                         toContain(
                             "$rootBulletPoint$toContainDescr: $separator" +
                                 "$regexWithIndent: ${roberto.toLowerCase()}",
-                            noSuchItemDescr
+                            noMatchFoundDescr
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
@@ -1,8 +1,6 @@
 package ch.tutteli.atrium.specs.integration
 
-import ch.tutteli.atrium.api.fluent.en_GB.message
-import ch.tutteli.atrium.api.fluent.en_GB.toContain
-import ch.tutteli.atrium.api.fluent.en_GB.toThrow
+import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainRegexExpectationsSpec.kt
@@ -134,7 +134,7 @@ abstract class CharSequenceToContainRegexExpectationsSpec(
                         toContain(
                             "$rootBulletPoint$toContainDescr: $separator" +
                                 "$regexWithIndent: ${roberto.toLowerCase()}",
-                            noSuchItemFoundDescr
+                            noSuchItemDescr
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
@@ -20,7 +20,7 @@ abstract class CharSequenceToContainSpecBase(spec: Root.() -> Unit) : Spek(spec)
         val numberOfOccurrences = DescriptionCharSequenceAssertion.NUMBER_OF_OCCURRENCES.getDefault()
         val value = DescriptionCharSequenceAssertion.VALUE.getDefault()
         val stringMatchingRegex = DescriptionCharSequenceAssertion.STRING_MATCHING_REGEX.getDefault()
-        val noSuchItemFoundDescr = DescriptionCharSequenceAssertion.NOT_FOUND.getDefault()
+        val noSuchItemDescr = DescriptionCharSequenceAssertion.NOT_FOUND.getDefault()
 
         val atLeast = DescriptionCharSequenceAssertion.AT_LEAST.getDefault()
         val atMost = DescriptionCharSequenceAssertion.AT_MOST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
@@ -20,7 +20,7 @@ abstract class CharSequenceToContainSpecBase(spec: Root.() -> Unit) : Spek(spec)
         val numberOfOccurrences = DescriptionCharSequenceAssertion.NUMBER_OF_OCCURRENCES.getDefault()
         val value = DescriptionCharSequenceAssertion.VALUE.getDefault()
         val stringMatchingRegex = DescriptionCharSequenceAssertion.STRING_MATCHING_REGEX.getDefault()
-        val noSuchItemDescr = DescriptionCharSequenceAssertion.NOT_FOUND.getDefault()
+        val noMatchFoundDescr = DescriptionCharSequenceAssertion.NOT_FOUND.getDefault()
 
         val atLeast = DescriptionCharSequenceAssertion.AT_LEAST.getDefault()
         val atMost = DescriptionCharSequenceAssertion.AT_MOST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
@@ -20,6 +20,7 @@ abstract class CharSequenceToContainSpecBase(spec: Root.() -> Unit) : Spek(spec)
         val numberOfOccurrences = DescriptionCharSequenceAssertion.NUMBER_OF_OCCURRENCES.getDefault()
         val value = DescriptionCharSequenceAssertion.VALUE.getDefault()
         val stringMatchingRegex = DescriptionCharSequenceAssertion.STRING_MATCHING_REGEX.getDefault()
+        val noSuchItemFoundDescr = DescriptionCharSequenceAssertion.NOT_FOUND.getDefault()
 
         val atLeast = DescriptionCharSequenceAssertion.AT_LEAST.getDefault()
         val atMost = DescriptionCharSequenceAssertion.AT_MOST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -27,7 +27,7 @@ abstract class IterableToContainEntriesSpecBase(
             val indexDescr = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
             return "$indexDescr: ${value.toString()}"
         }
-        val noSuchEntryDescr = DescriptionIterableAssertion.ENTRY_NOT_FOUND.getDefault()
+        val noSuchEntryDescr = DescriptionIterableAssertion.ELEMENT_NOT_FOUND.getDefault()
 
         fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -27,6 +27,7 @@ abstract class IterableToContainEntriesSpecBase(
             val indexDescr = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
             return "$indexDescr: ${value.toString()}"
         }
+        val noSuchEntryDescr = DescriptionIterableAssertion.ENTRY_NOT_FOUND.getDefault()
 
         fun index(index: Int) = String.format(DescriptionIterableAssertion.INDEX.getDefault(), index)
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
@@ -6,7 +6,6 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.specs.*
 
-// TODO ED: update specs for drop number of occurrences
 abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
     toContainInAnyOrderEntries: Fun2<Iterable<Double>, Expect<Double>.() -> Unit, Array<out Expect<Double>.() -> Unit>>,
     toContainInAnyOrderNullableEntries: Fun2<Iterable<Double?>, (Expect<Double>.() -> Unit)?, Array<out (Expect<Double>.() -> Unit)?>>,
@@ -63,8 +62,9 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                             "$rootBulletPoint$toContainInAnyOrder: $separator",
                             "$anElementWhich: $separator",
                             "$toBeLessThanDescr: 1.0",
-                            "$numberOfOccurrences: 0",
-                            "$atLeastDescr: 1"
+                            noSuchEntryDescr
+//                            "$numberOfOccurrences: 0",
+//                            "$atLeastDescr: 1"
                         )
                     }
                 }
@@ -76,8 +76,9 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                     message {
                         toContain.exactly(2).values(
                             "$anElementWhich: $separator",
-                            "$numberOfOccurrences: 0",
-                            "$atLeastDescr: 1"
+                            noSuchEntryDescr
+//                            "$numberOfOccurrences: 0",
+//                            "$atLeastDescr: 1"
                         )
                         toContain.exactly(1).values(
                             "$rootBulletPoint$toContainInAnyOrder: $separator",
@@ -101,8 +102,9 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                                 "$anElementWhich: $separator",
                                 "$toBeGreaterThanDescr: 1.0",
                                 "$toBeLessThanDescr: 2.0",
-                                "$numberOfOccurrences: 0",
-                                "$atLeastDescr: 1"
+                                noSuchEntryDescr
+//                                "$numberOfOccurrences: 0",
+//                                "$atLeastDescr: 1"
                             )
                         }
                     }
@@ -162,8 +164,9 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                                 "$rootBulletPoint$toContainInAnyOrder: $separator",
                                 "$anElementWhich: $separator",
                                 "$toBeDescr: 2.0",
-                                "$numberOfOccurrences: 0",
-                                "$atLeastDescr: 1"
+                                noSuchEntryDescr
+//                                "$numberOfOccurrences: 0",
+//                                "$atLeastDescr: 1"
                             )
                         }
                     }
@@ -178,8 +181,9 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                             message {
                                 toContain.exactly(2).values(
                                     "$anElementWhich: $separator",
-                                    "$numberOfOccurrences: 0",
-                                    "$atLeastDescr: 1"
+                                    noSuchEntryDescr
+//                                    "$numberOfOccurrences: 0",
+//                                    "$atLeastDescr: 1"
                                 )
                                 toContain.exactly(1).values(
                                     "$rootBulletPoint$toContainInAnyOrder: $separator",
@@ -201,8 +205,9 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                             "$rootBulletPoint$toContainInAnyOrder: $separator",
                             "$anElementWhich: $separator",
                             "$isDescr: null",
-                            "$numberOfOccurrences: 0",
-                            "$atLeastDescr: 1"
+                            noSuchEntryDescr
+//                            "$numberOfOccurrences: 0",
+//                            "$atLeastDescr: 1"
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
@@ -63,8 +63,6 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                             "$anElementWhich: $separator",
                             "$toBeLessThanDescr: 1.0",
                             noSuchEntryDescr
-//                            "$numberOfOccurrences: 0",
-//                            "$atLeastDescr: 1"
                         )
                     }
                 }
@@ -77,8 +75,6 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                         toContain.exactly(2).values(
                             "$anElementWhich: $separator",
                             noSuchEntryDescr
-//                            "$numberOfOccurrences: 0",
-//                            "$atLeastDescr: 1"
                         )
                         toContain.exactly(1).values(
                             "$rootBulletPoint$toContainInAnyOrder: $separator",
@@ -103,8 +99,6 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                                 "$toBeGreaterThanDescr: 1.0",
                                 "$toBeLessThanDescr: 2.0",
                                 noSuchEntryDescr
-//                                "$numberOfOccurrences: 0",
-//                                "$atLeastDescr: 1"
                             )
                         }
                     }
@@ -165,8 +159,6 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                                 "$anElementWhich: $separator",
                                 "$toBeDescr: 2.0",
                                 noSuchEntryDescr
-//                                "$numberOfOccurrences: 0",
-//                                "$atLeastDescr: 1"
                             )
                         }
                     }
@@ -182,8 +174,6 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                                 toContain.exactly(2).values(
                                     "$anElementWhich: $separator",
                                     noSuchEntryDescr
-//                                    "$numberOfOccurrences: 0",
-//                                    "$atLeastDescr: 1"
                                 )
                                 toContain.exactly(1).values(
                                     "$rootBulletPoint$toContainInAnyOrder: $separator",
@@ -206,8 +196,6 @@ abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
                             "$anElementWhich: $separator",
                             "$isDescr: null",
                             noSuchEntryDescr
-//                            "$numberOfOccurrences: 0",
-//                            "$atLeastDescr: 1"
                         )
                     }
                 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.specs.*
 
+// TODO ED: update specs for drop number of occurrences
 abstract class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec(
     toContainInAnyOrderEntries: Fun2<Iterable<Double>, Expect<Double>.() -> Unit, Array<out Expect<Double>.() -> Unit>>,
     toContainInAnyOrderNullableEntries: Fun2<Iterable<Double?>, (Expect<Double>.() -> Unit)?, Array<out (Expect<Double>.() -> Unit)?>>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
+// TODO ED: update specs for drop number of occurrences
 abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
     toContainInAnyOrderValues: Fun2<Iterable<Double>, Double, Array<out Double>>,
     toContainInAnyOrderNullableValues: Fun2<Iterable<Double?>, Double?, Array<out Double?>>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
@@ -41,7 +41,7 @@ abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
                     messageToContain(
                         "$rootBulletPoint$toContainInAnyOrder: $separator",
                         "$anElementWhichIs: 1.0",
-                        valueNotFoundDescr
+                        noSuchValueDescr
                     )
                 }
             }
@@ -72,7 +72,7 @@ abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
                         messageToContain(
                             "$rootBulletPoint$toContainInAnyOrder: $separator",
                             "$anElementWhichIs: 9.5",
-                            valueNotFoundDescr
+                            noSuchValueDescr
                         )
                     }
                 }
@@ -82,7 +82,7 @@ abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(2).values(
-                                valueNotFoundDescr
+                                noSuchValueDescr
                             )
                             toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainInAnyOrder: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
@@ -6,7 +6,6 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
-// TODO ED: update specs for drop number of occurrences
 abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
     toContainInAnyOrderValues: Fun2<Iterable<Double>, Double, Array<out Double>>,
     toContainInAnyOrderNullableValues: Fun2<Iterable<Double?>, Double?, Array<out Double?>>,
@@ -42,8 +41,7 @@ abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
                     messageToContain(
                         "$rootBulletPoint$toContainInAnyOrder: $separator",
                         "$anElementWhichIs: 1.0",
-                        "$numberOfOccurrences: 0",
-                        "$atLeastDescr: 1"
+                        valueNotFoundDescr
                     )
                 }
             }
@@ -74,8 +72,7 @@ abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
                         messageToContain(
                             "$rootBulletPoint$toContainInAnyOrder: $separator",
                             "$anElementWhichIs: 9.5",
-                            "$numberOfOccurrences: 0",
-                            "$atLeastDescr: 1"
+                            valueNotFoundDescr
                         )
                     }
                 }
@@ -85,8 +82,7 @@ abstract class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(2).values(
-                                "$numberOfOccurrences: 0",
-                                "$atLeastDescr: 1"
+                                valueNotFoundDescr
                             )
                             toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainInAnyOrder: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeastValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeastValuesExpectationsSpec.kt
@@ -90,14 +90,14 @@ abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
                 it("${toContainAtLeastPair.first("1.1", "once")} throws AssertionError") {
                     expect {
                         expect(oneToSeven()).toContainAtLeastFun(1, 1.1)
-                    }.toThrow<AssertionError> { messageToContain(valueNotFoundDescr, "$anElementWhichIs: 1.1") }
+                    }.toThrow<AssertionError> { messageToContain(noSuchValueDescr, "$anElementWhichIs: 1.1") }
                 }
                 it("${toContainAtLeastPair.first("1.0, 2.3", "once")} throws AssertionError mentioning only 2.3") {
                     expect {
                         expect(oneToSeven()).toContainAtLeastFun(1, 1.0, 2.3)
                     }.toThrow<AssertionError> {
                         message {
-                            toContain(valueNotFoundDescr, "$anElementWhichIs: 2.3")
+                            toContain(noSuchValueDescr, "$anElementWhichIs: 2.3")
                             notToContain("$anElementWhichIs: 1.0")
                         }
                     }
@@ -107,7 +107,7 @@ abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
                         expect(oneToSeven()).toContainAtLeastFun(1, 2.3, 1.0)
                     }.toThrow<AssertionError> {
                         message {
-                            toContain(valueNotFoundDescr, "$anElementWhichIs: 2.3")
+                            toContain(noSuchValueDescr, "$anElementWhichIs: 2.3")
                             notToContain("$anElementWhichIs: 1.0")
                         }
                     }
@@ -118,7 +118,7 @@ abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(2).values(
-                                valueNotFoundDescr
+                                noSuchValueDescr
                             )
                             toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainInAnyOrder: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeastValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeastValuesExpectationsSpec.kt
@@ -6,7 +6,6 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import org.spekframework.spek2.style.specification.Suite
 
-// TODO ED: update specs for drop number of occurrences
 abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
     toContainAtLeastPair: Pair<(String, String) -> String, Fun3<Iterable<Double>, Int, Double, Array<out Double>>>,
     toContainAtLeastButAtMostPair: Pair<(String, String, String) -> String, Fun4<Iterable<Double>, Int, Int, Double, Array<out Double>>>,
@@ -91,14 +90,14 @@ abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
                 it("${toContainAtLeastPair.first("1.1", "once")} throws AssertionError") {
                     expect {
                         expect(oneToSeven()).toContainAtLeastFun(1, 1.1)
-                    }.toThrow<AssertionError> { messageToContain("$atLeastDescr: 1", "$anElementWhichIs: 1.1") }
+                    }.toThrow<AssertionError> { messageToContain(valueNotFoundDescr, "$anElementWhichIs: 1.1") }
                 }
                 it("${toContainAtLeastPair.first("1.0, 2.3", "once")} throws AssertionError mentioning only 2.3") {
                     expect {
                         expect(oneToSeven()).toContainAtLeastFun(1, 1.0, 2.3)
                     }.toThrow<AssertionError> {
                         message {
-                            toContain("$atLeastDescr: 1", "$anElementWhichIs: 2.3")
+                            toContain(valueNotFoundDescr, "$anElementWhichIs: 2.3")
                             notToContain("$anElementWhichIs: 1.0")
                         }
                     }
@@ -108,7 +107,7 @@ abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
                         expect(oneToSeven()).toContainAtLeastFun(1, 2.3, 1.0)
                     }.toThrow<AssertionError> {
                         message {
-                            toContain("$atLeastDescr: 1", "$anElementWhichIs: 2.3")
+                            toContain(valueNotFoundDescr, "$anElementWhichIs: 2.3")
                             notToContain("$anElementWhichIs: 1.0")
                         }
                     }
@@ -119,8 +118,7 @@ abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             toContain.exactly(2).values(
-                                "$numberOfOccurrences: 0",
-                                "$atLeastDescr: 1"
+                                valueNotFoundDescr
                             )
                             toContain.exactly(1).values(
                                 "$rootBulletPoint$toContainInAnyOrder: $separator",

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeastValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderAtLeastValuesExpectationsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import org.spekframework.spek2.style.specification.Suite
 
+// TODO ED: update specs for drop number of occurrences
 abstract class IterableToContainInAnyOrderAtLeastValuesExpectationsSpec(
     toContainAtLeastPair: Pair<(String, String) -> String, Fun3<Iterable<Double>, Int, Double, Array<out Double>>>,
     toContainAtLeastButAtMostPair: Pair<(String, String, String) -> String, Fun4<Iterable<Double>, Int, Int, Double, Array<out Double>>>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -48,6 +48,7 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
         val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
         val valueNotFoundDescr = DescriptionIterableAssertion.VALUE_NOT_FOUND.getDefault()
+        val noSuchValueDescr = DescriptionIterableAssertion.VALUE_NOT_FOUND.getDefault()
 
         val sizeDescr = DescriptionCollectionAssertion.SIZE.getDefault()
         val atLeastDescr = DescriptionIterableAssertion.AT_LEAST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -47,7 +47,7 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val hasDescriptionBasic = DescriptionBasic.HAS.getDefault()
         val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
         val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
-        val noSuchValueDescr = DescriptionIterableAssertion.VALUE_NOT_FOUND.getDefault()
+        val noSuchValueDescr = DescriptionIterableAssertion.ELEMENT_NOT_FOUND.getDefault()
 
         val sizeDescr = DescriptionCollectionAssertion.SIZE.getDefault()
         val atLeastDescr = DescriptionIterableAssertion.AT_LEAST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -47,6 +47,7 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val hasDescriptionBasic = DescriptionBasic.HAS.getDefault()
         val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
         val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
+        val valueNotFoundDescr = DescriptionIterableAssertion.VALUE_NOT_FOUND.getDefault()
 
         val sizeDescr = DescriptionCollectionAssertion.SIZE.getDefault()
         val atLeastDescr = DescriptionIterableAssertion.AT_LEAST.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -47,7 +47,6 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val hasDescriptionBasic = DescriptionBasic.HAS.getDefault()
         val nextElement = DescriptionIterableAssertion.NEXT_ELEMENT.getDefault()
         val notToContainDescr = DescriptionIterableAssertion.CONTAINS_NOT.getDefault()
-        val valueNotFoundDescr = DescriptionIterableAssertion.VALUE_NOT_FOUND.getDefault()
         val noSuchValueDescr = DescriptionIterableAssertion.VALUE_NOT_FOUND.getDefault()
 
         val sizeDescr = DescriptionCollectionAssertion.SIZE.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAnyExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAnyExpectationsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionComparableAssertion
 
+// TODO ED: change specs for no such entry
 abstract class IterableToHaveElementsAndAnyExpectationsSpec(
     toHaveElementsAndAny: Fun1<Iterable<Double>, Expect<Double>.() -> Unit>,
     toHaveElementsAndAnyNullable: Fun1<Iterable<Double?>, (Expect<Double>.() -> Unit)?>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAnyExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAnyExpectationsSpec.kt
@@ -6,7 +6,6 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionComparableAssertion
 
-// TODO ED: change specs for no such entry
 abstract class IterableToHaveElementsAndAnyExpectationsSpec(
     toHaveElementsAndAny: Fun1<Iterable<Double>, Expect<Double>.() -> Unit>,
     toHaveElementsAndAnyNullable: Fun1<Iterable<Double?>, (Expect<Double>.() -> Unit)?>,
@@ -47,8 +46,7 @@ abstract class IterableToHaveElementsAndAnyExpectationsSpec(
                         "$rootBulletPoint$toContainInAnyOrder: $separator",
                         "$anElementWhich: $separator",
                         "$toBeLessThanDescr: 1.0",
-                        "$numberOfOccurrences: 0",
-                        "$atLeastDescr: 1"
+                        noSuchEntryDescr
                     )
 
                 }
@@ -66,8 +64,7 @@ abstract class IterableToHaveElementsAndAnyExpectationsSpec(
                             "$anElementWhich: $separator",
                             "$isGreaterThanDescr: 1.0",
                             "$toBeLessThanDescr: 2.0",
-                            "$numberOfOccurrences: 0",
-                            "$atLeastDescr: 1"
+                            noSuchEntryDescr
                         )
                     }
                 }
@@ -106,8 +103,7 @@ abstract class IterableToHaveElementsAndAnyExpectationsSpec(
                                     "$rootBulletPoint$toContainInAnyOrder: $separator",
                                     "$anElementWhich: $separator",
                                     "$toBeDescr: 2.0",
-                                    "$numberOfOccurrences: 0",
-                                    "$atLeastDescr: 1"
+                                    noSuchEntryDescr
                                 )
                             }
                         }
@@ -125,8 +121,7 @@ abstract class IterableToHaveElementsAndAnyExpectationsSpec(
                                 "$rootBulletPoint$toContainInAnyOrder: $separator",
                                 "$anElementWhich: $separator",
                                 "$isDescr: null",
-                                "$numberOfOccurrences: 0",
-                                "$atLeastDescr: 1"
+                                noSuchEntryDescr
                             )
                         }
                     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,12 @@ buildscript {
                         "IterableContains.*Spec.*points to containsNot",
                         // we improved reporting for notToContain with 0.17.0
                         "IterableContainsNot(Entries|Values)AssertionsSpec.*`containsNot( nullable)?`.*throws AssertionError",
-                        "IterableNoneAssertionsSpec.*`(none|containsNot)( nullable)?`.*throws AssertionError"
+                        "IterableNoneAssertionsSpec.*`(none|containsNot)( nullable)?`.*throws AssertionError",
+                        // changed reporting for contains.atLeast(1) with 0.17.0
+                        or(
+                            "(CharSequence|Iterable)Contains.*Spec",
+                            "IterableAnyAssertionsSpec"
+                        ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)"
                     ) + ".*)",
                 // we don't use asci bullet points in reporting since 0.17.0
                 // but have own tests to assure that changing bullet points work
@@ -98,7 +103,12 @@ buildscript {
                         "IterableContains.*Spec.*points to containsNot",
                         // we improved reporting for notToContain with 0.17.0
                         "IterableContainsNot(Entries|Values)AssertionsSpec.*`containsNot.*`.*throws AssertionError",
-                        "IterableNoneAssertionsSpec.*`(none|containsNot).*`.*throws AssertionError"
+                        "IterableNoneAssertionsSpec.*`(none|containsNot).*`.*throws AssertionError",
+                        // changed reporting for contains.atLeast(1) with 0.17.0
+                        or(
+                            "(CharSequence|Iterable)Contains.*Spec",
+                            "IterableAnyAssertionsSpec"
+                        ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)"
                     ) + ".*)",
                 // we don't use asci bullet points in reporting since 0.17.0
                 // but have own tests to assure that changing bullet points work
@@ -162,7 +172,12 @@ buildscript {
                 "IterableExpectationsSpec.*`(containsNoDuplicates|contains noDuplicates)`",
                 // we improved reporting for notToContain with 0.17.0
                 "IterableContainsNot(Entries|Values)ExpectationsSpec.*`containsNot.*`.*throws AssertionError",
-                "IterableNoneExpectationsSpec.*`(none|containsNot).*`.*throws AssertionError"
+                "IterableNoneExpectationsSpec.*`(none|containsNot).*`.*throws AssertionError",
+                // changed reporting for contains.atLeast(1) with 0.17.0
+                or(
+                    "(CharSequence|Iterable)Contains.*Spec",
+                    "IterableAnyExpectationsSpec"
+                ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)"
             ) + ".*)").let { commonPatterns ->
                 Pair(
                     // bc

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -19,8 +19,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     IGNORING_CASE("%s, Gross-/Kleinschreibung ignorierend"),
     MATCHES("stimmt vollständig überein mit"),
     MISMATCHES("stimmt nicht vollständig überein mit"),
-    // TODO Translate the following translatable
-    NOT_FOUND("(TRANSLATE) but no match was found"),
+    NOT_FOUND("aber es wurde kein Treffer gefunden"),
     NUMBER_OF_OCCURRENCES("Anzahl Treffer"),
     STARTS_WITH("beginnt mit"),
     STARTS_NOT_WITH("beginnt nicht mit"),

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -20,7 +20,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     MATCHES("stimmt vollständig überein mit"),
     MISMATCHES("stimmt nicht vollständig überein mit"),
     NOT_FOUND("aber es wurde kein Treffer gefunden"),
-    NUMBER_OF_MATCHES_FOUND(/* TODO translate */ "and %s matches were found"),
+    NUMBER_OF_MATCHES_FOUND("und %s Treffer wurden gefunden"),
     NUMBER_OF_OCCURRENCES("Anzahl Treffer"),
     STARTS_WITH("beginnt mit"),
     STARTS_NOT_WITH("beginnt nicht mit"),

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -20,7 +20,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     MATCHES("stimmt vollständig überein mit"),
     MISMATCHES("stimmt nicht vollständig überein mit"),
     // TODO Translate the following translatable
-    NOT_FOUND("but no such item was found."),
+    NOT_FOUND("(TRANSLATE) but no match was found"),
     NUMBER_OF_OCCURRENCES("Anzahl Treffer"),
     STARTS_WITH("beginnt mit"),
     STARTS_NOT_WITH("beginnt nicht mit"),

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -20,6 +20,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     MATCHES("stimmt vollständig überein mit"),
     MISMATCHES("stimmt nicht vollständig überein mit"),
     NOT_FOUND("aber es wurde kein Treffer gefunden"),
+    NUMBER_OF_MATCHES_FOUND(/* TODO translate */ "and %s matches were found"),
     NUMBER_OF_OCCURRENCES("Anzahl Treffer"),
     STARTS_WITH("beginnt mit"),
     STARTS_NOT_WITH("beginnt nicht mit"),

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -19,6 +19,8 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     IGNORING_CASE("%s, Gross-/Kleinschreibung ignorierend"),
     MATCHES("stimmt vollständig überein mit"),
     MISMATCHES("stimmt nicht vollständig überein mit"),
+    // TODO Translate the following translatable
+    NOT_FOUND("but no such item was found."),
     NUMBER_OF_OCCURRENCES("Anzahl Treffer"),
     STARTS_WITH("beginnt mit"),
     STARTS_NOT_WITH("beginnt nicht mit"),

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -47,9 +47,8 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NO_ELEMENTS("❗❗ kann nicht eruiert werden, leeres Iterable"),
     DUPLICATE_ELEMENTS("doppelte Elemente"),
     DUPLICATED_BY("(dupliziert von Index: %s"),
-    // TODO translate the following lines
-    ENTRY_NOT_FOUND("but no such entry was found."),
-    VALUE_NOT_FOUND("but no such item was found.")
+    ENTRY_NOT_FOUND("aber es konnte kein solches Element gefunden werden"),
+    VALUE_NOT_FOUND("aber es konnte kein solches Element gefunden werden")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS =

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -48,7 +48,7 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     DUPLICATE_ELEMENTS("doppelte Elemente"),
     DUPLICATED_BY("(dupliziert von Index: %s"),
     ELEMENT_NOT_FOUND("aber es konnte kein solches Element gefunden werden"),
-    NUMBER_OF_ELEMENTS_FOUND(/* TODO translate */ "and %s such elements were found")
+    NUMBER_OF_ELEMENTS_FOUND("und % Elemente wurden gefunden")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS =

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -46,7 +46,10 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NEXT_ELEMENT("ein nächstes Element"),
     NO_ELEMENTS("❗❗ kann nicht eruiert werden, leeres Iterable"),
     DUPLICATE_ELEMENTS("doppelte Elemente"),
-    DUPLICATED_BY("(dupliziert von Index: %s")
+    DUPLICATED_BY("(dupliziert von Index: %s"),
+    // TODO translate the following lines
+    ENTRY_NOT_FOUND("but no such entry was found."),
+    VALUE_NOT_FOUND("but no such item was found.")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS =

--- a/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/de_CH/atrium-translations-de_CH-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -47,8 +47,8 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NO_ELEMENTS("❗❗ kann nicht eruiert werden, leeres Iterable"),
     DUPLICATE_ELEMENTS("doppelte Elemente"),
     DUPLICATED_BY("(dupliziert von Index: %s"),
-    ENTRY_NOT_FOUND("aber es konnte kein solches Element gefunden werden"),
-    VALUE_NOT_FOUND("aber es konnte kein solches Element gefunden werden")
+    ELEMENT_NOT_FOUND("aber es konnte kein solches Element gefunden werden"),
+    NUMBER_OF_ELEMENTS_FOUND(/* TODO translate */ "and %s such elements were found")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS =

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -19,7 +19,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     IGNORING_CASE("%s, ignoring case"),
     MATCHES("matches entirely"),
     MISMATCHES("does not match entirely"),
-    NOT_FOUND("but no such item was found."),
+    NOT_FOUND("but no match was found"),
     NUMBER_OF_OCCURRENCES("number of matches"),
     STARTS_WITH("starts with"),
     STARTS_NOT_WITH("does not start with"),

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -20,6 +20,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     MATCHES("matches entirely"),
     MISMATCHES("does not match entirely"),
     NOT_FOUND("but no match was found"),
+    NUMBER_OF_MATCHES_FOUND("and %s matches were found"),
     NUMBER_OF_OCCURRENCES("number of matches"),
     STARTS_WITH("starts with"),
     STARTS_NOT_WITH("does not start with"),

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionCharSequenceAssertion.kt
@@ -19,6 +19,7 @@ enum class DescriptionCharSequenceAssertion(override val value: String) : String
     IGNORING_CASE("%s, ignoring case"),
     MATCHES("matches entirely"),
     MISMATCHES("does not match entirely"),
+    NOT_FOUND("but no such item was found."),
     NUMBER_OF_OCCURRENCES("number of matches"),
     STARTS_WITH("starts with"),
     STARTS_NOT_WITH("does not start with"),

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -46,7 +46,9 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NEXT_ELEMENT("a next element"),
     NO_ELEMENTS("❗❗ cannot be determined, empty Iterable"),
     DUPLICATE_ELEMENTS("duplicate elements"),
-    DUPLICATED_BY("duplicated by index: %s")
+    DUPLICATED_BY("duplicated by index: %s"),
+    ENTRY_NOT_FOUND("but no such entry was found."),
+    ITEM_NOT_FOUND("but no such item was found.")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS = "Could not evaluate the defined assertion(s)"

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -47,8 +47,8 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NO_ELEMENTS("❗❗ cannot be determined, empty Iterable"),
     DUPLICATE_ELEMENTS("duplicate elements"),
     DUPLICATED_BY("duplicated by index: %s"),
-    ENTRY_NOT_FOUND("but no such element was found"),
-    VALUE_NOT_FOUND("but no such element was found")
+    ELEMENT_NOT_FOUND("but no such element was found"),
+    NUMBER_OF_ELEMENTS_FOUND("and %s such elements were found")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS = "Could not evaluate the defined assertion(s)"

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -47,8 +47,8 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     NO_ELEMENTS("❗❗ cannot be determined, empty Iterable"),
     DUPLICATE_ELEMENTS("duplicate elements"),
     DUPLICATED_BY("duplicated by index: %s"),
-    ENTRY_NOT_FOUND("but no such entry was found."),
-    VALUE_NOT_FOUND("but no such item was found.")
+    ENTRY_NOT_FOUND("but no such element was found"),
+    VALUE_NOT_FOUND("but no such element was found")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS = "Could not evaluate the defined assertion(s)"

--- a/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
+++ b/translations/en_GB/atrium-translations-en_GB-common/src/main/kotlin/ch/tutteli/atrium/translations/DescriptionIterableAssertion.kt
@@ -48,7 +48,7 @@ enum class DescriptionIterableAssertion(override val value: String) : StringBase
     DUPLICATE_ELEMENTS("duplicate elements"),
     DUPLICATED_BY("duplicated by index: %s"),
     ENTRY_NOT_FOUND("but no such entry was found."),
-    ITEM_NOT_FOUND("but no such item was found.")
+    VALUE_NOT_FOUND("but no such item was found.")
 }
 
 internal const val COULD_NOT_EVALUATE_DEFINED_ASSERTIONS = "Could not evaluate the defined assertion(s)"


### PR DESCRIPTION
Resolves #310.

Modifies `featureFactory` in `ContainsAssertionCreator` to display a `no such item was found` text instead of a verbose feature assertion about the number of occurrences, specifically in the case `contains.atLeast(1)`. Creates a `descriptionNotFound` abstract property on the  `ContainsAssertionContainer` that gets overrode in its subclasses to provide the description for `but no such item was found`.

I created three new translatables for when an entry is not found, a value is not found, and a charSequence is not found (however they could all be the same if we chose).
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
