### PR TITLE
un-deprecate nested `expect`s in preparation of #1330

### DIFF
--- a/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -15,7 +15,7 @@ import ch.tutteli.atrium.reporting.translating.StringBasedTranslatable
 /**
  * Creates an [Expect] for the given [subject].
  *
- * @param subject The subject for which we are going to postulate assertions.
+ * @param subject The subject for which we are going to postulate expectations.
  *
  * @return The newly created [RootExpect].
  * @throws AssertionError in case an assertion does not hold.
@@ -34,7 +34,7 @@ fun <T> expect(subject: T): RootExpect<T> =
  * Creates an [Expect] for the given [subject] and [Expect.addAssertionsCreatedBy] the
  * given [assertionCreator]-lambda where the created [Assertion]s are added as a group and reported as a whole.
  *
- * @param subject The subject for which we are going to postulate assertions.
+ * @param subject The subject for which we are going to postulate expectations.
  * @param assertionCreator expectation-group with a non-fail fast behaviour.
  *
  * @return The newly created [RootExpect].

--- a/misc/atrium-verbs/src/commonMain/kotlin/ch/tutteli/atrium/api.verbs/expect.kt
+++ b/misc/atrium-verbs/src/commonMain/kotlin/ch/tutteli/atrium/api.verbs/expect.kt
@@ -11,7 +11,7 @@ import ch.tutteli.atrium.logic.manualFeature
 /**
  * Creates an [Expect] for the given [subject].
  *
- * @param subject The subject for which we are going to postulate assertions.
+ * @param subject The subject for which we are going to postulate expectations.
  *
  * @return The newly created [Expect].
  * @throws AssertionError in case an assertion does not hold.
@@ -26,7 +26,7 @@ fun <T> expect(subject: T): RootExpect<T> =
  * Creates an [Expect] for the given [subject] and appends the expectations the given
  * [assertionCreator]-lambda creates as group to it.
  *
- * @param subject The subject for which we are going to postulate assertions.
+ * @param subject The subject for which we are going to postulate expectations.
  * @param assertionCreator expectation-group with a non-fail fast behaviour.
  * @return The newly created [Expect].
  * @throws AssertionError in case an assertion does not hold.
@@ -34,13 +34,34 @@ fun <T> expect(subject: T): RootExpect<T> =
 fun <T> expect(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     expect(subject)._logic.appendAsGroup(assertionCreator)
 
-@Deprecated(
-    "`expect` should not be nested, use `feature` or `its` instead.",
-    ReplaceWith(
-        "feature(\"name of the feature\") { newSubject /* see also other overloads which do not require `name of the feature` and provide the subject as parameter, e.g. feature { f(it::yourFeature) } */}",
-        "ch.tutteli.atrium.api.infix.en_GB.feature",
-        "ch.tutteli.atrium.api.fluent.en_GB.feature"
-    )
-)
+/**
+ * Creates an [Expect] for the given (unrelated) [newSubject].
+ *
+ * We recommend to use `its` or `feature` or another feature extractor if you want to extract a feature out of the
+ * current subject.
+ *
+ * @param newSubject The subject for which we are going to postulate expectations.
+ * @return The newly created [Expect].
+ * @throws AssertionError in case an assertion does not hold.
+ *
+ * @since 0.19.0
+ */
 fun <T, R> Expect<T>.expect(newSubject: R): FeatureExpect<T, R> =
     _logic.manualFeature(EXPECT) { newSubject }.transform()
+
+/**
+ * Creates an [Expect] for the given (unrelated) [newSubject] and appends the expectations the given
+ * [assertionCreator]-lambda creates as group to it.
+ *
+ * We recommend to use `its` or `feature` or another feature extractor if you want to extract a feature out of the
+ * current subject.
+ *
+ * @param newSubject The new subject for which we are going to postulate expectations.
+ * @param assertionCreator expectation-group with a non-fail fast behaviour.
+ * @return The newly created [Expect].
+ * @throws AssertionError in case an assertion does not hold.
+ *
+ * @since 0.19.0
+ */
+fun <T, R> Expect<T>.expect(newSubject: R, assertionCreator: Expect<R>.() -> Unit): Expect<R> =
+    _logic.manualFeature(EXPECT) { newSubject }.transformAndAppend(assertionCreator)


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
