### PR TITLE
introduce InAnyOrderOnlyReportingOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ then only failing expectations are shown.
 <summary>💬 Show only failing expectations/elements earlier than 10 elements?</summary>
 
 You can use the `report` option to specify when Atrium shall start to show only failing expectations.
-Following an example changing the limit to 3 elements by using `showOnlyFailingIfMoreElementsThan` :
+Following an example changing the limit to 3 elements by using `showOnlyFailingIfMoreExpectedElementsThan` :
 
 <ex-collection-reportOptions-1>
 
@@ -1176,7 +1176,7 @@ expect(listOf(1, 2, 2, 4)).toContainExactly(
     { toBeLessThan(3) },
     { toBeLessThan(2) },
     { toBeGreaterThan(1) },
-    report = { showOnlyFailingIfMoreElementsThan(3) }
+    report = { showOnlyFailingIfMoreExpectedElementsThan(2) }
 )
 ```
 ↑ <sub>[Example](https://github.com/robstoll/atrium/tree/main/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt#L154)</sub> ↓ <sub>[Output](#ex-collection-reportOptions-1)</sub>

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -10,6 +10,8 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInAnyO
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.values
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInAnyOrderOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLikeToIterableTransformer
 import ch.tutteli.atrium.logic.utils.toVarArg
 import ch.tutteli.kbox.glue
@@ -26,7 +28,7 @@ import ch.tutteli.kbox.glue
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
-fun <E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
+fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
     values(expected)
 
 /**
@@ -36,15 +38,19 @@ fun <E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.val
  *
  * @param expected The value which is expected to be contained within the subject (an [IterableLike]).
  * @param otherExpected Additional values which are expected to be contained within [IterableLike].
+ * @param report The lambda configuring the [InAnyOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InAnyOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
-fun <E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.values(
+fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.values(
     expected: E,
-    vararg otherExpected: E
-): Expect<T> = _logicAppend { valuesInAnyOrderOnly(expected glue otherExpected) }
+    vararg otherExpected: E,
+    report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend { valuesInAnyOrderOnly(expected glue otherExpected, report) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -61,7 +67,7 @@ fun <E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.val
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
-fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entry(
+fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
 ): Expect<T> = entries(assertionCreatorOrNull)
 
@@ -85,15 +91,19 @@ fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBeh
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  * @param otherAssertionCreatorsOrNulls Additional identification lambdas which each identify (separately) an entry
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
+ * @param report The lambda configuring the [InAnyOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InAnyOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
-fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entries(
+fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entries(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,
-    vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?
-): Expect<T> = _logicAppend { entriesInAnyOrderOnly(assertionCreatorOrNull glue otherAssertionCreatorsOrNulls) }
+    vararg otherAssertionCreatorsOrNulls: (Expect<E>.() -> Unit)?,
+    report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logicAppend { entriesInAnyOrderOnly(assertionCreatorOrNull glue otherAssertionCreatorsOrNulls, report) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -106,6 +116,9 @@ fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBeh
  * This function expects [IterableLike] (which is a typealias for [Any]) to avoid cluttering the API.
  *
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike]
+ * @param report The lambda configuring the [InAnyOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InAnyOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not
@@ -114,6 +127,7 @@ fun <E : Any, T: IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBeh
  *
  * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
  */
-inline fun <reified E, T: IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
-    expectedIterableLike: IterableLike
-): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> values(first, *rest) }
+inline fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
+    expectedIterableLike: IterableLike,
+    noinline report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> values(first, *rest, report = report) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -37,6 +37,7 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value
  * @param otherExpected Additional values which are expected to be contained within [IterableLike].
  * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
  *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.17.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -81,6 +82,7 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  *   which we are looking for (see [assertionCreatorOrNull] for more information).
  * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
  *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.17.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -105,6 +107,7 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  * @param expectedIterableLike The [IterableLike] whose elements are expected to be contained within this [IterableLike].
  * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
  *   the default [InOrderOnlyReportingOptions] apply if not specified.
+     since 0.17.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expectedIterableLike] is not an

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyGroupedCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyGroupedCreators.kt
@@ -9,6 +9,7 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains.E
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnlyGrouped
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInOrderOnlyGrouped
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedWithinSearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import kotlin.jvm.JvmName
 
@@ -24,6 +25,10 @@ import kotlin.jvm.JvmName
  *   [IterableLike] whereas the groups have to appear in the given order.
  * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
  *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.17.0
+ * @param reportInGroup The lambda configuring the [InAnyOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -33,9 +38,10 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBeh
     firstGroup: Group<E>,
     secondGroup: Group<E>,
     vararg otherExpectedGroups: Group<E>,
-    report: InOrderOnlyReportingOptions.() -> Unit = {}
+    report: InOrderOnlyReportingOptions.() -> Unit = {},
+    reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit = {}
 ): Expect<T> = _logicAppend {
-    valuesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups), report)
+    valuesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups), report, reportInGroup)
 }
 
 /**
@@ -54,6 +60,10 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyGroupedWithinSearchBeh
  *   [IterableLike] whereas the groups have to appear in the given order.
  * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
  *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.17.0
+ * @param reportInGroup The lambda configuring the [InAnyOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -64,7 +74,8 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlyGroupedWith
     firstGroup: Group<(Expect<E>.() -> Unit)?>,
     secondGroup: Group<(Expect<E>.() -> Unit)?>,
     vararg otherExpectedGroups: Group<(Expect<E>.() -> Unit)?>,
-    report: InOrderOnlyReportingOptions.() -> Unit = {}
+    report: InOrderOnlyReportingOptions.() -> Unit = {},
+    reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit = {}
 ): Expect<T> = _logicAppend {
-    entriesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups), report)
+    entriesInOrderOnlyGrouped(groupsToList(firstGroup, secondGroup, otherExpectedGroups), report, reportInGroup)
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -33,6 +33,10 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
  * needs to contain only the given [keyValuePair] as well as the [otherPairs] in the specified order.
  *
+ * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
+ *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
@@ -41,7 +45,7 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
     keyValuePair: Pair<K, V>,
     vararg otherPairs: Pair<K, V>,
     report: InOrderOnlyReportingOptions.() -> Unit = {}
-): Expect<T> = _logicAppend { keyValuePairsInOrderOnly(keyValuePair glue otherPairs,report) }
+): Expect<T> = _logicAppend { keyValuePairsInOrderOnly(keyValuePair glue otherPairs, report) }
 
 
 /**
@@ -68,6 +72,10 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrde
  * a corresponding value which either holds all assertions [keyValue]'s
  * [KeyValue.valueAssertionCreatorOrNull] creates or needs to be `null` in case
  * [KeyValue.valueAssertionCreatorOrNull] is defined as `null`.
+ *
+ * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -104,10 +112,15 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
+ * @param report The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
+ *
  * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike,
     report: InOrderOnlyReportingOptions.() -> Unit = {}
-): Expect<T> = _logic.toVarArgPairs<K, V>(expectedMapLike).let { (first, rest) -> entries(first, *rest, report = report) }
+): Expect<T> =
+    _logic.toVarArgPairs<K, V>(expectedMapLike).let { (first, rest) -> entries(first, *rest, report = report) }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
@@ -43,7 +43,6 @@ class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec : Spek({
             else expect.toContain.inAnyOrder.atLeast(1).entries(a, *aX)
     }
 
-
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
         var list: Expect<List<Number>> = notImplemented()

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderExactlyValuesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderExactlyValuesExpectationsSpec.kt
@@ -46,5 +46,4 @@ class IterableToContainInAnyOrderExactlyValuesExpectationsSpec :
         subList = subList.toContain.inAnyOrder.exactly(2).values(1, 2.2)
         star = star.toContain.inAnyOrder.exactly(2).values(1, 1.2, "asdf")
     }
-
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInAnyOrderOnlyReportOptions
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
 import org.spekframework.spek2.Spek
@@ -15,11 +17,12 @@ class IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec : Spek({
         (functionDescription to C::toContainElementsOfNullable).withNullableSuffix()
     )
 
-    object BuilderIterableLikeToIterableSpec : ch.tutteli.atrium.specs.integration.IterableLikeToIterableSpec<List<Int>>(
-        functionDescription,
-        listOf(1, 2),
-        { input -> toContain.inAnyOrder.only.elementsOf(input) }
-    )
+    object BuilderIterableLikeToIterableSpec :
+        ch.tutteli.atrium.specs.integration.IterableLikeToIterableSpec<List<Int>>(
+            functionDescription,
+            listOf(1, 2),
+            { input -> toContain.inAnyOrder.only.elementsOf(input) }
+        )
 
     companion object : IterableToContainSpecBase() {
         val functionDescription = "$toContain.$inAnyOrder.$only.$elementsOf"
@@ -27,16 +30,23 @@ class IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun toContainElementsOf(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect.toContain.inAnyOrder.only.elementsOf(listOf(a, *aX))
+            aX: Array<out Double>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double>> =
+            if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inAnyOrder.only.elementsOf(listOf(a, *aX))
+            } else expect.toContain.inAnyOrder.only.elementsOf(listOf(a, *aX), report = report)
 
         private fun toContainElementsOfNullable(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect.toContain.inAnyOrder.only.elementsOf(sequenceOf(a, *aX))
+            aX: Array<out Double?>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double?>> =
+            if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inAnyOrder.only.elementsOf(listOf(a, *aX))
+            } else expect.toContain.inAnyOrder.only.elementsOf(listOf(a, *aX), report = report)
     }
-
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -49,5 +59,16 @@ class IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec : Spek({
         nList = nList.toContain.inAnyOrder.only.elementsOf(listOf<Int>())
         subList = subList.toContain.inAnyOrder.only.elementsOf(listOf<Int>())
         star = star.toContain.inAnyOrder.only.elementsOf(listOf<Int>())
+
+        list = list.toContain.inAnyOrder.only.elementsOf(listOf<Int>(), report = {})
+        nList = nList.toContain.inAnyOrder.only.elementsOf(listOf<Int>(), report = {})
+        subList = subList.toContain.inAnyOrder.only.elementsOf(listOf<Int>(), report = {})
+        star = star.toContain.inAnyOrder.only.elementsOf(listOf<Int>(), report = {})
+
+        nList = nList.toContain.inAnyOrder.only.elementsOf(listOf<Int?>())
+        star = star.toContain.inAnyOrder.only.elementsOf(listOf<Int?>())
+
+        list = list.toContain.inAnyOrder.only.elementsOf(listOf<Int?>(), report = {})
+        star = star.toContain.inAnyOrder.only.elementsOf(listOf<Int?>(), report = {})
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderOnlyEntriesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderOnlyEntriesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
 
@@ -15,20 +16,26 @@ class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec :
         private fun toContainInAnyOrderOnlyEntries(
             expect: Expect<Iterable<Double>>,
             a: Expect<Double>.() -> Unit,
-            aX: Array<out Expect<Double>.() -> Unit>
+            aX: Array<out Expect<Double>.() -> Unit>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect.toContain.inAnyOrder.only.entry(a)
-            else expect.toContain.inAnyOrder.only.entries(a, *aX)
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect.toContain.inAnyOrder.only.entry(a)
+                else expect.toContain.inAnyOrder.only.entries(a, *aX)
+            } else expect.toContain.inAnyOrder.only.entries(a, *aX, report = report)
+
 
         private fun toContainInAnyOrderOnlyNullableEntries(
             expect: Expect<Iterable<Double?>>,
             a: (Expect<Double>.() -> Unit)?,
-            aX: Array<out (Expect<Double>.() -> Unit)?>
+            aX: Array<out (Expect<Double>.() -> Unit)?>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect.toContain.inAnyOrder.only.entry(a)
-            else expect.toContain.inAnyOrder.only.entries(a, *aX)
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect.toContain.inAnyOrder.only.entry(a)
+                else expect.toContain.inAnyOrder.only.entries(a, *aX)
+            } else expect.toContain.inAnyOrder.only.entries(a, *aX, report = report)
     }
-
 
     @Suppress("unused", "UNUSED_VALUE")
     private fun ambiguityTest() {
@@ -50,7 +57,15 @@ class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec :
         subList = subList.toContain.inAnyOrder.only.entries({}, {})
         star = star.toContain.inAnyOrder.only.entries({}, {})
 
+        list = list.toContain.inAnyOrder.only.entries({}, {}, report = {})
+        nList = nList.toContain.inAnyOrder.only.entries({}, {}, report = {})
+        subList = subList.toContain.inAnyOrder.only.entries({}, {}, report = {})
+        star = star.toContain.inAnyOrder.only.entries({}, {}, report = {})
+
         nList = nList.toContain.inAnyOrder.only.entries(null, {}, null)
         star = star.toContain.inAnyOrder.only.entries(null, {}, null)
+
+        nList = nList.toContain.inAnyOrder.only.entries(null, {}, null, report = {})
+        star = star.toContain.inAnyOrder.only.entries(null, {}, null, report = {})
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderOnlyValuesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInAnyOrderOnlyValuesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
 
@@ -15,18 +16,24 @@ class IterableToContainInAnyOrderOnlyValuesExpectationsSpec :
         private fun toContainInAnyOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
+            aX: Array<out Double>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect.toContain.inAnyOrder.only.value(a)
-            else expect.toContain.inAnyOrder.only.values(a, *aX)
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect.toContain.inAnyOrder.only.value(a)
+                else expect.toContain.inAnyOrder.only.values(a, *aX)
+            } else expect.toContain.inAnyOrder.only.values(a, *aX, report = report)
 
         private fun toContainInAnyOrderOnlyNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
+            aX: Array<out Double?>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect.toContain.inAnyOrder.only.value(a)
-            else expect.toContain.inAnyOrder.only.values(a, *aX)
+            if (report === emptyInOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect.toContain.inAnyOrder.only.value(a)
+                else expect.toContain.inAnyOrder.only.values(a, *aX)
+            } else expect.toContain.inAnyOrder.only.values(a, *aX, report = report)
     }
 
     @Suppress("unused", "UNUSED_VALUE")
@@ -45,5 +52,16 @@ class IterableToContainInAnyOrderOnlyValuesExpectationsSpec :
         nList = nList.toContain.inAnyOrder.only.values(1, 1.2)
         subList = subList.toContain.inAnyOrder.only.values(1, 2.2)
         star = star.toContain.inAnyOrder.only.values(1, 1.2, "asdf")
+
+        list = list.toContain.inAnyOrder.only.values(1, 1.2, report = {})
+        nList = nList.toContain.inAnyOrder.only.values(1, 1.2, report = {})
+        subList = subList.toContain.inAnyOrder.only.values(1, 2.2, report = {})
+        star = star.toContain.inAnyOrder.only.values(1, 1.2, "asdf", report = {})
+
+        nList = nList.toContain.inAnyOrder.only.values(null, 1.2)
+        star = star.toContain.inAnyOrder.only.values(null, 1.2, "asdf")
+
+        nList = nList.toContain.inAnyOrder.only.values(null, 1.2, report = {})
+        star = star.toContain.inAnyOrder.only.values(null, 1.2, "asdf", report = {})
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
@@ -114,7 +114,7 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
         subList = subList.toContainExactly({}, {})
         star = star.toContainExactly({}, {})
 
-        list = list.toContainExactly({}, {}, report = { showOnlyFailingIfMoreElementsThan(20) })
+        list = list.toContainExactly({}, {}, report = { showOnlyFailingIfMoreExpectedElementsThan(20) })
         nList = nList.toContainExactly({}, {}, report = { showOnlyFailing() })
         subList = subList.toContainExactly({}, {}, report = { showAlwaysSummary() })
         star = star.toContainExactly({}, {}, report = { })

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.notImplemented
 
@@ -17,8 +19,26 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             expect: Expect<Iterable<Double?>>,
             a1: Group<(Expect<Double>.() -> Unit)?>,
             a2: Group<(Expect<Double>.() -> Unit)?>,
-            aX: Array<out Group<(Expect<Double>.() -> Unit)?>>
-        ): Expect<Iterable<Double?>> = expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
+            aX: Array<out Group<(Expect<Double>.() -> Unit)?>>,
+            report: InOrderOnlyReportingOptions.() -> Unit,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double?>> =
+            if (report === emptyInOrderOnlyReportOptions && reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
+            } else if (reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX, report = report)
+            } else if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX, reportInGroup = reportInGroup)
+            } else {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(
+                    a1,
+                    a2,
+                    *aX,
+                    report = report,
+                    reportInGroup = reportInGroup
+                )
+            }
+
 
         private fun groupFactory(groups: Array<out (Expect<Double>.() -> Unit)?>) =
             when (groups.size) {
@@ -47,7 +67,47 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), report = {})
         subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), report = {})
         //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Entry<Number> {}, Entries<Number>({}, {}))
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry<Number> {},
+            Entries<Number>({}, {}),
+            report = {}
+        )
+
+        list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), reportInGroup = {})
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), reportInGroup = {})
+        subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry {}, Entries({}, {}), reportInGroup = {})
+        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry<Number> {},
+            Entries<Number>({}, {}),
+            reportInGroup = {}
+        )
+
+        list = list.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry {},
+            Entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry {},
+            Entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+        subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry {},
+            Entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry<Number> {},
+            Entries<Number>({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry(null), Entries({}, null))
         //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
@@ -55,6 +115,32 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry(null), Entries({}, null), report = {})
         //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Entry<Number>(null), Entries<Number>(null, {}))
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry<Number>(null),
+            Entries<Number>(null, {}),
+            report = {})
+
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry(null),
+            Entries({}, null),
+            reportInGroup = {}
+        )
+        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry<Number>(null),
+            Entries<Number>(null, {}),
+            reportInGroup = {})
+
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry(null),
+            Entries({}, null),
+            report = {},
+            reportInGroup = {})
+        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Entry<Number>(null),
+            Entries<Number>(null, {}),
+            report = {},
+            reportInGroup = {})
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.notImplemented
 import ch.tutteli.atrium.specs.withNullableSuffix
@@ -14,14 +16,32 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
         "[Atrium][Builder] "
     ) {
     companion object : IterableToContainSpecBase() {
-        val functionDescription =  "$toContain.$inOrder.$only.$grouped.$within.$withinInAnyOrder"
+        val functionDescription = "$toContain.$inOrder.$only.$grouped.$within.$withinInAnyOrder"
 
         private fun toContainInOrderOnlyGroupedInAnyOrderValues(
             expect: Expect<Iterable<Double>>,
             a1: Group<Double>,
             a2: Group<Double>,
-            aX: Array<out Group<Double>>
-        ): Expect<Iterable<Double>> = expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
+            aX: Array<out Group<Double>>,
+            report: InOrderOnlyReportingOptions.() -> Unit,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double>> =
+            if (report === emptyInOrderOnlyReportOptions && reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
+            } else if (reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX, report = report)
+            } else if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX, reportInGroup = reportInGroup)
+            } else {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(
+                    a1,
+                    a2,
+                    *aX,
+                    report = report,
+                    reportInGroup = reportInGroup
+                )
+            }
+
 
         private fun groupFactory(groups: Array<out Double>): Group<Double> =
             when (groups.size) {
@@ -36,8 +56,25 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
             expect: Expect<Iterable<Double?>>,
             a1: Group<Double?>,
             a2: Group<Double?>,
-            aX: Array<out Group<Double?>>
-        ): Expect<Iterable<Double?>> = expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
+            aX: Array<out Group<Double?>>,
+            report: InOrderOnlyReportingOptions.() -> Unit,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double?>> =
+            if (report === emptyInOrderOnlyReportOptions && reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX)
+            } else if (reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX, report = report)
+            } else if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(a1, a2, *aX, reportInGroup = reportInGroup)
+            } else {
+                expect.toContain.inOrder.only.grouped.within.inAnyOrder(
+                    a1,
+                    a2,
+                    *aX,
+                    report = report,
+                    reportInGroup = reportInGroup
+                )
+            }
 
         private fun nullableGroupFactory(groups: Array<out Double?>): Group<Double?> =
             when (groups.size) {
@@ -66,10 +103,50 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
         subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), report = {})
         star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), report = {})
 
+        list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), reportInGroup = {})
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), reportInGroup = {})
+        subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), reportInGroup = {})
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), reportInGroup = {})
+
+        list = list.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Value(1),
+            Values(1, 2),
+            report = {},
+            reportInGroup = {})
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Value(1),
+            Values(1, 2),
+            report = {},
+            reportInGroup = {})
+        subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Value(1),
+            Values(1, 2),
+            report = {},
+            reportInGroup = {})
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Value(1),
+            Values(1, 2),
+            report = {},
+            reportInGroup = {})
+
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(1, null))
         star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(null, 2))
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(1, null), report = {})
         star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(null, 2), report = {})
+
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(1, null), reportInGroup = {})
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(null, 2), reportInGroup = {})
+
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Value(null),
+            Values(1, null),
+            report = {},
+            reportInGroup = {})
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
+            Value(null),
+            Values(null, 2),
+            report = {},
+            reportInGroup = {})
     }
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
@@ -78,13 +78,18 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         subList = subList.toContain.inOrder.only.values(1, 2.2, report = {})
         star = star.toContain.inOrder.only.values(1, 1.2, "asdf", report = {})
 
+        nList = nList.toContain.inOrder.only.values(null, 1.2)
+        star = star.toContain.inOrder.only.values(null, 1.2, "asdf")
+
+        nList = nList.toContain.inOrder.only.values(null, 1.2, report = {})
+        star = star.toContain.inOrder.only.values(null, 1.2, "asdf", report = {})
 
         list = list.toContainExactly(1)
         nList = nList.toContainExactly(1, 1.2)
         subList = subList.toContainExactly(1)
         star = star.toContainExactly(1, "a", null)
 
-        list = list.toContainExactly(1, report = { showOnlyFailingIfMoreElementsThan(1) })
+        list = list.toContainExactly(1, report = { showOnlyFailingIfMoreExpectedElementsThan(1) })
         nList = nList.toContainExactly(1, 1.2, report = { showOnlyFailing() })
         subList = subList.toContainExactly(1, 2.2, report = { showAlwaysSummary() })
         // TODO would wish this does not work, maybe @OnlyInputTypes would help?

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainSpecBase.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainSpecBase.kt
@@ -5,8 +5,9 @@ import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.logic.creating.iterable.contains.IterableLikeContains
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.*
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.AtLeastCheckerStep
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
-import kotlin.reflect.KFunction5
+import kotlin.reflect.KFunction6
 import kotlin.reflect.KProperty
 
 abstract class IterableToContainSpecBase {
@@ -32,8 +33,8 @@ abstract class IterableToContainSpecBase {
     protected val only = IterableLikeContains.EntryPointStep<Int, List<Int>, InAnyOrderSearchBehaviour>::only.name
     protected val grouped = IterableLikeContains.EntryPointStep<Int, List<Int>, InOrderOnlySearchBehaviour>::grouped.name
     protected val within = IterableLikeContains.EntryPointStep<Int, List<Int>, InOrderOnlyGroupedSearchBehaviour>::within.name
-    private val withinInAnyOrderFun: KFunction5<IterableLikeContains.EntryPointStep<Int, Iterable<Int>, InOrderOnlyGroupedWithinSearchBehaviour>, Group<Int>, Group<Int>, Array<out Group<Int>>, InOrderOnlyReportingOptions.() -> Unit, Expect<Iterable<Int>>> =
-        IterableLikeContains.EntryPointStep<Int, Iterable<Int>, InOrderOnlyGroupedWithinSearchBehaviour, >::inAnyOrder
+    private val withinInAnyOrderFun: KFunction6<IterableLikeContains.EntryPointStep<Int, Iterable<Int>, InOrderOnlyGroupedWithinSearchBehaviour>, Group<Int>, Group<Int>, Array<out Group<Int>>, InOrderOnlyReportingOptions.() -> Unit, InAnyOrderOnlyReportingOptions.() -> Unit, Expect<Iterable<Int>>> =
+        IterableLikeContains.EntryPointStep<Int, Iterable<Int>, InOrderOnlyGroupedWithinSearchBehaviour>::inAnyOrder
     protected val withinInAnyOrder = withinInAnyOrderFun.name
     //@formatter:on
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableExpectationSamples.kt
@@ -94,7 +94,7 @@ class IterableExpectationSamples {
                 // optional
                 report = { // allows configuring reporting, e.g.
                     showOnlyFailing() // would not show the successful `B`
-                    showOnlyFailingIfMoreElementsThan(10)
+                    showOnlyFailingIfMoreExpectedElementsThan(10)
                 }
             )
         }
@@ -142,7 +142,7 @@ class IterableExpectationSamples {
                 // optional
                 report = { // allows configuring reporting, e.g.
                     showOnlyFailing() // would not show the successful `toBeLessThan(11)`
-                    showOnlyFailingIfMoreElementsThan(10)
+                    showOnlyFailingIfMoreExpectedElementsThan(10)
                 }
             )
         }
@@ -166,7 +166,7 @@ class IterableExpectationSamples {
                 // optional
                 report = { // allows configuring reporting, e.g.
                     showOnlyFailing() // would not show the successful first and second `1, 2`
-                    showOnlyFailingIfMoreElementsThan(10)
+                    showOnlyFailingIfMoreExpectedElementsThan(10)
                 }
             )
         }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions.kt
@@ -1,0 +1,10 @@
+package ch.tutteli.atrium.api.infix.en_GB.creating.iterable
+
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+
+/**
+ * Parameter object to wrap a given [T] next to specifying [InAnyOrderOnlyReportingOptions].
+ *
+ * @since 0.18.0
+ */
+data class WithInAnyOrderOnlyReportingOptions<out T>(val options: InAnyOrderOnlyReportingOptions.() -> Unit, val t: T)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions.kt
@@ -7,4 +7,4 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderO
  *
  * @since 0.18.0
  */
-data class WithInOrderOnlyReportingOptions<out T>(val report: InOrderOnlyReportingOptions.() -> Unit, val t: T)
+data class WithInOrderOnlyReportingOptions<out T>(val options: InOrderOnlyReportingOptions.() -> Unit, val t: T)

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/helperFunctions.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/helperFunctions.kt
@@ -1,11 +1,13 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.*
+import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInOrderOnlyReportingOptions
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyValues
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyWithValueCreator
 import ch.tutteli.atrium.assertions.Assertion
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.creating.typeutils.MapLike
@@ -20,10 +22,10 @@ fun <T> all(t: T, vararg ts: T): All<T> = All(t, ts)
 
 /**
  * Helper function to create a [WithInOrderOnlyReportingOptions] wrapping an [IterableLike]
- * based on the given [iterableLike] and the given [report]-configuration-lambda.
+ * based on the given [iterableLike] and the given [reportOptionsInOrderOnly]-configuration-lambda.
  *
  * @param iterableLike The [IterableLike] whose elements this function is referring to.
- * @param report The lambda configuring the [InOrderOnlyReportingOptions].
+ * @param reportOptionsInOrderOnly The lambda configuring the [InOrderOnlyReportingOptions].
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableExpectationSamples.toContainExactlyElementsOf
  *
@@ -31,8 +33,22 @@ fun <T> all(t: T, vararg ts: T): All<T> = All(t, ts)
  */
 fun <T : IterableLike> elementsOf(
     iterableLike: T,
-    report: InOrderOnlyReportingOptions.() -> Unit
-): WithInOrderOnlyReportingOptions<T> = WithInOrderOnlyReportingOptions(report, iterableLike)
+    reportOptionsInOrderOnly: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<T> = WithInOrderOnlyReportingOptions(reportOptionsInOrderOnly, iterableLike)
+
+/**
+ * Helper function to create a [WithInAnyOrderOnlyReportingOptions] wrapping an [IterableLike]
+ * based on the given [iterableLike] and the given [reportOptionsInAnyOrderOnly]-configuration-lambda.
+ *
+ * @param iterableLike The [IterableLike] whose elements this function is referring to.
+ * @param reportOptionsInAnyOrderOnly The lambda configuring the [InAnyOrderOnlyReportingOptions].
+ *
+ * @since 0.18.0
+ */
+fun <T : IterableLike> elementsOf(
+    iterableLike: T,
+    reportOptionsInAnyOrderOnly: InAnyOrderOnlyReportingOptions.() -> Unit
+): WithInAnyOrderOnlyReportingOptions<T> = WithInAnyOrderOnlyReportingOptions(reportOptionsInAnyOrderOnly, iterableLike)
 
 /**
  * Helper function to create an [Entry] based on the given [assertionCreatorOrNull].
@@ -60,8 +76,8 @@ fun <T : Any> entries(
 
 /**
  * Helper function to create a [WithInOrderOnlyReportingOptions] wrapping an [Entries] based on the given
- * [assertionCreatorOrNull] and [otherAssertionCreatorsOrNulls] as well as the given [report]-configuration-lambda
- * -- allows expressing `{ }, vararg { }, report = { ... }`.
+ * [assertionCreatorOrNull] and [otherAssertionCreatorsOrNulls] as well as the given
+ * [reportOptionsInOrderOnly]-configuration-lambda -- allows expressing `{ }, vararg { }, reportOptionsInOrderOnly = { ... }`.
  *
  * In case `null` is used for an identification lambda then it is expected that the corresponding entry
  * is `null` as well.
@@ -70,7 +86,7 @@ fun <T : Any> entries(
  *   to be identified if it holds all [Assertion]s the lambda creates.
  *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
  * @param otherAssertionCreatorsOrNulls A variable amount of additional identification lambdas or `null`s.
- * @param report The lambda configuring the [InOrderOnlyReportingOptions].
+ * @param reportOptionsInOrderOnly The lambda configuring the [InOrderOnlyReportingOptions].
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableExpectationSamples.toContainExactlyAssertions
  *
@@ -79,23 +95,46 @@ fun <T : Any> entries(
 fun <T : Any> entries(
     assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
     vararg otherAssertionCreatorsOrNulls: (Expect<T>.() -> Unit)?,
-    report: InOrderOnlyReportingOptions.() -> Unit
+    reportOptionsInOrderOnly: InOrderOnlyReportingOptions.() -> Unit
 ): WithInOrderOnlyReportingOptions<Entries<T>> =
-    WithInOrderOnlyReportingOptions(report, Entries(assertionCreatorOrNull, otherAssertionCreatorsOrNulls))
+    WithInOrderOnlyReportingOptions(reportOptionsInOrderOnly, Entries(assertionCreatorOrNull, otherAssertionCreatorsOrNulls))
+
+/**
+ * Helper function to create a [WithInAnyOrderOnlyReportingOptions] wrapping an [Entries] based on the given
+ * [assertionCreatorOrNull] and [otherAssertionCreatorsOrNulls] as well as the given
+ * [reportOptionsInAnyOrderOnly]-configuration-lambda -- allows expressing `{ }, vararg { }, reportOptionsInAnyOrderOnly = { ... }`.
+ *
+ * In case `null` is used for an identification lambda then it is expected that the corresponding entry
+ * is `null` as well.
+ *
+ * @param assertionCreatorOrNull The identification lambda identifying the entry where an entry is considered
+ *   to be identified if it holds all [Assertion]s the lambda creates.
+ *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
+ * @param otherAssertionCreatorsOrNulls A variable amount of additional identification lambdas or `null`s.
+ * @param reportOptionsInAnyOrderOnly The lambda configuring the [InOrderOnlyReportingOptions].
+ *
+ * @since 0.18.0
+ */
+fun <T : Any> entries(
+    assertionCreatorOrNull: (Expect<T>.() -> Unit)?,
+    vararg otherAssertionCreatorsOrNulls: (Expect<T>.() -> Unit)?,
+    reportOptionsInAnyOrderOnly: InAnyOrderOnlyReportingOptions.() -> Unit
+): WithInAnyOrderOnlyReportingOptions<Entries<T>> =
+    WithInAnyOrderOnlyReportingOptions(reportOptionsInAnyOrderOnly, Entries(assertionCreatorOrNull, otherAssertionCreatorsOrNulls))
 
 /**
  * Helper function to create a [WithInOrderOnlyReportingOptions] wrapping an [MapLike]
- * based on the given [mapLike] and the given [report]-configuration-lambda.
+ * based on the given [mapLike] and the given [reportOptionsInOrderOnly]-configuration-lambda.
  *
  * @param mapLike The [MapLike] whose elements this function is referring to.
- * @param report The lambda configuring the [InOrderOnlyReportingOptions].
+ * @param reportOptionsInOrderOnly The lambda configuring the [InOrderOnlyReportingOptions].
  *
  * @since 0.18.0
  */
 fun <T : MapLike> entriesOf(
     mapLike: T,
-    report: InOrderOnlyReportingOptions.() -> Unit
-): WithInOrderOnlyReportingOptions<T> = WithInOrderOnlyReportingOptions(report, mapLike)
+    reportOptionsInOrderOnly: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<T> = WithInOrderOnlyReportingOptions(reportOptionsInOrderOnly, mapLike)
 
 /**
  * Helper function to create a [KeyValues] based on the given [keyValue] and [otherKeyValues]
@@ -113,15 +152,19 @@ fun <K, V : Any> keyValues(
 /**
  * Helper function to create a [KeyValues] based on the given [keyValue] and [otherKeyValues]
  * -- allows expressing `Pair<K, (Expect<V>.() -> Unit)?>, vararg Pair<K, (Expect<V>.() -> Unit)?>`.
+ *
+ * @param reportOptionsInOrderOnly The lambda configuring the [InOrderOnlyReportingOptions] -- it is optional where
+ *   the default [InOrderOnlyReportingOptions] apply if not specified.
+ *   since 0.18.0
  */
 // TODO 1.0.0: consider to rename to entries once updated to Kotlin 1.4 maybe the type inference is better and there
 // is no longer a clash with Iterable entries
 fun <K, V : Any> keyValues(
     keyValue: KeyWithValueCreator<K, V>,
     vararg otherKeyValues: KeyWithValueCreator<K, V>,
-    report: InOrderOnlyReportingOptions.() -> Unit
+    reportOptionsInOrderOnly: InOrderOnlyReportingOptions.() -> Unit
 ): WithInOrderOnlyReportingOptions<KeyValues<K, V>> =
-    WithInOrderOnlyReportingOptions(report, KeyValues(keyValue, otherKeyValues))
+    WithInOrderOnlyReportingOptions(reportOptionsInOrderOnly, KeyValues(keyValue, otherKeyValues))
 
 /**
  * Helper function to create a [KeyWithValueCreator] based on the given [key] and [valueAssertionCreatorOrNull]
@@ -152,8 +195,8 @@ fun <K, V> pairs(pair: Pair<K, V>, vararg otherPairs: Pair<K, V>): Pairs<K, V> =
 fun <K, V> pairs(
     pair: Pair<K, V>,
     vararg otherPairs: Pair<K, V>,
-    report: InOrderOnlyReportingOptions.() -> Unit
-): WithInOrderOnlyReportingOptions<Pairs<K, V>> = WithInOrderOnlyReportingOptions(report, Pairs(pair, otherPairs))
+    reportOptionsInOrderOnly: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<Pairs<K, V>> = WithInOrderOnlyReportingOptions(reportOptionsInOrderOnly, Pairs(pair, otherPairs))
 
 /**
  * Helper function to create a [PresentWithCreator] based on the given [assertionCreator].
@@ -198,16 +241,34 @@ fun <T> values(value: T, vararg otherValues: T): Values<T> = Values(value, other
 
 /**
  * Helper function to create a [WithInOrderOnlyReportingOptions] wrapping a [Values] based on the given
- * [value] and [otherValues] as well as the given [report]-configuration-lambda -- allows expressing
- * `T, vararg T, report = { ... }`.
+ * [value] and [otherValues] as well as the given [reportOptionsInOrderOnly]-configuration-lambda -- allows expressing
+ * `T, vararg T, reportOptionsInOrderOnly = { ... }`.
  *
  * @param value The first expected value.
  * @param otherValues The other expected values in the given order.
- * @param report The lambda configuring the [InOrderOnlyReportingOptions].
+ * @param reportOptionsInOrderOnly The lambda configuring the [InOrderOnlyReportingOptions].
+ *
  * @since 0.18.0
  */
 fun <T> values(
     value: T,
     vararg otherValues: T,
-    report: InOrderOnlyReportingOptions.() -> Unit
-): WithInOrderOnlyReportingOptions<Values<T>> = WithInOrderOnlyReportingOptions(report, Values(value, otherValues))
+    reportOptionsInOrderOnly: InOrderOnlyReportingOptions.() -> Unit
+): WithInOrderOnlyReportingOptions<Values<T>> = WithInOrderOnlyReportingOptions(reportOptionsInOrderOnly, Values(value, otherValues))
+
+/**
+ * Helper function to create a [WithInOrderOnlyReportingOptions] wrapping a [Values] based on the given
+ * [value] and [otherValues] as well as the given [reportOptionsInAnyOrderOnly]-configuration-lambda -- allows expressing
+ * `T, vararg T, reportOptionsInAnyOrderOnly = { ... }`.
+ *
+ * @param value The first expected value.
+ * @param otherValues The other expected values in the given order.
+ * @param reportOptionsInAnyOrderOnly The lambda configuring the [InOrderOnlyReportingOptions].
+ *
+ * @since 0.18.0
+ */
+fun <T> values(
+    value: T,
+    vararg otherValues: T,
+    reportOptionsInAnyOrderOnly: InAnyOrderOnlyReportingOptions.() -> Unit
+): WithInAnyOrderOnlyReportingOptions<Values<T>> = WithInAnyOrderOnlyReportingOptions(reportOptionsInAnyOrderOnly, Values(value, otherValues))

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableExpectations.kt
@@ -164,10 +164,10 @@ infix fun <E, T : Iterable<E>> Expect<T>.toContainExactly(values: Values<E>): Ex
  * Expects that the subject of `this` expectation (an [Iterable]) contains only
  * the expected [values] in the defined order.
  *
- * It is a shortcut for `toContain o inGiven order and only the values(..., report = {... })`
+ * It is a shortcut for `toContain o inGiven order and only the values(..., reportOptionsInOrderOnly = {... })`
  *
  * @param values The values which are expected to be contained within the [IterableLike] plus a lambda configuring
- *   the [InOrderOnlyReportingOptions] -- use the function `values(t, ..., report = { ... })`
+ *   the [InOrderOnlyReportingOptions] -- use the function `values(t, ..., reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [Values].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -231,10 +231,10 @@ infix fun <E : Any, T : Iterable<E?>> Expect<T>.toContainExactly(entries: Entrie
  * [entries].t.[otherAssertionCreatorsOrNulls][Entries.otherAssertionCreatorsOrNulls] (if given)
  * whereas the entries have to appear in the defined order.
  *
- * It is a shortcut for `toContain o inGiven order and only the entries(..., report = { ... })`
+ * It is a shortcut for `toContain o inGiven order and only the entries(..., reportOptionsInOrderOnly = { ... })`
  *
  * @param entries The entries which are expected to be contained within the [Iterable] plus a lambda configuring
- *   the [InOrderOnlyReportingOptions] -- use the function `entries(t, ..., report = { ... })`
+ *   the [InOrderOnlyReportingOptions] -- use the function `entries(t, ..., reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [Entries].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -278,11 +278,11 @@ inline infix fun <reified E, T : Iterable<E>> Expect<T>.toContainExactlyElements
  * [entries].t.[otherAssertionCreatorsOrNulls][Entries.otherAssertionCreatorsOrNulls] (if given)
  * whereas the entries have to appear in the defined order.
  *
- * It is a shortcut for `toContain o inGiven order and only the elementsOf(..., report = { ... })`
+ * It is a shortcut for `toContain o inGiven order and only the elementsOf(..., reportOptionsInOrderOnly = { ... })`
  *
  * @param elementsOf The [IterableLike] whose elements are expected to be contained within
  *   this [IterableLike] plus a lambda configuring the [InOrderOnlyReportingOptions] -- use the function
- *   `elementsOf(iterableLike, report = { ... })`
+ *   `elementsOf(iterableLike, reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [IterableLike].
  *
  * @return an [Expect] for the subject of `this` expectation.

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -2,6 +2,8 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.Entries
 import ch.tutteli.atrium.api.infix.en_GB.creating.Values
+import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInOrderOnlyReportingOptions
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic._logicAppend
@@ -10,9 +12,12 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInAnyO
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.values
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.valuesInAnyOrderOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLikeToIterableTransformer
 import ch.tutteli.atrium.logic.utils.toVarArg
+import kotlin.jvm.JvmName
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -38,7 +43,23 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehavio
  * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.the(values: Values<E>): Expect<T> =
-    _logicAppend { valuesInAnyOrderOnly(values.toList()) }
+    the(WithInAnyOrderOnlyReportingOptions({}, values))
+
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
+ * needs to contain only the expected [values] where it does not matter in which order.
+ *
+ * @param values The values which are expected to be contained within the [IterableLike] plus a lambda configuring
+ *   the [InAnyOrderOnlyReportingOptions] -- use the function `values(t, ..., reportOptionsInAnyOrderOnly = { ... })`
+ *   to create a [WithInAnyOrderOnlyReportingOptions] with a wrapped [Values].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.18.0
+ */
+@JvmName("theValuesWithReportingOptions")
+infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.the(values: WithInAnyOrderOnlyReportingOptions<Values<E>>): Expect<T> =
+    _logicAppend { valuesInAnyOrderOnly(values.t.toList(), values.options) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -76,10 +97,36 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  *
  * @return an [Expect] for the subject of `this` expectation.
  */
-
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.the(
     entries: Entries<E>
-): Expect<T> = _logicAppend { entriesInAnyOrderOnly(entries.toList()) }
+): Expect<T> = the(WithInAnyOrderOnlyReportingOptions({}, entries))
+
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
+ * needs to contain only the given [entries] where it does not matter in which order they appear -- an entry
+ * is contained if it either holds all assertions
+ * [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] creates or it needs to be `null` in case
+ * [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] is defined as `null`
+ *
+ * Notice, that a first-wins strategy applies which means your assertion creator lambdas -- which kind of serve as
+ * identification lambdas -- should be ordered in such a way that the most specific identification lambda appears
+ * first, not that a less specific lambda wins. For instance, given a `setOf(1, 2)` you should not search for
+ * `entries({ isGreaterThan(0) }, { toEqual(1) })` but for `entries({ toEqual(1) }, { isGreaterThan(0) })`
+ * otherwise `isGreaterThan(0)` matches `1` before `toEqual(1)` would match it. As a consequence `toEqual(1)` could
+ * only match the entry which is left -- in this case `2` -- and of course this would fail.
+ *
+ * @param entries The entries which are expected to be contained within the [IterableLike] plus a lambda configuring
+ *   the [InAnyOrderOnlyReportingOptions] -- use the function `entries(t, ..., reportOptionsInAnyOrderOnly = { ... })`
+ *   to create a [WithInAnyOrderOnlyReportingOptions] with a wrapped [Entries].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.18.0
+ */
+@JvmName("theEntriesWithReportingOptions")
+infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.the(
+    entries: WithInAnyOrderOnlyReportingOptions<Entries<E>>
+): Expect<T> = _logicAppend { entriesInAnyOrderOnly(entries.t.toList(), entries.options) }
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
@@ -103,3 +150,32 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
 ): Expect<T> = _logic.toVarArg<E>(expectedIterableLike).let { (first, rest) -> this the values(first, *rest) }
+
+/**
+ * Finishes the specification of the sophisticated `contains` assertion where the subject (an [IterableLike])
+ * needs to contain only and all elements of the given [IterableLike] in the specified order.
+ *
+ * Delegates to [values].
+ *
+ * Notice that a runtime check applies which assures that only [Iterable], [Sequence] or one of the [Array] types
+ * are passed (this can be changed via [IterableLikeToIterableTransformer]).
+ * This function expects [IterableLike] (which is a typealias for [Any]) to avoid cluttering the API.
+
+ * @param elementsOf The [IterableLike] whose elements are expected to be contained within
+ *   this [IterableLike] plus a lambda configuring the [InOrderOnlyReportingOptions] -- use the function
+ *   `elementsOf(iterableLike, report = { ... })`
+ *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [IterableLike].
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ * @throws IllegalArgumentException in case the wrapped [IterableLike] is not
+ *   an [Iterable], [Sequence] or one of the [Array] types
+ *   or the wrapped [IterableLike] does not have elements (is empty).
+ *
+ * @since 0.18.0
+ */
+@JvmName("theElementsOfsWithReportingOptions")
+inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.the(
+    elementsOf: WithInAnyOrderOnlyReportingOptions<IterableLike>
+): Expect<T> = _logic.toVarArg<E>(elementsOf.t).let { (first, rest) ->
+    this the values(first, *rest, reportOptionsInAnyOrderOnly = elementsOf.options)
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -50,18 +50,18 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>
  * needs to contain only the expected [values] in the specified order.
  *
  * @param values The values which are expected to be contained within the [IterableLike] plus a lambda configuring
- *   the [InOrderOnlyReportingOptions] -- use the function `values(t, ..., report = { ... })`
+ *   the [InOrderOnlyReportingOptions] -- use the function `values(t, ..., reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [Values].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.18.0
  */
-@JvmName("theValuesWithReportingOption")
+@JvmName("theValuesWithReportingOptions")
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.the(
     values: WithInOrderOnlyReportingOptions<Values<E>>
 ): Expect<T> = _logicAppend {
-    valuesInOrderOnly(values.t.toList(), values.report)
+    valuesInOrderOnly(values.t.toList(), values.options)
 }
 
 /**
@@ -110,20 +110,20 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  * [entries].[assertionCreatorOrNull][Entries.assertionCreatorOrNull] is defined as `null`
  *
  * @param entries The entries which are expected to be contained within the [IterableLike] plus a lambda configuring
- *   the [InOrderOnlyReportingOptions] -- use the function `entries(t, ..., report = { ... })`
+ *   the [InOrderOnlyReportingOptions] -- use the function `entries(t, ..., reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [Entries].
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.18.0
  */
-@JvmName("theEntriesWithReportingOption")
+@JvmName("theEntriesWithReportingOptions")
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.the(
     entries: WithInOrderOnlyReportingOptions<Entries<E>>
 ): Expect<T> = _logicAppend {
     entriesInOrderOnly(
         entries.t.toList(),
-        entries.report
+        entries.options
     )
 }
 
@@ -173,9 +173,9 @@ inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlyS
  *
  * @since 0.18.0
  */
-@JvmName("theElementsOfsWithReportingOption")
+@JvmName("theElementsOfWithReportingOptions")
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.the(
     elementsOf: WithInOrderOnlyReportingOptions<IterableLike>
 ): Expect<T> = _logic.toVarArg<E>(elementsOf.t).let { (first, rest) ->
-    this the values(first, *rest, report = elementsOf.report)
+    this the values(first, *rest, reportOptionsInOrderOnly = elementsOf.options)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -1,7 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.api.infix.en_GB.creating.Pairs
-import ch.tutteli.atrium.api.infix.en_GB.creating.Values
 import ch.tutteli.atrium.api.infix.en_GB.creating.iterable.WithInOrderOnlyReportingOptions
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyValues
 import ch.tutteli.atrium.api.infix.en_GB.creating.map.KeyWithValueCreator
@@ -54,7 +53,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  * needs to contain only the given [pairs] in the specified order.
  *
  * @param pairs The key-value pairs which are expected to be contained within the [MapLike]
- *   plus a lambda configuring the [InOrderOnlyReportingOptions] -- use the function `pairs(t, ..., report = { ... })`
+ *   plus a lambda configuring the [InOrderOnlyReportingOptions] -- use the function `pairs(t, ..., reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [Pairs].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -65,7 +64,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
     pairs: WithInOrderOnlyReportingOptions<Pairs<K, V>>
 ): Expect<T> = _logicAppend {
-    keyValuePairsInOrderOnly(pairs.t.toList(), pairs.report)
+    keyValuePairsInOrderOnly(pairs.t.toList(), pairs.options)
 }
 
 
@@ -119,7 +118,7 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`.
  *
  * @param keyValues The [KeyWithValueCreator]s plus a lambda configuring the [InOrderOnlyReportingOptions]
- *   -- use the function `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ..., report = { ... })`
+ *   -- use the function `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ..., reportOptionsInOrderOnly = { ... })`
  *   to create a [WithInOrderOnlyReportingOptions] with a wrapped [KeyValues].
  *
  * @return an [Expect] for the subject of `this` expectation.
@@ -139,7 +138,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
     keyWithValueAssertionsInOrderOnly(
         kClass,
         keyValues.t.toList().map { it.toPair() },
-        keyValues.report
+        keyValues.options
     )
 }
 
@@ -190,5 +189,5 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     entriesOf: WithInOrderOnlyReportingOptions<MapLike>
 ): Expect<T> = _logic.toVarArgPairs<K, V>(entriesOf.t).let { (first, rest) ->
-    this the pairs(first, *rest, report = entriesOf.report)
+    this the pairs(first, *rest, reportOptionsInOrderOnly = entriesOf.options)
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtLeast1ElementsOfExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtLeast1ElementsOfExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
@@ -74,6 +75,30 @@ class IterableToContainInAnyOrderAtLeast1ElementsOfExpectationsSpec : Spek({
             a: Double?,
             aX: Array<out Double?>
         ): Expect<Iterable<Double?>> = expect toContainElementsOf sequenceOf(a, *aX).asIterable()
+    }
 
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order atLeast 1 elementsOf listOf(1)
+        nList = nList toContain o inAny order atLeast 1 elementsOf listOf(1)
+        subList = subList toContain o inAny order atLeast 1 elementsOf listOf(1)
+        star = star toContain o inAny order atLeast 1 elementsOf listOf(1)
+
+        list = list toContainElementsOf listOf(1)
+        nList = nList toContainElementsOf listOf(1)
+        subList = subList toContainElementsOf listOf(1)
+        star = star toContainElementsOf listOf(1)
+
+        list = list toContainElementsOf listOf(1, 1.2)
+        nList = nList toContainElementsOf listOf(1, 1.2)
+        subList = subList toContainElementsOf listOf(1, 2.2)
+        subList = subList toContainElementsOf listOf(1)
+        star = star toContainElementsOf listOf(1, 1.2, "asdf")
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
@@ -69,5 +70,47 @@ class IterableToContainInAnyOrderAtLeast1EntriesExpectationsSpec : Spek({
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect toContain a
             else expect toContain entries(a, *aX)
+    }
+
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order atLeast 1 entry {}
+        nList = nList toContain o inAny order atLeast 1 entry {}
+        subList = subList toContain o inAny order atLeast 1 entry {}
+        star = star toContain o inAny order atLeast 1 entry {}
+
+        nList = nList toContain o inAny order atLeast 1 entry null
+        star = star toContain o inAny order atLeast 1 entry null
+
+        list = list toContain o inAny order atLeast 1 the entries({}, {})
+        nList = nList toContain o inAny order atLeast 1 the entries({}, {})
+        subList = subList toContain o inAny order atLeast 1 the entries({}, {})
+        star = star toContain o inAny order atLeast 1 the entries({}, {})
+
+        nList = nList toContain o inAny order atLeast 1 the entries(null, {}, null)
+        star = star toContain o inAny order atLeast 1 the entries(null, {}, null)
+
+        list = list toContain {}
+        nList = nList toContain {}
+        subList = subList toContain {}
+        star = star toContain {}
+
+        //TODO should work without cast, remove as soon as KT-6591 is fixed - (with Kotlin 1.4)
+        nList = nList toContain null as Number?
+        star = star toContain null as Number?
+
+        list = list toContain entries({}, {})
+        nList = nList toContain entries({}, {})
+        subList = subList toContain entries({}, {})
+        star = star toContain entries({}, {})
+
+        nList = nList toContain entries(null, {}, null)
+        star = star toContain entries(null, {}, null)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
@@ -70,6 +71,36 @@ class IterableToContainInAnyOrderAtLeast1ValuesExpectationsSpec : Spek({
         ): Expect<Iterable<Double?>> =
             if (aX.isEmpty()) expect toContain a
             else expect toContain values(a, *aX)
+    }
 
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order atLeast 1 value 1
+        nList = nList toContain o inAny order atLeast 1 value 1
+        subList = subList toContain o inAny order atLeast 1 value 1
+        star = star toContain o inAny order atLeast 1 value 1
+
+        //TODO type parameter should not be necessary, check with Kotlin 1.4
+        list = list toContain o inAny order atLeast 1 the values<Number>(1, 1.2)
+        nList = nList toContain o inAny order atLeast 1 the values<Number>(1, 1.2)
+        subList = subList toContain o inAny order atLeast 1 the values<Number>(1, 2.2)
+        star = star toContain o inAny order atLeast 1 the values(1, 1.2, "asdf")
+
+        list = list toContain 1
+        nList = nList toContain 1
+        subList = subList toContain 1
+        star = star toContain 1
+
+        list = list toContain values(1, 1.2)
+        nList = nList toContain values(1, 1.2)
+        subList = subList toContain values(1, 2.2)
+        // TODO would wish this does not work, maybe @OnlyInputTypes would help?
+        subList = subList toContain values("asdf")
+        star = star toContain values(1, 1.2, "asdf")
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtMostValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderAtMostValuesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
 
 class IterableToContainInAnyOrderAtMostValuesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableToContainInAnyOrderAtMostValuesExpectationsSpec(
@@ -28,5 +29,24 @@ class IterableToContainInAnyOrderAtMostValuesExpectationsSpec :
 
         private fun getErrorMsgExactly(times: Int) =
             "use `$exactly $times` instead of `$atMost $times`; `$atMost $times` defines implicitly `$atLeast $times` as well"
+    }
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order atMost 2 value(1)
+        nList = nList toContain o inAny order atMost 2 value(1)
+        subList = subList toContain o inAny order atMost 2 value(1)
+        star = star toContain o inAny order atMost 2 value(1)
+
+        //TODO type parameter should not be necessary, check with Kotlin 1.4
+        list = list toContain o inAny order atMost 2 the values<Number>(1, 1.2)
+        nList = nList toContain o inAny order atMost 2 the values<Number>(1, 1.2)
+        subList = subList toContain o inAny order atMost 2 the values<Number>(1, 2.2)
+        star = star toContain o inAny order atMost 2 the values(1, 1.2, "asdf")
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderExactlyValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderExactlyValuesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
 
 class IterableToContainInAnyOrderExactlyValuesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableToContainInAnyOrderExactlyValuesExpectationsSpec(
@@ -26,6 +27,25 @@ class IterableToContainInAnyOrderExactlyValuesExpectationsSpec :
         private fun getNotToContainPair() = notToContain to Companion::getErrorMsgNotToContain
 
         private fun getErrorMsgNotToContain(times: Int) = "use `$notToContain` instead of `$exactly $times`"
+    }
 
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order exactly 2 value 1
+        nList = nList toContain o inAny order exactly 2 value 1
+        subList = subList toContain o inAny order exactly 2 value 1
+        star = star toContain o inAny order exactly 2 value 1
+
+        //TODO type parameter should not be necessary, check with Kotlin 1.4
+        list = list toContain o inAny order exactly 2 the values<Number>(1, 1.2)
+        nList = nList toContain o inAny order exactly 2 the values<Number>(1, 1.2)
+        subList = subList toContain o inAny order exactly 2 the values<Number>(1, 2.2)
+        star = star toContain o inAny order exactly 2 the values(1, 1.2, "asdf")
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderNotOrAtMostValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderNotOrAtMostValuesExpectationsSpec.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.notImplemented
 
 class IterableToContainInAnyOrderNotOrAtMostValuesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableToContainInAnyOrderNotOrAtMostValuesExpectationsSpec(
@@ -26,6 +27,24 @@ class IterableToContainInAnyOrderNotOrAtMostValuesExpectationsSpec :
         private fun getNotToContainPair() = notToContain to Companion::getErrorMsgNotToContain
 
         private fun getErrorMsgNotToContain(times: Int) = "use `$notToContain` instead of `$notOrAtMost $times`"
+    }
 
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order notOrAtMost 1 value 1
+        nList = nList toContain o inAny order notOrAtMost 1 value 1
+        subList = subList toContain o inAny order notOrAtMost 1 value 1
+        star = star toContain o inAny order notOrAtMost 1 value 1
+
+        //TODO type parameter should not be necessary, check with Kotlin 1.4
+        list = list toContain o inAny order notOrAtMost 1 the values<Number>(1, 1.2)
+        nList = nList toContain o inAny order notOrAtMost 1 the values<Number>(1, 1.2)
+        subList = subList toContain o inAny order notOrAtMost 1 the values<Number>(1, 2.2)
+        star = star toContain o inAny order notOrAtMost 1 the values(1, 1.2, "asdf")
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec.kt
@@ -1,6 +1,9 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInAnyOrderOnlyReportOptions
+import ch.tutteli.atrium.specs.notImplemented
 import org.spekframework.spek2.Spek
 
 class IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec : Spek({
@@ -26,8 +29,17 @@ class IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun getToContainValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
-        ): Expect<Iterable<Double>> = expect toContain o inAny order but only elementsOf listOf(a, *aX)
+            aX: Array<out Double>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double>> =
+            if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inAny order but only elementsOf listOf(a, *aX)
+            } else {
+                expect toContain o inAny order but only the elementsOf(
+                    listOf(a, *aX),
+                    reportOptionsInAnyOrderOnly = report
+                )
+            }
 
         fun getToContainNullablePair() =
             "$toContain $filler $inAnyOrder $butOnly $inAnyOrderOnlyElementsOf" to Companion::getToContainNullableValues
@@ -35,7 +47,42 @@ class IterableToContainInAnyOrderOnlyElementsOfExpectationsSpec : Spek({
         private fun getToContainNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
-        ): Expect<Iterable<Double?>> = expect toContain o inAny order but only elementsOf sequenceOf(a, *aX)
+            aX: Array<out Double?>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
+        ): Expect<Iterable<Double?>> =
+            if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inAny order but only elementsOf listOf(a, *aX)
+            } else {
+                expect toContain o inAny order but only the elementsOf(
+                    listOf(a, *aX),
+                    reportOptionsInAnyOrderOnly = report
+                )
+            }
+    }
+
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order but only elementsOf listOf<Int>()
+        nList = nList toContain o inAny order but only elementsOf listOf<Int>()
+        subList = subList toContain o inAny order but only elementsOf listOf<Int>()
+        star = star toContain o inAny order but only elementsOf listOf<Int>()
+
+        list = list toContain o inAny order but only the elementsOf(listOf<Int>(), reportOptionsInAnyOrderOnly = {})
+        nList = nList toContain o inAny order but only the elementsOf(listOf<Int>(), reportOptionsInAnyOrderOnly = {})
+        subList =
+            subList toContain o inAny order but only the elementsOf(listOf<Int>(), reportOptionsInAnyOrderOnly = {})
+        star = star toContain o inAny order but only the elementsOf(listOf<Int>(), reportOptionsInAnyOrderOnly = {})
+
+        nList = nList toContain o inAny order but only elementsOf listOf<Int?>()
+        star = star toContain o inAny order but only elementsOf listOf<Int?>()
+
+        nList = nList toContain o inAny order but only the elementsOf(listOf<Int?>(), reportOptionsInAnyOrderOnly = {})
+        star = star toContain o inAny order but only the elementsOf(listOf<Int?>(), reportOptionsInAnyOrderOnly = {})
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderOnlyEntriesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderOnlyEntriesExpectationsSpec.kt
@@ -1,6 +1,9 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
+
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.notImplemented
 
 class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
@@ -15,10 +18,13 @@ class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec :
         private fun toContainInAnyOrderOnlyEntries(
             expect: Expect<Iterable<Double>>,
             a: Expect<Double>.() -> Unit,
-            aX: Array<out Expect<Double>.() -> Unit>
+            aX: Array<out Expect<Double>.() -> Unit>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect toContain o inAny order but only entry a
-            else expect toContain o inAny order but only the entries(a, *aX)
+            if (report === emptyInAnyOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inAny order but only entry a
+                else expect toContain o inAny order but only the entries(a, *aX)
+            } else expect toContain o inAny order but only the entries(a, *aX, reportOptionsInAnyOrderOnly = report)
 
 
         fun getContainsNullablePair() =
@@ -27,10 +33,44 @@ class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec :
         private fun toContainInAnyOrderOnlyNullableEntries(
             expect: Expect<Iterable<Double?>>,
             a: (Expect<Double>.() -> Unit)?,
-            aX: Array<out (Expect<Double>.() -> Unit)?>
+            aX: Array<out (Expect<Double>.() -> Unit)?>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect toContain o inAny order but only entry a
-            else expect toContain o inAny order but only the entries(a, *aX)
+            if (report === emptyInAnyOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inAny order but only entry a
+                else expect toContain o inAny order but only the entries(a, *aX)
+            } else expect toContain o inAny order but only the entries(a, *aX, reportOptionsInAnyOrderOnly = report)
+    }
 
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order but only entry {}
+        nList = nList toContain o inAny order but only entry {}
+        subList = subList toContain o inAny order but only entry {}
+        star = star toContain o inAny order but only entry {}
+
+        nList = nList toContain o inAny order but only entry (null)
+        star = star toContain o inAny order but only entry (null)
+
+        list = list toContain o inAny order but only the entries({}, {})
+        nList = nList toContain o inAny order but only the entries({}, {})
+        subList = subList toContain o inAny order but only the entries({}, {})
+        star = star toContain o inAny order but only the entries({}, {})
+
+        list = list toContain o inAny order but only the entries({}, {}, reportOptionsInAnyOrderOnly = {})
+        nList = nList toContain o inAny order but only the entries({}, {}, reportOptionsInAnyOrderOnly = {})
+        subList = subList toContain o inAny order but only the entries({}, {}, reportOptionsInAnyOrderOnly = {})
+        star = star toContain o inAny order but only the entries({}, {}, reportOptionsInAnyOrderOnly = {})
+
+        nList = nList toContain o inAny order but only the entries(null, {}, null)
+        star = star toContain o inAny order but only the entries(null, {}, null)
+
+        nList = nList toContain o inAny order but only the entries(null, {}, null, reportOptionsInAnyOrderOnly = {})
+        star = star toContain o inAny order but only the entries(null, {}, null, reportOptionsInAnyOrderOnly = {})
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderOnlyValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInAnyOrderOnlyValuesExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.specs.notImplemented
 
 class IterableToContainInAnyOrderOnlyValuesExpectationsSpec :
     ch.tutteli.atrium.specs.integration.IterableToContainInAnyOrderOnlyValuesExpectationsSpec(
@@ -15,10 +17,13 @@ class IterableToContainInAnyOrderOnlyValuesExpectationsSpec :
         private fun toContainInAnyOrderOnlyValues(
             expect: Expect<Iterable<Double>>,
             a: Double,
-            aX: Array<out Double>
+            aX: Array<out Double>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            if (aX.isEmpty()) expect toContain o inAny order but only value a
-            else expect toContain o inAny order but only the values(a, *aX)
+            if (report === emptyInAnyOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inAny order but only value a
+                else expect toContain o inAny order but only the values(a, *aX)
+            } else expect toContain o inAny order but only the values(a, *aX, reportOptionsInAnyOrderOnly = report)
 
 
         fun getContainsNullablePair() =
@@ -27,10 +32,43 @@ class IterableToContainInAnyOrderOnlyValuesExpectationsSpec :
         private fun toContainInAnyOrderOnlyNullableValues(
             expect: Expect<Iterable<Double?>>,
             a: Double?,
-            aX: Array<out Double?>
+            aX: Array<out Double?>,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            if (aX.isEmpty()) expect toContain o inAny order but only value a
-            else expect toContain o inAny order but only the values(a, *aX)
+            if (report === emptyInAnyOrderOnlyReportOptions) {
+                if (aX.isEmpty()) expect toContain o inAny order but only value a
+                else expect toContain o inAny order but only the values(a, *aX)
+            } else expect toContain o inAny order but only the values(a, *aX, reportOptionsInAnyOrderOnly = report)
+    }
 
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inAny order but only value(1)
+        nList = nList toContain o inAny order but only value(1)
+        subList = subList toContain o inAny order but only value(1)
+        star = star toContain o inAny order but only value(1)
+
+        //TODO type parameter should not be necessary, check with Kotlin 1.4
+        list = list toContain o inAny order but only the values<Number>(1, 1.2)
+        nList = nList toContain o inAny order but only the values<Number>(1, 1.2)
+        subList = subList toContain o inAny order but only the values<Number>(1, 2.2)
+        star = star toContain o inAny order but only the values(1, 1.2, "asdf")
+
+        list = list toContain o inAny order but only the values(1, 1.2, reportOptionsInAnyOrderOnly = {})
+        nList = nList toContain o inAny order but only the values(1, 1.2, reportOptionsInAnyOrderOnly = {})
+        subList = subList toContain o inAny order but only the values(1, 2.2, reportOptionsInAnyOrderOnly = {})
+        star = star toContain o inAny order but only the values(1, 1.2, "asdf", reportOptionsInAnyOrderOnly = {})
+
+        nList = nList toContain o inAny order but only the values(null, 1.2)
+        star = star toContain o inAny order but only the values(null, 1.2, "asdf")
+
+        nList = nList toContain o inAny order but only the values(null, 1.2, reportOptionsInAnyOrderOnly = {})
+        star = star toContain o inAny order but only the values(null, 1.2, "asdf", reportOptionsInAnyOrderOnly = {})
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyElementsOfExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyElementsOfExpectationsSpec.kt
@@ -51,7 +51,7 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
             report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
             if (report === emptyInOrderOnlyReportOptions) expect toContain o inGiven order and only elementsOf listOf(a, *aX)
-            else expect toContain o inGiven order and only the elementsOf(listOf(a, *aX), report = report)
+            else expect toContain o inGiven order and only the elementsOf(listOf(a, *aX), reportOptionsInOrderOnly = report)
 
         fun getToContainNullablePair() =
             "$toContain $filler $inOrder $andOnly $inOrderElementsOf" to Companion::toContainInOrderOnlyNullableValues
@@ -63,7 +63,7 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
             report: InOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
             if (report === emptyInOrderOnlyReportOptions) expect toContain o inGiven order and only elementsOf sequenceOf(a, *aX)
-            else expect toContain o inGiven order and only the elementsOf(listOf(a, *aX), report = report)
+            else expect toContain o inGiven order and only the elementsOf(listOf(a, *aX), reportOptionsInOrderOnly = report)
 
         private val toContainExactlyElementsOfShortcutFun: KFunction2<Expect<Iterable<Double>>, Iterable<Double>, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::toContainExactlyElementsOf
@@ -109,10 +109,10 @@ class IterableToContainInOrderOnlyElementsOfExpectationsSpec : Spek({
         subList = subList toContain o inGiven order and only elementsOf(listOf<Int>())
         star = star toContain o inGiven order and only elementsOf(listOf<Int>())
 
-        list = list toContain o inGiven order and only the elementsOf(listOf<Int>(), report = { showAlwaysSummary() })
-        nList = nList toContain o inGiven order and only the elementsOf(listOf<Int>(), report = { showOnlyFailing()})
-        subList = subList toContain o inGiven order and only the elementsOf(listOf<Int>(), report = {})
-        star = star toContain o inGiven order and only the elementsOf(listOf<Int>(), report = {})
+        list = list toContain o inGiven order and only the elementsOf(listOf<Int>(), reportOptionsInOrderOnly = { showAlwaysSummary() })
+        nList = nList toContain o inGiven order and only the elementsOf(listOf<Int>(), reportOptionsInOrderOnly = { showOnlyFailing()})
+        subList = subList toContain o inGiven order and only the elementsOf(listOf<Int>(), reportOptionsInOrderOnly = {})
+        star = star toContain o inGiven order and only the elementsOf(listOf<Int>(), reportOptionsInOrderOnly = {})
 
         list = list.toContainExactlyElementsOf(listOf(1))
         nList = nList.toContainExactlyElementsOf(listOf(1))

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
@@ -39,7 +39,7 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContain o inGiven order and only entry a
                 else expect toContain o inGiven order and only the entries(a, *aX)
-            } else expect toContain o inGiven order and only the entries(a, *aX, report = report)
+            } else expect toContain o inGiven order and only the entries(a, *aX, reportOptionsInOrderOnly = report)
 
         fun getToContainNullablePair() =
             "$toContain $filler $inOrder $andOnly $inOrderOnlyEntries" to Companion::toContainInOrderOnlyNullableEntriesPair
@@ -53,7 +53,7 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContain o inGiven order and only entry a
                 else expect toContain o inGiven order and only the entries(a, *aX)
-            } else expect toContain o inGiven order and only the entries(a, *aX, report = report)
+            } else expect toContain o inGiven order and only the entries(a, *aX, reportOptionsInOrderOnly = report)
 
         private val toContainShortcutFun: KFunction2<Expect<Iterable<Double>>, Expect<Double>.() -> Unit, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::toContainExactly
@@ -69,7 +69,7 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContainExactly { a() }
                 else expect toContainExactly entries(a, *aX)
-            } else expect toContainExactly entries(a, *aX, report = report)
+            } else expect toContainExactly entries(a, *aX, reportOptionsInOrderOnly = report)
 
         private val toContainNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, (Expect<Double>.() -> Unit)?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::toContainExactly
@@ -91,6 +91,6 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
                 } else {
                     expect toContainExactly entries(a, *aX)
                 }
-            } else expect toContainExactly entries(a, *aX, report = report)
+            } else expect toContainExactly entries(a, *aX, reportOptionsInOrderOnly = report)
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.notImplemented
 
