### PR TITLE
Show more than first line when using mocha test runner

### DIFF
--- a/samples/js/build.gradle.kts
+++ b/samples/js/build.gradle.kts
@@ -1,6 +1,8 @@
 // Example project to show how to use Atrium in combination with mocha
 // For more information on how to setup Atrium for a JS project -> https://github.com/robstoll/atrium#js
 
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 // for infix-api -> change to 'atrium-infix-en_GB-js'
 val atriumApi = "atrium-fluent-en_GB-js"
 val atriumVersion = "0.16.0"
@@ -28,6 +30,12 @@ version = "0.0.1"
 
 kotlin {
     js {
-        nodejs()
+        nodejs {
+            testTask {
+                testLogging {
+                    exceptionFormat = TestExceptionFormat.FULL // Show full exception when an assertion fails
+                }
+            }
+        }
     }
 }

--- a/samples/js/build.gradle.kts
+++ b/samples/js/build.gradle.kts
@@ -34,6 +34,9 @@ kotlin {
             testTask {
                 testLogging {
                     exceptionFormat = TestExceptionFormat.FULL // Show full exception when an assertion fails
+                    showExceptions = true                      // defaults to true
+                    showCauses = true                          // defaults to true
+                    showStackTraces = true                     // defaults to true
                 }
             }
         }


### PR DESCRIPTION
Resolves #691, adding settings to the `build.gradle.kts` to show the full exception when an assertion fails.

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/master/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
