### PR TITLE
Default result assertions fix 

### DIFF
--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/build.gradle.kts
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/build.gradle.kts
@@ -22,8 +22,8 @@ kotlin {
 
         configureEach {
             languageSettings.apply {
-                languageVersion = "1.3"
-                apiVersion = "1.3"
+                languageVersion = "1.4"
+                apiVersion = "1.4"
             }
         }
     }

--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/samples/ResultExpectationSamples.kt
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/samples/ResultExpectationSamples.kt
@@ -4,6 +4,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.toBeAFailure
 import ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.toBeASuccess
 import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.math.exp
 import kotlin.test.Test
 
 class ResultExpectationSamples {
@@ -57,69 +58,85 @@ class ResultExpectationSamples {
         }
     }
 
-    //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-//    @Test
-//    fun toBeAFailureFeature() {
-//        val message = "wrong argument"
-//        val failure = Result.failure<Int>(IllegalArgumentException(message))
-//
-//        expect(failure)
-//            .toBeAFailure<IllegalArgumentException>() // subject is now of type IllegalArgumentException
-//            .messageToContain("argument")
-//
-//
-//        fails { // because sub-expectation fails
-//            expect(failure)
-//                .toBeAFailure<IllegalArgumentException>()
-//                .messageToContain("parameter") // fails
-//        }
-//
-//        fails { // because wrong Expectation type expected
-//            expect(failure)
-//                .toBeAFailure<ArithmeticException>() // fails
-//                .messageToContain("parameter")       // not evaluated/reported because toBeAFailure already fails
-//            //                                          use `toBeAFailure<...> { ... }` if you want that all expectations are evaluated
-//        }
-//
-//        fails { // because it was a Success
-//            expect(Result.success(10))
-//                .toBeAFailure<IllegalArgumentException>() // fails
-//                .messageToContain("parameter")            // not evaluated/reported because toBeAFailure already fails
-//            //                                               use `toBeAFailure<...> { ... }` if you want that all expectations are evaluated
-//        }
-//    }
-//
-//    @Test
-//    fun toBeAFailure() {
-//        val errorMessage = "can not divide by zero"
-//        val failure = Result.failure<Int>(ArithmeticException(errorMessage))
-//
-//        expect(failure).toBeAFailure<ArithmeticException> {  // subject within this expectation-group is of type ArithmeticException
-//            messageToContain("by zero")
-//        } // subject here is back to type Result<Int>
-//
-//        fails { // because sub-expectation fails
-//            expect(failure).toBeAFailure<IllegalArgumentException> {
-//                messageToContain("parameter") // fails
-//                message.toStartWith("wrong")  // still evaluated even though messageToContain already fails
-//                //                               use `.toBeAFailure.` if you want a fail fast behaviour
-//            }
-//        }
-//
-//        fails { // because wrong Expectation type expected, but since we use an expectation-group...
-//            expect(failure).toBeAFailure<ArithmeticException> {
-//                messageToContain("parameter") // ...reporting mentions that subject's message was expected `to contain: "parameter"``
-//                //                               use `.toBeAFailure.` if you want a fail fast behaviour
-//            }
-//        }
-//
-//        fails { // because it was a Success, but since we use a block
-//            expect(Result.success(10)).toBeAFailure<IllegalArgumentException> {
-//                messageToContain("parameter") // ...reporting mentions that subject's message was expected `to contain: "parameter"``
-//                //                               use `.toBeAFailure.` if you want a fail fast behaviour
-//            }
-//        }
-//    }
+//    TODO 0.20.0 activate once we have the workaround for #1234 implemented
+
+
+    @Test
+    fun toBeAFailureResultFix() {
+        val message = "wrong argument"
+        val failure = Result.failure<Int>(IllegalArgumentException(message))
+
+
+
+        expect(failure) {
+            toBeAFailure<IllegalArgumentException>()
+        }
+
+
+    }
+
+    @Test
+    fun toBeAFailureFeature() {
+        val message = "wrong argument"
+        val failure = Result.failure<Int>(IllegalArgumentException(message))
+
+        expect(failure)
+            .toBeAFailure<IllegalArgumentException>() // subject is now of type IllegalArgumentException
+            .messageToContain("argument")
+
+
+        fails { // because sub-expectation fails
+            expect(failure)
+                .toBeAFailure<IllegalArgumentException>()
+                .messageToContain("parameter") // fails
+        }
+
+        fails { // because wrong Expectation type expected
+            expect(failure)
+                .toBeAFailure<ArithmeticException>() // fails
+                .messageToContain("parameter")       // not evaluated/reported because toBeAFailure already fails
+            //                                          use `toBeAFailure<...> { ... }` if you want that all expectations are evaluated
+        }
+
+        fails { // because it was a Success
+            expect(Result.success(10))
+                .toBeAFailure<IllegalArgumentException>() // fails
+                .messageToContain("parameter")            // not evaluated/reported because toBeAFailure already fails
+            //                                               use `toBeAFailure<...> { ... }` if you want that all expectations are evaluated
+        }
+    }
+
+    @Test
+    fun toBeAFailure() {
+        val errorMessage = "can not divide by zero"
+        val failure = Result.failure<Int>(ArithmeticException(errorMessage))
+
+        expect(failure).toBeAFailure<ArithmeticException> {  // subject within this expectation-group is of type ArithmeticException
+            messageToContain("by zero")
+        } // subject here is back to type Result<Int>
+
+        fails { // because sub-expectation fails
+            expect(failure).toBeAFailure<IllegalArgumentException> {
+                messageToContain("parameter") // fails
+                message.toStartWith("wrong")  // still evaluated even though messageToContain already fails
+                //                               use `.toBeAFailure.` if you want a fail fast behaviour
+            }
+        }
+
+        fails { // because wrong Expectation type expected, but since we use an expectation-group...
+            expect(failure).toBeAFailure<ArithmeticException> {
+                messageToContain("parameter") // ...reporting mentions that subject's message was expected `to contain: "parameter"``
+                //                               use `.toBeAFailure.` if you want a fail fast behaviour
+            }
+        }
+
+        fails { // because it was a Success, but since we use a block
+            expect(Result.success(10)).toBeAFailure<IllegalArgumentException> {
+                messageToContain("parameter") // ...reporting mentions that subject's message was expected `to contain: "parameter"``
+                //                               use `.toBeAFailure.` if you want a fail fast behaviour
+            }
+        }
+    }
 
 
 }

