### PR TITLE
#292 show only failing for inOrder.only if more than 10 elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,9 +1062,7 @@ This makes of course only sense if your `Iterable` contains nullable elements.
 Atrium provides also a `notToContain` shortcut function. 
 Furthermore, it provides aliases for `toContain` and `notToContain` named `toHaveNextAndAny` and `toHaveNextAndNone`,  
 which might be a better choice if you think in terms of: expect a predicate holds. 
-These two are completed with an `toHaveNextAndAll` assertion function. 
-
-<!-- TODO 0.17.0 add text about notToHaveNextOrAll -->
+These two are completed with an `toHaveNextAndAll` assertion function.
 
 Following each in action:
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableExpectations.kt
@@ -1,12 +1,17 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NoOpSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.NotCheckerStep
+import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
+import ch.tutteli.atrium.logic.utils.toVarArg
+import ch.tutteli.kbox.glue
 import ch.tutteli.kbox.identity
 
 /**
@@ -119,8 +124,16 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.toContain(
  *
  * @since 0.17.0
  */
-fun <E, T : Iterable<E>> Expect<T>.toContainExactly(expected: E, vararg otherExpected: E): Expect<T> =
-    toContain.inOrder.only.values(expected, *otherExpected)
+fun <E, T : Iterable<E>> Expect<T>.toContainExactly(
+    expected: E,
+    vararg otherExpected: E,
+    report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> =
+    //TODO 0.18.0 use the following
+    //toContain.inOrder.only.values(expected, *otherExpected, report = report)
+    toContain.inOrder.only._logicAppend {
+        valuesInOrderOnly(expected glue otherExpected, report)
+    }
 
 /**
  * Expects that the subject of `this` expectation (an [Iterable]) contains only an entry holding
@@ -172,8 +185,16 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.toContainExactly(assertionCreatorOrNul
  */
 fun <E : Any, T : Iterable<E?>> Expect<T>.toContainExactly(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,
-    vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?
-): Expect<T> = toContain.inOrder.only.entries(assertionCreatorOrNull, *otherAssertionCreatorsOrNulls)
+    vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?,
+    report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> =
+    //TODO 0.18.0 use the following
+    //toContain.inOrder.only.entries(assertionCreatorOrNull, *otherAssertionCreatorsOrNulls, report = report)
+    toContain.inOrder.only._logicAppend {
+        entriesInOrderOnly(
+            assertionCreatorOrNull glue otherAssertionCreatorsOrNulls,
+            report)
+    }
 
 /**
  * Expects that the subject of `this` expectation (an [Iterable]) contains only elements of [expectedIterableLike]
@@ -195,8 +216,13 @@ fun <E : Any, T : Iterable<E?>> Expect<T>.toContainExactly(
  * @since 0.17.0
  */
 inline fun <reified E, T : Iterable<E>> Expect<T>.toContainExactlyElementsOf(
-    expectedIterableLike: IterableLike
-): Expect<T> = toContain.inOrder.only.elementsOf(expectedIterableLike)
+    expectedIterableLike: IterableLike,
+    noinline report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> =
+//TODO 0.18.0 use the following
+//    toContain.inOrder.only.elementsOf(expectedIterableLike)
+    toContain.inOrder.only._logic.toVarArg<E>(expectedIterableLike)
+        .let { (first, rest) -> toContain.inOrder.only._logicAppend { valuesInOrderOnly(first glue rest, report) } }
 
 /** Expects that the subject of `this` expectation (an [Iterable]) contains all elements of [expectedIterableLike].
  *

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
@@ -51,7 +51,9 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value
 fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.values(
     expected: E,
     vararg otherExpected: E
-): Expect<T> = _logicAppend { valuesInOrderOnly(expected glue otherExpected) }
+    //TODO use the following with 0.18.0
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend { valuesInOrderOnly(expected glue otherExpected, {}) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -100,7 +102,9 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
 fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.entries(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,
     vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?
-): Expect<T> = _logicAppend { entriesInOrderOnly(assertionCreatorOrNull glue otherAssertionCreatorsOrNulls) }
+    //TODO 0.18.0 add the following
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend { entriesInOrderOnly(assertionCreatorOrNull glue otherAssertionCreatorsOrNulls, {}) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -127,4 +131,6 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  */
 inline fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
+    //TODO 0.18.0 add the following
+    //noinline report: InOrderOnlyReportingOptions.() -> Unit = {}
 ): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> values(first, *rest) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
@@ -30,11 +30,15 @@ import kotlin.jvm.JvmName
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
-fun <E, T: IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBehaviour>.inAnyOrder(
+fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBehaviour>.inAnyOrder(
     firstGroup: Group<E>,
     secondGroup: Group<E>,
     vararg otherExpectedGroups: Group<E>
-): Expect<T> = _logicAppend { valuesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups)) }
+    //TODO 0.18.0 add the following
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend {
+    valuesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups), {})
+}
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the expected [firstGroup] as well as
@@ -56,8 +60,12 @@ fun <E, T: IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBeha
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 @JvmName("inAnyOrderEntries")
-fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InOrderOnlyGroupedWithinSearchBehaviour>.inAnyOrder(
+fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlyGroupedWithinSearchBehaviour>.inAnyOrder(
     firstGroup: Group<(Expect<E>.() -> Unit)?>,
     secondGroup: Group<(Expect<E>.() -> Unit)?>,
     vararg otherExpectedGroups: Group<(Expect<E>.() -> Unit)?>
-): Expect<T> = _logicAppend { entriesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups)) }
+    //TODO 0.18.0 add the following
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend {
+    entriesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups), {})
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
@@ -26,7 +26,6 @@ import kotlin.reflect.KClass
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePair] as well as the [otherPairs] where it does not matter

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeContainsInOrderOnlyCreators.kt
@@ -29,7 +29,6 @@ import kotlin.reflect.KClass
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePair] as well as the [otherPairs] in the specified order.
@@ -41,7 +40,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
     vararg otherPairs: Pair<K, V>
