### PR TITLE
Update AssertJ syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ hence reports that both expectations do not hold.
 The reporting can be read as `I expected the subject of the expectation, which was 10, to be less than 5 and to be greater than 10`
 
 This is similar to the concept of soft assertions in AssertJ with the difference that you do not need an extra utility,
-you do not have to repeat the subject and most importantly, you do not have to deal with calling `assertAll()`.
+and you do not have to repeat the subject.
 The above is the equivalent of the following AssertJ example:
 ```kotlin
 assertSoftly {

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ you do not have to repeat the subject and most importantly, you do not have to d
 The above is the equivalent of the following AssertJ example:
 ```kotlin
 assertSoftly {
-    asserThat(4 + 6).isLessThan(5)
+    assertThat(4 + 6).isLessThan(5)
     assertThat(4 + 6).isGreatThan(10)
 }
 

--- a/README.md
+++ b/README.md
@@ -334,22 +334,26 @@ This is similar to the concept of soft assertions in AssertJ with the difference
 you do not have to repeat the subject and most importantly, you do not have to deal with calling `assertAll()`.
 The above is the equivalent of the following AssertJ example:
 ```kotlin
-val softly = SoftAssertions()
-softly.asserThat(4 + 6).isLessThan(5)
-softly.assertThat(4 + 6).isGreatThan(10)
-// Do not forget to call SoftAssertions global verification !
-softly.assertAll()
+assertSoftly {
+    asserThat(4 + 6).isLessThan(5)
+    assertThat(4 + 6).isGreatThan(10)
+}
+
+fun assertSoftly(body: SoftAssertions.() -> Unit) =
+    SoftAssertions.assertSoftly(body)
 ```
 
 Moreover, in contrast to AssertJ, the block syntax is provided at many places and not only on the top-level. 
 As an example, the following AssertJ example:
 ```kotlin
-val softly = SoftAssertions()
-softly.assertThat(mansion.numOfGuests).isEqualTo(7)
-softly.assertThat(mansion.kitchen.stastus).isEqualTo("clean")
-softly.assertThat(mansion.kitchen.numOfTables).isGreaterThan(5).isLessThan(10)
-// Do not forget to call SoftAssertions global verification !
-softly.assertAll()
+assertSoftly {
+    assertThat(mansion.numOfGuests).isEqualTo(7)
+    assertThat(mansion.kitchen.stastus).isEqualTo("clean")
+    assertThat(mansion.kitchen.numOfTables).isGreaterThan(5).isLessThan(10)
+}
+
+fun assertSoftly(body: SoftAssertions.() -> Unit) =
+    SoftAssertions.assertSoftly(body)
 ```
 could be written as follows in Atrium (see also [Feature Extractors](#feature-extractors)). 
 ```kotlin


### PR DESCRIPTION
AssertJ does provide SoftAssertions.assertSoftly(block) so users don't accidentally forget calling `assertAll`. Unfortunately, they do not provide Kotlin wrapper yet, so `softly.assertThat(..)` have to be duplicated.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
