### PR TITLE
Fail explanatory assertion group on empty assertionCreator

### DIFF
--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
@@ -16,6 +16,8 @@ import ch.tutteli.atrium.logic.collectForCompositionBasedOnSubject
  * Collects the assertions [assertionCreator] creates and uses them as [AssertionGroup.assertions].
  *
  * //TODO 0.18.0 in case we somehow incorporate the current container in AssertionsOptions, then remove container as parameter
+ *
+ * TODO 1.0.0 at the latest: use type ExplanatoryGroup.FinalStep when ExplanatoryAssertionGroupFinalStep is removed
  */
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalComponentFactoryContainer::class)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
@@ -3,9 +3,13 @@ package ch.tutteli.atrium.logic.creating.collectors
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.ExplanatoryAssertionGroupType
 import ch.tutteli.atrium.assertions.builders.AssertionsOption
+import ch.tutteli.atrium.assertions.builders.ExplanatoryAssertionGroupFinalStep
+import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.CollectingExpect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.logic.collectForCompositionBasedOnSubject
 
 /**
@@ -13,8 +17,19 @@ import ch.tutteli.atrium.logic.collectForCompositionBasedOnSubject
  *
  * //TODO 0.18.0 in case we somehow incorporate the current container in AssertionsOptions, then remove container as parameter
  */