-): Expect<T> = _logicAppend { keyValuePairsInOrderOnly(keyValuePair glue otherPairs) }
+    //TODO 0.18.0 add the following
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend { keyValuePairsInOrderOnly(keyValuePair glue otherPairs, {}) }
 
 
 /**
@@ -83,11 +84,12 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrde
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entries(
     kClass: KClass<V>,
     keyValues: List<KeyValue<K, V>>
+    //TODO 0.18.0 add the following
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
 ): Expect<T> = _logicAppend {
-    keyWithValueAssertionsInOrderOnly(kClass, keyValues.map { it.toPair() })
+    keyWithValueAssertionsInOrderOnly(kClass, keyValues.map { it.toPair() }, { })
 }
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only and all entries of the given [expectedMapLike] in the specified order.
@@ -108,5 +110,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike
+    //TODO 0.18.0 add the following
+    //report: InOrderOnlyReportingOptions.() -> Unit = {}
 ): Expect<T> = _logic.toVarArgPairs<K, V>(expectedMapLike).let { (first, rest) -> entries(first, *rest) }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyElementsOfExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyElementsOfExpectationsSpec.kt
@@ -1,6 +1,10 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
 import org.spekframework.spek2.Spek
@@ -45,26 +49,36 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         fun toContainInOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect.toContain.inOrder.only.elementsOf(listOf(a, *aX))
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double>> =
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) expect.toContain.inOrder.only.elementsOf(listOf(a, *aX))
+            else expect.toContain.inOrder.only._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
         private fun toContainInOrderOnlyNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect.toContain.inOrder.only.elementsOf(sequenceOf(a, *aX))
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit = {}
+        ): Expect<Iterable<Double?>> =
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) expect.toContain.inOrder.only.elementsOf(sequenceOf(a, *aX))
+            else expect.toContain.inOrder.only._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
         private fun toContainExactlyElementsOfShortcut(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect.toContainExactlyElementsOf(arrayOf(a, *aX))
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit = {}
+        ): Expect<Iterable<Double>> = expect.toContainExactlyElementsOf(arrayOf(a, *aX), report)
 
         private fun toContainExactlyElementsOfNullableShortcut(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect.toContainExactlyElementsOf(sequenceOf(a, *aX).asIterable())
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit = {}
+        ): Expect<Iterable<Double?>> = expect.toContainExactlyElementsOf(sequenceOf(a, *aX).asIterable(), report)
     }
 
 
@@ -79,17 +93,22 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         nList = nList.toContain.inOrder.only.elementsOf(listOf<Int>())
         subList = subList.toContain.inOrder.only.elementsOf(listOf<Int>())
         star = star.toContain.inOrder.only.elementsOf(listOf<Int>())
+        //TODO use the following with 0.18.0
+//        list = list.toContain.inOrder.only.elementsOf(listOf<Int>(), report = { showAlwaysSummary() })
+//        nList = nList.toContain.inOrder.only.elementsOf(listOf<Int>(), report = { showOnlyFailing() })
+//        subList = subList.toContain.inOrder.only.elementsOf(listOf<Int>(), report = { })
+//        star = star.toContain.inOrder.only.elementsOf(listOf<Int>(), report = { })
 
-        list = list.toContainExactlyElementsOf(1)
-        nList = nList.toContainExactlyElementsOf(1)
-        subList = subList.toContainExactlyElementsOf(1)
-        star = star.toContainExactlyElementsOf(1)
+        list = list.toContainExactlyElementsOf(1, report = { })
+        nList = nList.toContainExactlyElementsOf(1, report = { })
+        subList = subList.toContainExactlyElementsOf(1, report = { })
+        star = star.toContainExactlyElementsOf(1, report = { })
 
-        list = list.toContainExactlyElementsOf(listOf(1, 1.2))
-        nList = nList.toContainExactlyElementsOf(listOf(1, 1.2))
-        subList = subList.toContainExactlyElementsOf(listOf(1, 2.2))
-        subList = subList.toContainExactlyElementsOf(listOf(1))
-        star = star.toContainExactlyElementsOf(listOf(1, 1.2, "asdf"))
+        list = list.toContainExactlyElementsOf(listOf(1, 1.2), report = { })
+        nList = nList.toContainExactlyElementsOf(listOf(1, 1.2), report = { })
+        subList = subList.toContainExactlyElementsOf(listOf(1, 2.2), report = { })
+        subList = subList.toContainExactlyElementsOf(listOf(1), report = { })
+        star = star.toContainExactlyElementsOf(listOf(1, 1.2, "asdf"), report = { })
     }
 }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
@@ -1,7 +1,11 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.fun2
+import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.fun3
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
 import org.spekframework.spek2.Spek
@@ -20,8 +24,8 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
     )
 
     object ShortcutSpec : ch.tutteli.atrium.specs.integration.IterableToContainInOrderOnlyValuesExpectationsSpec(
-        fun2<Iterable<Double>, Double, Array<out Double>>(Expect<Iterable<Double>>::toContainExactly),
-        fun2<Iterable<Double?>, Double?, Array<out Double?>>(Expect<Iterable<Double?>>::toContainExactly).withNullableSuffix(),
+        fun3<Iterable<Double>, Double, Array<out Double>, InOrderOnlyReportingOptions.() -> Unit>(Expect<Iterable<Double>>::toContainExactly),
+        fun3<Iterable<Double?>, Double?, Array<out Double?>, InOrderOnlyReportingOptions.() -> Unit>(Expect<Iterable<Double?>>::toContainExactly).withNullableSuffix(),
         "[Atrium][Shortcut] "
     )
 
@@ -31,18 +35,26 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect.toContain.inOrder.only.value(a)
-            else expect.toContain.inOrder.only.values(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect.toContain.inOrder.only.value(a)
+                else expect.toContain.inOrder.only.values(a, *aX)
+            } else expect.toContain.inOrder.only._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
         private fun toContainInOrderOnlyNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect.toContain.inOrder.only.value(a)
-            else expect.toContain.inOrder.only.values(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect.toContain.inOrder.only.value(a)
+                else expect.toContain.inOrder.only.values(a, *aX)
+            } else expect.toContain.inOrder.only._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
     }
 
     @Suppress("unused", "UNUSED_VALUE")
@@ -63,17 +75,24 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         subList = subList.toContain.inOrder.only.values(1, 2.2)
         star = star.toContain.inOrder.only.values(1, 1.2, "asdf")
 
+        //TODO use the following with 0.18.0
+//        list = list.toContain.inOrder.only.values(1, 1.2, report = {})
+//        nList = nList.toContain.inOrder.only.values(1, 1.2, report = {})
+//        subList = subList.toContain.inOrder.only.values(1, 2.2, report = {})
+//        star = star.toContain.inOrder.only.values(1, 1.2, "asdf", report = {})
+
+
         list = list.toContainExactly(1)
         nList = nList.toContainExactly(1)
         subList = subList.toContainExactly(1)
         star = star.toContainExactly(1)
 
-        list = list.toContainExactly(1, 1.2)
-        nList = nList.toContainExactly(1, 1.2)
-        subList = subList.toContainExactly(1, 2.2)
+        list = list.toContainExactly(1, 1.2, report = { showOnlyFailingIfMoreElementsThan(1) })
+        nList = nList.toContainExactly(1, 1.2, report = { showOnlyFailing() })
+        subList = subList.toContainExactly(1, 2.2, report = { showAlwaysSummary() })
         // TODO would wish this does not work, maybe @OnlyInputTypes would help?
-        subList = subList.toContainExactly("asdf")
-        star = star.toContainExactly(1, 1.2, "asdf")
+        subList = subList.toContainExactly("asdf", report = {})
+        star = star.toContainExactly(1, 1.2, "asdf", report = {})
     }
 }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyAssertions.kt
@@ -248,7 +248,7 @@ inline infix fun <T> Expect<T>.and(@Suppress("UNUSED_PARAMETER") o: o): Expect<T
 infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     _logic.appendAsGroup(assertionCreator)
 
-//TODO 0.17.0 deprecate?
+//TODO move to anyExpectations.kt with 0.18.0
 /**
  * Inline property referring actually to `this` and allows to write infix assertions within an assertion group block
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/charSequenceExpectations.kt
@@ -12,14 +12,6 @@ import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.N
 import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NotSearchBehaviour
 import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerStep
 
-//TODO 0.17.0 reconsider if `toContain o` is good or if we should try to come up with another form which does not use
-//the filler. E.g. we could skip one step (thought I guess the api will be misleading as it is no longer based on two levels:
-// expect("hello") toContainAtLeast 1 value "hello"
-//
-// another idea is `expect("hello") to contain` but an infix `to` caused already problems in conjunction with pairs
-// but maybe this ambiguity problem was solved in the new inference algorithm?
-// the drawback of this, the shortcut has no longer the same prefix as the builder. But I guess that's fine if other
-// builders do not follow this rule in the infix API
 /**
  * Starts a sophisticated `toContain` assertion building process based on this [Expect].
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyCreators.kt
@@ -49,7 +49,13 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.the(values: Values<E>): Expect<T> =
-    _logicAppend { valuesInOrderOnly(values.toList()) }
+    _logicAppend {
+        valuesInOrderOnly(
+            values.toList(),
+            //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
+            {}
+        )
+    }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -92,9 +98,16 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
+
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.the(
     entries: Entries<E>
-): Expect<T> = _logicAppend { entriesInOrderOnly(entries.toList()) }
+): Expect<T> = _logicAppend {
+    entriesInOrderOnly(
+        entries.toList(),
+        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
+        {}
+    )
+}
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -120,6 +133,7 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  *
  * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
  */
+//TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
 ): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> this the values(first, *rest) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeContainsInOrderOnlyGroupedCreators.kt