@@ -18,9 +20,28 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             expect: Expect<Iterable<Double?>>,
             a1: Group<(Expect<Double>.() -> Unit)?>,
             a2: Group<(Expect<Double>.() -> Unit)?>,
-            aX: Array<out Group<(Expect<Double>.() -> Unit)?>>
+            aX: Array<out Group<(Expect<Double>.() -> Unit)?>>,
+            report: InOrderOnlyReportingOptions.() -> Unit,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            expect toContain o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
+            if (report === emptyInOrderOnlyReportOptions && reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX
+                )
+            } else if (reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, report = report
+                )
+            } else if (report == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, reportInGroup = reportInGroup
+                )
+            } else {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, report = report, reportInGroup = reportInGroup
+                )
+            }
+
 
         private fun groupFactory(groups: Array<out (Expect<Double>.() -> Unit)?>) =
             when (groups.size) {
@@ -86,6 +107,60 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             report = {}
         )
 
+        list = list toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            reportInGroup = {}
+        )
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            reportInGroup = {}
+        )
+        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            reportInGroup = {}
+        )
+
+        list = list toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number> {},
+            entries({}, {}),
+            report = {},
+            reportInGroup = {}
+        )
+
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
             //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
             entry<Number>(null),
@@ -108,6 +183,34 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             entry<Number>(null),
             entries(null, {}),
             report = {}
