### PR TITLE
Migrate files from DescribeSpec to FunSpec

### DIFF
--- a/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/AtriumErrorSpec.kt
+++ b/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/AtriumErrorSpec.kt
@@ -4,11 +4,11 @@ import ch.tutteli.atrium.api.infix.en_GB.feature
 import ch.tutteli.atrium.api.infix.en_GB.toEqual
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.reporting.erroradjusters.NoOpAtriumErrorAdjuster
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
 
-class AtriumErrorSpec : DescribeSpec ({
-    describe("creating an AtriumError") {
-        it("has `null` as cause - regression for #303") {
+class AtriumErrorSpec : FunSpec ({
+    context("creating an AtriumError") {
+        test("has `null` as cause - regression for #303") {
             val e = AtriumError.create("hello world", NoOpAtriumErrorAdjuster)
             expect(e).feature(Throwable::cause) toEqual null
         }

--- a/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/TextSpec.kt
+++ b/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/TextSpec.kt
@@ -3,11 +3,11 @@ package ch.tutteli.atrium.reporting
 import ch.tutteli.atrium.api.infix.en_GB.messageToContain
 import ch.tutteli.atrium.api.infix.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.expect
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
 
-class TextSpec : DescribeSpec({
-    describe("creating a Text") {
-        it("empty string; throws IllegalArgumentException") {
+class TextSpec : FunSpec({
+    context("creating a Text") {
+        test("empty string; throws IllegalArgumentException") {
             expect{
                 Text("")
             }.toThrow<IllegalArgumentException> {
@@ -15,7 +15,7 @@ class TextSpec : DescribeSpec({
             }
         }
 
-        it("blank string; does not throw") {
+        test("blank string; does not throw") {
             Text("  ")
         }
     }

--- a/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/text/BulletPointProviderSpec.kt
+++ b/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/text/BulletPointProviderSpec.kt
@@ -8,12 +8,12 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.logic.*
 import ch.tutteli.atrium.specs.defaultBulletPoints
+import io.kotest.core.spec.style.FunSpec
 import kotlin.reflect.KClass
-import io.kotest.core.spec.style.DescribeSpec
 
 @OptIn(ExperimentalWithOptions::class)
 @ExperimentalComponentFactoryContainer
-class BulletPointProviderSpec : DescribeSpec({
+class BulletPointProviderSpec : FunSpec({
 
     fun <T> expectWitNewBulletPoint(newBulletPoint: Pair<KClass<out BulletPointIdentifier>, String>, t: T) =
         expect(t).withOptions {
@@ -25,7 +25,7 @@ class BulletPointProviderSpec : DescribeSpec({
             }
         }
 
-    describe("specifying a provider allows to override bullet points") {
+    context("specifying a provider allows to override bullet points") {
         val redefinedBulletPoints =
             mapOf<KClass<out BulletPointIdentifier>, Pair<String, (Pair<KClass<out BulletPointIdentifier>, String>) -> Expect<*>>>(
                 RootAssertionGroupType::class to ("* " to { p ->
@@ -88,7 +88,7 @@ class BulletPointProviderSpec : DescribeSpec({
             )
 
         defaultBulletPoints.map { (kClass, defaultBulletPoint) ->
-            it("redefining ${kClass.simpleName}") {
+            test("redefining ${kClass.simpleName}") {
                 val (newBulletPoint, expectBuilder) = redefinedBulletPoints.getOrElse(kClass) {
                     throw AssertionError("case not covered")
                 }

--- a/bundles/fluent-en_GB/atrium-fluent-en_GB/src/jvmTest/kotlin/custom/SmokeSpec.kt
+++ b/bundles/fluent-en_GB/atrium-fluent-en_GB/src/jvmTest/kotlin/custom/SmokeSpec.kt
@@ -12,25 +12,25 @@ import ch.tutteli.atrium.logic.createDescriptiveAssertion
 import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
 import ch.tutteli.atrium.translations.DescriptionBasic.TO_BE
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Paths
 
-class SmokeSpec : DescribeSpec({
-    describe("Smoke Test") {
-        it("see if `toEqual` can be used") {
+class SmokeSpec : FunSpec({
+    context("Smoke Test") {
+        test("see if `toEqual` can be used") {
             expect(1).toEqual(1)
         }
 
-        it("see if `Path.existsNot` can be used") {
+        test("see if `Path.existsNot` can be used") {
             expect(Paths.get("nonExisting")).notToExist()
         }
 
-        it("see if own expectation function without i18n can be used") {
+        test("see if own expectation function without i18n can be used") {
             expect(2).toBeEven()
             expect(1).toBeOdd()
         }
 
-        it("see if own expectation function with i18n can be used") {
+        test("see if own expectation function with i18n can be used") {
             expect(4).toBeAMultipleOf(2)
         }
     }


### PR DESCRIPTION
js target doesn't support Describe Spec of Kotest hence we have to migrate the spek to Fun spec before enabling js target again. 
I am migrating the already migrated DescribeSpec files to FunSpec.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
