### PR TITLE
fix: display mismatch reasons in "following elements were mismatched"

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ThrowableFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ThrowableFeatureExtractorSamples.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.toContainSize
 import kotlin.test.Test
 
 class ThrowableFeatureExtractorSamples {
@@ -12,6 +13,33 @@ class ThrowableFeatureExtractorSamples {
 
         fails {
             expect(RuntimeException("abc")).messageToContain("d")
+        }
+    }
+
+    @Test
+    fun messageFeature2() {
+        data class User(val login: String, val password: String)
+
+        expect(listOf(User("joe", "qwerty"), User("j", "qwerty1"))) {
+            toHaveElementsAndAll {
+                feature("login", { login })
+                    .feature("size", { length })
+                    .because("login should be longer than one letter") {
+                        toBeGreaterThan(1)
+                    }
+                feature("password", { password })
+                    .because("password should be secure") {
+                        notToEqual("qwerty")
+                    }
+            }
+        }
+
+        expect(listOf(Throwable("abc"))) {
+            toHaveElementsAndAll {
+                message
+                    .toContain("d")
+                    .toStartWith("z")
+            }
         }
     }
 

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/impl/BaseExpectImpl.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/impl/BaseExpectImpl.kt
@@ -63,8 +63,7 @@ abstract class BaseExpectImpl<T>(
             representationInsteadOfFeature?.let { provider ->
                 maybeSubject.fold({ null }) { provider(it) }
             } ?: maybeSubject.getOrElse {
-                // a RootExpect without a defined subject is almost certain a bug
-                Text(SHOULD_NOT_BE_SHOWN_TO_THE_USER_BUG)
+                Text.EMPTY
             }
     }
 }

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/text/impl/TextFeatureAssertionGroupFormatter.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/text/impl/TextFeatureAssertionGroupFormatter.kt
@@ -61,6 +61,6 @@ class TextFeatureAssertionGroupFormatter(
         parameterObject: AssertionFormatterParameterObject
     ) : AssertionGroup by assertionGroup {
         override val description: Translatable = newName
-        override val representation: Any = if(parameterObject.isNotInExplanatoryFilterGroup()) assertionGroup.representation else Text.EMPTY
+        override val representation: Any = assertionGroup.representation
     }
 }

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/AssertionCreatorSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/AssertionCreatorSpec.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.creating.ErrorMessages
+import ch.tutteli.atrium.logic._logic
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -20,9 +21,14 @@ abstract class AssertionCreatorSpec<T>(
             describe("fun `$name`") {
                 it("throws and only reports the lambda which was empty") {
                     expect {
-                        expect(subject)
-                            .createAssertionOk()
-                            .createAssertionFail()
+                        try {
+                            expect(subject)
+                                .createAssertionOk()
+                                .createAssertionFail()
+                        }catch(it: Error){
+                            println("err: ${it.message}, ${it.cause}")
+                            throw it
+                        }
                     }.toThrow<AssertionError> {
                         message {
                             toContain(


### PR DESCRIPTION
Fixes https://github.com/robstoll/atrium/issues/1359



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