@@ -25,9 +25,16 @@ import kotlin.jvm.JvmName
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
+
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBehaviour>.inAny(
     order: Order<E, Group<E>>
-): Expect<T> = _logicAppend { valuesInOrderOnlyGrouped(order.toList()) }
+): Expect<T> = _logicAppend {
+    valuesInOrderOnlyGrouped(
+        order.toList(),
+        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
+        {}
+    )
+}
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the expected [Order.firstGroup] as well as
@@ -54,7 +61,13 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSea
 @JvmName("inAnyOrderEntries")
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlyGroupedWithinSearchBehaviour>.inAny(
     order: Order<(Expect<E>.() -> Unit)?, Group<(Expect<E>.() -> Unit)?>>
-): Expect<T> = _logicAppend { entriesInOrderOnlyGrouped(order.toList()) }
+): Expect<T> = _logicAppend {
+    entriesInOrderOnlyGrouped(
+        order.toList(),
+        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
+        {}
+    )
+}
 
 /**
  * Helper function to create an [Order] based on the given [firstGroup], [secondGroup] and [otherExpectedGroups].

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInAnyOrderOnlyCreators.kt
@@ -28,7 +28,6 @@ import kotlin.reflect.KClass
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     this the pairs(keyValuePair)
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePairs] where it does not matter

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeContainsInOrderOnlyCreators.kt
@@ -31,7 +31,6 @@ import kotlin.reflect.KClass
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     this the pairs(keyValuePair)
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePairs] in the specified order.
@@ -42,7 +41,13 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
     keyValuePairs: Pairs<K, V>
-): Expect<T> = _logicAppend { keyValuePairsInOrderOnly(keyValuePairs.toList()) }
+): Expect<T> = _logicAppend {
+    keyValuePairsInOrderOnly(
+        keyValuePairs.toList(),
+        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
+        {}
+    )
+}
 
 
 /**
@@ -62,7 +67,6 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
     keyValue: KeyWithValueCreator<K, V>
 ): Expect<T> = this the keyValues(keyValue)
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValues] in the specified order -- an entry
@@ -84,10 +88,14 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
     kClass: KClass<V>,
     keyValues: List<KeyWithValueCreator<K, V>>
 ): Expect<T> = _logicAppend {
-    keyWithValueAssertionsInOrderOnly(kClass, keyValues.map { it.toPair() })
+    keyWithValueAssertionsInOrderOnly(
+        kClass,
+        keyValues.map { it.toPair() },
+        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
+        {}
+    )
 }
 
-// TODO 0.17.0 implement https://github.com/robstoll/atrium/issues/292 for the new function in ...Expectations.kt file
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only and all entries of the given [expectedMapLike] in the specified order.
@@ -106,6 +114,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *
  * @since 0.15.0
  */
+//TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike
 ): Expect<T> = _logic.toVarArgPairs<K, V>(expectedMapLike).let { (first, rest) ->

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyElementsOfExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyElementsOfExpectationsSpec.kt
@@ -1,6 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.*
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
@@ -43,8 +47,12 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun toContainInOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect toContain o inGiven order and only elementsOf listOf(a, *aX)
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double>> =
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) expect toContain o inGiven order and only elementsOf listOf(a, *aX)
+            else (expect toContain o inGiven order and only)._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
         fun getToContainNullablePair() =
             "$toContain $filler $inOrder $andOnly $inOrderElementsOf" to Companion::toContainInOrderOnlyNullableValues
@@ -52,8 +60,12 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun toContainInOrderOnlyNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect toContain o inGiven order and only elementsOf sequenceOf(a, *aX)
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double?>> =
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) expect toContain o inGiven order and only elementsOf sequenceOf(a, *aX)
+            else (expect toContain o inGiven order and only)._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
         private val toContainExactlyElementsOfShortcutFun: KFunction2<Expect<Iterable<Double>>, Iterable<Double>, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::toContainExactlyElementsOf
@@ -64,8 +76,12 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun toContainExactlyElementsOfShortcut(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect toContainExactlyElementsOf arrayOf(a, *aX)
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double>> =
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions)  expect toContainExactlyElementsOf arrayOf(a, *aX)
+            else (expect toContain o inGiven order and only)._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
         private val toContainExactlyElementsOfNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Iterable<Double?>, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::toContainExactlyElementsOf
