### PR TITLE
add report option to mapLikeToContainInOrderOnlyCreators

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator.kt
@@ -13,6 +13,7 @@ data class KeyWithValueCreator<out K, V : Any> internal constructor(
     val valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?
 ) {
     fun toPair(): Pair<K, (Expect<V>.() -> Unit)?> = key to valueAssertionCreatorOrNull
+
     override fun toString(): String =
         "KeyValue(key=$key, value=${if (valueAssertionCreatorOrNull == null) "null" else "lambda"})"
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/helperFunctions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/helperFunctions.kt
@@ -2,10 +2,13 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.*
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInOrderOnlyReportingOptions
+import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyValues
+import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyWithValueCreator
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
+import ch.tutteli.atrium.logic.creating.typeutils.MapLike
 
 /**
  * Helper function to create an [All] based on the given [t] and [ts]
@@ -22,15 +25,14 @@ fun <T> all(t: T, vararg ts: T): All<T> = All(t, ts)
  * @param iterableLike The [IterableLike] whose elements this function is referring to.
  * @param report The lambda configuring the [InOrderOnlyReportingOptions].
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableExpectationSamples.toContainExactlyElementsOf
+ *
  * @since 0.18.0
  */
-fun <T: IterableLike> elementsOf(
+fun <T : IterableLike> elementsOf(
     iterableLike: T,
     report: InOrderOnlyReportingOptions.() -> Unit
-): WithInOrderOnlyReportingOptions<T> =
-    WithInOrderOnlyReportingOptions(report, iterableLike)
-
-
+): WithInOrderOnlyReportingOptions<T> = WithInOrderOnlyReportingOptions(report, iterableLike)
 
 /**
  * Helper function to create an [Entry] based on the given [assertionCreatorOrNull].
@@ -48,6 +50,8 @@ fun <T : Any> entry(assertionCreatorOrNull: (Expect<T>.() -> Unit)?): Entry<T> =
  *   to be identified if it holds all [Assertion]s the lambda creates.
  *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
  * @param otherAssertionCreatorsOrNulls A variable amount of additional identification lambdas or `null`s.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableExpectationSamples.toContainExactlyAssertions
  */
 fun <T : Any> entries(
     assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
@@ -68,6 +72,8 @@ fun <T : Any> entries(
  * @param otherAssertionCreatorsOrNulls A variable amount of additional identification lambdas or `null`s.
  * @param report The lambda configuring the [InOrderOnlyReportingOptions].
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableExpectationSamples.toContainExactlyAssertions
+ *
  * @since 0.18.0
  */
 fun <T : Any> entries(
@@ -77,6 +83,55 @@ fun <T : Any> entries(
 ): WithInOrderOnlyReportingOptions<Entries<T>> =
     WithInOrderOnlyReportingOptions(report, Entries(assertionCreatorOrNull, otherAssertionCreatorsOrNulls))
 
+/**
+ * Helper function to create a [WithInOrderOnlyReportingOptions] wrapping an [MapLike]
+ * based on the given [mapLike] and the given [report]-configuration-lambda.
+ *
+ * @param mapLike The [MapLike] whose elements this function is referring to.
+ * @param report The lambda configuring the [InOrderOnlyReportingOptions].
+ *
+ * @since 0.18.0
+ */
+fun <T : MapLike> entriesOf(
+    mapLike: T,
+    report: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<T> = WithInOrderOnlyReportingOptions(report, mapLike)
+
+/**
+ * Helper function to create a [KeyValues] based on the given [keyValue] and [otherKeyValues]
+ * -- allows expressing `Pair<K, (Expect<V>.() -> Unit)?>, vararg Pair<K, (Expect<V>.() -> Unit)?>`.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainKeyValues
+ */
+// TODO 1.0.0: consider to rename to entries once updated to Kotlin 1.4 maybe the type inference is better and there
+// is no longer a clash with Iterable entries
+fun <K, V : Any> keyValues(
+    keyValue: KeyWithValueCreator<K, V>,
+    vararg otherKeyValues: KeyWithValueCreator<K, V>
+): KeyValues<K, V> = KeyValues(keyValue, otherKeyValues)
+
+/**
+ * Helper function to create a [KeyValues] based on the given [keyValue] and [otherKeyValues]
+ * -- allows expressing `Pair<K, (Expect<V>.() -> Unit)?>, vararg Pair<K, (Expect<V>.() -> Unit)?>`.
+ */
+// TODO 1.0.0: consider to rename to entries once updated to Kotlin 1.4 maybe the type inference is better and there
+// is no longer a clash with Iterable entries
+fun <K, V : Any> keyValues(
+    keyValue: KeyWithValueCreator<K, V>,
+    vararg otherKeyValues: KeyWithValueCreator<K, V>,
+    report: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<KeyValues<K, V>> =
+    WithInOrderOnlyReportingOptions(report, KeyValues(keyValue, otherKeyValues))
+
+/**
+ * Helper function to create a [KeyWithValueCreator] based on the given [key] and [valueAssertionCreatorOrNull]
+ * -- allows expressing `Pair<K, (Expect<V>.() -> Unit)?>`.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainKeyValue
+ *
+ */
+fun <K, V : Any> keyValue(key: K, valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?): KeyWithValueCreator<K, V> =
+    KeyWithValueCreator(key, valueAssertionCreatorOrNull)
 
 /**
  * Helper function to create a [Pairs] based on the given [pair] and [otherPairs]
@@ -85,6 +140,20 @@ fun <T : Any> entries(
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainOnlyPairs
  */
 fun <K, V> pairs(pair: Pair<K, V>, vararg otherPairs: Pair<K, V>): Pairs<K, V> = Pairs(pair, otherPairs)
+
+/**
+ * Helper function to create a [Pairs] based on the given [pair] and [otherPairs]
+ * -- allows expressing `Pair<K, V>, vararg Pair<K, V>`.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainOnlyPairs
+ *
+ * @since 0.18.0
+ */
+fun <K, V> pairs(
+    pair: Pair<K, V>,
+    vararg otherPairs: Pair<K, V>,
+    report: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<Pairs<K, V>> = WithInOrderOnlyReportingOptions(report, Pairs(pair, otherPairs))
 
 /**
  * Helper function to create a [PresentWithCreator] based on the given [assertionCreator].

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapExpectations.kt
@@ -51,16 +51,16 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.toContainOnly(keyValuePair: Pair<K
     it toContain o inAny order but only entry keyValuePair
 
 /**
- * Expects the subject of `this` expectation (a [Map]) contains for each entry in [keyValuePairs],
+ * Expects the subject of `this` expectation (a [Map]) contains for each key-value pair in [pairs],
  * a key as defined by that entry's [Pair.first] with a corresponding value as defined by entry's [Pair.second].
  *
- * Delegates to `it toContain o inAny order the keyValuePairs`
+ * Delegates to `it toContain o inAny order the pairs`
  *
  * Notice, that it does not search for unique matches. Meaning, if the map is `mapOf('a' to 1)` and one of the [Pair]
- * in [keyValuePairs] is defined as `'a' to 1` and another one is defined as `'a' to 1` as well, then both match,
+ * in [pairs] is defined as `'a' to 1` and another one is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
- * @param keyValuePairs The key-value [Pairs] expected to be contained within this [Map]
+ * @param pairs The key-value [Pairs] expected to be contained within this [Map]
  *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -68,16 +68,16 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.toContainOnly(keyValuePair: Pair<K
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainPairs
  *
  */
-infix fun <K, V, T : Map<out K, V>> Expect<T>.toContain(keyValuePairs: Pairs<K, V>): Expect<T> =
-    it toContain o inAny order the keyValuePairs
+infix fun <K, V, T : Map<out K, V>> Expect<T>.toContain(pairs: Pairs<K, V>): Expect<T> =
+    it toContain o inAny order the pairs
 
 /**
- * Expects the subject of `this` expectation (a [Map]) contains only (in any order) for each entry in [keyValuePairs],
+ * Expects the subject of `this` expectation (a [Map]) contains only (in any order) for each key-value pair in [pairs],
  * a key as defined by that entry's [Pair.first] with a corresponding value as defined by entry's [Pair.second].
  *
- * Delegates to `it toContain o inAny order but only the keyValuePairs`
+ * Delegates to `it toContain o inAny order but only the pairs`
  *
- * @param keyValuePairs The key-value [Pairs] expected to be contained within this [Map]
+ * @param pairs The key-value [Pairs] expected to be contained within this [Map]
  *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -85,8 +85,8 @@ infix fun <K, V, T : Map<out K, V>> Expect<T>.toContain(keyValuePairs: Pairs<K, 
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainOnlyPairs
  *
  */
-infix fun <K, V, T : Map<out K, V>> Expect<T>.toContainOnly(keyValuePairs: Pairs<K, V>): Expect<T> =
-    it toContain o inAny order but only the keyValuePairs
+infix fun <K, V, T : Map<out K, V>> Expect<T>.toContainOnly(pairs: Pairs<K, V>): Expect<T> =
+    it toContain o inAny order but only the pairs
 
 /**
  * Expects that the subject of `this` expectation (a [Map]) contains a key as defined by [keyValue]'s [KeyWithValueCreator.key]
@@ -130,18 +130,6 @@ inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.toContain(ke
 inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.toContainOnly(keyValue: KeyWithValueCreator<K, V>): Expect<T> =
     it toContain o inAny order but only entry keyValue
 
-
-/**
- * Helper function to create a [KeyWithValueCreator] based on the given [key] and [valueAssertionCreatorOrNull]
- * -- allows expressing `Pair<K, (Expect<V>.() -> Unit)?>`.
- *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapExpectationSamples.toContainKeyValue
- *
- */
-fun <K, V : Any> keyValue(key: K, valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?): KeyWithValueCreator<K, V> =
-    KeyWithValueCreator(key, valueAssertionCreatorOrNull)
-
-
 /**
  * Expects that the subject of `this` expectation (a [Map]) contains for each [KeyWithValueCreator] in [keyValues],
  * a key as defined by [KeyWithValueCreator.key] with a corresponding value which either holds all
@@ -153,6 +141,9 @@ fun <K, V : Any> keyValue(key: K, valueAssertionCreatorOrNull: (Expect<V>.() -> 
  * Notice, that it does not search for unique matches. Meaning, if the map is `mapOf('a' to 1)` and
  * one [KeyWithValueCreator] in [keyValues] is defined as `Key('a') { isGreaterThan(0) }` and
  * another one is defined as `Key('a') { isLessThan(2) }`, then both match, even though they match the same entry.
+ *
+ * @param keyValues The [KeyWithValueCreator]s -- use the function
+ *   `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -170,6 +161,9 @@ inline infix fun <K, reified V : Any, T : Map<out K, V?>> Expect<T>.toContain(
  * to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
  *
  * Delegates to `it toContain o inAny order but only the keyValues`
+ *
+ * @param keyValues The [KeyWithValueCreator]s -- use the function
+ *   `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
@@ -29,16 +29,19 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
- * needs to contain only the given [keyValuePairs] where it does not matter
+ * needs to contain only the given key-value [pairs] where it does not matter
  * in which order they appear.
+ *
+ * @param pairs The key-value [Pairs] expected to be contained within this [MapLike]
+ *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.the(
-    keyValuePairs: Pairs<K, V>
-): Expect<T> = _logicAppend { keyValuePairsInAnyOrderOnly(keyValuePairs.toList()) }
+    pairs: Pairs<K, V>
+): Expect<T> = _logicAppend { keyValuePairsInAnyOrderOnly(pairs.toList()) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
@@ -48,6 +51,11 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
  * Delegates to `the keyValues(keyValue)`.
+ *
+ * @param keyValue The [KeyWithValueCreator] whose key is expected to be contained within this [MapLike] and
+ *   where the corresponding value holds all assertions the  [KeyWithValueCreator.valueAssertionCreatorOrNull] creates
+ *   or needs to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
+ *   -- use the function `keyValue(x) { ... }` to create a [KeyWithValueCreator].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -65,6 +73,9 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * a corresponding value which either holds all assertions [keyValue]'s
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
+ *
+ * @param keyValues The [KeyWithValueCreator]s -- use the function
+ *   `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -36,6 +36,9 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  * in [pairs] is defined as `'a' to 1` and another one is defined as `'a' to 1` as well, then both match,
  * even though they match the same entry.
  *
+ * @param pairs The key-value [Pairs] expected to be contained within this [MapLike]
+ *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
+ *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
@@ -52,6 +55,11 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
  * Delegates to `the keyValues(keyValue)`.
+ *
+ * @param keyValue The [KeyWithValueCreator] whose key is expected to be contained within this [MapLike] and
+ *   where the corresponding value holds all assertions the  [KeyWithValueCreator.valueAssertionCreatorOrNull] creates
+ *   or needs to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
+ *   -- use the function `keyValue(x) { ... }` to create a [KeyWithValueCreator].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -74,6 +82,9 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * [keyValues] is defined as `Key('a') { isGreaterThan(0) }` and another one is defined as `Key('a') { isLessThan(2) }`
  * , then both match, even though they match the same entry.
  *
+ * @param keyValues The [KeyWithValueCreator]s -- use the function
+ *   `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
+ *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
@@ -89,18 +100,6 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
 ): Expect<T> = _logicAppend {
     keyWithValueAssertionsInAnyOrder(kClass, keyValues.map { it.toPair() })
 }
-
-/**
- * Helper function to create a [KeyValues] based on the given [keyValue] and [otherKeyValues]
- * -- allows expressing `Pair<K, V>, vararg Pair<K, V>`.
- */
-// TODO 1.0.0: consider to rename to entries once updated to Kotlin 1.4 maybe the type inference is better and there
-// is no longer a clash with Iterable entries
-fun <K, V : Any> keyValues(
-    keyValue: KeyWithValueCreator<K, V>,
-    vararg otherKeyValues: KeyWithValueCreator<K, V>
-): KeyValues<K, V> = KeyValues(keyValue, otherKeyValues)
-
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -1,11 +1,14 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.Pairs
+import ch.tutteli.atrium.api.infix.en_GB.creating.Values
+import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInOrderOnlyReportingOptions
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyValues
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyWithValueCreator
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic._logicAppend
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.maplike.contains.MapLikeContains.EntryPointStep
 import ch.tutteli.atrium.logic.creating.maplike.contains.creators.keyValuePairsInOrderOnly
 import ch.tutteli.atrium.logic.creating.maplike.contains.creators.keyWithValueAssertionsInOrderOnly
@@ -15,6 +18,7 @@ import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLikeToIterableTransformer
 import ch.tutteli.atrium.logic.creating.typeutils.MapLikeToIterablePairTransformer
 import ch.tutteli.atrium.logic.utils.toVarArgPairs
+import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 
 /**
@@ -32,20 +36,36 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
- * needs to contain only the given [keyValuePairs] in the specified order.
+ * needs to contain only the given key-value [pairs] in the specified order.
+ *
+ * @param pairs The key-value pairs which are expected to be contained within the [MapLike]
+ *   -- use the function `pairs(x to y, ...)` to create a [Pairs].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
-    keyValuePairs: Pairs<K, V>
+    pairs: Pairs<K, V>
+): Expect<T> = the(WithInOrderOnlyReportingOptions({}, pairs))
+
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
+ * needs to contain only the given [pairs] in the specified order.
+ *
+ * @param pairs The key-value pairs which are expected to be contained within the [MapLike]
+ *   plus a lambda configuring the [InOrderOnlyReportingOptions] -- use the function `pairs(t, ..., report = { ... })`
+ *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [Pairs].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.18.0
+ */
+@JvmName("thePairsWithReportingOption")
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
+    pairs: WithInOrderOnlyReportingOptions<Pairs<K, V>>
 ): Expect<T> = _logicAppend {
-    keyValuePairsInOrderOnly(
-        keyValuePairs.toList(),
-        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
-        {}
-    )
+    keyValuePairsInOrderOnly(pairs.t.toList(), pairs.report)
 }
 
 
@@ -57,6 +77,11 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
  * Delegates to `the keyValues(keyValue)`.
+ *
+ * @param keyValue The [KeyWithValueCreator] whose key is expected to be contained within this [MapLike] and
+ *   where the corresponding value holds all assertions the  [KeyWithValueCreator.valueAssertionCreatorOrNull] creates
+ *   or needs to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
+ *   -- use the function `keyValue(x) { ... }` to create a [KeyWithValueCreator].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -74,24 +99,47 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
+ * @param keyValues The [KeyWithValueCreator]s -- use the function
+ *   `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
+ *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.the(
     keyValues: KeyValues<K, V>
-): Expect<T> = entries(V::class, keyValues.toList())
+): Expect<T> = the(WithInOrderOnlyReportingOptions({}, keyValues))
+
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
+ * needs to contain only the given [keyValues] in the specified order -- an entry
+ * is contained if it has a key as defined by [keyValue]'s [KeyWithValueCreator.key] and
+ * a corresponding value which either holds all assertions [keyValue]'s
+ * [KeyWithValueCreator.valueAssertionCreatorOrNull] creates or needs to be `null` in case
+ * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
+ *
+ * @param keyValues The [KeyWithValueCreator]s plus a lambda configuring the [InOrderOnlyReportingOptions]
+ *   -- use the function `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ..., report = { ... })`
+ *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [KeyValues].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.18.0
+ */
+@JvmName("theKeyValuesWithReportingOption")
+inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.the(
+    keyValues: WithInOrderOnlyReportingOptions<KeyValues<K, V>>
+): Expect<T> = entries(V::class, keyValues)
 
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entries(
     kClass: KClass<V>,
-    keyValues: List<KeyWithValueCreator<K, V>>
+    keyValues: WithInOrderOnlyReportingOptions<KeyValues<K, V>>
 ): Expect<T> = _logicAppend {
     keyWithValueAssertionsInOrderOnly(
         kClass,
-        keyValues.map { it.toPair() },
-        //TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
-        {}
+        keyValues.t.toList().map { it.toPair() },
+        keyValues.report
     )
 }
 
@@ -107,16 +155,40 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  * This function expects [MapLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
  * @return an [Expect] for the subject of `this` expectation.
- * @throws IllegalArgumentException in case [expectedMapLike] is not
- *   a [Map], [Sequence] or one of the [Array] types
- *   or the given [expectedMapLike] does not have elements (is empty).
+ * @throws IllegalArgumentException in case the given [MapLike] is an unsupported type, or in other words,
+ *   if the transformation from the given [MapLike] to `Iterable<Pair<K, V>>` fails,
+ *   or it does not have elements (is empty).
  *
  * @since 0.15.0
  */
-//TODO 0.18.0 add: report: InOrderOnlyReportingOptions.() -> Unit = {}
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike
-): Expect<T> = _logic.toVarArgPairs<K, V>(expectedMapLike).let { (first, rest) ->
-    this the pairs(first, *rest)
-}
+): Expect<T> = entriesOf(WithInOrderOnlyReportingOptions({}, expectedMapLike))
 
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
+ * needs to contain only and all entries of the given [MapLike] in the specified order.
+ *
+ * Delegates to [keyValue].
+ *
+ * Notice that a runtime check applies which assures that only [Map] and [IterableLike]
+ * (i.e. [Iterable], [Sequence] or one of the [Array] types) are passed (this can be changed via
+ * [MapLikeToIterablePairTransformer] and [IterableLikeToIterableTransformer]).
+ * This function expects [MapLike] (which is a typealias for [Any]) to avoid cluttering the API.
+ *
+ * @param entriesOf The [MapLike] whose elements are expected to be contained within
+ *   this [MapLike] plus a lambda configuring the [InOrderOnlyReportingOptions] -- use the function
+ *   `entriesOf(mapLike, report = { ... })` to create a [WithInOrderOnlyReportingOptions] with a wrapped [MapLike].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ * @throws IllegalArgumentException in case the given [MapLike] is an unsupported type, or in other words,
+ *   if the transformation from the given [MapLike] to `Iterable<Pair<K, V>>` fails,
+ *   or it does not have elements (is empty).
+ *
+ * @since 0.18.0
+ */
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
+    entriesOf: WithInOrderOnlyReportingOptions<MapLike>
+): Expect<T> = _logic.toVarArgPairs<K, V>(entriesOf.t).let { (first, rest) ->
+    this the pairs(first, *rest, report = entriesOf.report)
+}


### PR DESCRIPTION
and improve KDoc of mapLike.toContain final steps by describing how
to create the parameter object



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
