### PR TITLE
move renaming of iterable to iterableLike in logic to 0.19.0

### DIFF
--- a/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB-common/src/main/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -162,7 +162,7 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike
-): Expect<T> = entriesOf(WithInOrderOnlyReportingOptions({}, expectedMapLike))
+): Expect<T> = the(WithInOrderOnlyReportingOptions({}, expectedMapLike))
 
 /**
  * Finishes the specification of the sophisticated `contains` assertion where the subject (a [MapLike])
@@ -186,7 +186,7 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  *
  * @since 0.18.0
  */
-infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
     entriesOf: WithInOrderOnlyReportingOptions<MapLike>
 ): Expect<T> = _logic.toVarArgPairs<K, V>(entriesOf.t).let { (first, rest) ->
     this the pairs(first, *rest, reportOptionsInOrderOnly = entriesOf.options)

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains.kt
@@ -1,4 +1,4 @@
-//TODO 1.0.0 rename iterable.contains to iterablelike.contains
+//TODO 0.19.0 rename iterable.contains to iterablelike.contains
 package ch.tutteli.atrium.logic.creating.iterable.contains
 
 import ch.tutteli.atrium.assertions.Assertion

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtLeastChecker.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtLeastChecker.kt
@@ -1,4 +1,4 @@
-//TODO 0.18.0 rename package to iterableLike
+//TODO 0.19.0 rename package to iterableLike
 package ch.tutteli.atrium.logic.creating.iterable.contains.checkers.impl
 
 import ch.tutteli.atrium.assertions.Assertion

--- a/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultNotChecker.kt
+++ b/logic/atrium-logic-common/src/main/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultNotChecker.kt
@@ -1,4 +1,4 @@
-//TODO 0.18.0 rename package to iterablelike?
+//TODO 0.19.0 rename package to iterablelike?
 package ch.tutteli.atrium.logic.creating.iterable.contains.checkers.impl
 
 import ch.tutteli.atrium.assertions.Assertion

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceNotToContainExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceNotToContainExpectationsSpec.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.specs.integration
 import ch.tutteli.atrium.api.fluent.en_GB.messageToContain
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCharSequenceExpectation
@@ -35,7 +36,7 @@ abstract class CharSequenceNotToContainExpectationsSpec(
 
     val notToContainDescr = DescriptionCharSequenceExpectation.NOT_TO_CONTAIN.getDefault()
     val notToContainIgnoringCaseDescr =
-        String.format(DescriptionCharSequenceExpectation.IGNORING_CASE.getDefault(), notToContainDescr)
+        DescriptionCharSequenceExpectation.IGNORING_CASE.getDefault().format(notToContainDescr)
 
     val valueWithIndent = "$indentRootBulletPoint$listBulletPoint$value"
 

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/CharSequenceToContainSpecBase.kt
@@ -1,6 +1,6 @@
 package ch.tutteli.atrium.specs.integration
 
-import ch.tutteli.atrium.specs.format
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.specs.lineSeparator
 import ch.tutteli.atrium.translations.DescriptionCharSequenceExpectation
 import org.spekframework.spek2.Spek
@@ -13,8 +13,7 @@ abstract class CharSequenceToContainSpecBase(spec: Root.() -> Unit) : Spek(spec)
         const val helloWorld = "Hello World, I am Oskar"
 
         val toContainDescr = DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault()
-        val toContainIgnoringCase = String.format(
-            DescriptionCharSequenceExpectation.IGNORING_CASE.getDefault(),
+        val toContainIgnoringCase = DescriptionCharSequenceExpectation.IGNORING_CASE.getDefault().format(
             DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault()
         )
         val numberOfOccurrences = DescriptionCharSequenceExpectation.NUMBER_OF_MATCHES.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/FloatingPointWithErrorToleranceExpectationsSpec.kt
@@ -5,12 +5,12 @@ import ch.tutteli.atrium.api.fluent.en_GB.notToContain
 import ch.tutteli.atrium.api.fluent.en_GB.toContain
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.core.polyfills.formatFloatingPointNumber
 import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.specs.Fun2
 import ch.tutteli.atrium.specs.SubjectLessSpec
 import ch.tutteli.atrium.specs.forSubjectLess
-import ch.tutteli.atrium.specs.format
 import ch.tutteli.atrium.translations.DescriptionFloatingPointException
 import ch.tutteli.atrium.translations.DescriptionFloatingPointException.*
 import org.spekframework.spek2.Spek
@@ -82,20 +82,15 @@ fun <T : Number> Root.checkFloatingPoint(
                     }
                 }
 
-                val toEqualInclErrorToleranceDescr =
-                    String.format(TO_EQUAL_WITH_ERROR_TOLERANCE.getDefault(), tolerance)
-                val failureNotice = String.format(
-                    FAILURE_DUE_TO_FLOATING_POINT_NUMBER.getDefault(),
-                    subject::class.fullName
-                )
+                val toEqualInclErrorToleranceDescr = TO_EQUAL_WITH_ERROR_TOLERANCE.getDefault().format(tolerance)
+                val failureNotice = FAILURE_DUE_TO_FLOATING_POINT_NUMBER.getDefault().format(subject::class.fullName)
                 failing.forEach { num ->
                     it("... compare to $num throws AssertionError") {
                         expect {
                             expect(subject).toEqualWithErrorTolerance(num, tolerance)
                         }.toThrow<AssertionError> {
                             message {
-                                val exactCheck = String.format(
-                                    TO_EQUAL_WITH_ERROR_TOLERANCE_EXPLAINED.getDefault(),
+                                val exactCheck = TO_EQUAL_WITH_ERROR_TOLERANCE_EXPLAINED.getDefault().format(
                                     @Suppress("DEPRECATION")
                                     formatFloatingPointNumber(subject),
                                     @Suppress("DEPRECATION")

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainEntriesSpecBase.kt
@@ -1,6 +1,7 @@
 package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionComparableExpectation
@@ -24,12 +25,12 @@ abstract class IterableToContainEntriesSpecBase(
         val toBeLessThanDescr = DescriptionComparableExpectation.TO_BE_LESS_THAN.getDefault()
         val toBeGreaterThanDescr = DescriptionComparableExpectation.TO_BE_GREATER_THAN.getDefault()
         fun <T> mismatchedIndex(index: Int, value: T) : String {
-            val indexDescr = String.format(DescriptionIterableLikeExpectation.INDEX.getDefault(), index)
+            val indexDescr = DescriptionIterableLikeExpectation.INDEX.getDefault().format(index)
             return "$indexDescr: ${value.toString()}"
         }
         val noSuchElementDescr = DescriptionIterableLikeExpectation.ELEMENT_NOT_FOUND.getDefault()
 
-        fun index(index: Int) = String.format(DescriptionIterableLikeExpectation.INDEX.getDefault(), index)
+        fun index(index: Int) = DescriptionIterableLikeExpectation.INDEX.getDefault().format(index)
 
         //@formatter:off
         val afterExplanatory = "$indentRootBulletPoint$indentListBulletPoint$indentSuccessfulBulletPoint\\Q$explanatoryBulletPoint\\E"

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainSpecBase.kt
@@ -26,20 +26,16 @@ abstract class IterableToContainSpecBase(spec: Root.() -> Unit) : Spek(spec) {
         val oneToSevenNullable =
             { sequenceOf(1.0, null, 4.0, 4.0, 5.0, null, 5.0, 6.0, 4.0, 7.0).constrainOnce().asIterable() }
 
-        val toContainInAnyOrder = String.format(
-            DescriptionIterableLikeExpectation.IN_ANY_ORDER.getDefault(),
+        val toContainInAnyOrder = DescriptionIterableLikeExpectation.IN_ANY_ORDER.getDefault().format(
             DescriptionIterableLikeExpectation.TO_CONTAIN.getDefault()
         )
-        val toContainInAnyOrderOnly = String.format(
-            DescriptionIterableLikeExpectation.IN_ANY_ORDER_ONLY.getDefault(),
+        val toContainInAnyOrderOnly = DescriptionIterableLikeExpectation.IN_ANY_ORDER_ONLY.getDefault().format(
             DescriptionIterableLikeExpectation.TO_CONTAIN.getDefault()
         )
-        val toContainInOrderOnly = String.format(
-            DescriptionIterableLikeExpectation.IN_ORDER_ONLY.getDefault(),
+        val toContainInOrderOnly = DescriptionIterableLikeExpectation.IN_ORDER_ONLY.getDefault().format(
             DescriptionIterableLikeExpectation.TO_CONTAIN.getDefault()
         )
-        val toContainInOrderOnlyGrouped = String.format(
-            DescriptionIterableLikeExpectation.IN_ORDER_ONLY_GROUPED.getDefault(),
+        val toContainInOrderOnlyGrouped = DescriptionIterableLikeExpectation.IN_ORDER_ONLY_GROUPED.getDefault().format(
             DescriptionIterableLikeExpectation.TO_CONTAIN.getDefault()
         )
         val numberOfSuchElements = DescriptionIterableLikeExpectation.NUMBER_OF_SUCH_ELEMENTS.getDefault()

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAllExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/IterableToHaveElementsAndAllExpectationsSpec.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.specs.*
@@ -33,7 +34,7 @@ abstract class IterableToHaveElementsAndAllExpectationsSpec(
 
     val explanatoryPointWithIndent = "$indentRootBulletPoint$indentListBulletPoint$explanatoryBulletPoint"
 
-    fun index(index: Int) = listBulletPoint + String.format(DescriptionIterableLikeExpectation.INDEX.getDefault(), index)
+    fun index(index: Int) = listBulletPoint + DescriptionIterableLikeExpectation.INDEX.getDefault().format(index)
 
     nonNullableCases(
         describePrefix,

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ThrowableExpectationsSpec.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/integration/ThrowableExpectationsSpec.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.core.polyfills.fullName
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
@@ -192,15 +193,13 @@ abstract class ThrowableExpectationsSpec(
                         expect(throwableWithDifferentCauseType).causeFun { messageToContain("Cause exception") }
                     }.toThrow<AssertionError> {
                         messageToContain(
-                            String.format(
-                                OCCURRED_EXCEPTION_PROPERTIES.getDefault(),
+                            OCCURRED_EXCEPTION_PROPERTIES.getDefault().format(
                                 UnsupportedOperationException::class.simpleName!!
                             )
                         )
                     }
                 }
             }
-
         }
 
         context("Throwable.cause is null") {

--- a/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/testUtils.kt
+++ b/misc/specs/atrium-specs-common/src/main/kotlin/ch/tutteli/atrium/specs/testUtils.kt
@@ -272,9 +272,6 @@ inline fun <T, A1, A2, A3, A4, A5> fun5(f: KFunction6<Expect<T>, A1, A2, A3, A4,
 
 fun <T> notImplemented(): T = throw NotImplementedError()
 
-//TODO 0.18.0 rename (or remove?), we only introduced it so that it is easier to migrate specs from JVM to common
-fun String.Companion.format(string: String, arg: Any, vararg otherArgs: Any): String = string.format(arg, *otherArgs)
-
 val toEqualDescr = DescriptionAnyExpectation.TO_EQUAL.getDefault()
 val toBeDescr = DescriptionBasic.TO_BE.getDefault()
 val notToBeDescr = DescriptionBasic.NOT_TO_BE.getDefault()


### PR DESCRIPTION
and remove String.Companion.format in testUtils



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