@@ -76,8 +92,12 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun toContainExactlyElementsOfNullableShortcut(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect toContainExactlyElementsOf sequenceOf(a, *aX).asIterable()
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double?>> =
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) expect toContainExactlyElementsOf sequenceOf(a, *aX).asIterable()
+            else (expect toContain o inGiven order and only)._logicAppend { valuesInOrderOnly(listOf(a, *aX), report) }
 
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
@@ -1,6 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
@@ -29,10 +33,14 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
         private fun toContainInOrderOnly(
             expect: Expect<Iterable<Double>>,
             a: Expect<Double>.() -> Unit,
-            aX: Array<out Expect<Double>.() -> Unit>
+            aX: Array<out Expect<Double>.() -> Unit>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect toContain o inGiven order and only entry a
-            else expect toContain o inGiven order and only the entries(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inGiven order and only entry a
+                else expect toContain o inGiven order and only the entries(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend { entriesInOrderOnly(listOf(a, *aX), report) }
 
         fun getToContainNullablePair() =
             "$toContain $filler $inOrder $andOnly $inOrderOnlyEntries" to Companion::toContainInOrderOnlyNullableEntriesPair
@@ -40,10 +48,14 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyNullableEntriesPair(
             expect: Expect<Iterable<Double?>>,
             a: (Expect<Double>.() -> Unit)?,
-            aX: Array<out (Expect<Double>.() -> Unit)?>
+            aX: Array<out (Expect<Double>.() -> Unit)?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect toContain o inGiven order and only entry a
-            else expect toContain o inGiven order and only the entries(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inGiven order and only entry a
+                else expect toContain o inGiven order and only the entries(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend { entriesInOrderOnly(listOf(a, *aX), report) }
 
         private val toContainShortcutFun: KFunction2<Expect<Iterable<Double>>, Expect<Double>.() -> Unit, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::toContainExactly
@@ -53,10 +65,14 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyEntriesShortcut(
             expect: Expect<Iterable<Double>>,
             a: Expect<Double>.() -> Unit,
-            aX: Array<out Expect<Double>.() -> Unit>
+            aX: Array<out Expect<Double>.() -> Unit>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect toContainExactly { a() }
-            else expect toContainExactly entries(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContainExactly { a() }
+                else expect toContainExactly entries(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend { entriesInOrderOnly(listOf(a, *aX), report) }
 
         private val toContainNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, (Expect<Double>.() -> Unit)?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::toContainExactly
@@ -67,14 +83,18 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyNullableEntriesShortcut(
             expect: Expect<Iterable<Double?>>,
             a: (Expect<Double>.() -> Unit)?,
-            aX: Array<out (Expect<Double>.() -> Unit)?>
+            aX: Array<out (Expect<Double>.() -> Unit)?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) {
-                //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
-                if (a == null) expect toContainExactly a as Double?
-                else expect toContainExactly { a() }
-            } else {
-                expect toContainExactly entries(a, *aX)
-            }
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) {
+                    //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
+                    if (a == null) expect toContainExactly a as Double?
+                    else expect toContainExactly { a() }
+                } else {
+                    expect toContainExactly entries(a, *aX)
+                }
+            } else (expect toContain o inGiven order and only)._logicAppend { entriesInOrderOnly(listOf(a, *aX), report) }
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
@@ -1,6 +1,10 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
@@ -29,10 +33,16 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect toContain o inGiven order and only value a
-            else expect toContain o inGiven order and only the values(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inGiven order and only value a
+                else expect toContain o inGiven order and only the values(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend {
+                valuesInOrderOnly(listOf(a, *aX), report)
+            }
 
         fun getToContainNullablePair() =
             "$toContain $filler $inOrder $andOnly $inOrderOnlyValues" to Companion::toContainInOrderOnlyNullableValues
@@ -40,10 +50,16 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect toContain o inGiven order and only value a
-            else expect toContain o inGiven order and only the values(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inGiven order and only value a
+                else expect toContain o inGiven order and only the values(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend {
+                valuesInOrderOnly(listOf(a, *aX), report)
+            }
 
         private val toContainShortcutFun: KFunction2<Expect<Iterable<Double>>, Double, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::toContainExactly
@@ -53,10 +69,16 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyValuesShortcut(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
+            aX: Array<out Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect toContainExactly a
-            else expect toContainExactly values(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContainExactly a
+                else expect toContainExactly values(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend {
+                valuesInOrderOnly(listOf(a, *aX), report)
+            }
 
         private val toContainNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Double?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::toContainExactly
@@ -67,10 +89,16 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         private fun toContainInOrderOnlyNullableValuesShortcut(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
+            aX: Array<out Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect toContainExactly a
-            else expect toContainExactly values(a, *aX)
+            //TODO 0.18.0 remove if once implemented
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContainExactly a
+                else expect toContainExactly values(a, *aX)
+            } else (expect toContain o inGiven order and only)._logicAppend {
+                valuesInOrderOnly(listOf(a, *aX), report)
+            }
     }
 }
 

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/ErrorMessages.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/ErrorMessages.kt
@@ -7,7 +7,7 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  */
 enum class ErrorMessages(override val value: String) : StringBasedTranslatable {
     AT_LEAST_ONE_ASSERTION_DEFINED("at least one assertion defined"),
-    //TODO 0.17.0 deprecate and replace with FORGOT_DO_DEFINE_EXPECTATION
+    //TODO 0.18.0 deprecate and replace with FORGOT_TO_DEFINE_EXPECTATION
     FORGOT_DO_DEFINE_ASSERTION("You forgot to define assertions in the assertionCreator-lambda"),
     HINT_AT_LEAST_ONE_ASSERTION_DEFINED("Sometimes you can use an alternative to `{ }` For instance, instead of `toThrow<..> { }` you should use `toThrow<..>()`"),
 }

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/Expect.kt
@@ -41,7 +41,7 @@ interface ExpectInternal<T> : Expect<T>, AssertionContainer<T> {
  * @param T The type of the subject of `this` expectation.
  */
 @Suppress("DEPRECATION")
-@ExpectMarker
+//@ExpectMarker
 interface Expect<T> : @kotlin.Suppress("DEPRECATION") SubjectProvider<T> {
 
     @Deprecated(

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContains.kt
@@ -12,6 +12,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
@@ -25,14 +26,18 @@ fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InAnyOr
 fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InAnyOrderOnlySearchBehaviour>.entriesInAnyOrderOnly(assertionCreators: List<(Expect<E>.() -> Unit)?>): Assertion = impl.entriesInAnyOrderOnly(this, assertionCreators)
 
 
-fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlySearchBehaviour>.valuesInOrderOnly(expected: List<E>): Assertion = impl.valuesInOrderOnly(this, expected)
+fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlySearchBehaviour>.valuesInOrderOnly(expected: List<E>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.valuesInOrderOnly(this, expected, reportingOptions)
 
-fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlySearchBehaviour>.entriesInOrderOnly(assertionCreators: List<(Expect<E>.() -> Unit)?>): Assertion = impl.entriesInOrderOnly(this, assertionCreators)
+fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlySearchBehaviour>.entriesInOrderOnly(assertionCreators: List<(Expect<E>.() -> Unit)?>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.entriesInOrderOnly(this, assertionCreators, reportingOptions)
 
 
-fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>.valuesInOrderOnlyGrouped(groups: List<List<E>>): Assertion = impl.valuesInOrderOnlyGrouped(this, groups)
+fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>.valuesInOrderOnlyGrouped(groups: List<List<E>>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.valuesInOrderOnlyGrouped(this, groups, reportingOptions)
 
-fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>.entriesInOrderOnlyGrouped(groups: List<List<(Expect<E>.() -> Unit)?>>): Assertion = impl.entriesInOrderOnlyGrouped(this, groups)
+fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>.entriesInOrderOnlyGrouped(groups: List<List<(Expect<E>.() -> Unit)?>>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.entriesInOrderOnlyGrouped(this, groups, reportingOptions)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/mapLikeContains.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/mapLikeContains.kt
@@ -11,6 +11,7 @@ package ch.tutteli.atrium.logic.creating.maplike.contains.creators
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.maplike.contains.MapLikeContains
 import ch.tutteli.atrium.logic.creating.maplike.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.maplike.contains.searchbehaviours.InAnyOrderSearchBehaviour
@@ -33,10 +34,15 @@ fun <K, V : Any, T : MapLike> MapLikeContains.EntryPointStepLogic<K, out V?, T, 
     impl.keyWithValueAssertionsInAnyOrderOnly(this, valueType, keyValues)
 
 
-fun <K, V, T : MapLike> MapLikeContains.EntryPointStepLogic<K, V, T, InOrderOnlySearchBehaviour>.keyValuePairsInOrderOnly(keyValuePairs: List<Pair<K, V>>): Assertion = impl.keyValuePairsInOrderOnly(this, keyValuePairs)
+fun <K, V, T : MapLike> MapLikeContains.EntryPointStepLogic<K, V, T, InOrderOnlySearchBehaviour>.keyValuePairsInOrderOnly(keyValuePairs: List<Pair<K, V>>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.keyValuePairsInOrderOnly(this, keyValuePairs, reportingOptions)
 
+    //TODO remove with 0.18.0 only here for backward compatiblity with specs
 fun <K, V : Any, T : MapLike> MapLikeContains.EntryPointStepLogic<K, out V?, T, InOrderOnlySearchBehaviour>.keyWithValueAssertionsInOrderOnly(valueType: KClass<V>, keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>): Assertion =
     impl.keyWithValueAssertionsInOrderOnly(this, valueType, keyValues)
+
+fun <K, V : Any, T : MapLike> MapLikeContains.EntryPointStepLogic<K, out V?, T, InOrderOnlySearchBehaviour>.keyWithValueAssertionsInOrderOnly(valueType: KClass<V>, keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.keyWithValueAssertionsInOrderOnly(this, valueType, keyValues, reportingOptions)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains.kt
@@ -18,7 +18,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  * defines which [Checker]s should be applied and
  * is finalized by one of the [IterableLikeContainsAssertions] which usually use a [Creator].
  */
-//TODO 0.18.0 use IterableLikeToContains in combinatino with proof
+//TODO 0.18.0 use IterableLikeToContains in combination with Proof
 interface IterableLikeContains {
 
     /**

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker.kt
@@ -1,3 +1,4 @@
+//TODO 0.18.0 rename package to iterableLike
 package ch.tutteli.atrium.logic.creating.iterable.contains.checkers
 
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtLeastChecker.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtLeastChecker.kt
@@ -1,3 +1,4 @@
+//TODO 0.18.0 rename package to iterableLike
 package ch.tutteli.atrium.logic.creating.iterable.contains.checkers.impl
 
 import ch.tutteli.atrium.assertions.Assertion

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions.kt
@@ -5,6 +5,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
@@ -29,22 +30,26 @@ interface IterableLikeContainsAssertions {
 
     fun <E, T : IterableLike> valuesInOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlySearchBehaviour>,
-        expected: List<E>
+        expected: List<E>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 
     fun <E : Any, T : IterableLike> entriesInOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlySearchBehaviour>,
-        assertionCreators: List<(Expect<E>.() -> Unit)?>
+        assertionCreators: List<(Expect<E>.() -> Unit)?>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 
 
     fun <E, T : IterableLike> valuesInOrderOnlyGrouped(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>,
-        groups: List<List<E>>
+        groups: List<List<E>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 
     fun <E : Any, T : IterableLike> entriesInOrderOnlyGrouped(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>,
-        groups: List<List<(Expect<E>.() -> Unit)?>>
+        groups: List<List<(Expect<E>.() -> Unit)?>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderAssertions.kt
@@ -24,3 +24,5 @@ interface IterableLikeContainsInAnyOrderAssertions {
         assertionCreators: List<(Expect<E>.() -> Unit)?>
     ): Assertion
 }
+
+

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/DefaultIterableLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/DefaultIterableLikeContainsAssertions.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.IterableLikeContainsAssertions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
@@ -14,46 +15,62 @@ class DefaultIterableLikeContainsAssertions : IterableLikeContainsAssertions {
     override fun <E, T : IterableLike> valuesInAnyOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InAnyOrderOnlySearchBehaviour>,
         expected: List<E>
-    ): Assertion =
-        createAssertionGroupWithoutChecker(entryPointStepLogic, expected, ::InAnyOrderOnlyValuesAssertionCreator)
+    ): Assertion = createAssertionGroupWithoutCheckerInAnyOrder(
+        entryPointStepLogic, expected, ::InAnyOrderOnlyValuesAssertionCreator
+    )
 
     override fun <E : Any, T : IterableLike> entriesInAnyOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InAnyOrderOnlySearchBehaviour>,
         assertionCreators: List<(Expect<E>.() -> Unit)?>
-    ): Assertion = createAssertionGroupWithoutChecker(
+    ): Assertion = createAssertionGroupWithoutCheckerInAnyOrder(
         entryPointStepLogic, assertionCreators, ::InAnyOrderOnlyEntriesAssertionCreator
     )
 
 
     override fun <E, T : IterableLike> valuesInOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlySearchBehaviour>,
-        expected: List<E>
-    ): Assertion =
-        createAssertionGroupWithoutChecker(entryPointStepLogic, expected, ::InOrderOnlyValuesAssertionCreator)
+        expected: List<E>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+    ): Assertion = createAssertionGroupWithoutCheckerInOrder(
+        entryPointStepLogic, expected, reportingOptions, ::InOrderOnlyValuesAssertionCreator
+    )
 
     override fun <E : Any, T : IterableLike> entriesInOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlySearchBehaviour>,
-        assertionCreators: List<(Expect<E>.() -> Unit)?>
-    ): Assertion = createAssertionGroupWithoutChecker(
-        entryPointStepLogic, assertionCreators, ::InOrderOnlyEntriesAssertionCreator
+        assertionCreators: List<(Expect<E>.() -> Unit)?>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+    ): Assertion = createAssertionGroupWithoutCheckerInOrder(
+        entryPointStepLogic, assertionCreators, reportingOptions, ::InOrderOnlyEntriesAssertionCreator
     )
 
 
     override fun <E, T : IterableLike> valuesInOrderOnlyGrouped(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>,
-        groups: List<List<E>>
-    ): Assertion = createAssertionGroupWithoutChecker(
-            entryPointStepLogic, groups, ::InOrderOnlyGroupedValuesAssertionCreator
+        groups: List<List<E>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+    ): Assertion = createAssertionGroupWithoutCheckerInOrder(
+        entryPointStepLogic, groups, reportingOptions, ::InOrderOnlyGroupedValuesAssertionCreator
     )
 
     override fun <E : Any, T : IterableLike> entriesInOrderOnlyGrouped(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>,
-        groups: List<List<(Expect<E>.() -> Unit)?>>
-    ): Assertion = createAssertionGroupWithoutChecker(
-            entryPointStepLogic, groups, ::InOrderOnlyGroupedEntriesAssertionCreator
+        groups: List<List<(Expect<E>.() -> Unit)?>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+    ): Assertion = createAssertionGroupWithoutCheckerInOrder(
+        entryPointStepLogic, groups, reportingOptions, ::InOrderOnlyGroupedEntriesAssertionCreator
     )
 
-    private fun <E, T : IterableLike, SC, S : IterableLikeContains.SearchBehaviour> createAssertionGroupWithoutChecker(
+    private fun <E, T : IterableLike, SC, S : IterableLikeContains.SearchBehaviour> createAssertionGroupWithoutCheckerInOrder(
+        entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, S>,
+        expected: List<SC>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit,
+        factory: ((T) -> Iterable<E>, S, InOrderOnlyReportingOptions.() -> Unit) -> IterableLikeContains.Creator<T, SC>
+    ): AssertionGroup {
+        val creator = factory(entryPointStepLogic.converter, entryPointStepLogic.searchBehaviour, reportingOptions)
+        return creator.createAssertionGroup(entryPointStepLogic.container, expected)
+    }
+
+    private fun <E, T : IterableLike, SC, S : IterableLikeContains.SearchBehaviour> createAssertionGroupWithoutCheckerInAnyOrder(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, S>,
         expected: List<SC>,
         factory: ((T) -> Iterable<E>, S) -> IterableLikeContains.Creator<T, SC>

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -25,8 +26,9 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion.ELEMENT_WITH_
  */
 abstract class InOrderOnlyAssertionCreator<E, T : IterableLike, SC>(
     converter: (T) -> Iterable<E>,
-    searchBehaviour: InOrderOnlySearchBehaviour
-) : InOrderOnlyBaseAssertionCreator<E, T, SC>(converter, searchBehaviour),
+    searchBehaviour: InOrderOnlySearchBehaviour,
+    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyBaseAssertionCreator<E, T, SC>(converter, searchBehaviour, reportingOptions),
     //TODO use protected visibility once https://youtrack.jetbrains.com/issue/KT-24328 is implemented
     InOrderOnlyMatcher<E, SC> {
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesAssertionCreator.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -21,6 +22,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  */
 class InOrderOnlyEntriesAssertionCreator<E : Any, T : IterableLike>(
     converter: (T) -> Iterable<E?>,
-    searchBehaviour: InOrderOnlySearchBehaviour
-) : InOrderOnlyAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour),
+    searchBehaviour: InOrderOnlySearchBehaviour,
+    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour, reportingOptions),
     InOrderOnlyMatcher<E?, (Expect<E>.() -> Unit)?> by InOrderOnlyEntriesMatcher()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.extractFeature
@@ -13,8 +14,9 @@ import ch.tutteli.atrium.translations.DescriptionIterableAssertion
 
 abstract class InOrderOnlyGroupedAssertionCreator<E, T : IterableLike, SC>(
     converter: (T) -> Iterable<E>,
-    searchBehaviour: InOrderOnlyGroupedSearchBehaviour
-) : InOrderOnlyBaseAssertionCreator<E, T, List<SC>>(converter, searchBehaviour),
+    searchBehaviour: InOrderOnlyGroupedSearchBehaviour,
+    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyBaseAssertionCreator<E, T, List<SC>>(converter, searchBehaviour, reportingOptions),
     //TODO use protected visibility once https://youtrack.jetbrains.com/issue/KT-24328 is implemented
     InOrderOnlyMatcher<E, SC> {
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedEntriesAssertionCreator.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic._logicAppend
 import ch.tutteli.atrium.logic.builderContainsInIterableLike
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInAnyOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.butOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.inAnyOrder
@@ -13,8 +14,9 @@ import ch.tutteli.kbox.identity
 
 class InOrderOnlyGroupedEntriesAssertionCreator<E : Any, T : IterableLike>(
     converter: (T) -> Iterable<E?>,
-    searchBehaviour: InOrderOnlyGroupedSearchBehaviour
-) : InOrderOnlyGroupedAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour),
+    searchBehaviour: InOrderOnlyGroupedSearchBehaviour,
+    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyGroupedAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour, reportingOptions),
     InOrderOnlyMatcher<E?, (Expect<E>.() -> Unit)?> by InOrderOnlyEntriesMatcher() {
 
     override fun Expect<List<E?>>.addSublistAssertion(groupOfSearchCriteria: List<(Expect<E>.() -> Unit)?>) {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedValuesAssertionCreator.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic._logicAppend
 import ch.tutteli.atrium.logic.builderContainsInIterableLike
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInAnyOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.butOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.inAnyOrder
@@ -13,8 +14,9 @@ import ch.tutteli.kbox.identity
 
 class InOrderOnlyGroupedValuesAssertionCreator<E, T : IterableLike>(
     converter: (T) -> Iterable<E>,
-    searchBehaviour: InOrderOnlyGroupedSearchBehaviour
-) : InOrderOnlyGroupedAssertionCreator<E, T, E>(converter, searchBehaviour),
+    searchBehaviour: InOrderOnlyGroupedSearchBehaviour,
+    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyGroupedAssertionCreator<E, T, E>(converter, searchBehaviour, reportingOptions),
     InOrderOnlyMatcher<E, E> by InOrderOnlyValueMatcher() {
 
     override fun Expect<List<E>>.addSublistAssertion(groupOfSearchCriteria: List<E>) {

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValuesAssertionCreator.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl
 
 import ch.tutteli.atrium.assertions.AssertionGroup
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
@@ -19,7 +20,8 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  */
 class InOrderOnlyValuesAssertionCreator<E, T : IterableLike>(
     converter: (T) -> Iterable<E>,
-    searchBehaviour: InOrderOnlySearchBehaviour
-) : InOrderOnlyAssertionCreator<E, T, E>(converter, searchBehaviour),
+    searchBehaviour: InOrderOnlySearchBehaviour,
+    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyAssertionCreator<E, T, E>(converter, searchBehaviour, reportingOptions),
     //TODO use protected visibility once https://youtrack.jetbrains.com/issue/KT-24328 is implemented
     InOrderOnlyMatcher<E, E> by InOrderOnlyValueMatcher()

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions.kt
@@ -1,0 +1,34 @@
+package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting
+
+import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
+
+interface InOrderOnlyReportingOptions {
+
+    /**
+     * Always shows only failing expectations, same as [InOrderOnlyReportingOptions.showOnlyFailingIfMoreElementsThan]`(0)`
+     */
+    fun showOnlyFailing() = showOnlyFailingIfMoreElementsThan(0)
+
+    /**
+     * Always shows a summary where both failing and successful expectations are shown, same as
+     * [InOrderOnlyReportingOptions.showOnlyFailingIfMoreElementsThan]`(Int.MAX_VALUE)`.
+     */
+    fun showAlwaysSummary() = showOnlyFailingIfMoreElementsThan(Int.MAX_VALUE)
+
+    /**
+     * Show only failing expectations, i.e. elements which do not match, instead of a summary which
+     * lists also successful expectations/elements.
+     *
+     * Default shows up to 10 elements in a summary ans only failing afterwards,
+     * i.e. default is [showOnlyFailingIfMoreElementsThan]`(10)`
+     */
+    fun showOnlyFailingIfMoreElementsThan(number: Int)
+
+    /**
+     * Indicates until how many elements the summary view shall be used. If there are more elements in the
+     * [IterableLike], then only failing expectations shall be shown.
+     */
+    val numberOfElementsInSummary: Int
+}
+
+

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/InOrderOnlyReportingOptionsImpl.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/InOrderOnlyReportingOptionsImpl.kt
@@ -1,0 +1,13 @@
+package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.impl
+
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
+
+internal class InOrderOnlyReportingOptionsImpl : InOrderOnlyReportingOptions {
+    private var _numberOfElementsInSummary = 10
+    override val numberOfElementsInSummary: Int get() = _numberOfElementsInSummary
+
+    override fun showOnlyFailingIfMoreElementsThan(number: Int) {
+        // could check for negative numbers but it does not really matter that much, it still means always
+        _numberOfElementsInSummary = number
+    }
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsAssertions.kt
@@ -4,6 +4,7 @@ package ch.tutteli.atrium.logic.creating.maplike.contains.creators
 
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.maplike.contains.MapLikeContains
 import ch.tutteli.atrium.logic.creating.maplike.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.maplike.contains.searchbehaviours.InAnyOrderSearchBehaviour
@@ -43,12 +44,21 @@ interface MapLikeContainsAssertions {
 
     fun <K, V, T : MapLike> keyValuePairsInOrderOnly(
         entryPointStepLogic: MapLikeContains.EntryPointStepLogic<K, V, T, InOrderOnlySearchBehaviour>,
-        keyValuePairs: List<Pair<K, V>>
+        keyValuePairs: List<Pair<K, V>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+    ): Assertion
+
+    //TODO remove with 0.18.0 only here for backward compatiblity with specs
+    fun <K, V : Any, T : MapLike> keyWithValueAssertionsInOrderOnly(
+        entryPointStepLogic: MapLikeContains.EntryPointStepLogic<K, out V?, T, InOrderOnlySearchBehaviour>,
+        valueType: KClass<V>,
+        keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>
     ): Assertion
 
     fun <K, V : Any, T : MapLike> keyWithValueAssertionsInOrderOnly(
         entryPointStepLogic: MapLikeContains.EntryPointStepLogic<K, out V?, T, InOrderOnlySearchBehaviour>,
         valueType: KClass<V>,
-        keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>
+        keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions.kt
@@ -11,6 +11,7 @@ import ch.tutteli.atrium.creating.build
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.logic.assertions.impl.LazyThreadUnsafeAssertionGroup
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnly
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.andOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.inOrder
 import ch.tutteli.atrium.logic.creating.maplike.contains.MapLikeContains
@@ -204,18 +205,26 @@ class DefaultMapLikeContainsAssertions : MapLikeContainsAssertions {
 
     override fun <K, V, T : MapLike> keyValuePairsInOrderOnly(
         entryPointStepLogic: MapLikeContains.EntryPointStepLogic<K, V, T, InOrderOnlySearchBehaviour>,
-        keyValuePairs: List<Pair<K, V>>
+        keyValuePairs: List<Pair<K, V>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion =
         entryPointStepLogic.container
             .builderContainsInIterableLike { convertToMap(entryPointStepLogic).entries }
             ._logic.inOrder._logic.andOnly._logic.entriesInOrderOnly(keyValuePairs.map { (key, value) ->
                 expectLambda<Map.Entry<K, V>> { _logicAppend { isKeyValue(key, value) } }
-            })
+            }, reportingOptions)
 
     override fun <K, V : Any, T : MapLike> keyWithValueAssertionsInOrderOnly(
         entryPointStepLogic: MapLikeContains.EntryPointStepLogic<K, out V?, T, InOrderOnlySearchBehaviour>,
         valueType: KClass<V>,
         keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>
+    ): Assertion = keyWithValueAssertionsInOrderOnly(entryPointStepLogic, valueType, keyValues, reportingOptions = {})
+
+    override fun <K, V : Any, T : MapLike> keyWithValueAssertionsInOrderOnly(
+        entryPointStepLogic: MapLikeContains.EntryPointStepLogic<K, out V?, T, InOrderOnlySearchBehaviour>,
+        valueType: KClass<V>,
+        keyValues: List<Pair<K, (Expect<V>.() -> Unit)?>>,
+        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
     ): Assertion =
         entryPointStepLogic.container
             .builderContainsInIterableLike { convertToMap(entryPointStepLogic).entries }
@@ -224,5 +233,5 @@ class DefaultMapLikeContainsAssertions : MapLikeContainsAssertions {
                     _logic.key().collectAndLogicAppend { toBe(key) }
                     _logic.value().collectAndLogicAppend { toBeNullIfNullGivenElse(nullableAssertionCreator) }
                 }
-            })
+            }, reportingOptions)
 }

--- a/logic/atrium-logic-jvm/src/module/module-info.java
+++ b/logic/atrium-logic-jvm/src/module/module-info.java
@@ -21,6 +21,8 @@ module ch.tutteli.atrium.logic {
     exports ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours;
     exports ch.tutteli.atrium.logic.creating.iterable.contains.steps;
 
+    exports ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting;
+
     exports ch.tutteli.atrium.logic.creating.maplike.contains;
     exports ch.tutteli.atrium.logic.creating.maplike.contains.checkers;
     exports ch.tutteli.atrium.logic.creating.maplike.contains.creators;

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
@@ -3,43 +3,45 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.specs.*
 
 abstract class IterableToContainInOrderOnlyEntriesExpectationsSpec(
-    toContainInOrderOnlyEntries: Fun2<Iterable<Double>, Expect<Double>.() -> Unit, Array<out Expect<Double>.() -> Unit>>,
-    toContainInOrderOnlyNullableEntries: Fun2<Iterable<Double?>, (Expect<Double>.() -> Unit)?, Array<out (Expect<Double>.() -> Unit)?>>,
+    toContainInOrderOnlyEntries: Fun3<Iterable<Double>, Expect<Double>.() -> Unit, Array<out Expect<Double>.() -> Unit>, InOrderOnlyReportingOptions.() -> Unit>,
+    toContainInOrderOnlyNullableEntries: Fun3<Iterable<Double?>, (Expect<Double>.() -> Unit)?, Array<out (Expect<Double>.() -> Unit)?>, InOrderOnlyReportingOptions.() -> Unit>,
     describePrefix: String = "[Atrium] "
 ) : IterableToContainEntriesSpecBase({
 
     include(object : SubjectLessSpec<Iterable<Double>>(
         describePrefix,
-        toContainInOrderOnlyEntries.forSubjectLess({ toEqual(2.5) }, arrayOf())
+        toContainInOrderOnlyEntries.forSubjectLess({ toEqual(2.5) }, arrayOf(), emptyInOrderOnlyReportOptions)
     ) {})
     include(object : SubjectLessSpec<Iterable<Double?>>(
         "$describePrefix[nullable] ",
-        toContainInOrderOnlyNullableEntries.forSubjectLess(null, arrayOf())
+        toContainInOrderOnlyNullableEntries.forSubjectLess(null, arrayOf(), emptyInOrderOnlyReportOptions)
     ) {})
 
     include(object : AssertionCreatorSpec<Iterable<Double>>(
         describePrefix, listOf(1.2, 2.0),
         *toContainInOrderOnlyEntries.forAssertionCreatorSpec(
             "$toBeDescr: 1.2", "$toBeDescr: 2.0",
-            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) })
+            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) }), emptyInOrderOnlyReportOptions
         )
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
         "$describePrefix[nullable] ", listOf(1.2, 2.0) as Iterable<Double?>,
         *toContainInOrderOnlyNullableEntries.forAssertionCreatorSpec(
             "$toBeDescr: 1.2", "$toBeDescr: 2.0",
-            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) })
+            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) }), emptyInOrderOnlyReportOptions
         )
     ) {})
 
     fun Expect<Iterable<Double?>>.toContainInOrderOnlyNullableEntriesFun(
         t: (Expect<Double>.() -> Unit)?,
-        vararg tX: (Expect<Double>.() -> Unit)?
-    ) = toContainInOrderOnlyNullableEntries(this, t, tX)
+        vararg tX: (Expect<Double>.() -> Unit)?,
+        report : InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
+    ) = toContainInOrderOnlyNullableEntries(this, t, tX, report)
 
     fun Expect<String>.elementSuccess(index: Int, actual: Any, expected: String): Expect<String> {
         return this.toContain.exactly(1).regex(
@@ -71,8 +73,9 @@ abstract class IterableToContainInOrderOnlyEntriesExpectationsSpec(
 
         fun Expect<Iterable<Double>>.toContainEntriesFun(
             t: Expect<Double>.() -> Unit,
-            vararg tX: Expect<Double>.() -> Unit
-        ) = toContainEntriesFunArr(t, tX)
+            vararg tX: Expect<Double>.() -> Unit,
+            report : InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
+        ) = toContainEntriesFunArr(t, tX, report)
 
         context("empty collection") {
             it("$toBeLessThanFun(1.0) throws AssertionError") {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -8,6 +8,7 @@ import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
 import org.spekframework.spek2.style.specification.Suite
 
+//TODO 0.18.0 include InOrderReportOptions
 abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
     toContainInOrderOnlyGroupedEntries: Fun3<Iterable<Double?>, Group<(Expect<Double>.() -> Unit)?>, Group<(Expect<Double>.() -> Unit)?>, Array<out Group<(Expect<Double>.() -> Unit)?>>>,
     groupFactory: (Array<out (Expect<Double>.() -> Unit)?>) -> Group<(Expect<Double>.() -> Unit)?>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -7,6 +7,7 @@ import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
 
+//TODO 0.18.0 include InOrderReportOptions
 abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
     toContainInOrderOnlyGroupedValues: Fun3<Iterable<Double>, Group<Double>, Group<Double>, Array<out Group<Double>>>,
     groupFactory: (Array<out Double>) -> Group<Double>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
@@ -3,50 +3,69 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.specs.*
 
 abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
-    toContainInOrderOnlyValues: Fun2<Iterable<Double>, Double, Array<out Double>>,
-    toContainInOrderOnlyNullableValues: Fun2<Iterable<Double?>, Double?, Array<out Double?>>,
+    toContainInOrderOnlyValues: Fun3<Iterable<Double>, Double, Array<out Double>, InOrderOnlyReportingOptions.() -> Unit>,
+    toContainInOrderOnlyNullableValues: Fun3<Iterable<Double?>, Double?, Array<out Double?>, InOrderOnlyReportingOptions.() -> Unit>,
     describePrefix: String = "[Atrium] "
 ) : IterableToContainSpecBase({
 
     include(object : SubjectLessSpec<Iterable<Double>>(
         describePrefix,
-        toContainInOrderOnlyValues.forSubjectLess(2.5, arrayOf())
+        toContainInOrderOnlyValues.forSubjectLess(2.5, arrayOf(), emptyInOrderOnlyReportOptions)
     ) {})
     include(object : SubjectLessSpec<Iterable<Double?>>(
         describePrefix,
-        toContainInOrderOnlyNullableValues.forSubjectLess(2.5, arrayOf())
+        toContainInOrderOnlyNullableValues.forSubjectLess(2.5, arrayOf(), emptyInOrderOnlyReportOptions)
     ) {})
 
-    fun Expect<Iterable<Double?>>.toContainInOrderOnlyNullableValuesFun(t: Double?, vararg tX: Double?) =
-        toContainInOrderOnlyNullableValues(this, t, tX)
+    fun Expect<Iterable<Double?>>.toContainInOrderOnlyNullableValuesFun(
+        t: Double?,
+        vararg tX: Double?,
+        report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
+    ) =
+        toContainInOrderOnlyNullableValues(this, t, tX, report)
 
     val toBeWithFeature = "$indentFeatureArrow$featureBulletPoint$toBeDescr"
     val toBeAfterSuccess = "$indentRootBulletPoint$indentSuccessfulBulletPoint$toBeWithFeature"
     val toBeAfterFailing = "$indentRootBulletPoint$indentFailingBulletPoint$toBeWithFeature"
 
-    fun Expect<String>.elementSuccess(index: Int, expected: String): Expect<String> {
-        return this.toContain.exactly(1).regex(
-            "\\Q$successfulBulletPoint$featureArrow${elementWithIndex(index)}: $expected\\E.*$separator" +
+
+    fun Expect<String>.elementSuccess(index: Int, expected: String, withBulletPoint: Boolean = true): Expect<String> =
+        this.toContain.exactly(1).regex(
+            "\\Q${if (withBulletPoint) successfulBulletPoint else ""}$featureArrow${elementWithIndex(index)}: $expected\\E.*$separator" +
                 "$toBeAfterSuccess: $expected"
         )
-    }
 
     fun Expect<String>.elementSuccess(index: Int, expected: Double) = elementSuccess(index, expected.toString())
 
-    fun Expect<String>.elementFailing(index: Int, actual: Any, expected: Double): Expect<String> {
+    fun Expect<String>.notToContainElement(index: Int, expected: Double): Expect<String> {
+        return notToContain.regex("\\Q$featureArrow${elementWithIndex(index)}: ${expected}\\E.*$separator")
+    }
+
+    fun Expect<String>.elementFailing(
+        index: Int,
+        actual: Any,
+        expected: Double,
+        withBulletPoint: Boolean = true
+    ): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${elementWithIndex(index)}: $actual\\E.*$separator" +
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${elementWithIndex(index)}: $actual\\E.*$separator" +
                 "$toBeAfterFailing: $expected"
         )
     }
 
-    fun Expect<String>.elementNonExisting(index: Int, expected: Double): Expect<String> {
+
+    fun Expect<String>.elementNonExisting(
+        index: Int,
+        expected: Double,
+        withBulletPoint: Boolean = true
+    ): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${elementWithIndex(index)}: $sizeExceeded\\E.*$separator" +
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${elementWithIndex(index)}: $sizeExceeded\\E.*$separator" +
                 "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow$indentFeatureBulletPoint$explanatoryBulletPoint$toBeDescr: $expected"
         )
     }
@@ -58,8 +77,12 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
         toContainInOrderOnlyNullableValues
     ) { toContainValuesFunArr ->
 
-        fun Expect<Iterable<Double>>.toContainFun(t: Double, vararg tX: Double) =
-            toContainValuesFunArr(t, tX.toTypedArray())
+        fun Expect<Iterable<Double>>.toContainFun(
+            t: Double,
+            vararg tX: Double,
+            report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
+        ) =
+            toContainValuesFunArr(t, tX.toTypedArray(), report)
 
         context("empty collection") {
             it("1.0 throws AssertionError") {
@@ -184,6 +207,109 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
                             elementNonExisting(5, 5.0)
                             toContainSize(5, 6)
                         }
+                    }
+                }
+
+                it("shows only failing with report option `showOnlyFailing`") {
+                    expect {
+                        expect(oneToFour()).toContainFun(1.0, 2.0, 3.0, 4.0, 4.0, 5.0, report = { showOnlyFailing() })
+                    }.toThrow<AssertionError> {
+                        message {
+                            notToContainElement(0, 1.0)
+                            notToContainElement(1, 2.0)
+                            notToContainElement(2, 3.0)
+                            notToContainElement(3, 4.0)
+                            notToContainElement(4, 4.0)
+                            elementNonExisting(5, 5.0, withBulletPoint = false)
+
+                        }
+                    }
+                }
+                it("shows only failing with report option `showOnlyFailingIfMoreElementsThan(3)` because there are 5") {
+                    expect {
+                        expect(oneToFour()).toContainFun(
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            4.0,
+                            5.0,
+                            report = { showOnlyFailingIfMoreElementsThan(3) })
+                    }.toThrow<AssertionError> {
+                        message {
+                            notToContainElement(0, 1.0)
+                            notToContainElement(1, 2.0)
+                            notToContainElement(2, 3.0)
+                            notToContainElement(3, 4.0)
+                            notToContainElement(4, 4.0)
+                            elementNonExisting(5, 5.0, withBulletPoint = false)
+                        }
+                    }
+                }
+            }
+        }
+        val oneToEleven = (1..11).map { it.toDouble() }.asIterable()
+        context("iterable $oneToEleven") {
+            it("shows only failing per default as there are more than 10 elements") {
+                expect {
+                    expect(oneToEleven).toContainFun(
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        -1.0,
+                        6.0,
+                        7.0,
+                        -2.0,
+                        9.0,
+                        10.0,
+                        11.0
+                    )
+                }.toThrow<AssertionError> {
+                    message {
+                        notToContainElement(0, 1.0)
+                        notToContainElement(1, 2.0)
+                        notToContainElement(2, 3.0)
+                        notToContainElement(3, 4.0)
+                        elementFailing(4, 5.0, -1.0, withBulletPoint = false)
+                        notToContainElement(5, 6.0)
+                        notToContainElement(6, 7.0)
+                        elementFailing(7, 8.0, -2.0, withBulletPoint = false)
+                        notToContainElement(8, 9.0)
+                        notToContainElement(9, 10.0)
+                        notToContainElement(10, 11.0)
+                    }
+                }
+            }
+            it("shows all with report option `showsAlwaysSummary`") {
+                expect {
+                    expect(oneToEleven).toContainFun(
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        -1.0,
+                        6.0,
+                        7.0,
+                        -2.0,
+                        9.0,
+                        10.0,
+                        11.0,
+                        report = { showAlwaysSummary() }
+                    )
+                }.toThrow<AssertionError> {
+                    message {
+                        elementSuccess(0, 1.0)
+                        elementSuccess(1, 2.0)
+                        elementSuccess(2, 3.0)
+                        elementSuccess(3, 4.0)
+                        elementFailing(4, 5.0, -1.0, withBulletPoint = false)
+                        elementSuccess(5, 6.0)
+                        elementSuccess(6, 7.0)
+                        elementFailing(7, 8.0, -2.0, withBulletPoint = false)
+                        elementSuccess(8, 9.0)
+                        elementSuccess(9, 10.0)
+                        elementSuccess(10, 11.0)
                     }
                 }
             }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.regex
 import ch.tutteli.atrium.api.fluent.en_GB.toContain
 import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionBasic
 import ch.tutteli.atrium.translations.DescriptionCollectionAssertion
@@ -56,6 +57,8 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val fluentEmpty = { sequenceOf<Double>().constrainOnce().asIterable() }
         val illegalArgumentException = IllegalArgumentException::class.simpleName
         val separator = lineSeparator
+
+        val emptyInOrderOnlyReportOptions : InOrderOnlyReportingOptions.() -> Unit = {}
 
         fun Expect<String>.toContainSize(actual: Int, expected: Int) =
             toContain.exactly(1).regex("${DescriptionCollectionAssertion.SIZE.getDefault()}: $actual[^:]+: $expected")

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import org.spekframework.spek2.style.specification.Suite
 
+//TODO 0.18.0 include InOrderReportOptions
 abstract class MapToContainInOrderOnlyKeyValueExpectationsSpec(
     keyWithValueAssertions: MFun2<String, Int, Expect<Int>.() -> Unit>,
     keyWithNullableValueAssertions: MFun2<String?, Int?, (Expect<Int>.() -> Unit)?>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValuePairsExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValuePairsExpectationsSpec.kt
@@ -6,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import org.spekframework.spek2.style.specification.Suite
 
+//TODO 0.18.0 include InOrderReportOptions
 abstract class MapToContainInOrderOnlyKeyValuePairsExpectationsSpec(
     keyValuePairs: MFun2<String, Int, Int>,
     keyValuePairsNullable: MFun2<String?, Int?, Int?>,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/testUtils.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/testUtils.kt
@@ -111,6 +111,29 @@ inline fun <T, R> Fun2<T, Expect<R>.() -> Unit, Array<out Expect<R>.() -> Unit>>
         )
     )
 
+inline fun <T, R, A1> Fun3<T, Expect<R>.() -> Unit, Array<out Expect<R>.() -> Unit>, A1>.forAssertionCreatorSpec(
+    containsNot1: String,
+    containsNot2: String,
+    noinline subAssert: Expect<R>.() -> Unit,
+    subAsserts: Array<out Expect<R>.() -> Unit>,
+    a1: A1
+): Array<Triple<String, String, Pair<Expect<T>.() -> Expect<T>, Expect<T>.() -> Expect<T>>>> =
+    arrayOf(
+        assertionCreatorSpecTriple(
+            this.name + " - first empty",
+            containsNot1,
+            { this@forAssertionCreatorSpec(this, subAssert, subAsserts, a1) },
+            { this@forAssertionCreatorSpec(this, {}, subAsserts, a1) }
+        ),
+        assertionCreatorSpecTriple(
+            this.name + " - second empty",
+            containsNot2,
+            { this@forAssertionCreatorSpec(this, subAssert, subAsserts, a1) },
+            { this@forAssertionCreatorSpec(this, subAssert, arrayOf(expectLambda<R> {}) + subAsserts.drop(1), a1) }
+        )
+    )
+
+
 fun <T, R> unifySignatures(
     f0: Feature0<T, R>,
     f1: Fun1<T, Expect<R>.() -> Unit>


### PR DESCRIPTION
I decided that I will apply a default heuristic so that (I hope) most
users don't have to change reporting options.

implements #292 


______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