+        )
+
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number>(null),
+            entries({}, null),
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number>(null),
+            entries(null, {}),
+            reportInGroup = {}
+        )
+
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number>(null),
+            entries({}, null),
+            report = {},
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+            entry<Number>(null),
+            entries(null, {}),
+            report = {},
+            reportInGroup = {}
         )
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -1,6 +1,8 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.notImplemented
 
@@ -14,15 +16,31 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
     ) {
     companion object : IterableToContainSpecBase() {
         fun getContainsPair() =
-            "$toContain $filler $inOrder $andOnly $grouped $within $withinInAnyOrder" to Companion::toContainInOrderOnlyGroupedInAnyOrdervalues
+            "$toContain $filler $inOrder $andOnly $grouped $within $withinInAnyOrder" to Companion::toContainInOrderOnlyGroupedInAnyOrderValues
 
-        private fun toContainInOrderOnlyGroupedInAnyOrdervalues(
+        private fun toContainInOrderOnlyGroupedInAnyOrderValues(
             expect: Expect<Iterable<Double>>,
             a1: Group<Double>,
             a2: Group<Double>,
-            aX: Array<out Group<Double>>
+            aX: Array<out Group<Double>>,
+            report: InOrderOnlyReportingOptions.() -> Unit,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double>> =
-            expect toContain o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
+            if (report == emptyInOrderOnlyReportOptions && reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
+            } else if (reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, report = report
+                )
+            } else if (report == emptyInOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, reportInGroup = reportInGroup
+                )
+            } else {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, report = report, reportInGroup = reportInGroup
+                )
+            }
 
         private fun groupFactory(groups: Array<out Double>): Group<Double> =
             when (groups.size) {
@@ -33,17 +51,32 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
                 else -> values(groups[0], *groups.drop(1).toTypedArray())
             }
 
-
         fun getContainsNullablePair() =
-            "$toContain $filler $inOrder $andOnly $grouped $within $withinInAnyOrder" to Companion::toContainInOrderOnlyGroupedInAnyOrderNullablevalues
+            "$toContain $filler $inOrder $andOnly $grouped $within $withinInAnyOrder" to Companion::toContainInOrderOnlyGroupedInAnyOrderNullableValues
 
-        private fun toContainInOrderOnlyGroupedInAnyOrderNullablevalues(
+        private fun toContainInOrderOnlyGroupedInAnyOrderNullableValues(
             expect: Expect<Iterable<Double?>>,
             a1: Group<Double?>,
             a2: Group<Double?>,
-            aX: Array<out Group<Double?>>
+            aX: Array<out Group<Double?>>,
+            report: InOrderOnlyReportingOptions.() -> Unit,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit
         ): Expect<Iterable<Double?>> =
-            expect toContain o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
+            if (report == emptyInOrderOnlyReportOptions && reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(a1, a2, *aX)
+            } else if (reportInGroup == emptyInAnyOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, report = report
+                )
+            } else if (report == emptyInOrderOnlyReportOptions) {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, reportInGroup = reportInGroup
+                )
+            } else {
+                expect toContain o inGiven order and only grouped entries within group inAny order(
+                    a1, a2, *aX, report = report, reportInGroup = reportInGroup
+                )
+            }
 
         private fun nullableGroupFactory(groups: Array<out Double?>): Group<Double?> =
             when (groups.size) {
@@ -104,6 +137,52 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
             report = {}
         )
 
