### PR TITLE
Migrate TextSpec from spek to kotest

### DIFF
--- a/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/TextSpec.kt
+++ b/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/TextSpec.kt
@@ -3,10 +3,9 @@ package ch.tutteli.atrium.reporting
 import ch.tutteli.atrium.api.infix.en_GB.messageToContain
 import ch.tutteli.atrium.api.infix.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import io.kotest.core.spec.style.DescribeSpec
 
-class TextSpec : Spek({
+class TextSpec : DescribeSpec({
     describe("creating a Text") {
         it("empty string; throws IllegalArgumentException") {
             expect{

--- a/misc/atrium-specs/build.gradle.kts
+++ b/misc/atrium-specs/build.gradle.kts
@@ -4,7 +4,6 @@ description = "Provides specifications of Atrium which can be reused by" +
 val mockkVersion: String by rootProject.extra
 val spekVersion: String by rootProject.extra
 val niokVersion: String by rootProject.extra
-val kotestVersion: String by rootProject.extra
 val spekExtensionsVersion: String by rootProject.extra
 val mockitoKotlinVersion: String by rootProject.extra
 val kotestVersion: String by rootProject.extra

--- a/misc/atrium-specs/build.gradle.kts
+++ b/misc/atrium-specs/build.gradle.kts
@@ -4,6 +4,7 @@ description = "Provides specifications of Atrium which can be reused by" +
 val mockkVersion: String by rootProject.extra
 val spekVersion: String by rootProject.extra
 val niokVersion: String by rootProject.extra
+val kotestVersion: String by rootProject.extra
 val spekExtensionsVersion: String by rootProject.extra
 val mockitoKotlinVersion: String by rootProject.extra
 val kotestVersion: String by rootProject.extra


### PR DESCRIPTION
Migrated the TextSpec file from Spek to Kotest using Descibe Spec.

Resolves: #1197
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
