### PR TITLE
migrate AdjustStackSpec from Spek to Kotest

### DIFF
--- a/atrium-core/src/jvmTest/kotlin/ch/tutteli/atrium/reporting/erroradjusters/AdjustStackSpec.kt
+++ b/atrium-core/src/jvmTest/kotlin/ch/tutteli/atrium/reporting/erroradjusters/AdjustStackSpec.kt
@@ -13,12 +13,13 @@ import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.creating.RootExpectBuilder
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.reporting.AtriumErrorAdjuster
+import io.kotest.core.spec.style.DescribeSpec
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 @ExperimentalNewExpectTypes
 @ExperimentalComponentFactoryContainer
-class AdjustStackSpec : Spek({
+class AdjustStackSpec : DescribeSpec({
 
     describe("no-op adjuster") {
         fun <T : Any> assertNoOp(subject: T) =

--- a/atrium-core/src/jvmTest/kotlin/ch/tutteli/atrium/reporting/erroradjusters/AdjustStackSpec.kt
+++ b/atrium-core/src/jvmTest/kotlin/ch/tutteli/atrium/reporting/erroradjusters/AdjustStackSpec.kt
@@ -14,8 +14,6 @@ import ch.tutteli.atrium.logic.creating.RootExpectBuilder
 import ch.tutteli.atrium.logic.utils.expectLambda
 import ch.tutteli.atrium.reporting.AtriumErrorAdjuster
 import io.kotest.core.spec.style.DescribeSpec
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 
 @ExperimentalNewExpectTypes
 @ExperimentalComponentFactoryContainer


### PR DESCRIPTION
Migrated the AdjustStackSpec file from Spek to Kotest using Describe Spec.

It Resolves: #1201 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
