### PR TITLE
#1286 add as local date

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
@@ -19,6 +19,8 @@ import java.util.Date
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.DateSubjectChangerSamples.asLocalDateFeature
+ *
  * @since 0.19.0
  */
 fun <T : Date> Expect<T>.asLocalDate(): Expect<LocalDate> =
@@ -30,6 +32,8 @@ fun <T : Date> Expect<T>.asLocalDate(): Expect<LocalDate> =
  * The transformation as such is not reflected in reporting.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.DateSubjectChangerSamples.asLocalDate
  *
  * @since 0.19.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
@@ -1,0 +1,32 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.changeSubject
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+
+/**
+ * Turns `Expect<Date>` into `Expect<LocalDate>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.20.0
+ */
+fun <T : Date> Expect<T>.asLocalDate(): Expect<LocalDate> =
+    _logic.changeSubject.unreported { it.toInstant().atZone(ZoneId.systemDefault()).toLocalDate() }
+
+/**
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for the subject as[Date].
+ *
+ * The transformation as such is not reflected in reporting.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.20.0
+ */
+fun <T:Date> Expect<T>.asLocalDate(assertionCreator:Expect<LocalDate>.()->Unit): Expect<T> =
+    apply{ asLocalDate()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
@@ -28,5 +28,5 @@ fun <T : Date> Expect<T>.asLocalDate(): Expect<LocalDate> =
  *
  * @since 0.20.0
  */
-fun <T:Date> Expect<T>.asLocalDate(assertionCreator:Expect<LocalDate>.()->Unit): Expect<T> =
-    apply{ asLocalDate()._logic.appendAsGroup(assertionCreator) }
+fun <T : Date> Expect<T>.asLocalDate(assertionCreator: Expect<LocalDate>.() -> Unit): Expect<T> =
+    apply { asLocalDate()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
@@ -19,7 +19,7 @@ import java.util.Date
  *
  * @return The newly created [Expect] for the transformed subject.
  *
- * @since 0.20.0
+ * @since 0.19.0
  */
 fun <T : Date> Expect<T>.asLocalDate(): Expect<LocalDate> =
     _logic.changeSubject.unreported { it.toInstant().atZone(ZoneId.systemDefault()).toLocalDate() }
@@ -31,7 +31,7 @@ fun <T : Date> Expect<T>.asLocalDate(): Expect<LocalDate> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.20.0
+ * @since 0.19.0
  */
 fun <T : Date> Expect<T>.asLocalDate(assertionCreator: Expect<LocalDate>.() -> Unit): Expect<T> =
     apply { asLocalDate()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/dateSubjectChangers.kt
@@ -1,3 +1,8 @@
+@file:Suppress(
+    // TODO remove once https://youtrack.jetbrains.com/issue/KT-35343 is fixed
+    "JAVA_MODULE_DOES_NOT_READ_UNNAMED_MODULE"
+)
+
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/DateAsLocalDateExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/DateAsLocalDateExpectationsSpec.kt
@@ -1,0 +1,18 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.integration.DateAsLocalDateExpectationsSpec
+import ch.tutteli.atrium.specs.notImplemented
+import java.util.Date
+
+class DateAsLocalDateExpectationsSpec : DateAsLocalDateExpectationsSpec(
+    Expect<Date>::asLocalDate
+) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun isEqualToTest() {
+        var date: Expect<Date> = notImplemented()
+
+        date.asLocalDate()
+        date = date.asLocalDate {  }
+    }
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/DateAsLocalDateExpectationsSpec.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/DateAsLocalDateExpectationsSpec.kt
@@ -9,7 +9,7 @@ class DateAsLocalDateExpectationsSpec : DateAsLocalDateExpectationsSpec(
     Expect<Date>::asLocalDate
 ) {
     @Suppress("unused", "UNUSED_VALUE")
-    private fun isEqualToTest() {
+    private fun ambiguityTest() {
         var date: Expect<Date> = notImplemented()
 
         date.asLocalDate()

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
@@ -1,0 +1,51 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.internal.expect
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import kotlin.test.Test
+
+class DateSubjectChangerSamples {
+
+    private val formatter: DateFormat = SimpleDateFormat("yyyy-MM-dd")
+
+    @Test
+    fun asLocalDateFeature() {
+        val date = formatter.parse("1995-07-17")
+
+        expect(date)
+            .asLocalDate() // subject is now of type LocalDate
+            .toEqual(LocalDate.parse("1995-07-17"))
+
+        fails {
+            expect(date)
+                .asLocalDate()                                       // subject is now of type LocalDate
+                .toBeAfter(LocalDate.parse("2025-07-17"))       // fails
+                .toBeBefore(LocalDate.parse("1996-07-17"))      // not evaluated/reported because `cause` already fails
+                                                                     // use `.asLocalDate { ... }` if you want all assertions evaluated
+        }
+    }
+
+    @Test
+    fun asLocalDate() {
+        val date = formatter.parse("1995-07-17")
+
+        expect(date).asLocalDate { // subject within this expectation-group is of type LocalDate
+            toBeAfterOrTheSamePointInTimeAs(LocalDate.parse("1994-07-17"))
+            toBeBeforeOrTheSamePointInTimeAs(LocalDate.parse("1996-07-17"))
+        } // subject here is back to type Date
+
+        fails {
+            // all expectations inside an expectation-group are evaluated together; for more details see:
+            // https://github.com/robstoll/atrium#define-single-expectations-or-an-expectation-group
+
+            expect(date).asLocalDate {
+                toBeAfter(LocalDate.parse("2025-07-17"))            // fails
+                toBeBefore(LocalDate.parse("1994-07-17"))           // still evaluated even though `toBeAfter` already fails
+                                                                        // use `.asLocalDate().` if you want a fail fast behaviour
+            }
+        }
+    }
+}

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
@@ -21,10 +21,10 @@ class DateSubjectChangerSamples {
 
         fails {
             expect(date)
-                .asLocalDate()                                       // subject is now of type LocalDate
+                .asLocalDate()                                  // subject is now of type LocalDate
                 .toBeAfter(LocalDate.parse("2025-07-17"))       // fails
-                .toBeBefore(LocalDate.parse("1996-07-17"))      // not evaluated/reported because `cause` already fails
-                                                                     // use `.asLocalDate { ... }` if you want all assertions evaluated
+                .toBeBefore(LocalDate.parse("1996-07-17"))      // not evaluated/reported because `toBeAfter` already fails
+                                                                // use `.asLocalDate { ... }` if you want all assertions evaluated
         }
     }
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
@@ -44,7 +44,7 @@ class DateSubjectChangerSamples {
             expect(date).asLocalDate {
                 toBeAfter(LocalDate.parse("2025-07-17"))            // fails
                 toBeBefore(LocalDate.parse("1994-07-17"))           // still evaluated even though `toBeAfter` already fails
-                                                                        // use `.asLocalDate().` if you want a fail fast behaviour
+                                                                    // use `.asLocalDate().` if you want a fail fast behaviour
             }
         }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
@@ -35,7 +35,7 @@ class DateSubjectChangerSamples {
         expect(date).asLocalDate { // subject within this expectation-group is of type LocalDate
             toBeAfterOrTheSamePointInTimeAs(LocalDate.parse("1994-07-17"))
             toBeBeforeOrTheSamePointInTimeAs(LocalDate.parse("1996-07-17"))
-        } // subject here is back to type Date
+        } // subject here is back to type java.util.Date
 
         fails {
             // all expectations inside an expectation-group are evaluated together; for more details see:

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
@@ -19,6 +19,8 @@ import java.util.Date
  *
  * @return The newly created [Expect] for the transformed subject.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.DateSubjectChangerSamples.asLocalDateFeature
+ *
  * @since 0.19.0
  */
 infix fun <T : Date> Expect<T>.asLocalDate(@Suppress("UNUSED_PARAMETER") o : o) : Expect<LocalDate> =
@@ -31,6 +33,8 @@ infix fun <T : Date> Expect<T>.asLocalDate(@Suppress("UNUSED_PARAMETER") o : o) 
  * The transformation as such is not reflected in reporting.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.DateSubjectChangerSamples.asLocalDate
  *
  * @since 0.19.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
@@ -1,3 +1,8 @@
+@file:Suppress(
+    // TODO remove once https://youtrack.jetbrains.com/issue/KT-35343 is fixed
+    "JAVA_MODULE_DOES_NOT_READ_UNNAMED_MODULE"
+)
+
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
@@ -1,0 +1,33 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.logic._logic
+import ch.tutteli.atrium.logic.changeSubject
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+
+/**
+ * Turns `Expect<Date>` into `Expect<LocalDate>`.
+ *
+ * The transformation as such is not reflected in reporting.
+ *
+ * @return The newly created [Expect] for the transformed subject.
+ *
+ * @since 0.20.0
+ */
+infix fun <T : Date> Expect<T>.asLocalDate(@Suppress("UNUSED_PARAMETER") o : o) : Expect<LocalDate> =
+    _logic.changeSubject.unreported { it.toInstant().atZone(ZoneId.systemDefault()).toLocalDate() }
+
+/**
+ * Expects that the subject of `this` expectation holds all assertions the given [assertionCreator] creates for
+ * the subject as [LocalDate].
+ *
+ * The transformation as such is not reflected in reporting.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.20.0
+ */
+infix fun <T : Date> Expect<T>.asLocalDate(assertionCreator : Expect<LocalDate>.() -> Unit) : Expect<T> =
+    apply { asLocalDate(o)._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/dateSubjectChangers.kt
@@ -19,7 +19,7 @@ import java.util.Date
  *
  * @return The newly created [Expect] for the transformed subject.
  *
- * @since 0.20.0
+ * @since 0.19.0
  */
 infix fun <T : Date> Expect<T>.asLocalDate(@Suppress("UNUSED_PARAMETER") o : o) : Expect<LocalDate> =
     _logic.changeSubject.unreported { it.toInstant().atZone(ZoneId.systemDefault()).toLocalDate() }
@@ -32,7 +32,7 @@ infix fun <T : Date> Expect<T>.asLocalDate(@Suppress("UNUSED_PARAMETER") o : o) 
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.20.0
+ * @since 0.19.0
  */
 infix fun <T : Date> Expect<T>.asLocalDate(assertionCreator : Expect<LocalDate>.() -> Unit) : Expect<T> =
     apply { asLocalDate(o)._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/DateAsLocalDateExpectionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/DateAsLocalDateExpectionsSpec.kt
@@ -1,6 +1,5 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
-import ch.tutteli.atrium.api.fluent.en_GB.asLocalDate
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.DateAsLocalDateExpectationsSpec
 import ch.tutteli.atrium.specs.notImplemented

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/DateAsLocalDateExpectionsSpec.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/DateAsLocalDateExpectionsSpec.kt
@@ -1,0 +1,19 @@
+package ch.tutteli.atrium.api.infix.en_GB
+
+import ch.tutteli.atrium.api.fluent.en_GB.asLocalDate
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.integration.DateAsLocalDateExpectationsSpec
+import ch.tutteli.atrium.specs.notImplemented
+import java.util.Date
+
+class DateAsLocalDateExpectionsSpec : DateAsLocalDateExpectationsSpec(
+    Expect<Date>::asLocalDate
+) {
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var date: Expect<Date> = notImplemented()
+
+        date asLocalDate o
+        date = date asLocalDate {  }
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
@@ -1,0 +1,46 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.verbs.internal.expect
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import kotlin.test.Test
+
+class DateSubjectChangerSamples {
+
+    private val formatter: DateFormat = SimpleDateFormat("yyyy-MM-dd")
+
+    @Test
+    fun asLocalDateFeature() {
+        val date = formatter.parse("1995-07-17")
+
+        expect(date) asLocalDate o toEqual(LocalDate.parse("1995-07-17")) // Subject is now of type LocalDate
+
+        fails {
+            expect(date) asLocalDate
+                o toBeAfter(LocalDate.parse("2025-07-17")) toBeBefore(LocalDate.parse("1996-07-17"))
+        }
+    }
+
+    @Test
+    fun asLocalDate() {
+        val date = formatter.parse("1995-07-17")
+
+        expect(date) asLocalDate { // subject within this expectation-group is of type LocalDate
+            it toBeAfterOrTheSamePointInTimeAs(LocalDate.parse("1994-07-17"))
+            it toBeBeforeOrTheSamePointInTimeAs(LocalDate.parse("1996-07-17"))
+        } // subject here is back to type Date
+
+        fails {
+            // all expectations inside an expectation-group are evaluated together; for more details see:
+            // https://github.com/robstoll/atrium#define-single-expectations-or-an-expectation-group
+
+            expect(date) asLocalDate {
+                it toBeAfter(LocalDate.parse("2025-07-17"))            // fails
+                it toBeBefore(LocalDate.parse("1994-07-17"))           // still evaluated even though `toBeAfter` already fails
+                                                                            // use ` asLocalDate().` if you want a fail fast behaviour
+            }
+        }
+    }
+}

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
@@ -39,7 +39,7 @@ class DateSubjectChangerSamples {
             expect(date) asLocalDate {
                 it toBeAfter(LocalDate.parse("2025-07-17"))            // fails
                 it toBeBefore(LocalDate.parse("1994-07-17"))           // still evaluated even though `toBeAfter` already fails
-                                                                            // use ` asLocalDate().` if you want a fail fast behaviour
+                                                                       // use ` asLocalDate().` if you want a fail fast behaviour
             }
         }
     }

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
@@ -30,7 +30,7 @@ class DateSubjectChangerSamples {
         expect(date) asLocalDate { // subject within this expectation-group is of type LocalDate
             it toBeAfterOrTheSamePointInTimeAs(LocalDate.parse("1994-07-17"))
             it toBeBeforeOrTheSamePointInTimeAs(LocalDate.parse("1996-07-17"))
-        } // subject here is back to type Date
+        } // subject here is back to type java.util.Date
 
         fails {
             // all expectations inside an expectation-group are evaluated together; for more details see:

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/DateAsLocalDateExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/DateAsLocalDateExpectationsSpec.kt
@@ -5,16 +5,20 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.text.DateFormat
+import java.text.SimpleDateFormat
 import java.time.LocalDate
-import java.util.Date
+import java.util.*
+
 
 abstract class DateAsLocalDateExpectationsSpec(
     asLocalDate: Expect<Date>.(Expect<LocalDate>.() -> Unit) -> Expect<Date>
 ) : Spek({
     describe("asLocalDate") {
         it("transformation can be applied and a subsequent assertion made") {
-            val date = Date()
-            expect(date).asLocalDate { toEqual(LocalDate.now()) }
+            val formatter: DateFormat = SimpleDateFormat("yyyy-MM-dd")
+            val date = formatter.parse("1995-07-17")
+            expect(date).asLocalDate { toEqual(LocalDate.parse("1995-07-17")) }
         }
     }
 })

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/DateAsLocalDateExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/DateAsLocalDateExpectationsSpec.kt
@@ -1,0 +1,20 @@
+package ch.tutteli.atrium.specs.integration
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.creating.Expect
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+import java.util.Date
+
+abstract class DateAsLocalDateExpectationsSpec(
+    asLocalDate: Expect<Date>.(Expect<LocalDate>.() -> Unit) -> Expect<Date>
+) : Spek({
+    describe("asLocalDate") {
+        it("transformation can be applied and a subsequent assertion made") {
+            val date = Date()
+            expect(date).asLocalDate { toEqual(LocalDate.now()) }
+        }
+    }
+})


### PR DESCRIPTION
Fixes #1285. Adds an extension method to transform Expect<java.util.Date> to Expect<java.time.LocalDate> in both fluent and infix api styles.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
