### PR TITLE
Migrate DescriptiveWithBasedOnSubjectSpec from spek to kotest 

### DIFF
--- a/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/assertions/builders/DescriptiveWithBasedOnSubjectSpec.kt
+++ b/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/assertions/builders/DescriptiveWithBasedOnSubjectSpec.kt
@@ -5,16 +5,16 @@ import ch.tutteli.atrium.core.falseProvider
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic._logic
 import ch.tutteli.atrium.logic.utils.expectLambda
-import ch.tutteli.atrium.specs.SubjectLessSpec
-import org.spekframework.spek2.Spek
+import ch.tutteli.atrium.specs.subjectLessKotestBasedSpec
+import io.kotest.core.spec.style.FunSpec
 
-class DescriptiveWithBasedOnSubjectSpec : Spek({
+class DescriptiveWithBasedOnSubjectSpec : FunSpec({
 
     fun addDescriptive(f: (Expect<Int>, Descriptive.HoldsOption) -> Assertion) = expectLambda<Int> {
         _logic.append(f(this, assertionBuilder.descriptive))
     }
 
-    include(object : SubjectLessSpec<Int>("",
+    include(subjectLessKotestBasedSpec("",
         "withTest" to addDescriptive { expect, builder ->
             builder.withTest(expect) { it < 3 }
                 .withDescriptionAndRepresentation("what ever", 1)
@@ -66,5 +66,5 @@ class DescriptiveWithBasedOnSubjectSpec : Spek({
                 .withDescriptionAndRepresentation("what ever", 1)
                 .build()
         }
-    ) {})
+    ))
 })

--- a/misc/atrium-specs/build.gradle.kts
+++ b/misc/atrium-specs/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 apiWithExclude("io.kotest:kotest-runner-junit5:$kotestVersion")
                 // necessary in order that intellij sees the io.kotest symbols (runner-junit5 actually already depends on it)
                 apiWithExclude("io.kotest:kotest-framework-api:$kotestVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.3.9")
             }
         }
 

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/SubjectLessKotestBasedSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/SubjectLessKotestBasedSpec.kt
@@ -1,0 +1,85 @@
+package ch.tutteli.atrium.specs
+
+import ch.tutteli.atrium.api.fluent.en_GB.feature
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.fluent.en_GB.toHaveElementsAndAll
+import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.assertions.Assertion
+import ch.tutteli.atrium.assertions.AssertionGroup
+import ch.tutteli.atrium.assertions.ExplanatoryAssertionGroupType
+import ch.tutteli.atrium.assertions.builders.assertionBuilder
+import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
+import ch.tutteli.atrium.core.None
+import ch.tutteli.atrium.creating.CollectingExpect
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
+import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.creating.RootExpectBuilder
+import ch.tutteli.atrium.reporting.AtriumErrorAdjuster
+import ch.tutteli.atrium.reporting.erroradjusters.NoOpAtriumErrorAdjuster
+import io.kotest.core.spec.style.funSpec
+
+fun <T> subjectLessKotestBasedSpec(
+    groupPrefix: String,
+    vararg assertionCreator: Pair<String, Expect<T>.() -> Unit>
+) = funSpec {
+    context("${groupPrefix}assertion function can be used in an ${AssertionGroup::class.simpleName} with an ${ExplanatoryAssertionGroupType::class.simpleName} and report without failure") {
+        assertionCreator.forEach { (name, createAssertion) ->
+            test("fun `$name`") {
+                @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+                @UseExperimental(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
+                val assertions = CollectingExpect<T>(None, expect(1)._logic.components)
+                    .appendAsGroup(createAssertion)
+                    .getAssertions()
+
+                expandAssertionGroups(assertions)
+
+
+                @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+                @UseExperimental(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
+                val expect = RootExpectBuilder.forSubject(1.0)
+                    .withVerb("custom assertion verb")
+                    .withOptions {
+                        withComponent(AtriumErrorAdjuster::class) { _ -> NoOpAtriumErrorAdjuster }
+                    }
+                    .build()
+
+                val explanatoryGroup = assertionBuilder.explanatoryGroup
+                    .withDefaultType
+                    .withAssertions(assertions)
+                    .build()
+                expect._logic.append(explanatoryGroup)
+            }
+        }
+    }
+
+    context("${groupPrefix}expectation function does not hold if there is no subject") {
+        assertionCreator.forEach { (name, createAssertion) ->
+            test("fun `$name`") {
+                @Suppress("DEPRECATION" /* OptIn is only available since 1.3.70 which we cannot use if we want to support 1.2 */)
+                @UseExperimental(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
+                val assertions = CollectingExpect<T>(None, expect(1)._logic.components)
+                    .appendAsGroup(createAssertion)
+                    .getAssertions()
+                expect(assertions).toHaveElementsAndAll {
+                    feature(Assertion::holds).toEqual(false)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Calls recursively [AssertionGroup.assertions] on every expectation-group contained in [assertions].
+ */
+private tailrec fun expandAssertionGroups(assertions: List<Assertion>) {
+    if (assertions.isEmpty()) return
+
+    expandAssertionGroups(
+        assertions
+            .asSequence()
+            .filterIsInstance<AssertionGroup>()
+            .flatMap { it.assertions.asSequence() }
+            .toList()
+    )
+}


### PR DESCRIPTION
Refers to https://github.com/robstoll/atrium/issues/1194


______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