--- a/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -3,11 +3,13 @@ package ch.tutteli.atrium.logic.kotlin_1_3.impl
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.getOrElse
+import ch.tutteli.atrium.core.polyfills.cast
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.creating.FeatureExpect
 import ch.tutteli.atrium.creating.FeatureExpectOptions
 import ch.tutteli.atrium.logic.changeSubject
+import ch.tutteli.atrium.logic.creating.FeatureExpectOptions
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import ch.tutteli.atrium.logic.creating.transformers.impl.ThrowableThrownFailureHandler
@@ -34,21 +36,42 @@ class DefaultResultAssertions : ResultAssertions {
     override fun <TExpected : Throwable> isFailureOfType(
         container: AssertionContainer<out Result<*>>,
         expectedType: KClass<TExpected>
-    ):  SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
+    ): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
         container.manualFeature(EXCEPTION) {
 
 
-            if(exceptionOrNull() == null
-                &&
-                container.maybeSubject.map { exceptionOrNull() }.getOrElse { null } != null){
-
-                container.maybeSubject.map { exceptionOrNull() }.getOrElse { null }
-
-            } else {
-
-                exceptionOrNull()
+            //fix is here for bug in kotlin 1.3, 1.4, 1.5 (fixed in 1.6) => https://youtrack.jetbrains.com/issue/KT-50974
+            //Comments below explain the fix
+            val badResult = exceptionOrNull()
+            //mapping manually to get internal value throwable - exception or null just produced null + we lost the exception
+            val maybeSubjectResult = container.maybeSubject.map {
+                onSuccess { null }
+                onFailure { it.cause }
             }
 
+
+            if (maybeSubjectResult.getOrElse { null } != null && badResult == null) {
+                //there is something inside first option type so unwrap
+                val successError = maybeSubjectResult.getOrElse { null }
+
+                if (successError == null) {
+
+                    return@manualFeature exceptionOrNull()
+                }
+                //if the result is a success we have another value to check
+                if (successError.isSuccess) {
+
+                    val valueInsideSuccess = getOrNull() as Result<*>
+                    if (valueInsideSuccess.isFailure) {
+                        return@manualFeature valueInsideSuccess.exceptionOrNull()
+                    }
+                }
+
+            }
+
+
+
+            exceptionOrNull()
 
 
         }.transform().let { previousExpect ->

--- a/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -38,9 +38,10 @@ class DefaultResultAssertions : ResultAssertions {
 
 
             if(exceptionOrNull() == null && container.maybeSubject.map { exceptionOrNull() } != null){
-                //unwrap
+                //unwrap somehow (?) todo
                 exceptionOrNull()
             } else {
+
                 exceptionOrNull()
             }
 

--- a/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.logic.kotlin_1_3.impl
 
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.Option
+import ch.tutteli.atrium.core.getOrElse
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.creating.FeatureExpect
@@ -37,9 +38,12 @@ class DefaultResultAssertions : ResultAssertions {
         container.manualFeature(EXCEPTION) {
 
 
-            if(exceptionOrNull() == null && container.maybeSubject.map { exceptionOrNull() } != null){
-                //unwrap somehow (?) todo
-                exceptionOrNull()
+            if(exceptionOrNull() == null
+                &&
+                container.maybeSubject.map { exceptionOrNull() }.getOrElse { null } != null){
+
+                container.maybeSubject.map { exceptionOrNull() }.getOrElse { null }
+
             } else {
 
                 exceptionOrNull()

--- a/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -34,7 +34,19 @@ class DefaultResultAssertions : ResultAssertions {
         container: AssertionContainer<out Result<*>>,
         expectedType: KClass<TExpected>
     ):  SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
-        container.manualFeature(EXCEPTION) { exceptionOrNull() }.transform().let { previousExpect ->
+        container.manualFeature(EXCEPTION) {
+
+
+            if(exceptionOrNull() == null && container.maybeSubject.map { exceptionOrNull() } != null){
+                //unwrap
+                exceptionOrNull()
+            } else {
+                exceptionOrNull()
+            }
+
+
+
+        }.transform().let { previousExpect ->
             FeatureExpect(
                 previousExpect,
                 FeatureExpectOptions(representationInsteadOfFeature = { it ?: IS_NOT_FAILURE })

--- a/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -68,9 +68,6 @@ class DefaultResultAssertions : ResultAssertions {
                 }
 
             }
-
-
-
             exceptionOrNull()
 
 

--- a/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
+++ b/logic/extensions/atrium-logic-kotlin_1_3/src/commonMain/kotlin/ch/tutteli/atrium/logic/kotlin_1_3/impl/DefaultResultAssertions.kt
@@ -3,13 +3,11 @@ package ch.tutteli.atrium.logic.kotlin_1_3.impl
 import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.core.Option
 import ch.tutteli.atrium.core.getOrElse
-import ch.tutteli.atrium.core.polyfills.cast
 import ch.tutteli.atrium.creating.AssertionContainer
 import ch.tutteli.atrium.creating.ExperimentalComponentFactoryContainer
 import ch.tutteli.atrium.creating.FeatureExpect
 import ch.tutteli.atrium.creating.FeatureExpectOptions
 import ch.tutteli.atrium.logic.changeSubject
-import ch.tutteli.atrium.logic.creating.FeatureExpectOptions
 import ch.tutteli.atrium.logic.creating.transformers.FeatureExtractorBuilder
 import ch.tutteli.atrium.logic.creating.transformers.SubjectChangerBuilder
 import ch.tutteli.atrium.logic.creating.transformers.impl.ThrowableThrownFailureHandler

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ResultExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ResultExpectationsSpec.kt
@@ -44,128 +44,128 @@ abstract class ResultExpectationsSpec(
         toBeASuccessNullable.forAssertionCreatorSpec("$toEqualDescr: 2") { toEqual(2) }
     ) {})
 
-//    //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-//    include(object : AssertionCreatorSpec<Result<Int>>(
-//        "$describePrefix[failure] ", Result.failure(IllegalArgumentException("oh no...")),
-//        assertionCreatorSpecTriple(
-//            toBeAFailure.name,
-//            "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh no...\"",
-//            { apply { toBeAFailure.invoke(this) { messageToContain("oh no...") } } },
-//            { apply { toBeAFailure.invoke(this) {} } }
-//        )
-//    ) {})
-//
-//    fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
-//        describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
-//
-//    val resultSuccess = Result.success(1)
-//    val resultFailure = Result.failure<Int>(IllegalArgumentException("oh no..."))
-//    val resultNullSuccess = Result.success(null as Int?)
-//    val resultNullableFailure = Result.failure<Int?>(IllegalArgumentException("oh no nullable..."))
-//
-//    val isNotSuccessDescr = DescriptionResultExpectation.IS_NOT_SUCCESS.getDefault()
-//    val isNotFailureDescr = DescriptionResultExpectation.IS_NOT_FAILURE.getDefault()
-//    val exceptionDescr = DescriptionResultExpectation.EXCEPTION.getDefault()
-//
-//    describeFun(toBeASuccessFeature, toBeASuccess, toBeASuccessFeatureNullable, toBeASuccessNullable, toBeAFailureFeature, toBeAFailure) {
-//        val successFunctions = uncheckedToNonNullable(
-//            unifySignatures(toBeASuccessFeature, toBeASuccess),
-//            unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
-//        )
-//        val failureFunctions = unifySignatures(toBeAFailureFeature, toBeAFailure)
-//
-//        context("subject is $resultSuccess") {
-//            successFunctions.forEach { (name, toBeASuccessFun, _) ->
-//                it("$name - can perform sub-assertion which holds") {
-//                    expect(resultSuccess).toBeASuccessFun { toEqual(1) }
-//                }
-//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-//                    expect {
-//                        expect(resultSuccess).toBeASuccessFun { toEqual(2) }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain("value: 1", "$toEqualDescr: 2")
-//                    }
-//                }
-//            }
-//
-//            failureFunctions.forEach { (name, toBeAFailureFun, hasExtraHint) ->
-//                it("$name - throws AssertionError showing the expected type" + if (hasExtraHint) " and the expected message" else "") {
-//                    expect {
-//                        expect(resultSuccess).toBeAFailureFun { messageToContain("oh yes...") }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain(
-//                            "exception: $isNotFailureDescr",
-//                            "$toBeAnInstanceOfDescr: ${IllegalArgumentException::class.simpleName}"
-//                        )
-//                        if (hasExtraHint) {
-//                            messageToContain(
-//                                DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(),
-//                                "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
-//                            )
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//
-//        context("subject is $resultFailure") {
-//            successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
-//                it("$name throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
-//                    expect {
-//                        expect(resultFailure).toBeASuccessFun { toEqual(1) }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain("value: $isNotSuccessDescr")
-//                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
-//                    }
-//                }
-//            }
-//
-//            //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-//            failureFunctions.forEach { (name, toBeAFailureFun, _) ->
-//                it("$name - can perform sub-assertion which holds") {
-//                    expect(resultFailure).toBeAFailureFun { messageToContain("oh no...") }
-//                }
-//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-//                    expect {
-//                        expect(resultFailure).toBeAFailureFun { messageToContain("oh yes...") }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain(
-//                            "$exceptionDescr: ${IllegalArgumentException::class.fullName}",
-//                            DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(), "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
-//                        )
-//                    }
-//                }
-//            }
-//        }
-//    }
-//
-//    describeFun(toBeASuccessFeatureNullable, toBeASuccessNullable) {
-//        val successFunctions = unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
-//
-//        successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
-//            context("subject is $resultNullSuccess") {
-//                it("$name - can perform sub-assertion which holds") {
-//                    expect(resultNullSuccess).toBeASuccessFun { toEqual(null) }
-//                }
-//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-//                    expect {
-//                        expect(resultNullSuccess).toBeASuccessFun { toEqual(2) }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain("value: null", "$toEqualDescr: 2")
-//                    }
-//                }
-//            }
-//
-//            context("subject is $resultNullableFailure") {
-//                it("${toBeASuccessFeature.name} throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
-//                    expect {
-//                        expect(resultNullableFailure).toBeASuccessFun { toEqual(1) }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain("value: $isNotSuccessDescr")
-//                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
-//                    }
-//                }
-//            }
-//        }
-//    }
+    //TODO 0.20.0 activate once we have the workaround for #1234 implemented
+    include(object : AssertionCreatorSpec<Result<Int>>(
+        "$describePrefix[failure] ", Result.failure(IllegalArgumentException("oh no...")),
+        assertionCreatorSpecTriple(
+            toBeAFailure.name,
+            "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh no...\"",
+            { apply { toBeAFailure.invoke(this) { messageToContain("oh no...") } } },
+            { apply { toBeAFailure.invoke(this) {} } }
+        )
+    ) {})
+
+    fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
+        describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
+
+    val resultSuccess = Result.success(1)
+    val resultFailure = Result.failure<Int>(IllegalArgumentException("oh no..."))
+    val resultNullSuccess = Result.success(null as Int?)
+    val resultNullableFailure = Result.failure<Int?>(IllegalArgumentException("oh no nullable..."))
+
+    val isNotSuccessDescr = DescriptionResultExpectation.IS_NOT_SUCCESS.getDefault()
+    val isNotFailureDescr = DescriptionResultExpectation.IS_NOT_FAILURE.getDefault()
+    val exceptionDescr = DescriptionResultExpectation.EXCEPTION.getDefault()
+
+    describeFun(toBeASuccessFeature, toBeASuccess, toBeASuccessFeatureNullable, toBeASuccessNullable, toBeAFailureFeature, toBeAFailure) {
+        val successFunctions = uncheckedToNonNullable(
+            unifySignatures(toBeASuccessFeature, toBeASuccess),
+            unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
+        )
+        val failureFunctions = unifySignatures(toBeAFailureFeature, toBeAFailure)
+
+        context("subject is $resultSuccess") {
+            successFunctions.forEach { (name, toBeASuccessFun, _) ->
+                it("$name - can perform sub-assertion which holds") {
+                    expect(resultSuccess).toBeASuccessFun { toEqual(1) }
+                }
+                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+                    expect {
+                        expect(resultSuccess).toBeASuccessFun { toEqual(2) }
+                    }.toThrow<AssertionError> {
+                        messageToContain("value: 1", "$toEqualDescr: 2")
+                    }
+                }
+            }
+
+            failureFunctions.forEach { (name, toBeAFailureFun, hasExtraHint) ->
+                it("$name - throws AssertionError showing the expected type" + if (hasExtraHint) " and the expected message" else "") {
+                    expect {
+                        expect(resultSuccess).toBeAFailureFun { messageToContain("oh yes...") }
+                    }.toThrow<AssertionError> {
+                        messageToContain(
+                            "exception: $isNotFailureDescr",
+                            "$toBeAnInstanceOfDescr: ${IllegalArgumentException::class.simpleName}"
+                        )
+                        if (hasExtraHint) {
+                            messageToContain(
+                                DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(),
+                                "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        context("subject is $resultFailure") {
+            successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
+                it("$name throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
+                    expect {
+                        expect(resultFailure).toBeASuccessFun { toEqual(1) }
+                    }.toThrow<AssertionError> {
+                        messageToContain("value: $isNotSuccessDescr")
+                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
+                    }
+                }
+            }
+
+            //TODO 0.20.0 activate once we have the workaround for #1234 implemented
+            failureFunctions.forEach { (name, toBeAFailureFun, _) ->
+                it("$name - can perform sub-assertion which holds") {
+                    expect(resultFailure).toBeAFailureFun { messageToContain("oh no...") }
+                }
+                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+                    expect {
+                        expect(resultFailure).toBeAFailureFun { messageToContain("oh yes...") }
+                    }.toThrow<AssertionError> {
+                        messageToContain(
+                            "$exceptionDescr: ${IllegalArgumentException::class.fullName}",
+                            DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(), "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    describeFun(toBeASuccessFeatureNullable, toBeASuccessNullable) {
+        val successFunctions = unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
+
+        successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
+            context("subject is $resultNullSuccess") {
+                it("$name - can perform sub-assertion which holds") {
+                    expect(resultNullSuccess).toBeASuccessFun { toEqual(null) }
+                }
+                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+                    expect {
+                        expect(resultNullSuccess).toBeASuccessFun { toEqual(2) }
+                    }.toThrow<AssertionError> {
+                        messageToContain("value: null", "$toEqualDescr: 2")
+                    }
+                }
+            }
+
+            context("subject is $resultNullableFailure") {
+                it("${toBeASuccessFeature.name} throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
+                    expect {
+                        expect(resultNullableFailure).toBeASuccessFun { toEqual(1) }
+                    }.toThrow<AssertionError> {
+                        messageToContain("value: $isNotSuccessDescr")
+                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
+                    }
+                }
+            }
+        }
+    }
 })

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ResultExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ResultExpectationsSpec.kt
@@ -44,128 +44,128 @@ abstract class ResultExpectationsSpec(
         toBeASuccessNullable.forAssertionCreatorSpec("$toEqualDescr: 2") { toEqual(2) }
     ) {})
 
-    //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-    include(object : AssertionCreatorSpec<Result<Int>>(
-        "$describePrefix[failure] ", Result.failure(IllegalArgumentException("oh no...")),
-        assertionCreatorSpecTriple(
-            toBeAFailure.name,
-            "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh no...\"",
-            { apply { toBeAFailure.invoke(this) { messageToContain("oh no...") } } },
-            { apply { toBeAFailure.invoke(this) {} } }
-        )
-    ) {})
-
-    fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
-        describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
-
-    val resultSuccess = Result.success(1)
-    val resultFailure = Result.failure<Int>(IllegalArgumentException("oh no..."))
-    val resultNullSuccess = Result.success(null as Int?)
-    val resultNullableFailure = Result.failure<Int?>(IllegalArgumentException("oh no nullable..."))
-
-    val isNotSuccessDescr = DescriptionResultExpectation.IS_NOT_SUCCESS.getDefault()
-    val isNotFailureDescr = DescriptionResultExpectation.IS_NOT_FAILURE.getDefault()
-    val exceptionDescr = DescriptionResultExpectation.EXCEPTION.getDefault()
-
-    describeFun(toBeASuccessFeature, toBeASuccess, toBeASuccessFeatureNullable, toBeASuccessNullable, toBeAFailureFeature, toBeAFailure) {
-        val successFunctions = uncheckedToNonNullable(
-            unifySignatures(toBeASuccessFeature, toBeASuccess),
-            unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
-        )
-        val failureFunctions = unifySignatures(toBeAFailureFeature, toBeAFailure)
-
-        context("subject is $resultSuccess") {
-            successFunctions.forEach { (name, toBeASuccessFun, _) ->
-                it("$name - can perform sub-assertion which holds") {
-                    expect(resultSuccess).toBeASuccessFun { toEqual(1) }
-                }
-                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-                    expect {
-                        expect(resultSuccess).toBeASuccessFun { toEqual(2) }
-                    }.toThrow<AssertionError> {
-                        messageToContain("value: 1", "$toEqualDescr: 2")
-                    }
-                }
-            }
-
-            failureFunctions.forEach { (name, toBeAFailureFun, hasExtraHint) ->
-                it("$name - throws AssertionError showing the expected type" + if (hasExtraHint) " and the expected message" else "") {
-                    expect {
-                        expect(resultSuccess).toBeAFailureFun { messageToContain("oh yes...") }
-                    }.toThrow<AssertionError> {
-                        messageToContain(
-                            "exception: $isNotFailureDescr",
-                            "$toBeAnInstanceOfDescr: ${IllegalArgumentException::class.simpleName}"
-                        )
-                        if (hasExtraHint) {
-                            messageToContain(
-                                DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(),
-                                "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        context("subject is $resultFailure") {
-            successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
-                it("$name throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
-                    expect {
-                        expect(resultFailure).toBeASuccessFun { toEqual(1) }
-                    }.toThrow<AssertionError> {
-                        messageToContain("value: $isNotSuccessDescr")
-                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
-                    }
-                }
-            }
-
-            //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-            failureFunctions.forEach { (name, toBeAFailureFun, _) ->
-                it("$name - can perform sub-assertion which holds") {
-                    expect(resultFailure).toBeAFailureFun { messageToContain("oh no...") }
-                }
-                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-                    expect {
-                        expect(resultFailure).toBeAFailureFun { messageToContain("oh yes...") }
-                    }.toThrow<AssertionError> {
-                        messageToContain(
-                            "$exceptionDescr: ${IllegalArgumentException::class.fullName}",
-                            DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(), "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    describeFun(toBeASuccessFeatureNullable, toBeASuccessNullable) {
-        val successFunctions = unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
-
-        successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
-            context("subject is $resultNullSuccess") {
-                it("$name - can perform sub-assertion which holds") {
-                    expect(resultNullSuccess).toBeASuccessFun { toEqual(null) }
-                }
-                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-                    expect {
-                        expect(resultNullSuccess).toBeASuccessFun { toEqual(2) }
-                    }.toThrow<AssertionError> {
-                        messageToContain("value: null", "$toEqualDescr: 2")
-                    }
-                }
-            }
-
-            context("subject is $resultNullableFailure") {
-                it("${toBeASuccessFeature.name} throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
-                    expect {
-                        expect(resultNullableFailure).toBeASuccessFun { toEqual(1) }
-                    }.toThrow<AssertionError> {
-                        messageToContain("value: $isNotSuccessDescr")
-                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
-                    }
-                }
-            }
-        }
-    }
+//    //TODO 0.20.0 activate once we have the workaround for #1234 implemented
+//    include(object : AssertionCreatorSpec<Result<Int>>(
+//        "$describePrefix[failure] ", Result.failure(IllegalArgumentException("oh no...")),
+//        assertionCreatorSpecTriple(
+//            toBeAFailure.name,
+//            "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh no...\"",
+//            { apply { toBeAFailure.invoke(this) { messageToContain("oh no...") } } },
+//            { apply { toBeAFailure.invoke(this) {} } }
+//        )
+//    ) {})
+//
+//    fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
+//        describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
+//
+//    val resultSuccess = Result.success(1)
+//    val resultFailure = Result.failure<Int>(IllegalArgumentException("oh no..."))
+//    val resultNullSuccess = Result.success(null as Int?)
+//    val resultNullableFailure = Result.failure<Int?>(IllegalArgumentException("oh no nullable..."))
+//
+//    val isNotSuccessDescr = DescriptionResultExpectation.IS_NOT_SUCCESS.getDefault()
+//    val isNotFailureDescr = DescriptionResultExpectation.IS_NOT_FAILURE.getDefault()
+//    val exceptionDescr = DescriptionResultExpectation.EXCEPTION.getDefault()
+//
+//    describeFun(toBeASuccessFeature, toBeASuccess, toBeASuccessFeatureNullable, toBeASuccessNullable, toBeAFailureFeature, toBeAFailure) {
+//        val successFunctions = uncheckedToNonNullable(
+//            unifySignatures(toBeASuccessFeature, toBeASuccess),
+//            unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
+//        )
+//        val failureFunctions = unifySignatures(toBeAFailureFeature, toBeAFailure)
+//
+//        context("subject is $resultSuccess") {
+//            successFunctions.forEach { (name, toBeASuccessFun, _) ->
+//                it("$name - can perform sub-assertion which holds") {
+//                    expect(resultSuccess).toBeASuccessFun { toEqual(1) }
+//                }
+//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+//                    expect {
+//                        expect(resultSuccess).toBeASuccessFun { toEqual(2) }
+//                    }.toThrow<AssertionError> {
+//                        messageToContain("value: 1", "$toEqualDescr: 2")
+//                    }
+//                }
+//            }
+//
+//            failureFunctions.forEach { (name, toBeAFailureFun, hasExtraHint) ->
+//                it("$name - throws AssertionError showing the expected type" + if (hasExtraHint) " and the expected message" else "") {
+//                    expect {
+//                        expect(resultSuccess).toBeAFailureFun { messageToContain("oh yes...") }
+//                    }.toThrow<AssertionError> {
+//                        messageToContain(
+//                            "exception: $isNotFailureDescr",
+//                            "$toBeAnInstanceOfDescr: ${IllegalArgumentException::class.simpleName}"
+//                        )
+//                        if (hasExtraHint) {
+//                            messageToContain(
+//                                DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(),
+//                                "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
+//                            )
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//
+//        context("subject is $resultFailure") {
+//            successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
+//                it("$name throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
+//                    expect {
+//                        expect(resultFailure).toBeASuccessFun { toEqual(1) }
+//                    }.toThrow<AssertionError> {
+//                        messageToContain("value: $isNotSuccessDescr")
+//                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
+//                    }
+//                }
+//            }
+//
+//            //TODO 0.20.0 activate once we have the workaround for #1234 implemented
+//            failureFunctions.forEach { (name, toBeAFailureFun, _) ->
+//                it("$name - can perform sub-assertion which holds") {
+//                    expect(resultFailure).toBeAFailureFun { messageToContain("oh no...") }
+//                }
+//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+//                    expect {
+//                        expect(resultFailure).toBeAFailureFun { messageToContain("oh yes...") }
+//                    }.toThrow<AssertionError> {
+//                        messageToContain(
+//                            "$exceptionDescr: ${IllegalArgumentException::class.fullName}",
+//                            DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(), "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
+//                        )
+//                    }
+//                }
+//            }
+//        }
+//    }
+//
+//    describeFun(toBeASuccessFeatureNullable, toBeASuccessNullable) {
+//        val successFunctions = unifySignatures(toBeASuccessFeatureNullable, toBeASuccessNullable)
+//
+//        successFunctions.forEach { (name, toBeASuccessFun, hasExtraHint) ->
+//            context("subject is $resultNullSuccess") {
+//                it("$name - can perform sub-assertion which holds") {
+//                    expect(resultNullSuccess).toBeASuccessFun { toEqual(null) }
+//                }
+//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+//                    expect {
+//                        expect(resultNullSuccess).toBeASuccessFun { toEqual(2) }
+//                    }.toThrow<AssertionError> {
+//                        messageToContain("value: null", "$toEqualDescr: 2")
+//                    }
+//                }
+//            }
+//
+//            context("subject is $resultNullableFailure") {
+//                it("${toBeASuccessFeature.name} throws AssertionError" + showsSubAssertionIf(hasExtraHint)) {
+//                    expect {
+//                        expect(resultNullableFailure).toBeASuccessFun { toEqual(1) }
+//                    }.toThrow<AssertionError> {
+//                        messageToContain("value: $isNotSuccessDescr")
+//                        if (hasExtraHint) messageToContain("$toEqualDescr: 1")
+//                    }
+//                }
+//            }
+//        }
+//    }
 })

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ResultExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ResultExpectationsSpec.kt
@@ -45,15 +45,15 @@ abstract class ResultExpectationsSpec(
     ) {})
 
     //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-//    include(object : AssertionCreatorSpec<Result<Int>>(
-//        "$describePrefix[failure] ", Result.failure(IllegalArgumentException("oh no...")),
-//        assertionCreatorSpecTriple(
-//            toBeAFailure.name,
-//            "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh no...\"",
-//            { apply { toBeAFailure.invoke(this) { messageToContain("oh no...") } } },
-//            { apply { toBeAFailure.invoke(this) {} } }
-//        )
-//    ) {})
+    include(object : AssertionCreatorSpec<Result<Int>>(
+        "$describePrefix[failure] ", Result.failure(IllegalArgumentException("oh no...")),
+        assertionCreatorSpecTriple(
+            toBeAFailure.name,
+            "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh no...\"",
+            { apply { toBeAFailure.invoke(this) { messageToContain("oh no...") } } },
+            { apply { toBeAFailure.invoke(this) {} } }
+        )
+    ) {})
 
     fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
@@ -121,21 +121,21 @@ abstract class ResultExpectationsSpec(
             }
 
             //TODO 0.20.0 activate once we have the workaround for #1234 implemented
-//            failureFunctions.forEach { (name, toBeAFailureFun, _) ->
-//                it("$name - can perform sub-assertion which holds") {
-//                    expect(resultFailure).toBeAFailureFun { messageToContain("oh no...") }
-//                }
-//                it("$name - can perform sub-assertion which fails, throws AssertionError") {
-//                    expect {
-//                        expect(resultFailure).toBeAFailureFun { messageToContain("oh yes...") }
-//                    }.toThrow<AssertionError> {
-//                        messageToContain(
-//                            "$exceptionDescr: ${IllegalArgumentException::class.fullName}",
-//                            DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(), "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
-//                        )
-//                    }
-//                }
-//            }
+            failureFunctions.forEach { (name, toBeAFailureFun, _) ->
+                it("$name - can perform sub-assertion which holds") {
+                    expect(resultFailure).toBeAFailureFun { messageToContain("oh no...") }
+                }
+                it("$name - can perform sub-assertion which fails, throws AssertionError") {
+                    expect {
+                        expect(resultFailure).toBeAFailureFun { messageToContain("oh yes...") }
+                    }.toThrow<AssertionError> {
+                        messageToContain(
+                            "$exceptionDescr: ${IllegalArgumentException::class.fullName}",
+                            DescriptionCharSequenceExpectation.TO_CONTAIN.getDefault(), "${DescriptionCharSequenceExpectation.VALUE.getDefault()}: \"oh yes...\""
+                        )
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Implemented a fix which pasts the tests.
Using exception or null discarded inner exception value, so manually mapped to retain that value.
Let me know what I'm needing to do to improve the code
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
