### PR TITLE
Make Iterable.all and Iterable.containsNoDuplicates use hasNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -2206,8 +2206,11 @@ expect(Person("Susanne", "Whitley", 43, listOf()))
 ```text
 expected that subject: Person(firstName=Susanne, lastName=Whitley, age=43, children=[])        (readme.examples.Person <1234789>)
 ◆ ▶ children: []        (kotlin.collections.EmptyList <1234789>)
-    ◾ ▶ has at least one element: false
-        ◾ is: true
+    ◾ has: a next element
+      » all entries: 
+          » ▶ age: 
+          » ▶ age: 
+              ◾ is greater than or equal to: 18        (kotlin.Int <1234789>)
 ```
 </ex-own-compose-4>
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator.kt
@@ -2,12 +2,10 @@ package ch.tutteli.atrium.logic.creating.basic.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
-import ch.tutteli.atrium.assertions.builders.assertionBuilder
-import ch.tutteli.atrium.assertions.builders.invisibleGroup
-import ch.tutteli.atrium.core.trueProvider
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.Contains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
+import ch.tutteli.atrium.logic.impl.createAssertionGroupFromListOfAssertions
 import ch.tutteli.atrium.logic.impl.createExplanatoryGroupForMismatches
 import ch.tutteli.atrium.reporting.translating.Translatable
 
@@ -50,15 +48,7 @@ abstract class ContainsObjectsAssertionCreator<T : Any, TT : Any, in SC, S : Con
             assertions.add(featureAssertion)
         }
 