-fun <T, G : ExplanatoryAssertionGroupType, R> AssertionsOption<G, R>.collectAssertions(
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalComponentFactoryContainer::class)
+fun <T, G : ExplanatoryAssertionGroupType, R: ExplanatoryAssertionGroupFinalStep> AssertionsOption<G, R>.collectAssertions(
     container: AssertionContainer<*>,
     maybeSubject: Option<T>,
     assertionCreator: Expect<T>.() -> Unit
-): R = withAssertions(container.collectForCompositionBasedOnSubject(maybeSubject, assertionCreator))
+): ExplanatoryAssertionGroupFinalStep {
+    val collectingExpect = CollectingExpect<T>(None, container.components)
+    // not using addAssertionsCreatedBy on purpose so that we don't append a failing assertion
+    collectingExpect.assertionCreator()
+    return withAssertions(container.collectForCompositionBasedOnSubject(maybeSubject, assertionCreator))
+        .let {
+            if(collectingExpect.getAssertions().isEmpty()) it.failing
+            else it
+        }
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensions.kt
@@ -1,3 +1,6 @@
+// TODO 1.0.0 at the latest: use type ExplanatoryGroup.FinalStep when ExplanatoryAssertionGroupFinalStep is removed
+@file:Suppress("DEPRECATION")
+
 package ch.tutteli.atrium.logic.creating.collectors
 
 import ch.tutteli.atrium.assertions.AssertionGroup

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -94,8 +94,6 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
         val featureAssertion = featureFactory(count, DescriptionIterableAssertion.NUMBER_OF_OCCURRENCES)
         val assertions = mutableListOf<Assertion>(explanatoryGroup)
         if (searchBehaviour is NotSearchBehaviour) {
-            createEmptyAssertionHintIfNecessary(multiConsumableContainer, searchCriterion, count)
-                ?.let { assertions.add(it) }
             val mismatches = createIndexAssertions(list) { (_, element) ->
                 allCreatedAssertionsHold(multiConsumableContainer, element, searchCriterion)
             }
@@ -117,28 +115,5 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
         val group = createExplanatoryAssertionGroup(container, assertionCreatorOrNull)
         val count = list.count { allCreatedAssertionsHold(container, it, assertionCreatorOrNull) }
         return group to count
-    }
-
-    //TODO 0.18.0 check if this is still state of the art to add a hint that no assertion was created
-    // in the assertionCreator-lambda, maybe it is a special case and needs to be handled like this,
-    // maybe it would be enough to collect
-    @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
-    @UseExperimental(ExperimentalComponentFactoryContainer::class)
-    private fun createEmptyAssertionHintIfNecessary(
-        container: AssertionContainer<*>,
-        searchCriterion: (Expect<E>.() -> Unit)?,
-        count: Int
-    ): Assertion? {
-        if (searchCriterion != null && count == 0) {
-            val collectingExpect = CollectingExpect<E>(None, container.components)
-            // not using addAssertionsCreatedBy on purpose so that we don't append a failing assertion
-            collectingExpect.searchCriterion()
-            val collectedAssertions = collectingExpect.getAssertions()
-            if (collectedAssertions.isEmpty()) {
-                // no assertion created in the lambda, so return the failing assertion containing the hint
-                return container.collectBasedOnSubject(None, searchCriterion)
-            }
-        }
-        return null
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -8,9 +8,7 @@ import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.core.trueProvider
 import ch.tutteli.atrium.creating.AssertionContainer
-import ch.tutteli.atrium.creating.CollectingExpect
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.logic.collectBasedOnSubject
 import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.reporting.Text
@@ -38,8 +36,6 @@ internal fun <E : Any> allCreatedAssertionsHold(
     else -> assertionCreator != null && container.collectBasedOnSubject(Some(subject), assertionCreator).holds()
 }
 
-@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
-@UseExperimental(ExperimentalComponentFactoryContainer::class)
 internal fun <E : Any> createExplanatoryAssertionGroup(
     container: AssertionContainer<*>,
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
@@ -50,14 +46,7 @@ internal fun <E : Any> createExplanatoryAssertionGroup(
             //TODO 0.18.0 looks a lot like toBeNullIfNullGiven
             if (assertionCreatorOrNull != null) {
                 // we don't use a subject, we will not show it anyway
-                val collectingExpect = CollectingExpect<E>(None, container.components)
-                // not using addAssertionsCreatedBy on purpose so that we don't append a failing assertion
-                collectingExpect.assertionCreatorOrNull()
-                if(collectingExpect.getAssertions().isEmpty()) {
-                    it.collectAssertions(container, None, assertionCreatorOrNull).failing
-                } else {
-                    it.collectAssertions(container, None, assertionCreatorOrNull)
-                }
+                it.collectAssertions(container, None, assertionCreatorOrNull)
             } else {
                 it.withAssertion(
                     // it is for an explanatoryGroup where it does not matter if the assertion holds or not

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -8,7 +8,9 @@ import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.core.trueProvider
 import ch.tutteli.atrium.creating.AssertionContainer
+import ch.tutteli.atrium.creating.CollectingExpect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.logic.collectBasedOnSubject
 import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.reporting.Text
@@ -36,6 +38,8 @@ internal fun <E : Any> allCreatedAssertionsHold(
     else -> assertionCreator != null && container.collectBasedOnSubject(Some(subject), assertionCreator).holds()
 }
 
+@Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+@UseExperimental(ExperimentalComponentFactoryContainer::class)
 internal fun <E : Any> createExplanatoryAssertionGroup(
     container: AssertionContainer<*>,
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
@@ -46,7 +50,14 @@ internal fun <E : Any> createExplanatoryAssertionGroup(
             //TODO 0.18.0 looks a lot like toBeNullIfNullGiven
             if (assertionCreatorOrNull != null) {
                 // we don't use a subject, we will not show it anyway
-                it.collectAssertions(container, None, assertionCreatorOrNull)
+                val collectingExpect = CollectingExpect<E>(None, container.components)
+                // not using addAssertionsCreatedBy on purpose so that we don't append a failing assertion
+                collectingExpect.assertionCreatorOrNull()
+                if(collectingExpect.getAssertions().isEmpty()) {
+                    it.collectAssertions(container, None, assertionCreatorOrNull).failing
+                } else {
+                    it.collectAssertions(container, None, assertionCreatorOrNull)
+                }
             } else {
                 it.withAssertion(
                     // it is for an explanatoryGroup where it does not matter if the assertion holds or not


### PR DESCRIPTION
Resolves #933. Whenever an assertionCreator is taken as an argument of an expectation, an explanatory group is created that describes the assertions created. If no assertions are created, then an empty lambda failure hint is given. This PR makes the explanatory group fail when the empty lambda failure hint is given, and then removes the `createEmptyAssertionHintIfNecessary` from the assertion creators.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
