### PR TITLE
rename ErrorMessages translatable enums to expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1956,8 +1956,8 @@ expect(listOf(1)).get(0) {}
 ```text
 expected that subject: [1]        (java.util.Collections.SingletonList <1234789>)
 ◆ ▶ get(0): 1        (kotlin.Int <1234789>)
-    ◾ at least one assertion defined: false
-        » You forgot to define assertions in the assertionCreator-lambda
+    ◾ at least one expectation defined: false
+        » You forgot to define expectations in the expectationCreator-lambda
         » Sometimes you can use an alternative to `{ }` For instance, instead of `toThrow<..> { }` you should use `toThrow<..>()`
 ```
 </ex-pitfall-2>

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/ErrorMessages.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/ErrorMessages.kt
@@ -6,8 +6,24 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
  * Contains translations which are used in error like messages.
  */
 enum class ErrorMessages(override val value: String) : StringBasedTranslatable {
+    @Deprecated(
+        "USE AT_LEAST_ONE_EXPECTATION_DEFINED, will be removed with 0.19.0",
+        ReplaceWith("AT_LEAST_ONE_EXPECTATION_DEFINED")
+    )
     AT_LEAST_ONE_ASSERTION_DEFINED("at least one assertion defined"),
-    //TODO 0.18.0 deprecate and replace with FORGOT_TO_DEFINE_EXPECTATION
+    AT_LEAST_ONE_EXPECTATION_DEFINED("at least one expectation defined"),
+
+    @Deprecated(
+        "USE FORGOT_DO_DEFINE_EXPECTATION, will be removed with 0.19.0",
+        ReplaceWith("FORGOT_DO_DEFINE_EXPECTATION")
+    )
     FORGOT_DO_DEFINE_ASSERTION("You forgot to define assertions in the assertionCreator-lambda"),
+    FORGOT_DO_DEFINE_EXPECTATION("You forgot to define expectations in the expectationCreator-lambda"),
+
+    @Deprecated(
+        "USE HINT_AT_LEAST_ONE_EXPECTATION_DEFINED, will be removed with 0.19.0",
+        ReplaceWith("HINT_AT_LEAST_ONE_EXPECTATION_DEFINED")
+    )
     HINT_AT_LEAST_ONE_ASSERTION_DEFINED("Sometimes you can use an alternative to `{ }` For instance, instead of `toThrow<..> { }` you should use `toThrow<..>()`"),
+    HINT_AT_LEAST_ONE_EXPECTATION_DEFINED("Sometimes you can use an alternative to `{ }` For instance, instead of `toThrow<..> { }` you should use `toThrow<..>()`"),
 }

--- a/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/CollectingExpectImpl.kt
+++ b/core/atrium-core-common/src/main/kotlin/ch/tutteli/atrium/creating/impl/CollectingExpectImpl.kt
@@ -39,15 +39,15 @@ internal class CollectingExpectImpl<T>(
                     assertionBuilder.explanatoryGroup
                         .withDefaultType
                         .withAssertions(
-                            assertionBuilder.explanatory.withExplanation(ErrorMessages.FORGOT_DO_DEFINE_ASSERTION)
+                            assertionBuilder.explanatory.withExplanation(ErrorMessages.FORGOT_DO_DEFINE_EXPECTATION)
                                 .build(),
-                            assertionBuilder.explanatory.withExplanation(ErrorMessages.HINT_AT_LEAST_ONE_ASSERTION_DEFINED)
+                            assertionBuilder.explanatory.withExplanation(ErrorMessages.HINT_AT_LEAST_ONE_EXPECTATION_DEFINED)
                                 .build()
                         )
                         .build()
                 }
                 .showForAnyFailure
-                .withDescriptionAndRepresentation(ErrorMessages.AT_LEAST_ONE_ASSERTION_DEFINED, false)
+                .withDescriptionAndRepresentation(ErrorMessages.AT_LEAST_ONE_EXPECTATION_DEFINED, false)
                 .build()
             )
         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/AssertionCreatorSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/AssertionCreatorSpec.kt
@@ -26,9 +26,9 @@ abstract class AssertionCreatorSpec<T>(
                     }.toThrow<AssertionError> {
                         message {
                             toContain(
-                                ErrorMessages.AT_LEAST_ONE_ASSERTION_DEFINED.getDefault() + ": false",
-                                ErrorMessages.FORGOT_DO_DEFINE_ASSERTION.getDefault(),
-                                ErrorMessages.HINT_AT_LEAST_ONE_ASSERTION_DEFINED.getDefault()
+                                ErrorMessages.AT_LEAST_ONE_EXPECTATION_DEFINED.getDefault() + ": false",
+                                ErrorMessages.FORGOT_DO_DEFINE_EXPECTATION.getDefault(),
+                                ErrorMessages.HINT_AT_LEAST_ONE_EXPECTATION_DEFINED.getDefault()
                             )
                             notToContain(stringNotInMessage)
                         }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FeatureExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FeatureExpectationsSpec.kt
@@ -265,9 +265,9 @@ abstract class FeatureExpectationsSpec(
                         expect(TestData("hello robert", 1)).lambda()
                     }.toThrow<AssertionError> {
                         messageToContain(
-                            ErrorMessages.AT_LEAST_ONE_ASSERTION_DEFINED.getDefault() + ": false",
-                            ErrorMessages.FORGOT_DO_DEFINE_ASSERTION.getDefault(),
-                            ErrorMessages.HINT_AT_LEAST_ONE_ASSERTION_DEFINED.getDefault()
+                            ErrorMessages.AT_LEAST_ONE_EXPECTATION_DEFINED.getDefault() + ": false",
+                            ErrorMessages.FORGOT_DO_DEFINE_EXPECTATION.getDefault(),
+                            ErrorMessages.HINT_AT_LEAST_ONE_EXPECTATION_DEFINED.getDefault()
                         )
                     }
                 }


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
