### PR TITLE
Feature/add specs maptocontain

### DIFF
--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
@@ -268,11 +268,36 @@ abstract class MapToContainInOrderOnlyKeyValueExpectationsSpec(
                     }.toThrow<AssertionError> {
                         message {
                             toContainSize(2, 3)
+                            elementSuccess(0, "1", "a", "1")
+                            elementFailing(0, "2", "a", "1")
                             elementOutOfBound(3, "d", "4")
-                            elementSuccess(0, "a", "a", "1")
                         }
                     }
                 }
+                it("shows only failing with report option `showOnlyFailingIfMoreExpectedElementsThan(2)` because there are 3") {
+                    expect {
+                        expect(map).toContainFun(
+                            keyValue("a") {toEqual(1)},
+                            keyValue("b") {toEqual(2)},
+                            keyValue("c") {toEqual(3)},
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(2) }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(2, 3)
+                            elementSuccess(0, "1", "a", "1")
+                            elementFailing(0, "2", "a", "1")
+                            elementOutOfBound(3, "d", "4")
+                        }
+                    }
+                }
+                it("shows summary with report option `showOnlyFailingIfMoreExpectedElementsThan(2)` because there are 2") {
+
+                }
+                it("shows summary without report option if there are 10 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 10") {
+
+                }
+                it("shows only failing without report option if there are 11 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 10") {
             }
         }
     }

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
@@ -7,7 +7,6 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderO
 import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.nonNullableCases
 import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.nullableCases
-import org.spekframework.spek2.style.specification.Suite
 
 abstract class MapToContainInOrderOnlyKeyValueExpectationsSpec(
     keyWithValueAssertions: MFun3<String, Int, Expect<Int>.() -> Unit, InOrderOnlyReportingOptions.() -> Unit>,
@@ -257,6 +256,24 @@ abstract class MapToContainInOrderOnlyKeyValueExpectationsSpec(
 
         context("report options") {
             //TODO #1129 add tests, see IterableToContainInOrderOnlyValuesExpectationsSpec -> report options
+            context("") {
+                it("shows only failing with report option `showOnlyFailing`") {
+                    expect {
+                        expect(map).toContainFun(
+                            keyValue("a") {toEqual(1)},
+                            keyValue("b") {toEqual(2)},
+                            keyValue("c") {toEqual(3)},
+                            report = { showOnlyFailing() }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(2, 3)
+                            elementOutOfBound(3, "d", "4")
+                            elementSuccess(0, "a", "a", "1")
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/MapToContainInOrderOnlyKeyValueExpectationsSpec.kt
@@ -260,9 +260,9 @@ abstract class MapToContainInOrderOnlyKeyValueExpectationsSpec(
                 it("shows only failing with report option `showOnlyFailing`") {
                     expect {
                         expect(map).toContainFun(
-                            keyValue("a") {toEqual(1)},
-                            keyValue("b") {toEqual(2)},
-                            keyValue("c") {toEqual(3)},
+                            keyValue("a") { toEqual(1) },
+                            keyValue("b") { toEqual(2) },
+                            keyValue("c") { toEqual(3) },
                             report = { showOnlyFailing() }
                         )
                     }.toThrow<AssertionError> {
@@ -277,27 +277,65 @@ abstract class MapToContainInOrderOnlyKeyValueExpectationsSpec(
                 it("shows only failing with report option `showOnlyFailingIfMoreExpectedElementsThan(2)` because there are 3") {
                     expect {
                         expect(map).toContainFun(
-                            keyValue("a") {toEqual(1)},
-                            keyValue("b") {toEqual(2)},
-                            keyValue("c") {toEqual(3)},
+                            keyValue("a") { toEqual(1) },
+                            keyValue("b") { toEqual(2) },
+                            keyValue("c") { toEqual(3) },
                             report = { showOnlyFailingIfMoreExpectedElementsThan(2) }
                         )
                     }.toThrow<AssertionError> {
                         message {
-                            toContainSize(2, 3)
                             elementSuccess(0, "1", "a", "1")
                             elementFailing(0, "2", "a", "1")
                             elementOutOfBound(3, "d", "4")
+                            toContainSize(2, 3)
                         }
                     }
                 }
                 it("shows summary with report option `showOnlyFailingIfMoreExpectedElementsThan(2)` because there are 2") {
-
+                    expect {
+                        expect(map).toContainFun(
+                            keyValue("a") { toEqual(1) },
+                            report = { showOnlyFailingIfMoreExpectedElementsThan(1) }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            toContainSize(2, 1)
+                            elementSuccess(0, "1", "a", "1")
+                        }
+                    }
                 }
-                it("shows summary without report option if there are 10 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 10") {
-
+                it("shows summary without report option if there are 2 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 2") {
+                    expect {
+                        expect(map).toContainFun(
+                            keyValue("a") { toEqual(1) },
+                            keyValue("b") { toEqual(2) },
+                            keyValue("c") { toEqual(3) }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            elementSuccess(0, "1", "a", "1")
+                            elementFailing(0, "2", "a", "1")
+                            elementOutOfBound(3, "d", "4")
+                            toContainSize(2, 3)
+                        }
+                    }
                 }
-                it("shows only failing without report option if there are 11 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 10") {
+                it("shows only failing without report option if there are 3 expected elements because default for showOnlyFailingIfMoreExpectedElementsThan is 2") {
+                    expect {
+                        expect(map).toContainFun(
+                            keyValue("a") { toEqual(1) },
+                            keyValue("b") { toEqual(2) },
+                            keyValue("c") { toEqual(3) }
+                        )
+                    }.toThrow<AssertionError> {
+                        message {
+                            elementSuccess(0, "1", "a", "1")
+                            elementFailing(0, "2", "a", "1")
+                            elementOutOfBound(3, "d", "4")
+                            toContainSize(2, 3)
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
# Outline
Add some specs to `MapToContainInOrderOnlyKeyValueExpectationsSpec` .

I made those reference to `IterableToContainInOrderOnlyValuesExpectationsSpec` .

# Issue
#1129 

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
