### PR TITLE
show representation for failure in feature extraction if subject defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -2192,8 +2192,8 @@ fun Expect<Person>.toHaveAdultChildren(): Expect<Person> =
 
 We once again use `feature` with an [assertion group block](#define-single-assertions-or-assertion-groups) 
 for the same reason as above.
-We might be tempted to add a size check -- because a Person with 0 children does not have adult children --
-but we do not have to, as `all` already checks that there is at least one element. 
+Note how `toHaveElementsAndAll` already checks that there is at least one element. 
+I.e. it fails for a `Person` with 0 children, because such a person does not have adult children. 
 
 <ex-own-compose-4>
 
@@ -2208,7 +2208,6 @@ expected that subject: Person(firstName=Susanne, lastName=Whitley, age=43, child
 ◆ ▶ children: []        (kotlin.collections.EmptyList <1234789>)
     ◾ has: a next element
       » all entries: 
-          » ▶ age: 
           » ▶ age: 
               ◾ is greater than or equal to: 18        (kotlin.Int <1234789>)
 ```

--- a/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/ResultExpectationsSpec.kt
+++ b/apis/infix-en_GB/extensions/kotlin_1_3/atrium-api-infix-en_GB-kotlin_1_3-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/ResultExpectationsSpec.kt
@@ -1,7 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3
 
 import ch.tutteli.atrium.api.infix.en_GB.aSuccess
-import ch.tutteli.atrium.api.infix.en_GB.success
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.ResultExpectationsSpec
 import ch.tutteli.atrium.specs.notImplemented

--- a/bundles/fluent-en_GB/extensions/atrium-fluent-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
+++ b/bundles/fluent-en_GB/extensions/atrium-fluent-en_GB-smoke-test-kotlin_1_3/src/test/kotlin/custom/SmokeSpec.kt
@@ -5,7 +5,7 @@
 
 package custom
 
-import ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.isSuccess
+import ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.toBeASuccess
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
 import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.assertions.Assertion
@@ -25,7 +25,7 @@ object SmokeSpec : Spek({
     }
 
     test("see if `Result.isSuccess` can be used") {
-        expect(Result.success(1)).isSuccess { toEqual(1) }
+        expect(Result.success(1)).toBeASuccess { toEqual(1) }
     }
 
     test("see if own assertion function without i18n can be used") {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions.kt
@@ -91,8 +91,8 @@ class DefaultIterableLikeAssertions : IterableLikeAssertions {
         val listAssertionContainer = turnSubjectToList(container, converter)
         val list = listAssertionContainer.maybeSubject.getOrElse { emptyList() }
 
-        val explanatoryGroup = createExplanatoryAssertionGroup(container, assertionCreatorOrNull)
-        val assertions = mutableListOf<Assertion>(explanatoryGroup)
+        val assertions = ArrayList<Assertion>(2)
+        assertions.add(createExplanatoryAssertionGroup(container, assertionCreatorOrNull))
         val mismatches = createIndexAssertions(list) { (_, element) ->
             !allCreatedAssertionsHold(container, element, assertionCreatorOrNull)
         }


### PR DESCRIPTION
or in case failure hints or sub-assertions are defined.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