+        list = list toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            reportInGroup = {}
+        )
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            reportInGroup = {}
+        )
+        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            reportInGroup = {}
+        )
+
+        list = list toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            report = {},
+            reportInGroup = {}
+        )
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            report = {},
+            reportInGroup = {}
+        )
+        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            report = {},
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            value(1),
+            values(1, 2),
+            report = {},
+            reportInGroup = {}
+        )
+
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
             value(null),
             values(1, null),
@@ -124,6 +203,30 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
             value(null),
             values(null, 2),
             report = {}
+        )
+
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            value(null),
+            values(1, null),
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            value(null),
+            values(null, 2),
+            reportInGroup = {}
+        )
+
+        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+            value(null),
+            values(1, null),
+            report = {},
+            reportInGroup = {}
+        )
+        star = star toContain o inGiven order and only grouped entries within group inAny order(
+            value(null),
+            values(null, 2),
+            report = {},
+            reportInGroup = {}
         )
     }
 }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
@@ -38,7 +38,7 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContain o inGiven order and only value a
                 else expect toContain o inGiven order and only the values(a, *aX)
-            } else expect toContain o inGiven order and only the values(a, *aX, report = report)
+            } else expect toContain o inGiven order and only the values(a, *aX, reportOptionsInOrderOnly = report)
 
         fun getToContainNullablePair() =
             "$toContain $filler $inOrder $andOnly $inOrderOnlyValues" to Companion::toContainInOrderOnlyNullableValues
@@ -52,7 +52,7 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContain o inGiven order and only value a
                 else expect toContain o inGiven order and only the values(a, *aX)
-            } else expect toContain o inGiven order and only the values(a, *aX, report = report)
+            } else expect toContain o inGiven order and only the values(a, *aX, reportOptionsInOrderOnly = report)
 
         private val toContainShortcutFun: KFunction2<Expect<Iterable<Double>>, Double, Expect<Iterable<Double>>> =
             Expect<Iterable<Double>>::toContainExactly
@@ -68,7 +68,7 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContainExactly a
                 else expect toContainExactly values(a, *aX)
-            } else expect toContainExactly values(a, *aX, report = report)
+            } else expect toContainExactly values(a, *aX, reportOptionsInOrderOnly = report)
 
         private val toContainNullableShortcutFun: KFunction2<Expect<Iterable<Double?>>, Double?, Expect<Iterable<Double?>>> =
             Expect<Iterable<Double?>>::toContainExactly
@@ -85,7 +85,7 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
             if (report === emptyInOrderOnlyReportOptions) {
                 if (aX.isEmpty()) expect toContainExactly a
                 else expect toContainExactly values(a, *aX)
-            } else expect toContainExactly values(a, *aX, report = report)
+            } else expect toContainExactly values(a, *aX, reportOptionsInOrderOnly = report)
     }
 
     @Suppress("unused", "UNUSED_VALUE")
@@ -106,10 +106,10 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         subList = subList toContain o inGiven order and only the values<Number>(1, 2.2)
         star = star toContain o inGiven order and only the values<Any?>(1, 1.2, "asdf")
 
-        list = list toContain o inGiven order and only the values(1, 1.2, report = {})
-        nList = nList toContain o inGiven order and only the values(1, 1.2, report = {})
-        subList = subList toContain o inGiven order and only the values(1, 2.2, report = {})
-        star = star toContain o inGiven order and only the values(1, 1.2, "asdf", report = {})
+        list = list toContain o inGiven order and only the values(1, 1.2, reportOptionsInOrderOnly = {})
+        nList = nList toContain o inGiven order and only the values(1, 1.2, reportOptionsInOrderOnly = {})
+        subList = subList toContain o inGiven order and only the values(1, 2.2, reportOptionsInOrderOnly = {})
+        star = star toContain o inGiven order and only the values(1, 1.2, "asdf", reportOptionsInOrderOnly = {})
 
         list = list toContainExactly 1
         nList = nList toContainExactly values(1, 1.2)
@@ -119,12 +119,14 @@ class IterableToContainInOrderOnlyValuesExpectationsSpec : Spek({
         //TODO we should actually setup proper tests for those cases as we only see it compiles (has no ambiguity)
         // but don't know if it has chosen the correct overload in the end
         // (because we sometimes have Any as param and passing a ParamObject to such a function is not a compile error)
-        list = list toContainExactly values(1, 1.2, report = { showOnlyFailingIfMoreElementsThan(1) })
-        nList = nList toContainExactly values(1, 1.2, report = { showOnlyFailing() })
-        subList = subList toContainExactly values(1, 2.2, report = { showAlwaysSummary() })
+        list = list toContainExactly values(1, 1.2, reportOptionsInOrderOnly = {
+            showOnlyFailingIfMoreExpectedElementsThan(1)
+        })
+        nList = nList toContainExactly values(1, 1.2, reportOptionsInOrderOnly = { showOnlyFailing() })
+        subList = subList toContainExactly values(1, 2.2, reportOptionsInOrderOnly = { showAlwaysSummary() })
         // TODO would wish this does not work, maybe @OnlyInputTypes would help?
-        subList = subList toContainExactly values("asdf", report = {})
-        star = star toContainExactly values(1, 1.2, "asdf", report = {})
+        subList = subList toContainExactly values("asdf", reportOptionsInOrderOnly = {})
+        star = star toContainExactly values(1, 1.2, "asdf", reportOptionsInOrderOnly = {})
     }
 }
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/test/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableExpectationSamples.kt
@@ -96,9 +96,9 @@ class IterableExpectationSamples {
                 "C",
                 "B",
                 // optional
-                report = { // allows configuring reporting, e.g.
+                reportOptionsInOrderOnly = { // allows configuring reporting, e.g.
                     showOnlyFailing() // would not show the successful `B`
-                    showOnlyFailingIfMoreElementsThan(10)
+                    showOnlyFailingIfMoreExpectedElementsThan(10)
                 }
             )
         }
