### PR TITLE
Overload deprecate in chronoZoned context

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
-
+import java.time.chrono.ChronoLocalDateTime //attempted import
 /**
  * Expects that the subject of `this` expectation is less than (`<`) [expected].
  * The comparison is carried out with [Comparable.compareTo].

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/comparableExpectations.kt
@@ -2,7 +2,6 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.*
-import java.time.chrono.ChronoLocalDateTime //attempted import
 /**
  * Expects that the subject of `this` expectation is less than (`<`) [expected].
  * The comparison is carried out with [Comparable.compareTo].

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
@@ -18,8 +18,7 @@ import java.time.chrono.ChronoZonedDateTime
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -29,8 +28,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
 
@@ -41,8 +39,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): N
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
 
@@ -53,8 +50,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Noth
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
 
@@ -65,10 +61,10 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): No
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
+
 @Suppress("UNUSED_PARAMETER", "unused")
 @Deprecated(
     "'notToBeLessThan' is now deprecated, use 'toBeAfterOrTheSamePointInTimeAs' instead.",
@@ -76,10 +72,10 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T)
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
+
 @Suppress("UNUSED_PARAMETER", "unused")
 @Deprecated(
     "'toBeGreaterThan' is now deprecated, use 'toBeAfter' instead.",
@@ -87,8 +83,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
@@ -6,9 +6,19 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.PleaseUseReplacementException
 import ch.tutteli.atrium.logic.*
 import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoZonedDateTime
+
+//Deprecated Overloads for comparableExpectations.kt
+@Deprecated("'toBeLessThan' is now deprecated, use 'isBefore' instead.",
+ReplaceWith("isBefore(expected"))
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor ")
 
 /**
  * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])
@@ -23,6 +33,7 @@ import java.time.chrono.ChronoZonedDateTime
 fun <T : ChronoZonedDateTime<out ChronoLocalDate>> Expect<T>.toBeBefore(
     expected: ChronoZonedDateTime<*>
 ): Expect<T> = _logicAppend { isBefore(expected) }
+
 
 /**
  * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
@@ -11,14 +11,87 @@ import ch.tutteli.atrium.logic.*
 import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoZonedDateTime
 
-//Deprecated Overloads for comparableExpectations.kt
-@Deprecated("'toBeLessThan' is now deprecated, use 'isBefore' instead.",
-ReplaceWith("isBefore(expected"))
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeLessThan' is now deprecated, use 'toBeBefore' instead.",
+    ReplaceWith("toBeBefore(expected")
+)
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
         "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeLessThanOrEqualTo is now deprecated, use 'toBeBeforeOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeBeforeOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor ")
+            ", use a feature extractor "
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'notToBeGreaterThan' is now deprecated, use 'toBeBeforeOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeBeforeOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeEqualComparingTo' is now deprecated, use 'toBeTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeGreaterThanOrEqualTo' is now deprecated, use 'toBeAfterOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeAfterOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'notToBeLessThan' is now deprecated, use 'toBeAfterOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeAfterOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeGreaterThan' is now deprecated, use 'toBeAfter' instead.",
+    ReplaceWith("toBeAfter(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
 
 /**
  * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/chronoZonedDateTimeExpectations.kt
@@ -28,8 +28,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -39,8 +38,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): N
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -50,8 +48,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Noth
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -61,8 +58,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): No
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -72,8 +68,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T)
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -83,8 +78,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeExpectations.kt
@@ -17,7 +17,6 @@ import java.time.chrono.ChronoZonedDateTime
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
@@ -28,7 +27,6 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
@@ -40,7 +38,6 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): N
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
@@ -52,7 +49,6 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Noth
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
@@ -64,7 +60,6 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): No
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
@@ -75,7 +70,6 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T)
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )
@@ -86,7 +80,6 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-        "" +
             "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
             ", use a feature extractor "
     )

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeExpectations.kt
@@ -6,9 +6,91 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.PleaseUseReplacementException
 import ch.tutteli.atrium.logic.*
 import java.time.chrono.ChronoLocalDate
 import java.time.chrono.ChronoZonedDateTime
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeLessThan' is now deprecated, use 'toBeBefore' instead.",
+    ReplaceWith("toBeBefore(expected")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeLessThanOrEqualTo is now deprecated, use 'toBeBeforeOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeBeforeOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'notToBeGreaterThan' is now deprecated, use 'toBeBeforeOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeBeforeOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeEqualComparingTo' is now deprecated, use 'toBeTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeGreaterThanOrEqualTo' is now deprecated, use 'toBeAfterOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeAfterOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'notToBeLessThan' is now deprecated, use 'toBeAfterOrTheSamePointInTimeAs' instead.",
+    ReplaceWith("toBeAfterOrTheSamePointInTimeAs(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+@Suppress("UNUSED_PARAMETER", "unused")
+@Deprecated(
+    "'toBeGreaterThan' is now deprecated, use 'toBeAfter' instead.",
+    ReplaceWith("toBeAfter(expected)")
+)
+fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThan(expected: T): Nothing =
+    throw PleaseUseReplacementException(
+        "" +
+            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
+            ", use a feature extractor "
+    )
+
 
 /**
  * Expects that the subject of `this` expectation (a [ChronoZonedDateTime])

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/chronoZonedDateTimeExpectations.kt
@@ -27,8 +27,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThan(expected: T): Nothing =
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -38,8 +37,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeLessThanOrEqualTo(expected: T): N
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -49,8 +47,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeGreaterThan(expected: T): Noth
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 @Suppress("UNUSED_PARAMETER", "unused")
@@ -60,8 +57,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeEqualComparingTo(expected: T): No
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T): Nothing =
     throw PleaseUseReplacementException(
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 @Suppress("UNUSED_PARAMETER", "unused")
 @Deprecated(
@@ -70,8 +66,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThanOrEqualTo(expected: T)
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 @Suppress("UNUSED_PARAMETER", "unused")
 @Deprecated(
@@ -80,8 +75,7 @@ fun <T : ChronoZonedDateTime<T>> Expect<T>.notToBeLessThan(expected: T): Nothing
 )
 fun <T : ChronoZonedDateTime<T>> Expect<T>.toBeGreaterThan(expected: T): Nothing =
     throw PleaseUseReplacementException(
-            "If you wish to use deprecated methods for ChronoZonedDateTime functions" +
-            ", use a feature extractor "
+        "If you wish to use deprecated methods for ChronoZonedDateTime functions, use a feature extractor"
     )
 
 


### PR DESCRIPTION
I've implemented the overloads and deprecations on chronoZonedDateTime functions for both API's and put them at the top of both files. If these need to be moved to a specific file, I'm happy to do so.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