-        return if (assertions.isEmpty()) {
-            assertionBuilder.invisibleGroup
-                .withAssertion(
-                    assertionBuilder.createDescriptive(groupDescription, searchCriterion, trueProvider)
-                ).build()
-        } else assertionBuilder.list
-            .withDescriptionAndRepresentation(groupDescription, searchCriterion)
-            .withAssertions(assertions)
-            .build()
+        return createAssertionGroupFromListOfAssertions(groupDescription, searchCriterion, assertions)
     }
 
     /**

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator.kt
@@ -3,7 +3,6 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
-import ch.tutteli.atrium.assertions.builders.invisibleGroup
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
@@ -16,15 +15,10 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
-import ch.tutteli.atrium.logic.hasNext
-import ch.tutteli.atrium.logic.impl.allCreatedAssertionsHold
-import ch.tutteli.atrium.logic.impl.createExplanatoryAssertionGroup
-import ch.tutteli.atrium.logic.impl.createExplanatoryGroupForMismatches
-import ch.tutteli.atrium.logic.impl.createIndexAssertions
+import ch.tutteli.atrium.logic.impl.*
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion.AN_ELEMENT_WHICH
-import ch.tutteli.kbox.identity
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
@@ -63,20 +57,9 @@ class InAnyOrderEntriesAssertionCreator<E : Any, T : IterableLike>(
         inAnyOrderAssertion: AssertionGroup,
         multiConsumableContainer: AssertionContainer<List<E?>>
     ): AssertionGroup {
-        val hasNext = multiConsumableContainer.hasNext(::identity)
-        return if (searchBehaviour is NotSearchBehaviour && !hasNext.holds()) {
-            assertionBuilder.invisibleGroup
-                .withAssertions(
-                    hasNext,
-                    assertionBuilder.explanatoryGroup
-                        .withDefaultType
-                        .withAssertion(inAnyOrderAssertion)
-                        .build()
-                )
-                .build()
-        } else {
-            inAnyOrderAssertion
-        }
+        return if (searchBehaviour is NotSearchBehaviour)
+            decorateAssertionWithHasNext(inAnyOrderAssertion, multiConsumableContainer)
+        else inAnyOrderAssertion
     }
 
     override fun searchAndCreateAssertion(

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator.kt
@@ -2,8 +2,6 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
-import ch.tutteli.atrium.assertions.builders.assertionBuilder
-import ch.tutteli.atrium.assertions.builders.invisibleGroup
 import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.basic.contains.creators.impl.ContainsObjectsAssertionCreator
@@ -11,12 +9,10 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
-import ch.tutteli.atrium.logic.hasNext
-import ch.tutteli.atrium.logic.impl.createExplanatoryGroupForMismatches
 import ch.tutteli.atrium.logic.impl.createIndexAssertions
+import ch.tutteli.atrium.logic.impl.decorateAssertionWithHasNext
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
-import ch.tutteli.kbox.identity
 
 /**
  * Represents a creator of a sophisticated `contains` assertions for [Iterable] where an expected entry can appear
@@ -71,17 +67,8 @@ class InAnyOrderValuesAssertionCreator<SC, T : IterableLike>(
         inAnyOrderAssertion: AssertionGroup,
         multiConsumableContainer: AssertionContainer<List<SC>>
     ): AssertionGroup {
-        val hasNext = multiConsumableContainer.hasNext(::identity)
-        return if (searchBehaviour is NotSearchBehaviour && !hasNext.holds()) {
-            assertionBuilder.invisibleGroup.withAssertions(
-                hasNext,
-                assertionBuilder.explanatoryGroup
-                    .withDefaultType
-                    .withAssertion(inAnyOrderAssertion)
-                    .build()
-            ).build()
-        } else {
-            inAnyOrderAssertion
-        }
+        return if (searchBehaviour is NotSearchBehaviour)
+            decorateAssertionWithHasNext(inAnyOrderAssertion, multiConsumableContainer)
+        else inAnyOrderAssertion
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -1,15 +1,16 @@
 package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.*
 import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.logic.IterableLikeAssertions
-import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
-import ch.tutteli.atrium.logic.createDescriptiveAssertion
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl.turnSubjectToList
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.impl.NoOpSearchBehaviourImpl
@@ -19,13 +20,11 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.steps.impl.EntryPointS
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.notCheckerStep
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
-import ch.tutteli.atrium.logic.extractFeature
-import ch.tutteli.atrium.reporting.Text
-import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion.NEXT_ELEMENT
+import ch.tutteli.kbox.identity
 import ch.tutteli.kbox.mapWithIndex
 
 class DefaultIterableLikeAssertions : IterableLikeAssertions {
@@ -91,60 +90,51 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
         converter: (T) -> Iterable<E?>,
         assertionCreatorOrNull: (Expect<E>.() -> Unit)?
     ): Assertion = LazyThreadUnsafeAssertionGroup {
-        val list = transformToList(container, converter)
+        val listAssertionContainer = turnSubjectToList(container, converter)
+        val list = listAssertionContainer.maybeSubject.getOrElse { emptyList() }
 
-        val assertions = ArrayList<Assertion>(2)
-        assertions.add(createExplanatoryAssertionGroup(container, assertionCreatorOrNull))
-
+        val explanatoryGroup = createExplanatoryAssertionGroup(container, assertionCreatorOrNull)
+        val assertions = mutableListOf<Assertion>(explanatoryGroup)
         val mismatches = createIndexAssertions(list) { (_, element) ->
             !allCreatedAssertionsHold(container, element, assertionCreatorOrNull)
         }
-        assertions.add(createExplanatoryGroupForMismatches(mismatches))
+        if (mismatches.isNotEmpty()) assertions.add(createExplanatoryGroupForMismatches(mismatches))
 
-        createHasElementPlusFixedClaimGroup(
-            list,
-            DescriptionIterableAssertion.ALL,
-            Text.EMPTY,
-            mismatches.isEmpty(),
-            assertions
-        )
-    }
-
-    private fun <T : IterableLike, E> transformToList(
-        container: AssertionContainer<T>,
-        converter: (T) -> Iterable<E>
-    ): List<E> =
-        container.maybeSubject.fold({ emptyList() }) { subject ->
-            val iterable = converter(subject)
-            when (iterable) {
-                is List<E> -> iterable
-                else -> iterable.toList()
-            }
-        }
-
-    private fun <E> createHasElementPlusFixedClaimGroup(
-        list: List<E>,
-        description: Translatable,
-        representation: IterableLike,
-        claim: Boolean,
-        assertions: List<Assertion>
-    ) = assertionBuilder.invisibleGroup
-        .withAssertions(
-            createHasElementAssertion(list),
-            assertionBuilder.fixedClaimGroup
-                .withListType
-                .withClaim(claim)
-                .withDescriptionAndRepresentation(description, representation)
+        decorateAssertionWithHasNext(
+            listAssertionContainer,
+            assertionBuilder.list
+                .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.ALL)
                 .withAssertions(assertions)
                 .build()
         )
-        .build()
+    }
+
+    private fun <E> decorateAssertionWithHasNext(
+        listAssertionContainer: AssertionContainer<List<E>>,
+        assertion: AssertionGroup
+    ): AssertionGroup {
+        val hasNext = listAssertionContainer.hasNext(::identity)
+        return if (hasNext.holds()) {
+            assertion
+        } else {
+            assertionBuilder.invisibleGroup
+                .withAssertions(
+                    hasNext,
+                    assertionBuilder.explanatoryGroup
+                        .withDefaultType
+                        .withAssertion(assertion)
+                        .build()
+                )
+                .build()
+        }
+    }
 
     override fun <T : IterableLike, E> containsNoDuplicates(
         container: AssertionContainer<T>,
         converter: (T) -> Iterable<E>
     ): Assertion = LazyThreadUnsafeAssertionGroup {
-        val list = transformToList(container, converter)
+        val listAssertionContainer = turnSubjectToList(container, converter)
+        val list = listAssertionContainer.maybeSubject.getOrElse { emptyList() }
 
         val lookupHashMap = HashMap<E, Int>()
         val duplicateIndices = HashMap<Int, Pair<E, MutableList<Int>>>()
@@ -163,34 +153,35 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
 
         val duplicates = duplicateIndices
             .map { (index, pair) ->
-                pair.let { (element, duplicateIndices) ->
-                    assertionBuilder.descriptive
-                        .failing
-                        .withFailureHint {
-                            assertionBuilder.explanatoryGroup
-                                .withDefaultType
-                                .withExplanatoryAssertion(
-                                    TranslatableWithArgs(
-                                        DescriptionIterableAssertion.DUPLICATED_BY,
-                                        duplicateIndices.joinToString(", ")
-                                    )
+                val (element, indices) = pair
+                assertionBuilder.descriptive
+                    .failing
+                    .withFailureHint {
+                        assertionBuilder.explanatoryGroup
+                            .withDefaultType
+                            .withExplanatoryAssertion(
+                                TranslatableWithArgs(
+                                    DescriptionIterableAssertion.DUPLICATED_BY,
+                                    indices.joinToString(", ")
                                 )
-                                .build()
-                        }
-                        .showForAnyFailure
-                        .withDescriptionAndRepresentation(
-                            TranslatableWithArgs(DescriptionIterableAssertion.INDEX, index),
-                            element
-                        )
-                        .build()
-                }
+                            )
+                            .build()
+                    }
+                    .showForAnyFailure
+                    .withDescriptionAndRepresentation(
+                        TranslatableWithArgs(DescriptionIterableAssertion.INDEX, index),
+                        element
+                    )
+                    .build()
             }
 
-        createHasElementPlusFixedClaimGroup(
-            list,
-            DescriptionBasic.HAS_NOT, DescriptionIterableAssertion.DUPLICATE_ELEMENTS,
-            duplicates.isEmpty(),
-            duplicates
+        decorateAssertionWithHasNext(
+            listAssertionContainer,
+            createAssertionGroupFromListOfAssertions(
+                DescriptionBasic.HAS_NOT,
+                DescriptionIterableAssertion.DUPLICATE_ELEMENTS,
+                duplicates
+            )
         )
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -1,7 +1,6 @@
 package ch.tutteli.atrium.logic.impl
 
 import ch.tutteli.atrium.assertions.Assertion
-import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.*
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.getOrElse
@@ -24,7 +23,6 @@ import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion.NEXT_ELEMENT
-import ch.tutteli.kbox.identity
 import ch.tutteli.kbox.mapWithIndex
 
 class DefaultIterableLikeAssertions : IterableLikeAssertions {
@@ -101,32 +99,12 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
         if (mismatches.isNotEmpty()) assertions.add(createExplanatoryGroupForMismatches(mismatches))
 
         decorateAssertionWithHasNext(
-            listAssertionContainer,
             assertionBuilder.list
                 .withDescriptionAndEmptyRepresentation(DescriptionIterableAssertion.ALL)
                 .withAssertions(assertions)
-                .build()
+                .build(),
+            listAssertionContainer
         )
-    }
-
-    private fun <E> decorateAssertionWithHasNext(
-        listAssertionContainer: AssertionContainer<List<E>>,
-        assertion: AssertionGroup
-    ): AssertionGroup {
-        val hasNext = listAssertionContainer.hasNext(::identity)
-        return if (hasNext.holds()) {
-            assertion
-        } else {
-            assertionBuilder.invisibleGroup
-                .withAssertions(
-                    hasNext,
-                    assertionBuilder.explanatoryGroup
-                        .withDefaultType
-                        .withAssertion(assertion)
-                        .build()
-                )
-                .build()
-        }
     }
 
     override fun <T : IterableLike, E> containsNoDuplicates(
@@ -176,12 +154,12 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
             }
 
         decorateAssertionWithHasNext(
-            listAssertionContainer,
             createAssertionGroupFromListOfAssertions(
                 DescriptionBasic.HAS_NOT,
                 DescriptionIterableAssertion.DUPLICATE_ELEMENTS,
                 duplicates
-            )
+            ),
+            listAssertionContainer
         )
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.logic.impl
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.assertions.builders.invisibleGroup
 import ch.tutteli.atrium.core.None
 import ch.tutteli.atrium.core.Some
 import ch.tutteli.atrium.core.falseProvider
@@ -12,20 +13,12 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.collectBasedOnSubject
 import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
 import ch.tutteli.atrium.reporting.Text
+import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.kbox.WithIndex
 import ch.tutteli.kbox.mapWithIndex
-
-internal fun createHasElementAssertion(list: List<*>): Assertion {
-    return assertionBuilder.feature
-        .withDescriptionAndRepresentation(DescriptionIterableAssertion.HAS_ELEMENT, Text(list.isNotEmpty().toString()))
-        .withAssertion(
-            assertionBuilder.createDescriptive(DescriptionBasic.IS, Text(true.toString())) { list.isNotEmpty() }
-        )
-        .build()
-}
 
 internal fun <E : Any> allCreatedAssertionsHold(
     container: AssertionContainer<*>,
@@ -88,3 +81,18 @@ internal fun createExplanatoryGroupForMismatches(
         .failing
         .build()
 }
+
+internal fun createAssertionGroupFromListOfAssertions(
+    description: Translatable,
+    representation: Any?,
+    assertions: List<Assertion>
+) : AssertionGroup =
+    if (assertions.isEmpty())
+        assertionBuilder.invisibleGroup
+            .withAssertion(
+                assertionBuilder.createDescriptive(description, representation, trueProvider)
+            ).build()
+    else assertionBuilder.list
+        .withDescriptionAndRepresentation(description, representation)
+        .withAssertions(assertions)
+        .build()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -12,12 +12,14 @@ import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.collectBasedOnSubject
 import ch.tutteli.atrium.logic.creating.collectors.collectAssertions
+import ch.tutteli.atrium.logic.hasNext
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 import ch.tutteli.kbox.WithIndex
+import ch.tutteli.kbox.identity
 import ch.tutteli.kbox.mapWithIndex
 
 internal fun <E : Any> allCreatedAssertionsHold(
@@ -69,7 +71,7 @@ internal fun <E> createIndexAssertions(
 
 internal fun createExplanatoryGroupForMismatches(
     mismatches: List<Assertion>
-) : AssertionGroup {
+): AssertionGroup {
     return assertionBuilder.explanatoryGroup
         .withWarningType
         .withAssertion(
@@ -86,7 +88,7 @@ internal fun createAssertionGroupFromListOfAssertions(
     description: Translatable,
     representation: Any?,
     assertions: List<Assertion>
-) : AssertionGroup =
+): AssertionGroup =
     if (assertions.isEmpty())
         assertionBuilder.invisibleGroup
             .withAssertion(
@@ -96,3 +98,24 @@ internal fun createAssertionGroupFromListOfAssertions(
         .withDescriptionAndRepresentation(description, representation)
         .withAssertions(assertions)
         .build()
+
+internal fun <E> decorateAssertionWithHasNext(
+    assertion: AssertionGroup,
+    listAssertionContainer: AssertionContainer<List<E>>
+): AssertionGroup {
+    val hasNext = listAssertionContainer.hasNext(::identity)
+    return if (hasNext.holds()) {
+        assertion
+    } else {
+        assertionBuilder.invisibleGroup
+            .withAssertions(
+                hasNext,
+                assertionBuilder.explanatoryGroup
+                    .withDefaultType
+                    .withAssertion(assertion)
+                    .build()
+            )
+            .build()
+    }
+}
+

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAllExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAllExpectationsSpec.kt
@@ -30,7 +30,6 @@ abstract class IterableToHaveElementsAndAllExpectationsSpec(
     ) {})
 
     val toHaveElementsAndAllDescr = DescriptionIterableAssertion.ALL.getDefault()
-    val hasElement = DescriptionIterableAssertion.HAS_ELEMENT.getDefault()
 
     val explanatoryPointWithIndent = "$indentRootBulletPoint$indentListBulletPoint$explanatoryBulletPoint"
 
@@ -47,9 +46,10 @@ abstract class IterableToHaveElementsAndAllExpectationsSpec(
                 expect {
                     expect(fluentEmpty()).toHaveElementsAndAllFun { toBeLessThan(1.0) }
                 }.toThrow<AssertionError> {
-                    messageToContain(
-                        "$rootBulletPoint$featureArrow$hasElement: false$separator" +
-                            "$indentRootBulletPoint$indentFeatureArrow$featureBulletPoint$isDescr: true"
+                    message.toContainRegex(
+                        "$hasANextElement",
+                        "$explanatoryBulletPoint$toHaveElementsAndAllDescr: ",
+                        "$explanatoryPointWithIndent$toBeLessThanDescr: 1.0"
                     )
                 }
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,7 +40,9 @@ buildscript {
                         or(
                             "(CharSequence|Iterable)Contains.*Spec",
                             "IterableAnyAssertionsSpec"
-                        ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)"
+                        ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)",
+                        // changed reporting for Iterable.all empty collection cases with 0.17.0
+                        "IterableAllAssertionsSpec.*" + "empty collection.*" + "throws AssertionError"
                     ) + ".*)",
                 // we don't use asci bullet points in reporting since 0.17.0
                 // but have own tests to assure that changing bullet points work
@@ -108,7 +110,9 @@ buildscript {
                         or(
                             "(CharSequence|Iterable)Contains.*Spec",
                             "IterableAnyAssertionsSpec"
-                        ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)"
+                        ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)",
+                        // changed reporting for Iterable.all empty collection cases with 0.17.0
+                        "IterableAllAssertionsSpec.*" + "empty collection.*" + "throws AssertionError"
                     ) + ".*)",
                 // we don't use asci bullet points in reporting since 0.17.0
                 // but have own tests to assure that changing bullet points work
@@ -177,7 +181,9 @@ buildscript {
                 or(
                     "(CharSequence|Iterable)Contains.*Spec",
                     "IterableAnyExpectationsSpec"
-                ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)"
+                ) + ".*`.*(any|contains).*`.*(throws.*AssertionError|failing cases)",
+                // changed reporting for Iterable.all empty collection cases with 0.17.0
+                "IterableAllExpectationsSpec.*" + "empty collection.*" + "throws AssertionError"
             ) + ".*)").let { commonPatterns ->
                 Pair(
                     // bc


### PR DESCRIPTION
This PR resolves #305 by making Iterable.all and Iterable.containsNoDuplicates use the common implementation of `hasNext`. When they are used on empty collections, they also display an explanatory assertion of what the assertion was searching for.

```kotlin
expect(emptyList<Int>()).toHaveElementsAndAll { toBeGreaterThan(2) }
``` 
gives
```
expected that subject: []        (EmptyList <53>)
◆ has: a next element
  » all entries: 
      » is greater than: 2 
```
And
```kotlin
expect(emptyList<Int>()).notToContainDuplicates()
```
gives
```
expected that subject: []        (EmptyList <53>)
◆ has: a next element
  » has not: duplicate elements
```
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