@@ -152,11 +152,11 @@ class IterableExpectationSamples {
         fails {
             expect(listOf(3, 5)) toContainExactly entries(
                 { toEqual(1) },       // fails
-                { toBeLessThan(11) }, // succeeds,
+                { toBeLessThan(11) }, // succeeds
                 // optional
-                report = { // allows configuring reporting, e.g.
+                reportOptionsInOrderOnly = { // allows configuring reporting, e.g.
                     showOnlyFailing() // would not show the successful `toBeLessThan(11)`
-                    showOnlyFailingIfMoreElementsThan(10)
+                    showOnlyFailingIfMoreExpectedElementsThan(10)
                 }
             )
         }
@@ -178,9 +178,9 @@ class IterableExpectationSamples {
             // alternative form where you can specify a lambda configuring the InOrderOnlyReportingOptions.
             expect(listOf(1, 2, 2, 4)) toContainExactly elementsOf(
                 listOf(1, 2, 4),
-                report = { // allows configuring reporting, e.g.
+                reportOptionsInOrderOnly = { // allows configuring reporting, e.g.
                     showOnlyFailing() // would not show the successful first and second `1, 2`
-                    showOnlyFailingIfMoreElementsThan(10)
+                    showOnlyFailingIfMoreExpectedElementsThan(10)
                 }
             )
         }

--- a/build.gradle
+++ b/build.gradle
@@ -381,13 +381,17 @@ def createJsTestTask(String... subprojectNames) {
     }
 }
 
-createJsTestTask(
-    'core-js',
-    'api-fluent-en_GB-js',
-    'api-infix-en_GB-js',
-    'fluent-en_GB-js',
-    'infix-en_GB-js'
-)
+//TODO 0.19.0 enable JS-tests again once we use the new MPP plugins because then they should only re-run if something
+// changed, in contrast to now where they re-run all the time
+if (Boolean.parseBoolean(System.getenv('CI'))) {
+    createJsTestTask(
+        'core-js',
+        'api-fluent-en_GB-js',
+        'api-infix-en_GB-js',
+        'fluent-en_GB-js',
+        'infix-en_GB-js'
+    )
+}
 
 def useJupiter(String... projectNames) {
     configure(projectNamesToProject(projectNames)) {

--- a/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/generated/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/iterableLikeContains.kt
@@ -16,14 +16,17 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderO
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.impl.DefaultIterableLikeContainsAssertions
 
 
-fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InAnyOrderOnlySearchBehaviour>.valuesInAnyOrderOnly(expected: List<E>): Assertion = impl.valuesInAnyOrderOnly(this, expected)
+fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InAnyOrderOnlySearchBehaviour>.valuesInAnyOrderOnly(expected: List<E>, reportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.valuesInAnyOrderOnly(this, expected, reportingOptions)
 
-fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InAnyOrderOnlySearchBehaviour>.entriesInAnyOrderOnly(assertionCreators: List<(Expect<E>.() -> Unit)?>): Assertion = impl.entriesInAnyOrderOnly(this, assertionCreators)
+fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InAnyOrderOnlySearchBehaviour>.entriesInAnyOrderOnly(assertionCreators: List<(Expect<E>.() -> Unit)?>, reportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.entriesInAnyOrderOnly(this, assertionCreators, reportingOptions)
 
 
 fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlySearchBehaviour>.valuesInOrderOnly(expected: List<E>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
@@ -33,11 +36,11 @@ fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?,
     impl.entriesInOrderOnly(this, assertionCreators, reportingOptions)
 
 
-fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>.valuesInOrderOnlyGrouped(groups: List<List<E>>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
-    impl.valuesInOrderOnlyGrouped(this, groups, reportingOptions)
+fun <E, T : IterableLike> IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>.valuesInOrderOnlyGrouped(groups: List<List<E>>, inOrderOnlyReportingOptions: InOrderOnlyReportingOptions.() -> Unit, inAnyOrderOnlyReportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.valuesInOrderOnlyGrouped(this, groups, inOrderOnlyReportingOptions, inAnyOrderOnlyReportingOptions)
 
-fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>.entriesInOrderOnlyGrouped(groups: List<List<(Expect<E>.() -> Unit)?>>, reportingOptions: InOrderOnlyReportingOptions.() -> Unit): Assertion =
-    impl.entriesInOrderOnlyGrouped(this, groups, reportingOptions)
+fun <E : Any, T : IterableLike> IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>.entriesInOrderOnlyGrouped(groups: List<List<(Expect<E>.() -> Unit)?>>, inOrderOnlyReportingOptions: InOrderOnlyReportingOptions.() -> Unit, inAnyOrderOnlyReportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit): Assertion =
+    impl.entriesInOrderOnlyGrouped(this, groups, inOrderOnlyReportingOptions, inAnyOrderOnlyReportingOptions)
 
 @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
 @UseExperimental(ExperimentalNewExpectTypes::class)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions.kt
@@ -9,6 +9,7 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderO
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlySearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 
 /**
@@ -19,12 +20,14 @@ interface IterableLikeContainsAssertions {
 
     fun <E, T : IterableLike> valuesInAnyOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InAnyOrderOnlySearchBehaviour>,
-        expected: List<E>
+        expected: List<E>,
+        reportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 
     fun <E : Any, T : IterableLike> entriesInAnyOrderOnly(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InAnyOrderOnlySearchBehaviour>,
-        assertionCreators: List<(Expect<E>.() -> Unit)?>
+        assertionCreators: List<(Expect<E>.() -> Unit)?>,
+        reportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 
 
@@ -44,12 +47,14 @@ interface IterableLikeContainsAssertions {
     fun <E, T : IterableLike> valuesInOrderOnlyGrouped(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<E, T, InOrderOnlyGroupedSearchBehaviour>,
         groups: List<List<E>>,
-        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+        inOrderOnlyReportingOptions: InOrderOnlyReportingOptions.() -> Unit,
+        inAnyOrderOnlyReportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 
     fun <E : Any, T : IterableLike> entriesInOrderOnlyGrouped(
         entryPointStepLogic: IterableLikeContains.EntryPointStepLogic<out E?, T, InOrderOnlyGroupedSearchBehaviour>,
         groups: List<List<(Expect<E>.() -> Unit)?>>,
-        reportingOptions: InOrderOnlyReportingOptions.() -> Unit
+        inOrderOnlyReportingOptions: InOrderOnlyReportingOptions.() -> Unit,
+        inAnyOrderOnlyReportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
     ): Assertion
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator.kt
@@ -7,6 +7,7 @@ import ch.tutteli.atrium.assertions.builders.fixedClaimGroup
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.logic.impl.allCreatedAssertionsHold
 import ch.tutteli.atrium.logic.impl.createExplanatoryAssertionGroup
@@ -29,8 +30,9 @@ import ch.tutteli.atrium.translations.DescriptionIterableLikeExpectation.AN_ELEM
  */
 class InAnyOrderOnlyEntriesAssertionCreator<E : Any, T : IterableLike>(
     converter: (T) -> Iterable<E?>,
-    searchBehaviour: InAnyOrderOnlySearchBehaviour
-) : InAnyOrderOnlyAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour) {
+    searchBehaviour: InAnyOrderOnlySearchBehaviour,
+    reportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
+) : InAnyOrderOnlyAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour, reportingOptions) {
 
     override fun createAssertionForSearchCriterionAndRemoveMatchFromList(
         container: AssertionContainer<*>,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.assertions.AssertionGroup
 import ch.tutteli.atrium.assertions.builders.assertionBuilder
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InAnyOrderOnlySearchBehaviour
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.translations.DescriptionIterableLikeExpectation.AN_ELEMENT_WHICH_EQUALS
@@ -23,8 +24,9 @@ import ch.tutteli.atrium.translations.DescriptionIterableLikeExpectation.AN_ELEM
  */
 class InAnyOrderOnlyValuesAssertionCreator<E, T : IterableLike>(
     converter: (T) -> Iterable<E>,
-    searchBehaviour: InAnyOrderOnlySearchBehaviour
-) : InAnyOrderOnlyAssertionCreator<E, T, E>(converter, searchBehaviour) {
+    searchBehaviour: InAnyOrderOnlySearchBehaviour,
+    reportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
+) : InAnyOrderOnlyAssertionCreator<E, T, E>(converter, searchBehaviour, reportingOptions) {
 
     override fun createAssertionForSearchCriterionAndRemoveMatchFromList(
         container: AssertionContainer<*>,

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
@@ -33,7 +33,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
         return LazyThreadUnsafeAssertionGroup {
             // TODO 0.19.0 more efficient and pragmatic than turnSubjectToList, use at other places too
             val maybeList = container.maybeSubject.map {
-                //TODO move into when with 1.0.0, update to Kotlin 1.4 respectively
+                //TODO move into when with 1.0.0, update to Kotlin >= 1.4 respectively
                 val iterable = converter(it)
                 when (iterable) {
                     is List -> iterable
@@ -63,7 +63,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
 
             val description = searchBehaviour.decorateDescription(DescriptionIterableLikeExpectation.TO_CONTAIN)
             val options = InOrderOnlyReportingOptionsImpl().apply(reportingOptions)
-            val assertionGroup = (if (list.size <= options.numberOfElementsInSummary) {
+            val assertionGroup = (if (searchCriteria.size <= options.maxNumberOfExpectedElementsForSummary) {
                 assertionBuilder.summary.withDescription(description)
             } else {
                 assertionBuilder.list.withDescriptionAndEmptyRepresentation(description)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedEntriesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedEntriesAssertionCreator.kt
@@ -5,23 +5,28 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic._logicAppend
 import ch.tutteli.atrium.logic.builderContainsInIterableLike
 import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInAnyOrderOnly
-import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.butOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.inAnyOrder
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.kbox.identity
 
 class InOrderOnlyGroupedEntriesAssertionCreator<E : Any, T : IterableLike>(
     converter: (T) -> Iterable<E?>,
     searchBehaviour: InOrderOnlyGroupedSearchBehaviour,
-    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
-) : InOrderOnlyGroupedAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(converter, searchBehaviour, reportingOptions),
-    InOrderOnlyMatcher<E?, (Expect<E>.() -> Unit)?> by InOrderOnlyEntriesMatcher() {
+    inOrderOnlyReportingOptions: InOrderOnlyReportingOptions.() -> Unit,
+    private val inAnyOrderOnlyReportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyGroupedAssertionCreator<E?, T, (Expect<E>.() -> Unit)?>(
+    converter,
+    searchBehaviour,
+    inOrderOnlyReportingOptions
+), InOrderOnlyMatcher<E?, (Expect<E>.() -> Unit)?> by InOrderOnlyEntriesMatcher() {
 
     override fun Expect<List<E?>>.addSublistAssertion(groupOfSearchCriteria: List<(Expect<E>.() -> Unit)?>) {
         _logic.builderContainsInIterableLike(::identity)._logic.inAnyOrder._logic.butOnly._logicAppend {
-            entriesInAnyOrderOnly(groupOfSearchCriteria)
+            entriesInAnyOrderOnly(groupOfSearchCriteria, inAnyOrderOnlyReportingOptions)
         }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedValuesAssertionCreator.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedValuesAssertionCreator.kt
@@ -9,19 +9,21 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderO
 import ch.tutteli.atrium.logic.creating.iterable.contains.searchbehaviours.InOrderOnlyGroupedSearchBehaviour
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.butOnly
 import ch.tutteli.atrium.logic.creating.iterable.contains.steps.inAnyOrder
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 import ch.tutteli.kbox.identity
 
 class InOrderOnlyGroupedValuesAssertionCreator<E, T : IterableLike>(
     converter: (T) -> Iterable<E>,
     searchBehaviour: InOrderOnlyGroupedSearchBehaviour,
-    reportingOptions: InOrderOnlyReportingOptions.() -> Unit
-) : InOrderOnlyGroupedAssertionCreator<E, T, E>(converter, searchBehaviour, reportingOptions),
+    inOrderOnlyReportingOptions: InOrderOnlyReportingOptions.() -> Unit,
+    private val inAnyOrderOnlyReportingOptions: InAnyOrderOnlyReportingOptions.() -> Unit
+) : InOrderOnlyGroupedAssertionCreator<E, T, E>(converter, searchBehaviour, inOrderOnlyReportingOptions),
     InOrderOnlyMatcher<E, E> by InOrderOnlyValueMatcher() {
 
     override fun Expect<List<E>>.addSublistAssertion(groupOfSearchCriteria: List<E>) {
         _logic.builderContainsInIterableLike(::identity)._logic.inAnyOrder._logic.butOnly._logicAppend {
-            valuesInAnyOrderOnly(groupOfSearchCriteria)
+            valuesInAnyOrderOnly(groupOfSearchCriteria, inAnyOrderOnlyReportingOptions)
         }
     }
 }

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions.kt
@@ -1,0 +1,8 @@
+package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting
+
+/**
+ * Reporting options for `toContain.inAnyOrder.only` expectation functions.
+ *
+ * @since 0.18.0
+ */
+interface InAnyOrderOnlyReportingOptions : OnlyReportingOptions

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions.kt
@@ -2,32 +2,37 @@ package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting
 
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
 
-interface InOrderOnlyReportingOptions {
-
+/**
+ * Reporting options for `toContain.inOrder.only` expectation functions.
+ *
+ * @since 0.17.0
+ */
+interface InOrderOnlyReportingOptions : OnlyReportingOptions{
     /**
-     * Always shows only failing expectations, same as [InOrderOnlyReportingOptions.showOnlyFailingIfMoreElementsThan]`(0)`
-     */
-    fun showOnlyFailing() = showOnlyFailingIfMoreElementsThan(0)
-
-    /**
-     * Always shows a summary where both failing and successful expectations are shown, same as
-     * [InOrderOnlyReportingOptions.showOnlyFailingIfMoreElementsThan]`(Int.MAX_VALUE)`.
-     */
-    fun showAlwaysSummary() = showOnlyFailingIfMoreElementsThan(Int.MAX_VALUE)
-
-    /**
-     * Show only failing expectations, i.e. elements which do not match, instead of a summary which
-     * lists also successful expectations/elements.
+     * Show only failing expectations, i.e. elements which do not match, instead of a summary (which
+     * lists also successful expectations/elements) if there are more than [number] elements.
      *
-     * Default shows up to 10 elements in a summary ans only failing afterwards,
+     * Default shows up to 10 elements in a summary and only failing afterwards,
      * i.e. default is [showOnlyFailingIfMoreElementsThan]`(10)`
+     *
+     * @since 0.17.0
      */
+    @Deprecated(
+        "Use showOnlyFailingIfMoreExpectedElementsThan instead; will be removed with 0.19.0",
+        ReplaceWith("this.showOnlyFailingIfMoreExpectedElementsThan(number)")
+    )
     fun showOnlyFailingIfMoreElementsThan(number: Int)
 
     /**
      * Indicates until how many elements the summary view shall be used. If there are more elements in the
      * [IterableLike], then only failing expectations shall be shown.
+     *
+     * @since 0.17.0
      */
+    @Deprecated(
+        "Use maxNumberOfExpectedElementsForSummary; will be removed with 0.19.0",
+        ReplaceWith("this.maxNumberOfExpectedElementsForSummary")
+    )
     val numberOfElementsInSummary: Int
 }
 

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions.kt
@@ -1,0 +1,44 @@
+package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting
+
+/**
+ * Base interface for OnlyReportingOptions
+ * @since 0.18.0
+ */
+interface OnlyReportingOptions {
+
+    /**
+     * Always shows only failing expectations, same as [OnlyReportingOptions.showOnlyFailingIfMoreExpectedElementsThan]`(0)`
+     *
+     * @since 0.17.0
+     */
+    fun showOnlyFailing() = showOnlyFailingIfMoreExpectedElementsThan(0)
+
+    /**
+     * Always shows a summary where both failing and successful expectations are shown, same as
+     * [OnlyReportingOptions.showOnlyFailingIfMoreExpectedElementsThan]`(Int.MAX_VALUE)`.
+     *
+     * @since 0.17.0
+     */
+    fun showAlwaysSummary() = showOnlyFailingIfMoreExpectedElementsThan(Int.MAX_VALUE)
+
+    /**
+     * Show only failing expectations, i.e. elements which do not match, instead of a summary (which
+     * lists also successful expectations/elements) if there are more than [number] expected elements.
+     *
+     * Default shows up to 10 elements in a summary and only failing afterwards,
+     * i.e. default is [showOnlyFailingIfMoreExpectedElementsThan]`(10)`
+     *
+     * @since 0.17.0
+     */
+    fun showOnlyFailingIfMoreExpectedElementsThan(number: Int)
+
+    /**
+     * Indicates until how many expected elements the summary view shall be used. If there are more expected elements,
+     * then only failing expectations shall be shown.
+     *
+     * @since 0.18.0
+     */
+    val maxNumberOfExpectedElementsForSummary: Int
+}
+
+

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/BaseOnlyReportingOptionsImpl.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/BaseOnlyReportingOptionsImpl.kt
@@ -1,0 +1,13 @@
+package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.impl
+
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.OnlyReportingOptions
+
+internal abstract class BaseOnlyReportingOptionsImpl : OnlyReportingOptions {
+    private var _maxNumberOfExpectedElementsInSummary = 10
+    override val maxNumberOfExpectedElementsForSummary: Int get() = _maxNumberOfExpectedElementsInSummary
+
+    override fun showOnlyFailingIfMoreExpectedElementsThan(number: Int) {
+        // could check for negative numbers, but it does not really matter that much, it still means always
+        _maxNumberOfExpectedElementsInSummary = number
+    }
+}

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/InAnyOrderOnlyReportingOptionsImpl.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/InAnyOrderOnlyReportingOptionsImpl.kt
@@ -1,0 +1,6 @@
+package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.impl
+
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+
+internal class InAnyOrderOnlyReportingOptionsImpl : BaseOnlyReportingOptionsImpl(), InAnyOrderOnlyReportingOptions
+

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/InOrderOnlyReportingOptionsImpl.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/impl/InOrderOnlyReportingOptionsImpl.kt
@@ -2,12 +2,10 @@ package ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.impl
 
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 
-internal class InOrderOnlyReportingOptionsImpl : InOrderOnlyReportingOptions {
-    private var _numberOfElementsInSummary = 10
-    override val numberOfElementsInSummary: Int get() = _numberOfElementsInSummary
-
-    override fun showOnlyFailingIfMoreElementsThan(number: Int) {
-        // could check for negative numbers but it does not really matter that much, it still means always
-        _numberOfElementsInSummary = number
-    }
+internal class InOrderOnlyReportingOptionsImpl : BaseOnlyReportingOptionsImpl(), InOrderOnlyReportingOptions{
+    //TODO 0.19.0 remove
+    @Suppress("OverridingDeprecatedMember")
+    override val numberOfElementsInSummary: Int get() = maxNumberOfExpectedElementsForSummary
+    @Suppress("OverridingDeprecatedMember")
+    override fun showOnlyFailingIfMoreElementsThan(number: Int) = showOnlyFailingIfMoreExpectedElementsThan(number)
 }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderOnlyEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderOnlyEntriesExpectationsSpec.kt
@@ -3,42 +3,38 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.specs.*
 
 abstract class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
-    toContainInAnyOrderOnlyEntries: Fun2<Iterable<Double>, Expect<Double>.() -> Unit, Array<out Expect<Double>.() -> Unit>>,
-    toContainInAnyOrderOnlyNullableEntries: Fun2<Iterable<Double?>, (Expect<Double>.() -> Unit)?, Array<out (Expect<Double>.() -> Unit)?>>,
+    toContainInAnyOrderOnlyEntries: Fun3<Iterable<Double>, Expect<Double>.() -> Unit, Array<out Expect<Double>.() -> Unit>, InAnyOrderOnlyReportingOptions.() -> Unit>,
+    toContainInAnyOrderOnlyNullableEntries: Fun3<Iterable<Double?>, (Expect<Double>.() -> Unit)?, Array<out (Expect<Double>.() -> Unit)?>, InAnyOrderOnlyReportingOptions.() -> Unit>,
     describePrefix: String = "[Atrium] "
 ) : IterableToContainEntriesSpecBase({
 
     include(object : SubjectLessSpec<Iterable<Double>>(
         describePrefix,
-        toContainInAnyOrderOnlyEntries.forSubjectLess({ toEqual(2.5) }, arrayOf())
+        toContainInAnyOrderOnlyEntries.forSubjectLess({ toEqual(2.5) }, arrayOf(), emptyInAnyOrderOnlyReportOptions)
     ) {})
     include(object : SubjectLessSpec<Iterable<Double?>>(
         describePrefix,
-        toContainInAnyOrderOnlyNullableEntries.forSubjectLess(null, arrayOf())
+        toContainInAnyOrderOnlyNullableEntries.forSubjectLess(null, arrayOf(), emptyInAnyOrderOnlyReportOptions)
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double>>(
         describePrefix, listOf(1.2, 2.0),
         *toContainInAnyOrderOnlyEntries.forAssertionCreatorSpec(
             "$toEqualDescr: 1.2", "$toEqualDescr: 2.0",
-            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) })
+            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) }), emptyInAnyOrderOnlyReportOptions
         )
     ) {})
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
         "$describePrefix[nullable] ", listOf(1.2, 2.0),
         *toContainInAnyOrderOnlyNullableEntries.forAssertionCreatorSpec(
             "$toEqualDescr: 1.2", "$toEqualDescr: 2.0",
-            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) })
+            { toEqual(1.2) }, arrayOf(expectLambda { toEqual(2.0) }), emptyInAnyOrderOnlyReportOptions
         )
     ) {})
-
-    fun Expect<Iterable<Double?>>.toContainInAnyOrderOnlyNullableEntriesFun(
-        t: (Expect<Double>.() -> Unit)?,
-        vararg tX: (Expect<Double>.() -> Unit)?
-    ) = toContainInAnyOrderOnlyNullableEntries(this, t, tX)
 
 
     //@formatter:off
@@ -53,8 +49,9 @@ abstract class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
     ) { toContainEntriesFunArr ->
         fun Expect<Iterable<Double>>.toContainEntriesFun(
             t: Expect<Double>.() -> Unit,
-            vararg tX: Expect<Double>.() -> Unit
-        ) = toContainEntriesFunArr(t, tX)
+            vararg tX: Expect<Double>.() -> Unit,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+        ) = toContainEntriesFunArr(t, tX, report)
 
         context("empty collection") {
             it("$toBeLessThanFun(1.0) throws AssertionError") {
@@ -261,9 +258,144 @@ abstract class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
                 }
             }
         }
+
+        context("report options") {
+            context("iterable ${oneToFour().toList()}") {
+                it("shows only failing with report option `showOnlyFailing`") {
+                    expect {
+                        expect(oneToFour()).toContainEntriesFun({ toEqual(2.0) }, report = { showOnlyFailing() })
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 1)
+                            toContain.exactly(1).values(
+                                "$rootBulletPoint$toContainInAnyOrderOnly:",
+                                "$warningBulletPoint$additionalElements:",
+                                "${listBulletPoint}1.0",
+                                "${listBulletPoint}3.0"
+                            )
+                            toContain.exactly(2).value("${listBulletPoint}4.0")
+                            notToContain("$toEqualDescr: 2.0")
+
+                        }
+                    }
+                }
+                it("shows only failing with report option `showOnlyFailingIfMoreExpectedElementsThan(3)` because there are 5") {
+                    expect {
+                        expect(oneToFour()).toContainEntriesFun(
+                            { toEqual(1.0) },
+                            { toEqual(2.0) },
+                            { toEqual(3.0) },
+                            { toEqual(4.0) },
+                            { toEqual(4.0) },
+                            { toEqual(5.0) },
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(3) })
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 6)
+                            toContain.exactly(1).values("$listBulletPoint$anEntryAfterSuccess$toEqualDescr: 5.0")
+                            notToContain(
+                                "$toEqualDescr: 1.0",
+                                "$toEqualDescr: 2.0",
+                                "$toEqualDescr: 3.0",
+                                "$toEqualDescr: 4.0"
+                            )
+                            notToContain(additionalElements, mismatches, mismatchesAdditionalElements)
+                        }
+                    }
+                }
+
+            }
+
+            context("iterable $oneToEleven") {
+                it("shows only failing per default as there are more than 10 expected elements") {
+                    expect {
+                        expect(oneToEleven).toContainEntriesFun(
+                            { toEqual(1.0) },
+                            { toEqual(2.0) },
+                            { toEqual(3.0) },
+                            { toEqual(4.0) },
+                            { toEqual(-1.0) },
+                            { toEqual(6.0) },
+                            { toEqual(7.0) },
+                            { toEqual(-2.0) },
+                            { toEqual(9.0) },
+                            { toEqual(10.0) },
+                            { toEqual(11.0) }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContain.exactly(1).values(
+                                "$listBulletPoint$anEntryAfterSuccess$toEqualDescr: -1.0",
+                                "$listBulletPoint$anEntryAfterSuccess$toEqualDescr: -2.0",
+                                "$warningBulletPoint$mismatches:",
+                                "${listBulletPoint}5.0",
+                                "${listBulletPoint}8.0"
+                            )
+                            notToContain(
+                                "$toEqualDescr: 1.0",
+                                "$toEqualDescr: 2.0",
+                                "$toEqualDescr: 3.0",
+                                "$toEqualDescr: 4.0",
+                                "$toEqualDescr: 6.0",
+                                "$toEqualDescr: 7.0",
+                                "$toEqualDescr: 9.0",
+                                "$toEqualDescr: 10.0",
+                                "$toEqualDescr: 11.0",
+
+                                additionalElements, mismatchesAdditionalElements
+                            )
+                        }
+                    }
+                }
+                it("shows all with report option `showAlwaysSummary`") {
+                    expect {
+                        expect(oneToEleven).toContainEntriesFun(
+                            { toEqual(1.0) },
+                            { toEqual(2.0) },
+                            { toEqual(3.0) },
+                            { toEqual(4.0) },
+                            { toEqual(-1.0) },
+                            { toEqual(6.0) },
+                            { toEqual(7.0) },
+                            { toEqual(-2.0) },
+                            { toEqual(9.0) },
+                            { toEqual(10.0) },
+                            { toEqual(11.0) },
+                            report = { showAlwaysSummary() }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContain.exactly(1).values(
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 1.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 2.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 3.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 4.0",
+                                "$failingBulletPoint$anEntryAfterFailing$toEqualDescr: -1.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 6.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 7.0",
+                                "$failingBulletPoint$anEntryAfterFailing$toEqualDescr: -2.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 9.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 10.0",
+                                "$successfulBulletPoint$anEntryAfterSuccess$toEqualDescr: 11.0",
+                                "$warningBulletPoint$mismatches:",
+                                "${listBulletPoint}5.0",
+                                "${listBulletPoint}8.0"
+                            )
+                            notToContain(additionalElements, mismatchesAdditionalElements)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     nullableCases(describePrefix) {
+
+        fun Expect<Iterable<Double?>>.toContainFun(
+            t: (Expect<Double>.() -> Unit)?,
+            vararg tX: (Expect<Double>.() -> Unit)?,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+        ) = toContainInAnyOrderOnlyNullableEntries(this, t, tX, report)
 
         describeFun(toContainInAnyOrderOnlyNullableEntries) {
             val null1null3 = { sequenceOf(null, 1.0, null, 3.0).constrainOnce().asIterable() }
@@ -271,22 +403,22 @@ abstract class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
             context("iterable ${null1null3().toList()}") {
                 context("happy cases (do not throw)") {
                     it("null, $toEqualFun(1.0), null, $toEqualFun(3.0)") {
-                        expect(null1null3()).toContainInAnyOrderOnlyNullableEntriesFun(
+                        expect(null1null3()).toContainFun(
                             null, { toEqual(1.0) }, null, { toEqual(3.0) }
                         )
                     }
                     it("$toEqualFun(1.0), null, null, $toEqualFun(3.0)") {
-                        expect(null1null3()).toContainInAnyOrderOnlyNullableEntriesFun(
+                        expect(null1null3()).toContainFun(
                             { toEqual(1.0) }, null, null, { toEqual(3.0) }
                         )
                     }
                     it("$toEqualFun(1.0), null, $toEqualFun(3.0), null") {
-                        expect(null1null3()).toContainInAnyOrderOnlyNullableEntriesFun(
+                        expect(null1null3()).toContainFun(
                             { toEqual(1.0) }, null, { toEqual(3.0) }, null
                         )
                     }
                     it("$toEqualFun(1.0), $toEqualFun(3.0), null, null") {
-                        expect(null1null3()).toContainInAnyOrderOnlyNullableEntriesFun(
+                        expect(null1null3()).toContainFun(
                             { toEqual(1.0) }, { toEqual(3.0) }, null, null
                         )
                     }
@@ -295,7 +427,7 @@ abstract class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
                 context("failing cases") {
                     it("null, $toEqualFun(1.0), $toEqualFun(3.0) -- second null was missing") {
                         expect {
-                            expect(null1null3()).toContainInAnyOrderOnlyNullableEntriesFun(
+                            expect(null1null3()).toContainFun(
                                 null, { toEqual(1.0) }, { toEqual(3.0) }
                             )
                         }.toThrow<AssertionError> {
@@ -315,7 +447,7 @@ abstract class IterableToContainInAnyOrderOnlyEntriesExpectationsSpec(
 
                     it("first wins: $toBeLessThanFun(4.0), null, null, $toEqualDescr(1.0)") {
                         expect {
-                            expect(null1null3()).toContainInAnyOrderOnlyNullableEntriesFun(
+                            expect(null1null3()).toContainFun(
                                 { toBeLessThan(4.0) },
                                 null,
                                 null,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderOnlyValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInAnyOrderOnlyValuesExpectationsSpec.kt
@@ -3,26 +3,24 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.specs.*
 
 abstract class IterableToContainInAnyOrderOnlyValuesExpectationsSpec(
-    toContainInAnyOrderOnlyValues: Fun2<Iterable<Double>, Double, Array<out Double>>,
-    toContainInAnyOrderOnlyNullableValues: Fun2<Iterable<Double?>, Double?, Array<out Double?>>,
+    toContainInAnyOrderOnlyValues: Fun3<Iterable<Double>, Double, Array<out Double>, InAnyOrderOnlyReportingOptions.() -> Unit>,
+    toContainInAnyOrderOnlyNullableValues: Fun3<Iterable<Double?>, Double?, Array<out Double?>, InAnyOrderOnlyReportingOptions.() -> Unit>,
     describePrefix: String = "[Atrium] "
 ) : IterableToContainSpecBase({
 
     include(object : SubjectLessSpec<Iterable<Double>>(
         describePrefix,
-        toContainInAnyOrderOnlyValues.forSubjectLess(2.5, arrayOf())
+        toContainInAnyOrderOnlyValues.forSubjectLess(2.5, arrayOf(), emptyInAnyOrderOnlyReportOptions)
 
     ) {})
     include(object : SubjectLessSpec<Iterable<Double?>>(
         describePrefix,
-        toContainInAnyOrderOnlyNullableValues.forSubjectLess(2.5, arrayOf())
+        toContainInAnyOrderOnlyNullableValues.forSubjectLess(2.5, arrayOf(), emptyInAnyOrderOnlyReportOptions)
     ) {})
-
-    fun Expect<Iterable<Double?>>.toContainInAnyOrderNullableValuesFun(t: Double?, vararg tX: Double?) =
-        toContainInAnyOrderOnlyNullableValues(this, t, tX)
 
     nonNullableCases(
         describePrefix,
@@ -30,8 +28,11 @@ abstract class IterableToContainInAnyOrderOnlyValuesExpectationsSpec(
         toContainInAnyOrderOnlyNullableValues
     ) { toContainValuesFunArr ->
 
-        fun Expect<Iterable<Double>>.toContainFun(t: Double, vararg tX: Double) =
-            toContainValuesFunArr(t, tX.toTypedArray())
+        fun Expect<Iterable<Double>>.toContainFun(
+            t: Double,
+            vararg tX: Double,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+        ) = toContainValuesFunArr(t, tX.toTypedArray(), report)
 
         context("empty collection") {
             it("1.0 throws AssertionError") {
@@ -188,10 +189,148 @@ abstract class IterableToContainInAnyOrderOnlyValuesExpectationsSpec(
                 }
             }
         }
+
+        context("report options") {
+            context("iterable ${oneToFour().toList()}") {
+                it("shows only failing with report option `showOnlyFailing`") {
+                    expect {
+                        expect(oneToFour()).toContainFun(2.0, report = { showOnlyFailing() })
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 1)
+                            toContain.exactly(1).values(
+                                "$rootBulletPoint$toContainInAnyOrderOnly:",
+                                "$warningBulletPoint$additionalElements:",
+                                "${listBulletPoint}1.0",
+                                "${listBulletPoint}3.0"
+                            )
+                            toContain.exactly(2).value("${listBulletPoint}4.0")
+                            notToContain("$anElementWhichEquals: 2.0")
+
+                        }
+                    }
+                }
+                it("shows only failing with report option `showOnlyFailingIfMoreExpectedElementsThan(3)` because there are 5") {
+                    expect {
+                        expect(oneToFour()).toContainFun(
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            4.0,
+                            5.0,
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(3) })
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 6)
+                            toContain.exactly(1).values("$listBulletPoint$anElementWhichEquals: 5.0")
+                            notToContain(
+                                "$anElementWhichEquals: 1.0",
+                                "$anElementWhichEquals: 2.0",
+                                "$anElementWhichEquals: 3.0",
+                                "$anElementWhichEquals: 4.0"
+                            )
+                            notToContain(additionalElements, mismatches, mismatchesAdditionalElements)
+                        }
+                    }
+                }
+
+            }
+
+            context("iterable $oneToEleven") {
+                it("shows only failing per default as there are more than 10 expected elements") {
+                    expect {
+                        expect(oneToEleven).toContainFun(
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            -1.0,
+                            6.0,
+                            7.0,
+                            -2.0,
+                            9.0,
+                            10.0,
+                            11.0
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContain.exactly(1).values(
+                                "$listBulletPoint$anElementWhichEquals: -1.0",
+                                "$listBulletPoint$anElementWhichEquals: -2.0",
+                                "$warningBulletPoint$mismatches:",
+                                "${listBulletPoint}5.0",
+                                "${listBulletPoint}8.0"
+                            )
+                            notToContain(
+                                "$anElementWhichEquals: 1.0",
+                                "$anElementWhichEquals: 2.0",
+                                "$anElementWhichEquals: 3.0",
+                                "$anElementWhichEquals: 4.0",
+                                "$anElementWhichEquals: 6.0",
+                                "$anElementWhichEquals: 7.0",
+                                "$anElementWhichEquals: 9.0",
+                                "$anElementWhichEquals: 10.0",
+                                "$anElementWhichEquals: 11.0",
+
+                                additionalElements, mismatchesAdditionalElements
+                            )
+                        }
+                    }
+                }
+                it("shows all with report option `showAlwaysSummary`") {
+                    expect {
+                        expect(oneToEleven).toContainFun(
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            -1.0,
+                            6.0,
+                            7.0,
+                            -2.0,
+                            9.0,
+                            10.0,
+                            11.0,
+                            report = { showAlwaysSummary() }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContain.exactly(1).values(
+                                "$successfulBulletPoint$anElementWhichEquals: 1.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 2.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 3.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 4.0",
+                                "$failingBulletPoint$anElementWhichEquals: -1.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 6.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 7.0",
+                                "$failingBulletPoint$anElementWhichEquals: -2.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 9.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 10.0",
+                                "$successfulBulletPoint$anElementWhichEquals: 11.0",
+                                "$warningBulletPoint$mismatches:",
+                                "${listBulletPoint}5.0",
+                                "${listBulletPoint}8.0"
+                            )
+                            notToContain(additionalElements, mismatchesAdditionalElements)
+                        }
+                    }
+                }
+            }
+        }
     }
 
 
     nullableCases(describePrefix) {
+
+
+        fun Expect<Iterable<Double?>>.toContainFun(
+            t: Double?,
+            vararg tX: Double?,
+            report: InAnyOrderOnlyReportingOptions.() -> Unit = {}
+        ) = toContainInAnyOrderOnlyNullableValues(this, t, tX, report)
+
+
         describeFun(toContainInAnyOrderOnlyValues) {
 
             val null1null3 = { sequenceOf(null, 1.0, null, 3.0).constrainOnce().asIterable() }
@@ -199,23 +338,23 @@ abstract class IterableToContainInAnyOrderOnlyValuesExpectationsSpec(
             context("iterable ${null1null3().toList()}") {
                 context("happy cases (do not throw)") {
                     it("null, 1.0, null, 3.0") {
-                        expect(null1null3()).toContainInAnyOrderNullableValuesFun(null, 1.0, null, 3.0)
+                        expect(null1null3()).toContainFun(null, 1.0, null, 3.0)
                     }
                     it("1.0, null, null, 3.0") {
-                        expect(null1null3()).toContainInAnyOrderNullableValuesFun(1.0, null, null, 3.0)
+                        expect(null1null3()).toContainFun(1.0, null, null, 3.0)
                     }
                     it("1.0, null, 3.0, null") {
-                        expect(null1null3()).toContainInAnyOrderNullableValuesFun(1.0, null, 3.0, null)
+                        expect(null1null3()).toContainFun(1.0, null, 3.0, null)
                     }
                     it("1.0, 3.0, null, null") {
-                        expect(null1null3()).toContainInAnyOrderNullableValuesFun(1.0, 3.0, null, null)
+                        expect(null1null3()).toContainFun(1.0, 3.0, null, null)
                     }
                 }
 
                 context("failing cases") {
                     it("null, 1.0, 3.0 -- null was missing") {
                         expect {
-                            expect(null1null3()).toContainInAnyOrderNullableValuesFun(null, 1.0, 3.0)
+                            expect(null1null3()).toContainFun(null, 1.0, 3.0)
                         }.toThrow<AssertionError> {
                             message {
                                 toContain.exactly(1).values(

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -2,15 +2,25 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionExpectation
+import ch.tutteli.atrium.translations.DescriptionIterableLikeExpectation
 import org.spekframework.spek2.style.specification.Suite
 
-//TODO 0.18.0 include InOrderReportOptions
 abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
-    toContainInOrderOnlyGroupedEntries: Fun3<Iterable<Double?>, Group<(Expect<Double>.() -> Unit)?>, Group<(Expect<Double>.() -> Unit)?>, Array<out Group<(Expect<Double>.() -> Unit)?>>>,
+    toContainInOrderOnlyGroupedEntries: Fun5<
+        Iterable<Double?>,
+        Group<(Expect<Double>.() -> Unit)?>,
+        Group<(Expect<Double>.() -> Unit)?>,
+        Array<out Group<(Expect<Double>.() -> Unit)?>>,
+        InOrderOnlyReportingOptions.() -> Unit,
+        InAnyOrderOnlyReportingOptions.() -> Unit
+        >,
     groupFactory: (Array<out (Expect<Double>.() -> Unit)?>) -> Group<(Expect<Double>.() -> Unit)?>,
     describePrefix: String = "[Atrium] "
 ) : IterableToContainEntriesSpecBase({
@@ -22,23 +32,25 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
         toContainInOrderOnlyGroupedEntries.forSubjectLess(
             context({ toEqual(2.5) }),
             context({ toEqual(4.1) }),
-            arrayOf()
+            arrayOf(),
+            emptyInOrderOnlyReportOptions,
+            emptyInAnyOrderOnlyReportOptions
         )
     ) {})
     //@formatter:off
     include(object : AssertionCreatorSpec<Iterable<Double?>>(
         describePrefix, listOf(1.2, 2.0, 3.0),
         assertionCreatorSpecTriple(toContainInOrderOnlyGroupedEntries.name + " [first empty]", "$toEqualDescr: 1.2",
-            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry { toEqual(3.0) })) },
-            { toContainInOrderOnlyGroupedEntries(this, Entry { }, Entry { toEqual(2.0) }, arrayOf( Entry { toEqual(3.0) })) }
+            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry { toEqual(3.0) }), emptyInOrderOnlyReportOptions, emptyInAnyOrderOnlyReportOptions) },
+            { toContainInOrderOnlyGroupedEntries(this, Entry { }, Entry { toEqual(2.0) }, arrayOf( Entry { toEqual(3.0) }), emptyInOrderOnlyReportOptions, emptyInAnyOrderOnlyReportOptions) }
         ),
         assertionCreatorSpecTriple(toContainInOrderOnlyGroupedEntries.name + " [second empty]", "$toEqualDescr: 2.0",
-            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry { toEqual(3.0) })) },
-            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { }, arrayOf( Entry { toEqual(3.0) })) }
+            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry { toEqual(3.0) }), emptyInOrderOnlyReportOptions, emptyInAnyOrderOnlyReportOptions) },
+            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { }, arrayOf( Entry { toEqual(3.0) }), emptyInOrderOnlyReportOptions, emptyInAnyOrderOnlyReportOptions) }
         ),
         assertionCreatorSpecTriple(toContainInOrderOnlyGroupedEntries.name + " [third empty]", "$toEqualDescr: 3.0",
-            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry { })) },
-            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry {  })) }
+            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry { }), emptyInOrderOnlyReportOptions, emptyInAnyOrderOnlyReportOptions) },
+            { toContainInOrderOnlyGroupedEntries(this, Entry { toEqual(1.2) }, Entry { toEqual(2.0) }, arrayOf( Entry {  }), emptyInOrderOnlyReportOptions, emptyInAnyOrderOnlyReportOptions) }
         )
     ) {})
     //@formatter:on
@@ -49,8 +61,10 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
     fun Expect<Iterable<Double?>>.toContainInOrderOnlyGroupedEntriesFun(
         t1: Group<(Expect<Double>.() -> Unit)?>,
         t2: Group<(Expect<Double>.() -> Unit)?>,
-        vararg tX: Group<(Expect<Double>.() -> Unit)?>
-    ) = toContainInOrderOnlyGroupedEntries(this, t1, t2, tX)
+        vararg tX: Group<(Expect<Double>.() -> Unit)?>,
+        report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions,
+        reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit = emptyInAnyOrderOnlyReportOptions
+    ) = toContainInOrderOnlyGroupedEntries(this, t1, t2, tX, report, reportInGroup)
 
     fun element(prefix: String, bulletPoint: String, indentRootBulletPoint: String, expected: Array<out String>) =
         expected.joinToString(".*$separator") {
@@ -58,24 +72,35 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
                 "$prefix$indentRootBulletPoint$indentListBulletPoint$explanatoryBulletPoint$it"
         }
 
-    fun size(prefix: String, bulletPoint: String, actual: Int, expected: Int) =
-        "$prefix\\Q$bulletPoint\\E${featureArrow}${DescriptionCollectionExpectation.SIZE.getDefault()}: $actual[^:]+: $expected"
+    fun size(prefix: String, bulletPoint: String, actual: Int?, expected: Int) =
+        "$prefix\\Q$bulletPoint\\E${featureArrow}${DescriptionCollectionExpectation.SIZE.getDefault()}:${actual?.let { " $it" } ?: ""}[^:]+: $expected"
 
     fun sizeCheck(actual: Int, expected: Int) = size(
-        "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow", featureBulletPoint, actual, expected)
+        "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow", featureBulletPoint, actual, expected
+    )
 
     val afterFail = "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
-    fun failAfterFail(vararg expected: String) =
-        element(afterFail, failingBulletPoint, indentFailingBulletPoint, expected)
+    fun failAfterFail(vararg expected: String, withBulletPoint: Boolean = true) =
+        element(afterFail, if (withBulletPoint) failingBulletPoint else listBulletPoint, indentFailingBulletPoint, expected)
 
     fun successAfterFail(vararg expected: String) =
         element(afterFail, successfulBulletPoint, indentSuccessfulBulletPoint, expected)
+
+
+    fun Expect<String>.notToContainIndex(from: Int, to: Int) =
+        notToContain.regex("\\Q${DescriptionIterableLikeExpectation.INDEX.getDefault().format("$from..$to")}")
 
     val additionalElementsFail = "$indentRootBulletPoint$indentFailingBulletPoint"
 
     fun <T> additionalElementsWarning(msg: String, values: Array<out T>, act: (T) -> String) =
         "$additionalElementsFail\\Q$warningBulletPoint$msg\\E: $separator" +
-            values.joinToString(".*$separator") { "$additionalElementsFail$indentWarningBulletPoint$listBulletPoint${act(it)}" }
+            values.joinToString(".*$separator") {
+                "$additionalElementsFail$indentWarningBulletPoint$listBulletPoint${
+                    act(
+                        it
+                    )
+                }"
+            }
 
     fun <T> warning(msg: String, values: Array<out T>, act: (T) -> String) =
         "$afterFail\\Q$warningBulletPoint$msg\\E: $separator" +
@@ -90,6 +115,8 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
     val afterSuccess = "$indentRootBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
     fun successAfterSuccess(vararg expected: String) =
         element(afterSuccess, successfulBulletPoint, indentSuccessfulBulletPoint, expected)
+    fun failAfterSuccess(vararg expected: String) = element(afterSuccess, failingBulletPoint, indentFailingBulletPoint, expected)
+
 
     fun Expect<String>.indexSuccess(index: Int, actual: Any, expected: String): Expect<String> {
         return this.toContain.exactly(1).regex(
@@ -114,35 +141,59 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
         )
     }
 
-    fun Expect<String>.indexFail(index: Int, actual: Any, expected: String): Expect<String> {
+    fun Expect<String>.indexFail(
+        index: Int,
+        actual: Any,
+        expected: String,
+        withBulletPoint: Boolean = true
+    ): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${index(index)}: $actual\\E.*$separator" +
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${index(index)}: $actual\\E.*$separator" +
                 "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow$featureBulletPoint$expected"
         )
     }
 
-    fun Expect<String>.indexNonExisting(index: Int, expected: String): Expect<String> {
-        return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${index(index)}: $sizeExceeded\\E.*$separator" +
-                "$afterFail$explanatoryBulletPoint$expected"
-        )
-    }
-
-    sizeExceeded
     fun Expect<String>.indexFail(
         fromIndex: Int,
         toIndex: Int,
         actual: List<Double?>,
-        sizeCheck: String,
-        vararg expected: String
+        sizeCheck: String?,
+        vararg expected: String,
+        withBulletPoint: Boolean = true
     ): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${index(fromIndex, toIndex)}: $actual\\E.*$separator" +
-                "$sizeCheck.*$separator" +
-                "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow$featureBulletPoint$toContainInAnyOrderOnly: $separator" +
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${
+                index(fromIndex, toIndex)
+            }: $actual\\E.*$separator" +
+                (sizeCheck?.let { "$sizeCheck.*$separator" } ?: "") +
+                "$indentRootBulletPoint${if (withBulletPoint) indentFailingBulletPoint else indentListBulletPoint}$indentFeatureArrow$featureBulletPoint$toContainInAnyOrderOnly: $separator" +
                 expected.joinToString(".*$separator")
         )
     }
+
+    fun Expect<String>.indexNonExisting(index: Int, expected: String, withBulletPoint: Boolean = true): Expect<String> {
+        return this.toContain.exactly(1).regex(
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${IterableToContainSpecBase.index(index)}: $sizeExceeded\\E.*$separator" +
+                "$afterFail$explanatoryBulletPoint$expected"
+        )
+    }
+
+    fun Expect<String>.indexNonExisting(
+        fromIndex: Int, toIndex: Int,
+        sizeCheck: String,
+        vararg expected: String,
+        withBulletPoint: Boolean = true
+    ): Expect<String> {
+        return this.toContain.exactly(1).regex(
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${
+                index(fromIndex, toIndex)
+            }: $sizeExceeded\\E.*$separator" +
+                "$afterFail$sizeCheck.*$separator" +
+                "$indentRootBulletPoint${if (withBulletPoint) indentFailingBulletPoint else indentListBulletPoint}$indentFeatureArrow$indentFeatureBulletPoint$explanatoryBulletPoint$toContainInAnyOrderOnly: $separator" +
+                expected.joinToString(".*$separator") { ".*$anElementWhichNeedsDescr:.*$separator.*$it" }
+        )
+    }
+
 
     describeFun(toContainInOrderOnlyGroupedEntries) {
         context("describe non-nullable cases") {
@@ -321,7 +372,11 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
                                 indexSuccess(
                                     1, 3, listOf(2.0, 3.0, 4.0),
                                     sizeCheck(3, 3),
-                                    successAfterSuccess("$toEqualDescr: 4.0", "$toEqualDescr: 2.0", "$toEqualDescr: 3.0")
+                                    successAfterSuccess(
+                                        "$toEqualDescr: 4.0",
+                                        "$toEqualDescr: 2.0",
+                                        "$toEqualDescr: 3.0"
+                                    )
                                 )
                                 toContainRegex(additional(4 to 4.0))
                             }
@@ -397,8 +452,349 @@ abstract class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
                     }
                 }
             }
+
+            context("report options") {
+                context("iterable ${oneToFour().toList()}") {
+                    it("shows only failing indices with report option `showOnlyFailing` but still default behaviour per group (i.e. only failing if more than 10") {
+                        expect {
+                            expect(oneToFour() as Iterable<Double?>).toContainInOrderOnlyGroupedEntriesFun(
+                                context({ toEqual(1.0) }),
+                                context({ toEqual(2.0) }, { toEqual(4.0) }),
+                                context(
+                                    { toEqual(1.0) },
+                                    { toEqual(2.0) },
+                                    { toEqual(3.0) },
+                                    { toEqual(4.0) },
+                                    { toEqual(5.0) },
+                                    { toEqual(6.0) },
+                                    { toEqual(7.0) },
+                                    { toEqual(8.0) },
+                                    { toEqual(9.0) },
+                                    { toEqual(10.0) },
+                                    { toEqual(11.0) }
+                                ),
+                                report = { showOnlyFailing() }
+                            )
+                        }.toThrow<AssertionError> {
+                            message {
+                                toContainSize(5, 14)
+                                toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                                notToContainIndex(0, 0)
+                                indexFail(
+                                    1, 2, listOf(2.0, 3.0),
+                                    null,
+                                    successAfterSuccess("$toEqualDescr: 2.0"),
+                                    failAfterSuccess("$toEqualDescr: 4.0"),
+                                    withBulletPoint = false
+                                )
+                                indexFail(
+                                    3,
+                                    13,
+                                    listOf(4.0, 4.0),
+                                    sizeCheck(2, 11),
+                                    failAfterFail("$toEqualDescr: 1.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 2.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 3.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 5.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 6.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 7.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 8.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 9.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 10.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 11.0", withBulletPoint = false),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(4.0)
+                            }
+                        }
+                    }
+
+                    it("shows only failing indices with report option `showOnlyFailing` and only failing elements with reportInGroup option `showOnlyFailing` ") {
+                        expect {
+                            expect(oneToFour() as Iterable<Double?>).toContainInOrderOnlyGroupedEntriesFun(
+                                context({ toEqual(1.0) }, { toEqual(2.0) }, { toEqual(3.0) }),
+                                context({ toEqual(4.0) }, { toEqual(4.0) }, { toEqual(5.0) }),
+                                report = { showOnlyFailing() },
+                                reportInGroup = { showOnlyFailing() }
+                            )
+                        }.toThrow<AssertionError> {
+                            message {
+                                toContainSize(5, 6)
+                                toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                                notToContainIndex(1, 2)
+                                indexFail(
+                                    3, 5, listOf(4.0, 4.0),
+                                    sizeCheck(2, 3),
+                                    failAfterFail("$toEqualDescr: 5.0", withBulletPoint = false),
+                                    withBulletPoint = false
+                                )
+                                notToContain("$anElementWhichEquals: 4.0")
+                            }
+                        }
+                    }
+
+                    it("shows only failing indices with report option `showOnlyFailingIfMoreExpectedElementsThan(3)` because there are 5 but still all elements in group") {
+                        expect {
+                            expect(oneToFour() as Iterable<Double?>).toContainInOrderOnlyGroupedEntriesFun(
+                                context({ toEqual(1.0) }, { toEqual(2.0) }, { toEqual(3.0) }),
+                                context({ toEqual(4.0) }, { toEqual(4.0) }, { toEqual(5.0) }),
+                                report = { showOnlyFailingIfMoreExpectedElementsThan(3) }
+                            )
+                        }.toThrow<AssertionError> {
+                            message {
+                                toContainSize(5, 6)
+                                toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                                notToContainIndex(1, 2)
+                                indexFail(
+                                    3, 5, listOf(4.0, 4.0),
+                                    sizeCheck(2, 3),
+                                    successAfterSuccess("$toEqualDescr: 4.0", "$toEqualDescr: 4.0"),
+                                    failAfterFail("$toEqualDescr: 5.0"),
+                                    withBulletPoint = false
+                                )
+                            }
+                        }
+                    }
+                }
+
+                context("iterable $oneToEleven") {
+                    it("shows only failing indices per default as there are more than 10 expected groups, yet still summary in group") {
+                        expect {
+                            expect(oneToEleven as Iterable<Double?>).toContainInOrderOnlyGroupedEntriesFun(
+                                context({ toEqual(1.0) }, { toEqual(1.0) }),
+                                context({ toEqual(2.0) }),
+                                context({ toEqual(3.0) }, { toEqual(-3.0) }),
+                                context({ toEqual(1.0) }, { toEqual(4.0) }),
+                                context({ toEqual(8.0) }),
+                                context({ toEqual(10.0) }, { toEqual(9.0) }),
+                                context({ toEqual(-1.0) }, { toEqual(-2.0) }, { toEqual(9.0) }),
+                                context({ toEqual(7.0) }, { toEqual(8.0) }),
+                                context({ toEqual(9.0) }, { toEqual(-8.0) }),
+                                context({ toEqual(10.0) }, { toEqual(11.0) }),
+                                context({ toEqual(12.0) })
+                            )
+                        }.toThrow<AssertionError> {
+
+                            message {
+                                toContainSize(11, 20)
+                                toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                                indexFail(
+                                    0, 1, listOf(1.0, 2.0),
+                                    null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                    successAfterFail("$toEqualDescr: 1.0"),
+                                    failAfterSuccess("$toEqualDescr: 1.0"),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(2.0)
+                                indexFail(2, 3.0, "$toEqualDescr: 2.0", withBulletPoint = false)
+                                indexFail(
+                                    3, 4, listOf(4.0, 5.0),
+                                    null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                    failAfterSuccess("$toEqualDescr: 3.0"),
+                                    failAfterFail("$toEqualDescr: -3.0"),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(4.0, 5.0)
+                                indexFail(
+                                    5, 6, listOf(6.0, 7.0),
+                                    null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                    failAfterSuccess("$toEqualDescr: 1.0"),
+                                    failAfterFail("$toEqualDescr: 4.0"),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(6.0, 7.0)
+                                notToContainIndex(7, 7)
+                                notToContainIndex(8, 9)
+                                indexFail(
+                                    10, 12, listOf(11.0),
+                                    sizeCheck(1, 3),
+                                    failAfterSuccess("$toEqualDescr: -1.0"),
+                                    failAfterFail("$toEqualDescr: -2.0"),
+                                    failAfterFail("$toEqualDescr: 9.0"),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(11.0)
+                                indexNonExisting(
+                                    13, 14,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 7.0", "$toEqualDescr: 8.0",
+                                    withBulletPoint = false
+                                )
+                                indexNonExisting(
+                                    15, 16,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 9.0", "$toEqualDescr: -8.0",
+                                    withBulletPoint = false
+                                )
+                                indexNonExisting(
+                                    17, 18,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 10.0", "$toEqualDescr: 11.0",
+                                    withBulletPoint = false
+                                )
+                                indexNonExisting(19, "$toEqualDescr: 12.0", withBulletPoint = false)
+                            }
+                        }
+                    }
+                    it("shows all indices with report option `showAlwaysSummary`") {
+                        expect {
+                            expect(oneToEleven as Iterable<Double?>).toContainInOrderOnlyGroupedEntriesFun(
+                                context({ toEqual(1.0) }, { toEqual(1.0) }),
+                                context({ toEqual(2.0) }),
+                                context({ toEqual(3.0) }, { toEqual(-3.0) }),
+                                context({ toEqual(1.0) }, { toEqual(4.0) }),
+                                context({ toEqual(8.0) }),
+                                context({ toEqual(10.0) }, { toEqual(9.0) }),
+                                context({ toEqual(-1.0) }, { toEqual(-2.0) }, { toEqual(9.0) }),
+                                context({ toEqual(7.0) }, { toEqual(8.0) }),
+                                context({ toEqual(9.0) }, { toEqual(-8.0) }),
+                                context({ toEqual(10.0) }, { toEqual(11.0) }),
+                                context({ toEqual(12.0) }),
+                                report = { showAlwaysSummary() }
+                            )
+                        }.toThrow<AssertionError> {
+                            message {
+                                toContainSize(11, 20)
+                                indexFail(
+                                    0, 1, listOf(1.0, 2.0),
+                                    sizeCheck(2, 2),
+                                    successAfterFail("$toEqualDescr: 1.0"),
+                                    failAfterSuccess("$toEqualDescr: 1.0")
+                                )
+                                mismatchesAfterFail(2.0)
+                                indexFail(2, 3.0, "$toEqualDescr: 2.0")
+                                indexFail(
+                                    3, 4, listOf(4.0, 5.0),
+                                    sizeCheck(2, 2),
+                                    failAfterSuccess("$toEqualDescr: 3.0"),
+                                    failAfterFail("$toEqualDescr: -3.0")
+                                )
+                                mismatchesAfterFail(4.0, 5.0)
+                                indexFail(
+                                    5, 6, listOf(6.0, 7.0),
+                                    sizeCheck(2, 2),
+                                    failAfterSuccess("$toEqualDescr: 1.0"),
+                                    failAfterFail("$toEqualDescr: 4.0")
+                                )
+                                mismatchesAfterFail(6.0, 7.0)
+                                indexSuccess(7, 8.0, "$toEqualDescr: 8.0")
+                                indexSuccess(
+                                    8, 9, listOf(9.0, 10.0),
+                                    //TODO 0.20.0: https://github.com/robstoll/atrium/issues/724 should not be shown, is enough to show the indices
+                                    sizeCheck(2, 2),
+                                    successAfterSuccess("$toEqualDescr: 10.0"),
+                                    successAfterSuccess("$toEqualDescr: 9.0")
+                                )
+                                indexFail(
+                                    10, 12, listOf(11.0),
+                                    sizeCheck(1, 3),
+                                    failAfterFail("$toEqualDescr: -1.0"),
+                                    failAfterFail("$toEqualDescr: -2.0"),
+                                    failAfterFail("$toEqualDescr: 9.0")
+                                )
+                                mismatchesAfterFail(11.0)
+                                indexNonExisting(
+                                    13, 14,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 7.0", "$toEqualDescr: 8.0"
+                                )
+                                indexNonExisting(
+                                    15, 16,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 9.0", "$toEqualDescr: -8.0"
+                                )
+                                indexNonExisting(
+                                    17, 18,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 10.0", "$toEqualDescr: 11.0"
+                                )
+                                indexNonExisting(19, "$toEqualDescr: 12.0")
+                            }
+                        }
+                    }
+
+                    it("shows only failing indices per default and only failing in group with reportInGroup `showOnlyFailing`") {
+                        expect {
+                            expect(oneToEleven as Iterable<Double?>).toContainInOrderOnlyGroupedEntriesFun(
+                                context({ toEqual(1.0) }, { toEqual(1.0) }),
+                                context({ toEqual(2.0) }),
+                                context({ toEqual(3.0) }, { toEqual(-3.0) }),
+                                context({ toEqual(1.0) }, { toEqual(4.0) }),
+                                context({ toEqual(8.0) }),
+                                context({ toEqual(10.0) }, { toEqual(9.0) }),
+                                context({ toEqual(-1.0) }, { toEqual(-2.0) }, { toEqual(9.0) }),
+                                context({ toEqual(7.0) }, { toEqual(8.0) }),
+                                context({ toEqual(9.0) }, { toEqual(-8.0) }),
+                                context({ toEqual(10.0) }, { toEqual(11.0) }),
+                                context({ toEqual(12.0) }),
+                                reportInGroup = { showOnlyFailing() }
+                            )
+                        }.toThrow<AssertionError> {
+                            message {
+                                toContainSize(11, 20)
+                                toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                                indexFail(
+                                    0, 1, listOf(1.0, 2.0),
+                                    null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                    failAfterFail("$toEqualDescr: 1.0", withBulletPoint = false),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(2.0)
+                                indexFail(2, 3.0, "$toEqualDescr: 2.0", withBulletPoint = false)
+                                indexFail(
+                                    3, 4, listOf(4.0, 5.0),
+                                    null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                    failAfterFail("$toEqualDescr: 3.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: -3.0", withBulletPoint = false),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(4.0, 5.0)
+                                indexFail(
+                                    5, 6, listOf(6.0, 7.0),
+                                    null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                    failAfterFail("$toEqualDescr: 1.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 4.0", withBulletPoint = false),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(6.0, 7.0)
+                                notToContainIndex(7, 7)
+                                notToContainIndex(8, 9)
+                                indexFail(
+                                    10, 12, listOf(11.0),
+                                    sizeCheck(1, 3),
+                                    failAfterFail("$toEqualDescr: -1.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: -2.0", withBulletPoint = false),
+                                    failAfterFail("$toEqualDescr: 9.0", withBulletPoint = false),
+                                    withBulletPoint = false
+                                )
+                                mismatchesAfterFail(11.0)
+                                indexNonExisting(
+                                    13, 14,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 7.0", "$toEqualDescr: 8.0",
+                                    withBulletPoint = false
+                                )
+                                indexNonExisting(
+                                    15, 16,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 9.0", "$toEqualDescr: -8.0",
+                                    withBulletPoint = false
+                                )
+                                indexNonExisting(
+                                    17, 18,
+                                    size("", explanatoryBulletPoint, null, 2),
+                                    "$toEqualDescr: 10.0", "$toEqualDescr: 11.0",
+                                    withBulletPoint = false
+                                )
+                                indexNonExisting(19, "$toEqualDescr: 12.0", withBulletPoint = false)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
+
     nullableCases(describePrefix) {
         describeFun(toContainInOrderOnlyGroupedEntries) {
             val null1null3 = { sequenceOf(null, 1.0, null, 3.0).constrainOnce().asIterable() }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -2,16 +2,33 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCollectionExpectation
+import ch.tutteli.atrium.translations.DescriptionIterableLikeExpectation
 
 //TODO 0.18.0 include InOrderReportOptions
 abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
-    toContainInOrderOnlyGroupedValues: Fun3<Iterable<Double>, Group<Double>, Group<Double>, Array<out Group<Double>>>,
+    toContainInOrderOnlyGroupedValues: Fun5<
+        Iterable<Double>, Group<Double>,
+        Group<Double>,
+        Array<out Group<Double>>,
+        InOrderOnlyReportingOptions.() -> Unit,
+        InAnyOrderOnlyReportingOptions.() -> Unit
+        >,
     groupFactory: (Array<out Double>) -> Group<Double>,
-    toContainInOrderOnlyGroupedNullableValues: Fun3<Iterable<Double?>, Group<Double?>, Group<Double?>, Array<out Group<Double?>>>,
+    toContainInOrderOnlyGroupedNullableValues: Fun5<
+        Iterable<Double?>,
+        Group<Double?>,
+        Group<Double?>,
+        Array<out Group<Double?>>,
+        InOrderOnlyReportingOptions.() -> Unit,
+        InAnyOrderOnlyReportingOptions.() -> Unit
+        >,
     nullableGroupFactory: (Array<out Double?>) -> Group<Double?>,
     describePrefix: String = "[Atrium] "
 ) : IterableToContainSpecBase({
@@ -21,38 +38,49 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
 
     include(object : SubjectLessSpec<Iterable<Double>>(
         describePrefix,
-        toContainInOrderOnlyGroupedValues.forSubjectLess(context(2.5), context(4.1), arrayOf())
+        toContainInOrderOnlyGroupedValues.forSubjectLess(
+            context(2.5),
+            context(4.1),
+            arrayOf(),
+            emptyInOrderOnlyReportOptions,
+            emptyInAnyOrderOnlyReportOptions
+        )
     ) {})
     include(object : SubjectLessSpec<Iterable<Double?>>(
         describePrefix,
-        toContainInOrderOnlyGroupedNullableValues.forSubjectLess(nullableGroup(2.5), nullableGroup(4.1), arrayOf())
+        toContainInOrderOnlyGroupedNullableValues.forSubjectLess(
+            nullableGroup(2.5),
+            nullableGroup(4.1),
+            arrayOf(),
+            emptyInOrderOnlyReportOptions,
+            emptyInAnyOrderOnlyReportOptions
+        )
     ) {})
 
-    fun Expect<Iterable<Double?>>.toContainInOrderOnlyGroupedNullableValuesFun(
-        t1: Group<Double?>,
-        t2: Group<Double?>,
-        vararg tX: Group<Double?>
-    ) = toContainInOrderOnlyGroupedNullableValues(this, t1, t2, tX)
-
-    val toBeWithFeature = "$indentFeatureArrow$featureBulletPoint$toEqualDescr"
-    val toBeAfterSuccess = "$indentRootBulletPoint$indentSuccessfulBulletPoint$toBeWithFeature"
-    val toBeAfterFailing = "$indentRootBulletPoint$indentFailingBulletPoint$toBeWithFeature"
+    val toEqualWithFeature = "$indentFeatureArrow$featureBulletPoint$toEqualDescr"
+    val toEqualAfterSuccess = "$indentRootBulletPoint$indentSuccessfulBulletPoint$toEqualWithFeature"
+    val toEqualAfterFailing = "$indentRootBulletPoint$indentFailingBulletPoint$toEqualWithFeature"
 
 
     fun element(prefix: String, bulletPoint: String, expected: Array<out Double?>) =
         expected.joinToString(".*$separator") { "$prefix\\Q$bulletPoint$anElementWhichEquals: $it\\E" }
 
-    fun size(prefix: String, bulletPoint: String, actual: Int, expected: Int) =
-        "$prefix\\Q$bulletPoint\\E${featureArrow}${DescriptionCollectionExpectation.SIZE.getDefault()}: $actual[^:]+: $expected"
+    fun size(prefix: String, bulletPoint: String, actual: Int?, expected: Int) =
+        "$prefix\\Q$bulletPoint\\E${featureArrow}${DescriptionCollectionExpectation.SIZE.getDefault()}:${actual?.let { " $it" } ?: ""}[^:]+: $expected"
 
     val afterFail = "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
     val additionalElementsFail = "$indentRootBulletPoint$indentFailingBulletPoint"
-    fun failAfterFail(vararg expected: Double?) = element(afterFail, failingBulletPoint, expected)
+    fun failAfterFail(vararg expected: Double?, withBulletPoint: Boolean = true) =
+        element(afterFail, if (withBulletPoint) failingBulletPoint else listBulletPoint, expected)
 
     fun successAfterFail(vararg expected: Double?) = element(afterFail, successfulBulletPoint, expected)
 
-    fun sizeCheck(actual: Int, expected: Int) = size(
-        "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow", featureBulletPoint, actual, expected)
+    fun sizeCheck(actual: Int?, expected: Int, bulletPoint: String = featureBulletPoint) = size(
+        "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow", bulletPoint, actual, expected
+    )
+
+    fun Expect<String>.notToContainIndex(from: Int, to: Int) =
+        notToContain.regex("\\Q${DescriptionIterableLikeExpectation.INDEX.getDefault().format("$from..$to")}")
 
     fun <T> mismatchesWarning(msg: String, values: Array<out T>, act: (T) -> String) =
         "$afterFail\\Q$warningBulletPoint$msg\\E: $separator" +
@@ -60,9 +88,12 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
 
     fun <T> additionalElementsWarning(msg: String, values: Array<out T>, act: (T) -> String) =
         "$additionalElementsFail\\Q$warningBulletPoint$msg\\E: $separator" +
-            values.joinToString(".*$separator") { "$additionalElementsFail$indentWarningBulletPoint$listBulletPoint${act(it)}" }
+            values.joinToString(".*$separator") {
+                "$additionalElementsFail$indentWarningBulletPoint$listBulletPoint${act(it)}"
+            }
 
-    fun mismatchesAfterFail(vararg mismatched: Double) = mismatchesWarning(mismatches, mismatched.toTypedArray()) { "$it" }
+    fun mismatchesAfterFail(vararg mismatched: Double) =
+        mismatchesWarning(mismatches, mismatched.toTypedArray()) { "$it" }
 
     fun additional(vararg entryWithValue: Pair<Int, Double>) =
         additionalElementsWarning(additionalElements, entryWithValue) { "${elementWithIndex(it.first)}: ${it.second}" }
@@ -70,12 +101,13 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
 
     val afterSuccess = "$indentRootBulletPoint$indentSuccessfulBulletPoint$indentFeatureArrow$indentFeatureBulletPoint"
     fun successAfterSuccess(vararg expected: Double?) = element(afterSuccess, successfulBulletPoint, expected)
+    fun failAfterSuccess(vararg expected: Double?) = element(afterSuccess, failingBulletPoint, expected)
 
 
     fun Expect<String>.indexSuccess(index: Int, expected: Double): Expect<String> {
         return this.toContain.exactly(1).regex(
             "\\Q$successfulBulletPoint$featureArrow${index(index)}: $expected\\E.*$separator" +
-                "$toBeAfterSuccess: $expected"
+                "$toEqualAfterSuccess: $expected"
         )
     }
 
@@ -95,10 +127,15 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
         )
     }
 
-    fun Expect<String>.indexFail(index: Int, actual: Any, expected: Double): Expect<String> {
+    fun Expect<String>.indexFail(
+        index: Int,
+        actual: Any,
+        expected: Double,
+        withBulletPoint: Boolean = true
+    ): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${index(index)}: $actual\\E.*$separator" +
-                "$toBeAfterFailing: $expected"
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${index(index)}: $actual\\E.*$separator" +
+                "$toEqualAfterFailing: $expected"
         )
     }
 
@@ -106,21 +143,40 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
         fromIndex: Int,
         toIndex: Int,
         actual: List<Double?>,
-        sizeCheck: String,
-        vararg expected: String
+        sizeCheck: String?,
+        vararg expected: String,
+        withBulletPoint: Boolean = true
     ): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${index(fromIndex, toIndex)}: $actual\\E.*$separator" +
-                "$sizeCheck.*$separator" +
-                "$indentRootBulletPoint$indentFailingBulletPoint$indentFeatureArrow$featureBulletPoint$toContainInAnyOrderOnly: $separator" +
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${
+                index(fromIndex, toIndex)
+            }: $actual\\E.*$separator" +
+                (sizeCheck?.let { "$sizeCheck.*$separator" } ?: "") +
+                "$indentRootBulletPoint${if (withBulletPoint) indentFailingBulletPoint else indentListBulletPoint}$indentFeatureArrow$featureBulletPoint$toContainInAnyOrderOnly: $separator" +
                 expected.joinToString(".*$separator")
         )
     }
 
-    fun Expect<String>.indexNonExisting(index: Int, expected: Double): Expect<String> {
+    fun Expect<String>.indexNonExisting(index: Int, expected: Double, withBulletPoint: Boolean = true): Expect<String> {
         return this.toContain.exactly(1).regex(
-            "\\Q$failingBulletPoint$featureArrow${index(index)}: $sizeExceeded\\E.*$separator" +
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${index(index)}: $sizeExceeded\\E.*$separator" +
                 "$afterFail$explanatoryBulletPoint$toEqualDescr: $expected"
+        )
+    }
+
+    fun Expect<String>.indexNonExisting(
+        fromIndex: Int, toIndex: Int,
+        sizeCheck: String,
+        vararg expected: Double,
+        withBulletPoint: Boolean = true
+    ): Expect<String> {
+        return this.toContain.exactly(1).regex(
+            "\\Q${if (withBulletPoint) failingBulletPoint else ""}$featureArrow${
+                index(fromIndex, toIndex)
+            }: $sizeExceeded\\E.*$separator" +
+                "$afterFail$sizeCheck.*$separator" +
+                "$indentRootBulletPoint${if (withBulletPoint) indentFailingBulletPoint else indentListBulletPoint}$indentFeatureArrow$indentFeatureBulletPoint$explanatoryBulletPoint$toContainInAnyOrderOnly: $separator" +
+                expected.joinToString(".*$separator") { ".*$anElementWhichEquals: $it" }
         )
     }
 
@@ -131,8 +187,13 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
         toContainInOrderOnlyGroupedNullableValues
     ) { toContainFunArr ->
 
-        fun Expect<Iterable<Double>>.toContainFun(t1: Group<Double>, t2: Group<Double>, vararg tX: Group<Double>) =
-            toContainFunArr(t1, t2, tX)
+        fun Expect<Iterable<Double>>.toContainFun(
+            t1: Group<Double>,
+            t2: Group<Double>,
+            vararg tX: Group<Double>,
+            report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit = emptyInAnyOrderOnlyReportOptions
+        ) = toContainFunArr(t1, t2, tX, report, reportInGroup)
 
         context("throws an $illegalArgumentException") {
             it("if an empty group is given as first parameter") {
@@ -163,11 +224,11 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
                     expect(fluentEmpty()).toContainFun(context(1.0), context(1.2))
                 }.toThrow<AssertionError> {
                     message {
+                        toContainSize(0, 2)
                         toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
                         indexNonExisting(0, 1.0)
                         indexNonExisting(1, 1.2)
                         notToContain(additionalElements)
-                        toContainSize(0, 2)
                     }
                 }
             }
@@ -285,7 +346,333 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
                                 failAfterFail(5.0),
                                 successAfterFail(4.0)
                             )
-                            sizeCheck(5, 6)
+                            sizeCheck(5, 7) // TODO change back to 5,6
+                        }
+                    }
+                }
+            }
+        }
+
+        context("report options") {
+            context("iterable ${oneToFour().toList()}") {
+                it("shows only failing indices with report option `showOnlyFailing` but still default behaviour per group (i.e. only failing if more than 10") {
+                    expect {
+                        expect(oneToFour()).toContainFun(
+                            context(1.0),
+                            context(2.0, 4.0),
+                            context(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0),
+                            report = { showOnlyFailing() })
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 14)
+                            toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                            notToContainIndex(0, 0)
+                            indexFail(
+                                1, 2, listOf(2.0, 3.0),
+                                null,
+                                successAfterSuccess(2.0),
+                                failAfterSuccess(4.0),
+                                withBulletPoint = false
+                            )
+                            indexFail(
+                                3,
+                                13,
+                                listOf(4.0, 4.0),
+                                sizeCheck(2, 11),
+                                failAfterFail(1.0, withBulletPoint = false),
+                                failAfterFail(2.0, withBulletPoint = false),
+                                failAfterFail(3.0, withBulletPoint = false),
+                                failAfterFail(5.0, withBulletPoint = false),
+                                failAfterFail(6.0, withBulletPoint = false),
+                                failAfterFail(7.0, withBulletPoint = false),
+                                failAfterFail(8.0, withBulletPoint = false),
+                                failAfterFail(9.0, withBulletPoint = false),
+                                failAfterFail(10.0, withBulletPoint = false),
+                                failAfterFail(11.0, withBulletPoint = false),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(4.0)
+                        }
+                    }
+                }
+
+                it("shows only failing indices with report option `showOnlyFailing` and only failing elements with reportInGroup option `showOnlyFailing` ") {
+                    expect {
+                        expect(oneToFour()).toContainFun(
+                            context(1.0, 2.0, 3.0),
+                            context(4.0, 4.0, 5.0),
+                            report = { showOnlyFailing() },
+                            reportInGroup = { showOnlyFailing() }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 6)
+                            toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                            notToContainIndex(1, 2)
+                            indexFail(
+                                3, 5, listOf(4.0, 4.0),
+                                sizeCheck(2, 3),
+                                failAfterFail(5.0, withBulletPoint = false),
+                                withBulletPoint = false
+                            )
+                            notToContain("$anElementWhichEquals: 4.0")
+                        }
+                    }
+                }
+
+                it("shows only failing indices with report option `showOnlyFailingIfMoreExpectedElementsThan(3)` because there are 5 but still all elements in group") {
+                    expect {
+                        expect(oneToFour()).toContainFun(
+                            context(1.0, 2.0, 3.0),
+                            context(4.0, 4.0, 5.0),
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(3) })
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 6)
+                            toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                            notToContainIndex(1, 2)
+                            indexFail(
+                                3, 5, listOf(4.0, 4.0),
+                                sizeCheck(2, 3),
+                                successAfterSuccess(4.0, 4.0),
+                                failAfterFail(5.0),
+                                withBulletPoint = false
+                            )
+                        }
+                    }
+                }
+            }
+
+            context("iterable $oneToEleven") {
+                it("shows only failing indices per default as there are more than 10 expected groups, yet still summary in group") {
+                    expect {
+                        expect(oneToEleven).toContainFun(
+                            context(1.0, 1.0),
+                            context(2.0),
+                            context(3.0, -3.0),
+                            context(1.0, 4.0),
+                            context(8.0),
+                            context(10.0, 9.0),
+                            context(-1.0, -2.0, 9.0),
+                            context(7.0, 8.0),
+                            context(9.0, -8.0),
+                            context(10.0, 11.0),
+                            context(12.0)
+                        )
+                    }.toThrow<AssertionError> {
+
+                        message {
+                            toContainSize(11, 20)
+                            toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                            indexFail(
+                                0, 1, listOf(1.0, 2.0),
+                                null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                successAfterFail(1.0),
+                                failAfterSuccess(1.0),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(2.0)
+                            indexFail(2, 3.0, 2.0, withBulletPoint = false)
+                            indexFail(
+                                3, 4, listOf(4.0, 5.0),
+                                null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                failAfterSuccess(3.0),
+                                failAfterFail(-3.0),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(4.0, 5.0)
+                            indexFail(
+                                5, 6, listOf(6.0, 7.0),
+                                null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                failAfterSuccess(1.0),
+                                failAfterFail(4.0),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(6.0, 7.0)
+                            notToContainIndex(7, 7)
+                            notToContainIndex(8, 9)
+                            indexFail(
+                                10, 12, listOf(11.0),
+                                sizeCheck(1, 3),
+                                failAfterSuccess(-1.0),
+                                failAfterFail(-2.0),
+                                failAfterFail(9.0),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(11.0)
+                            indexNonExisting(
+                                13, 14,
+                                size("", explanatoryBulletPoint, null, 2),
+                                7.0, 8.0,
+                                withBulletPoint = false
+                            )
+                            indexNonExisting(
+                                15, 16,
+                                size("", explanatoryBulletPoint, null, 2),
+                                9.0, -8.0,
+                                withBulletPoint = false
+                            )
+                            indexNonExisting(
+                                17, 18,
+                                size("", explanatoryBulletPoint, null, 2),
+                                10.0, 11.0,
+                                withBulletPoint = false
+                            )
+                            indexNonExisting(19, 12.0, withBulletPoint = false)
+                        }
+                    }
+                }
+                it("shows all indices with report option `showAlwaysSummary`") {
+                    expect {
+                        expect(oneToEleven).toContainFun(
+                            context(1.0, 1.0),
+                            context(2.0),
+                            context(3.0, -3.0),
+                            context(1.0, 4.0),
+                            context(8.0),
+                            context(10.0, 9.0),
+                            context(-1.0, -2.0, 9.0),
+                            context(7.0, 8.0),
+                            context(9.0, -8.0),
+                            context(10.0, 11.0),
+                            context(12.0),
+                            report = { showAlwaysSummary() }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(11, 20)
+                            indexFail(
+                                0, 1, listOf(1.0, 2.0),
+                                sizeCheck(2, 2),
+                                successAfterFail(1.0),
+                                failAfterSuccess(1.0)
+                            )
+                            mismatchesAfterFail(2.0)
+                            indexFail(2, 3.0, 2.0)
+                            indexFail(
+                                3, 4, listOf(4.0, 5.0),
+                                sizeCheck(2, 2),
+                                failAfterSuccess(3.0),
+                                failAfterFail(-3.0)
+                            )
+                            mismatchesAfterFail(4.0, 5.0)
+                            indexFail(
+                                5, 6, listOf(6.0, 7.0),
+                                sizeCheck(2, 2),
+                                failAfterSuccess(1.0),
+                                failAfterFail(4.0)
+                            )
+                            mismatchesAfterFail(6.0, 7.0)
+                            indexSuccess(7, 8.0)
+                            indexSuccess(
+                                8, 9, listOf(9.0, 10.0),
+                                //TODO 0.20.0: https://github.com/robstoll/atrium/issues/724 should not be shown, is enough to show the indices
+                                sizeCheck(2, 2),
+                                successAfterSuccess(10.0),
+                                successAfterSuccess(9.0)
+                            )
+                            indexFail(
+                                10, 12, listOf(11.0),
+                                sizeCheck(1, 3),
+                                failAfterFail(-1.0),
+                                failAfterFail(-2.0),
+                                failAfterFail(9.0)
+                            )
+                            mismatchesAfterFail(11.0)
+                            indexNonExisting(
+                                13, 14,
+                                size("", explanatoryBulletPoint, null, 2),
+                                7.0, 8.0
+                            )
+                            indexNonExisting(
+                                15, 16,
+                                size("", explanatoryBulletPoint, null, 2),
+                                9.0, -8.0
+                            )
+                            indexNonExisting(
+                                17, 18,
+                                size("", explanatoryBulletPoint, null, 2),
+                                10.0, 11.0
+                            )
+                            indexNonExisting(19, 12.0)
+                        }
+                    }
+                }
+
+                it("shows only failing indices per default and only failing in group with reportInGroup `showOnlyFailing`") {
+                    expect {
+                        expect(oneToEleven).toContainFun(
+                            context(1.0, 1.0),
+                            context(2.0),
+                            context(3.0, -3.0),
+                            context(1.0, 4.0),
+                            context(8.0),
+                            context(10.0, 9.0),
+                            context(-1.0, -2.0, 9.0),
+                            context(7.0, 8.0),
+                            context(9.0, -8.0),
+                            context(10.0, 11.0),
+                            context(12.0),
+                            reportInGroup = { showOnlyFailing() }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(11, 20)
+                            toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnlyGrouped:")
+                            indexFail(
+                                0, 1, listOf(1.0, 2.0),
+                                null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                failAfterFail(1.0, withBulletPoint = false),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(2.0)
+                            indexFail(2, 3.0, 2.0, withBulletPoint = false)
+                            indexFail(
+                                3, 4, listOf(4.0, 5.0),
+                                null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                failAfterFail(3.0, withBulletPoint = false),
+                                failAfterFail(-3.0, withBulletPoint = false),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(4.0, 5.0)
+                            indexFail(
+                                5, 6, listOf(6.0, 7.0),
+                                null, //i.e no size check is shown as 2=2 and summary is only for inReportGroup
+                                failAfterFail(1.0, withBulletPoint = false),
+                                failAfterFail(4.0, withBulletPoint = false),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(6.0, 7.0)
+                            notToContainIndex(7, 7)
+                            notToContainIndex(8, 9)
+                            indexFail(
+                                10, 12, listOf(11.0),
+                                sizeCheck(1, 3),
+                                failAfterFail(-1.0, withBulletPoint = false),
+                                failAfterFail(-2.0, withBulletPoint = false),
+                                failAfterFail(9.0, withBulletPoint = false),
+                                withBulletPoint = false
+                            )
+                            mismatchesAfterFail(11.0)
+                            indexNonExisting(
+                                13, 14,
+                                size("", explanatoryBulletPoint, null, 2),
+                                7.0, 8.0,
+                                withBulletPoint = false
+                            )
+                            indexNonExisting(
+                                15, 16,
+                                size("", explanatoryBulletPoint, null, 2),
+                                9.0, -8.0,
+                                withBulletPoint = false
+                            )
+                            indexNonExisting(
+                                17, 18,
+                                size("", explanatoryBulletPoint, null, 2),
+                                10.0, 11.0,
+                                withBulletPoint = false
+                            )
+                            indexNonExisting(19, 12.0, withBulletPoint = false)
                         }
                     }
                 }
@@ -294,6 +681,14 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
     }
 
     nullableCases(describePrefix) {
+
+        fun Expect<Iterable<Double?>>.toContainInOrderOnlyGroupedNullableValuesFun(
+            t1: Group<Double?>,
+            t2: Group<Double?>,
+            vararg tX: Group<Double?>,
+            report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions,
+            reportInGroup: InAnyOrderOnlyReportingOptions.() -> Unit = emptyInAnyOrderOnlyReportOptions
+        ) = toContainInOrderOnlyGroupedNullableValues(this, t1, t2, tX, report, reportInGroup)
 
         describeFun(toContainInOrderOnlyGroupedNullableValues) {
             val null1null3 = { sequenceOf(null, 1.0, null, 3.0).constrainOnce().asIterable() }

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyValuesExpectationsSpec.kt
@@ -22,13 +22,6 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
         toContainInOrderOnlyNullableValues.forSubjectLess(2.5, arrayOf(), emptyInOrderOnlyReportOptions)
     ) {})
 
-    fun Expect<Iterable<Double?>>.toContainInOrderOnlyNullableValuesFun(
-        t: Double?,
-        vararg tX: Double?,
-        report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
-    ) =
-        toContainInOrderOnlyNullableValues(this, t, tX, report)
-
     val toBeWithFeature = "$indentFeatureArrow$featureBulletPoint$toEqualDescr"
     val toBeAfterSuccess = "$indentRootBulletPoint$indentSuccessfulBulletPoint$toBeWithFeature"
     val toBeAfterFailing = "$indentRootBulletPoint$indentFailingBulletPoint$toBeWithFeature"
@@ -42,10 +35,6 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
 
     fun Expect<String>.elementSuccess(index: Int, expected: Double) = elementSuccess(index, expected.toString())
 
-    fun Expect<String>.notToContainElement(index: Int, expected: Double): Expect<String> {
-        return notToContain.regex("\\Q$featureArrow${elementWithIndex(index)}: ${expected}\\E.*$separator")
-    }
-
     fun Expect<String>.elementFailing(
         index: Int,
         actual: Any,
@@ -57,7 +46,6 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
                 "$toBeAfterFailing: $expected"
         )
     }
-
 
     fun Expect<String>.elementNonExisting(
         index: Int,
@@ -81,8 +69,7 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
             t: Double,
             vararg tX: Double,
             report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
-        ) =
-            toContainValuesFunArr(t, tX.toTypedArray(), report)
+        ) = toContainValuesFunArr(t, tX.toTypedArray(), report)
 
         context("empty collection") {
             it("1.0 throws AssertionError") {
@@ -209,12 +196,17 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
                         }
                     }
                 }
+            }
+        }
 
+        context("report options") {
+            context("iterable ${oneToFour().toList()}") {
                 it("shows only failing with report option `showOnlyFailing`") {
                     expect {
                         expect(oneToFour()).toContainFun(1.0, 2.0, 3.0, 4.0, 4.0, 5.0, report = { showOnlyFailing() })
                     }.toThrow<AssertionError> {
                         message {
+                            toContainSize(5, 6)
                             notToContainElement(0, 1.0)
                             notToContainElement(1, 2.0)
                             notToContainElement(2, 3.0)
@@ -225,7 +217,7 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
                         }
                     }
                 }
-                it("shows only failing with report option `showOnlyFailingIfMoreElementsThan(3)` because there are 5") {
+                it("shows only failing with report option `showOnlyFailingIfMoreExpectedElementsThan(5)` because there are 6") {
                     expect {
                         expect(oneToFour()).toContainFun(
                             1.0,
@@ -234,9 +226,10 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
                             4.0,
                             4.0,
                             5.0,
-                            report = { showOnlyFailingIfMoreElementsThan(3) })
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(5) })
                     }.toThrow<AssertionError> {
                         message {
+                            toContainSize(5, 6)
                             notToContainElement(0, 1.0)
                             notToContainElement(1, 2.0)
                             notToContainElement(2, 3.0)
@@ -246,70 +239,62 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
                         }
                     }
                 }
-            }
-        }
-        val oneToEleven = (1..11).map { it.toDouble() }.asIterable()
-        context("iterable $oneToEleven") {
-            it("shows only failing per default as there are more than 10 elements") {
-                expect {
-                    expect(oneToEleven).toContainFun(
-                        1.0,
-                        2.0,
-                        3.0,
-                        4.0,
-                        -1.0,
-                        6.0,
-                        7.0,
-                        -2.0,
-                        9.0,
-                        10.0,
-                        11.0
-                    )
-                }.toThrow<AssertionError> {
-                    message {
-                        notToContainElement(0, 1.0)
-                        notToContainElement(1, 2.0)
-                        notToContainElement(2, 3.0)
-                        notToContainElement(3, 4.0)
-                        elementFailing(4, 5.0, -1.0, withBulletPoint = false)
-                        notToContainElement(5, 6.0)
-                        notToContainElement(6, 7.0)
-                        elementFailing(7, 8.0, -2.0, withBulletPoint = false)
-                        notToContainElement(8, 9.0)
-                        notToContainElement(9, 10.0)
-                        notToContainElement(10, 11.0)
+                it("shows summary with report option `showOnlyFailingIfMoreExpectedElementsThan(2)` because there are 2") {
+                    expect {
+                        expect(oneToFour()).toContainFun(
+                            1.0,
+                            2.0,
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(2) }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 2)
+                            elementSuccess(0, 1.0)
+                            elementSuccess(1, 2.0)
+                            toContain(
+                                "$warningBulletPoint$additionalElements:",
+                                "$listBulletPoint${elementWithIndex(2)}: 3.0",
+                                "$listBulletPoint${elementWithIndex(3)}: 4.0",
+                                "$listBulletPoint${elementWithIndex(4)}: 4.0"
+                            )
+
+                        }
                     }
                 }
-            }
-            it("shows all with report option `showsAlwaysSummary`") {
-                expect {
-                    expect(oneToEleven).toContainFun(
-                        1.0,
-                        2.0,
-                        3.0,
-                        4.0,
-                        -1.0,
-                        6.0,
-                        7.0,
-                        -2.0,
-                        9.0,
-                        10.0,
-                        11.0,
-                        report = { showAlwaysSummary() }
-                    )
-                }.toThrow<AssertionError> {
-                    message {
-                        elementSuccess(0, 1.0)
-                        elementSuccess(1, 2.0)
-                        elementSuccess(2, 3.0)
-                        elementSuccess(3, 4.0)
-                        elementFailing(4, 5.0, -1.0, withBulletPoint = false)
-                        elementSuccess(5, 6.0)
-                        elementSuccess(6, 7.0)
-                        elementFailing(7, 8.0, -2.0, withBulletPoint = false)
-                        elementSuccess(8, 9.0)
-                        elementSuccess(9, 10.0)
-                        elementSuccess(10, 11.0)
+
+                it("shows summary without report option if there are 10 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 10") {
+                    expect {
+                        expect(oneToFour()).toContainFun(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
+                    }.toThrow<AssertionError> {
+                        message {
+                            elementSuccess(0, 1.0)
+                            elementSuccess(1, 2.0)
+                            elementSuccess(2, 3.0)
+                            elementSuccess(3, 4.0)
+                            elementFailing(4, 4.0, 5.0)
+                            elementNonExisting(5, 6.0)
+                            elementNonExisting(6, 7.0)
+                            elementNonExisting(7, 8.0)
+                            elementNonExisting(8, 9.0)
+                            elementNonExisting(9, 10.0)
+                            toContainSize(5, 10)
+                        }
+                    }
+                }
+                it("shows only failing without report option if there are 11 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 10") {
+                    expect {
+                        expect(oneToFour()).toContainFun(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0)
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(5, 11)
+                            elementFailing(4, 4.0, 5.0, withBulletPoint = false)
+                            elementNonExisting(5, 6.0, withBulletPoint = false)
+                            elementNonExisting(6, 7.0, withBulletPoint = false)
+                            elementNonExisting(7, 8.0, withBulletPoint = false)
+                            elementNonExisting(8, 9.0, withBulletPoint = false)
+                            elementNonExisting(9, 10.0, withBulletPoint = false)
+                            elementNonExisting(10, 11.0, withBulletPoint = false)
+                        }
                     }
                 }
             }
@@ -318,20 +303,26 @@ abstract class IterableToContainInOrderOnlyValuesExpectationsSpec(
 
     nullableCases(describePrefix) {
 
+        fun Expect<Iterable<Double?>>.toContainFun(
+            t: Double?,
+            vararg tX: Double?,
+            report: InOrderOnlyReportingOptions.() -> Unit = emptyInOrderOnlyReportOptions
+        ) = toContainInOrderOnlyNullableValues(this, t, tX, report)
+
         describeFun(toContainInOrderOnlyNullableValues) {
             val null1null3 = { sequenceOf(null, 1.0, null, 3.0).constrainOnce().asIterable() }
 
             context("iterable ${null1null3().toList()}") {
                 context("happy cases (do not throw)") {
                     it("null, 1.0, null, 3.0") {
-                        expect(null1null3()).toContainInOrderOnlyNullableValuesFun(null, 1.0, null, 3.0)
+                        expect(null1null3()).toContainFun(null, 1.0, null, 3.0)
                     }
                 }
 
                 context("failing cases") {
                     it("null, 1.0, 3.0 -- null was missing") {
                         expect {
-                            expect(null1null3()).toContainInOrderOnlyNullableValuesFun(null, 1.0, 3.0)
+                            expect(null1null3()).toContainFun(null, 1.0, 3.0)
                         }.toThrow<AssertionError> {
                             message {
                                 toContain.exactly(1).value("$rootBulletPoint$toContainInOrderOnly:")

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -1,10 +1,12 @@
 package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.exactly
+import ch.tutteli.atrium.api.fluent.en_GB.notToContain
 import ch.tutteli.atrium.api.fluent.en_GB.regex
 import ch.tutteli.atrium.api.fluent.en_GB.toContain
 import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionBasic
@@ -19,6 +21,7 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
 
     companion object {
         val oneToFour = { sequenceOf(1.0, 2.0, 3.0, 4.0, 4.0).constrainOnce().asIterable() }
+        val oneToEleven = (1..11).map { it.toDouble() }.asIterable()
         val oneToSeven = { sequenceOf(1.0, 2.0, 4.0, 4.0, 5.0, 3.0, 5.0, 6.0, 4.0, 7.0).constrainOnce().asIterable() }
         val oneToSevenNullable =
             { sequenceOf(1.0, null, 4.0, 4.0, 5.0, null, 5.0, 6.0, 4.0, 7.0).constrainOnce().asIterable() }
@@ -59,9 +62,13 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val separator = lineSeparator
 
         val emptyInOrderOnlyReportOptions : InOrderOnlyReportingOptions.() -> Unit = {}
+        val emptyInAnyOrderOnlyReportOptions : InAnyOrderOnlyReportingOptions.() -> Unit = {}
 
         fun Expect<String>.toContainSize(actual: Int, expected: Int) =
             toContain.exactly(1).regex("${DescriptionCollectionExpectation.SIZE.getDefault()}: $actual[^:]+: $expected")
+
+        fun Expect<String>.notToContainElement(index: Int, expected: Double): Expect<String> =
+            notToContain.regex("\\Q${elementWithIndex(index)}: ${expected}\\E.*$separator")
 
         fun Suite.describeFun(spec: SpecPair<*>, body: Suite.() -> Unit) = describeFun(spec.name, body)
         private fun Suite.describeFun(funName: String, body: Suite.() -> Unit) = context("fun `$funName`", body = body)

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/testUtils.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/testUtils.kt
@@ -23,12 +23,14 @@ typealias Feature1<T, A1, R> = SpecPair<Expect<T>.(A1) -> Expect<R>>
 typealias Feature2<T, A1, A2, R> = SpecPair<Expect<T>.(A1, A2) -> Expect<R>>
 typealias Feature3<T, A1, A2, A3, R> = SpecPair<Expect<T>.(A1, A2, A3) -> Expect<R>>
 typealias Feature4<T, A1, A2, A3, A4, R> = SpecPair<Expect<T>.(A1, A2, A3, A4) -> Expect<R>>
+typealias Feature5<T, A1, A2, A3, A4, A5, R> = SpecPair<Expect<T>.(A1, A2, A3, A4, A5) -> Expect<R>>
 
 typealias Fun0<T> = Feature0<T, T>
 typealias Fun1<T, A1> = Feature1<T, A1, T>
 typealias Fun2<T, A1, A2> = Feature2<T, A1, A2, T>
 typealias Fun3<T, A1, A2, A3> = Feature3<T, A1, A2, A3, T>
 typealias Fun4<T, A1, A2, A3, A4> = Feature4<T, A1, A2, A3, A4, T>
+typealias Fun5<T, A1, A2, A3, A4, A5> = Feature5<T, A1, A2, A3, A4, A5, T>
 
 inline operator fun <T, R> Feature0<T, R>.invoke(expect: Expect<T>): Expect<R> = this.second(expect)
 inline operator fun <T, A1, R> Feature1<T, A1, R>.invoke(expect: Expect<T>, a1: A1): Expect<R> = this.second(expect, a1)
@@ -43,23 +45,32 @@ inline operator fun <T, A1, A2, A3, A4, R> Feature4<T, A1, A2, A3, A4, R>.invoke
     expect: Expect<T>, a1: A1, a2: A2, a3: A3, a4: A4
 ): Expect<R> = this.second(expect, a1, a2, a3, a4)
 
+inline operator fun <T, A1, A2, A3, A4, A5, R> Feature5<T, A1, A2, A3, A4, A5, R>.invoke(
+    expect: Expect<T>, a1: A1, a2: A2, a3: A3, a4: A4, a5: A5
+): Expect<R> = this.second(expect, a1, a2, a3, a4, a5)
+
 
 inline fun <T, R> Feature0<T, R>.forSubjectLess(): Pair<String, Expect<T>.() -> Unit> =
-    this.name to expectLambda { this@forSubjectLess(this) }
+    this.name to expectLambda { this@forSubjectLess.invoke(this) }
 
 inline fun <T, A1, R> Feature1<T, A1, R>.forSubjectLess(a1: A1): Pair<String, Expect<T>.() -> Unit> =
-    this.name to expectLambda { this@forSubjectLess(this, a1) }
+    this.name to expectLambda { this@forSubjectLess.invoke(this, a1) }
 
 inline fun <T, A1, A2, R> Feature2<T, A1, A2, R>.forSubjectLess(a1: A1, a2: A2): Pair<String, Expect<T>.() -> Unit> =
-    this.name to expectLambda { this@forSubjectLess(this, a1, a2) }
+    this.name to expectLambda { this@forSubjectLess.invoke(this, a1, a2) }
 
 inline fun <T, A1, A2, A3, R> Feature3<T, A1, A2, A3, R>.forSubjectLess(
     a1: A1, a2: A2, a3: A3
-): Pair<String, Expect<T>.() -> Unit> = this.name to expectLambda { this@forSubjectLess(this, a1, a2, a3) }
+): Pair<String, Expect<T>.() -> Unit> = this.name to expectLambda { this@forSubjectLess.invoke(this, a1, a2, a3) }
 
 inline fun <T, A1, A2, A3, A4, R> Feature4<T, A1, A2, A3, A4, R>.forSubjectLess(
     a1: A1, a2: A2, a3: A3, a4: A4
-): Pair<String, Expect<T>.() -> Unit> = this.name to expectLambda { this@forSubjectLess(this, a1, a2, a3, a4) }
+): Pair<String, Expect<T>.() -> Unit> = this.name to expectLambda { this@forSubjectLess.invoke(this, a1, a2, a3, a4) }
+
+inline fun <T, A1, A2, A3, A4, A5, R> Feature5<T, A1, A2, A3, A4, A5, R>.forSubjectLess(
+    a1: A1, a2: A2, a3: A3, a4: A4, a5: A5
+): Pair<String, Expect<T>.() -> Unit> =
+    this.name to expectLambda { this@forSubjectLess.invoke(this, a1, a2, a3, a4, a5) }
 
 
 inline fun <T, R> Fun1<T, Expect<R>.() -> Unit>.forAssertionCreatorSpec(
@@ -256,6 +267,7 @@ inline fun <T, A1> fun1(f: KFunction2<Expect<T>, A1, Expect<T>>): Fun1<T, A1> = 
 inline fun <T, A1, A2> fun2(f: KFunction3<Expect<T>, A1, A2, Expect<T>>): Fun2<T, A1, A2> = f.name to f
 inline fun <T, A1, A2, A3> fun3(f: KFunction4<Expect<T>, A1, A2, A3, Expect<T>>): Fun3<T, A1, A2, A3> = f.name to f
 inline fun <T, A1, A2, A3, A4> fun4(f: KFunction5<Expect<T>, A1, A2, A3, A4, Expect<T>>): Fun4<T, A1, A2, A3, A4> = f.name to f
+inline fun <T, A1, A2, A3, A4, A5> fun5(f: KFunction6<Expect<T>, A1, A2, A3, A4, A5, Expect<T>>): Fun5<T, A1, A2, A3, A4, A5> = f.name to f
 //@formatter:on
 
 fun <T> notImplemented(): T = throw NotImplementedError()

--- a/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
+++ b/misc/tools/readme-examples/src/main/kotlin/readme/examples/MostExamplesSpec.kt
@@ -156,7 +156,7 @@ class MostExamplesSpec : Spek({
             { toBeLessThan(3) },
             { toBeLessThan(2) },
             { toBeGreaterThan(1) },
-            report = { showOnlyFailingIfMoreElementsThan(3) }
+            report = { showOnlyFailingIfMoreExpectedElementsThan(2) }
         )
     }
     test("ex-collection-builder-2") {

--- a/misc/verbs-internal/atrium-verbs-internal-common/src/main/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/verbs-internal/atrium-verbs-internal-common/src/main/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -49,5 +49,5 @@ fun <T> expect(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
  * Might be removed at any time without previous notice or the behaviour could change etc.
  */
 enum class AssertionVerb(override val value: String) : StringBasedTranslatable {
-    EXPECT("expected subject");
+    EXPECT("I expected subject");
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -85,7 +85,10 @@ fun Settings_gradle.includeBundleAndApisWithExtensionsAndSmokeTest(vararg apiNam
 
 fun Settings_gradle.includeKotlinJvmJs(subPath: String, module: String) {
     include(subPath, "$module-common")
-    include(subPath, "$module-js")
+    // js starts to be annoying on local development. Let's carry this only out on CI
+    if (System.getenv("CI") == "true") {
+        include(subPath, "$module-js")
+    }
     include(subPath, "$module-jvm")
 }
 


### PR DESCRIPTION
On one hand for contains.inAnyOrder but on the other also for
contains.inOrder.only.grouped.inAnyOrder. There both should be
configurable, the grouped reporting as well as the in-group reporting
options

moreover:
- deprecate InOrderOnlyReportingOptions.numberOfElementsInSummary,
  instead provide showOnlyFailingIfMoreExpectedElementsThan
- only run js test tasks in CI (as they currently re-run even if they
  are successful)



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
