### PR TITLE
don't use internal verb in samples

### DIFF
--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/build.gradle.kts
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(prefixedProject("specs"))
+                // in order that we can use the correct import in the samples
+                implementation(prefixedProject("verbs"))
             }
         }
     }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/AnyExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/AnyExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class AnyExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ArraySubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ArraySubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ArraySubjectChangerSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CharSequenceExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CharSequenceExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class CharSequenceExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CollectionExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CollectionExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class CollectionExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CollectionFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CollectionFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class CollectionFeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ComparableExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ComparableExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ComparableExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DocumentationUtilSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DocumentationUtilSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class DocumentationUtilSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class FeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FloatingPointExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FloatingPointExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.toEqualWithErrorTolerance
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class FloatingPointExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/Fun0ExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/Fun0ExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class Fun0ExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableSubjectChangerSamples.kt
@@ -3,7 +3,7 @@ package ch.tutteli.atrium.api.fluent.en_GB.samples
 import ch.tutteli.atrium.api.fluent.en_GB.asList
 import ch.tutteli.atrium.api.fluent.en_GB.toContain
 import ch.tutteli.atrium.api.fluent.en_GB.toEqual
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableSubjectChangerSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IteratorExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IteratorExpectationSamples.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.notToHaveNext
 import ch.tutteli.atrium.api.fluent.en_GB.toHaveNext
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IteratorExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ListFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ListFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ListFeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapEntryExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapEntryFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapEntryFeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapExpectationSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapFeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapSubjectChangerSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PairFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PairFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class PairFeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/SequenceSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/SequenceSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class SequenceSubjectChangerSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ThrowableFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ThrowableFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ThrowableFeatureExtractorSamples {

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/assertIf.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/assertIf.kt
@@ -1,5 +1,5 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
-fun assertIf(shouldAssert: Boolean, assert: () -> Unit) {
-    if (shouldAssert) assert()
+fun runIf(shouldRun: Boolean, action: () -> Unit) {
+    if (shouldRun) action()
 }

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/fails.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/fails.kt
@@ -1,6 +1,6 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 
 fun fails(b: () -> Unit) = expect(b).toThrow<AssertionError>()

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalExpectations.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalExpectations.kt
@@ -20,7 +20,7 @@ import java.util.*
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.OptionalExpectationsSamples.toBeEmpty
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.OptionalExpectationSamples.toBeEmpty
  *
  * @since 0.17.0
  */

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/BigDecimalExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/BigDecimalExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.math.BigDecimal
 import kotlin.test.Test
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ChronoLocalDateExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ChronoLocalDateExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.LocalDate
 import java.time.Month
 import kotlin.test.Test

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ChronoLocalDateTimeExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ChronoLocalDateTimeExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.LocalDateTime
 import java.time.Month
 import kotlin.test.Test

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ChronoZonedDateTimeExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ChronoZonedDateTimeExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import kotlin.test.Test

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/DateSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.time.LocalDate

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FileSubjectChangerSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/FileSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.niok.newFile
 import java.nio.file.Files
 import kotlin.test.Test

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/LocalDateFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/LocalDateFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/LocalDateTimeFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/LocalDateTimeFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.Month

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/OptionalExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/OptionalExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.util.*
 import kotlin.test.Test
 

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.specs.fileSystemSupportsPosixPermissions
 import ch.tutteli.niok.*
 import java.nio.file.FileSystems
@@ -122,7 +122,7 @@ class PathExpectationSamples {
 
     @Test
     fun notToBeReadable() {
-        assertIf(ifPosixSupported) {
+        runIf(ifPosixSupported) {
             val writeOnlyPermissions =
                 PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("-w--w--w-"))
             val readyWritePermissions =
@@ -166,7 +166,7 @@ class PathExpectationSamples {
 
     @Test
     fun notToBeWritable() {
-        assertIf(ifPosixSupported) {
+        runIf(ifPosixSupported) {
             val readyOnlyPermissions =
                 PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("r--r--r--"))
             val readyWritePermissions =
@@ -206,7 +206,7 @@ class PathExpectationSamples {
 
     @Test
     fun notToBeExecutable() {
-        assertIf(ifPosixSupported) {
+        runIf(ifPosixSupported) {
             val readyOnlyPermissions =
                 PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("r--r--r--"))
             val readyWriteExecutePermissions =

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/PathFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.specs.fileSystemSupportsPosixPermissions
 import ch.tutteli.niok.*
 import java.nio.file.FileSystems

--- a/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ZonedDateTimeFeatureExtractorSamples.kt
+++ b/apis/fluent-en_GB/atrium-api-fluent-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/ZonedDateTimeFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.fluent.en_GB.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.*
 import kotlin.test.Test
 

--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/build.gradle.kts
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/build.gradle.kts
@@ -12,6 +12,8 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(prefixedProject("specs"))
+                // in order that we can use the correct import in the samples
+                implementation(prefixedProject("verbs"))
             }
         }
     }

--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/samples/ResultExpectationSamples.kt
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/samples/ResultExpectationSamples.kt
@@ -3,7 +3,7 @@ package ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.samples
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.toBeAFailure
 import ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.toBeASuccess
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ResultExpectationSamples {

--- a/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/samples/fails.kt
+++ b/apis/fluent-en_GB/extensions/atrium-api-fluent-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/kotlin_1_3/samples/fails.kt
@@ -1,6 +1,6 @@
 package ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.samples
 
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 
 fun fails(b: () -> Unit) = expect(b).toThrow<AssertionError>()

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/build.gradle.kts
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/build.gradle.kts
@@ -22,6 +22,8 @@ kotlin {
                     exclude(module = "${rootProject.name}-translations-en_GB")
                 }
                 implementation(prefixedProject("translations-de_CH"))
+                // in order that we can use the correct import in the samples
+                implementation(prefixedProject("verbs"))
             }
         }
         val jvmTest by getting {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/AnyExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/AnyExpectationSamples.kt
@@ -2,7 +2,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.creating.Expect
 import kotlin.test.Test
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ArraySubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ArraySubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ArraySubjectChangerSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CharSequenceExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CharSequenceExpectationSamples.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.samples.fails
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class CharSequenceExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CollectionExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CollectionExpectationSamples.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.api.infix.en_GB.empty
 import ch.tutteli.atrium.api.infix.en_GB.notToBe
 import ch.tutteli.atrium.api.infix.en_GB.toBe
 import ch.tutteli.atrium.api.infix.en_GB.toHaveSize
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class CollectionExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CollectionFeatureExtractorSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/CollectionFeatureExtractorSamples.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.api.infix.en_GB.it
 import ch.tutteli.atrium.api.infix.en_GB.size
 import ch.tutteli.atrium.api.infix.en_GB.toBeGreaterThan
 import ch.tutteli.atrium.api.infix.en_GB.toBeLessThan
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class CollectionFeatureExtractorSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ComparableExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ComparableExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ComparableExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DocumentationUtilSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DocumentationUtilSamples.kt
@@ -2,7 +2,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.creating.Expect
 import kotlin.test.Test
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/Fun0ExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/Fun0ExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class Fun0ExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.creating.Expect
 import kotlin.test.Test
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableSubjectChangerSamples.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.api.infix.en_GB.it
 import ch.tutteli.atrium.api.infix.en_GB.o
 import ch.tutteli.atrium.api.infix.en_GB.toContain
 import ch.tutteli.atrium.api.infix.en_GB.toEqual
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableSubjectChangerSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IteratorExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IteratorExpectationSamples.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.samples.fails
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IteratorExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ListFeatureExtractorSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ListFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.translations.DescriptionComparableExpectation
 import kotlin.test.Test
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapEntryExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapEntryExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.toEqualKeyValue
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapEntryExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapEntryFeatureExtractorSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapEntryFeatureExtractorSamples.kt
@@ -4,7 +4,7 @@ import ch.tutteli.atrium.api.infix.en_GB.key
 import ch.tutteli.atrium.api.infix.en_GB.toEqual
 import ch.tutteli.atrium.api.infix.en_GB.toEqualKeyValue
 import ch.tutteli.atrium.api.infix.en_GB.value
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapEntryFeatureExtractorSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapExpectationSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapFeatureExtractorSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapFeatureExtractorSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapSubjectChangerSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/PairFeatureExtractorSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/PairFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class PairFeatureExtractorSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/SequenceSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/SequenceSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class SequenceSubjectChangerSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ThrowableFeatureExtractorSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ThrowableFeatureExtractorSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ThrowableFeatureExtractorSamples {

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/fails.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/fails.kt
@@ -1,6 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.toThrow
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 
 fun fails(b: () -> Unit) = expect(b).toThrow<AssertionError>()

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathExpectations.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/pathExpectations.kt
@@ -163,7 +163,7 @@ infix fun <T : Path> Expect<T>.toHaveTheSameBinaryContentAs(targetPath: Path): E
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathExpectationSamples.toExist
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathExpectationSamples.toBeExisting
  *
  * @since 0.12.0
  */
@@ -179,7 +179,7 @@ infix fun <T : Path> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") existing: exis
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathExpectationSamples.notToExist
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.PathExpectationSamples.notToBeExisting
  *
  * @since 0.12.0
  */

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/BigDecimalExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/BigDecimalExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.math.BigDecimal
 import kotlin.test.Test
 

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ChronoLocalDateExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ChronoLocalDateExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.LocalDate
 import java.time.Month
 import kotlin.test.Test

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ChronoLocalDateTimeExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ChronoLocalDateTimeExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.LocalDateTime
 import java.time.Month
 import kotlin.test.Test

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ChronoZonedDateTimeExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ChronoZonedDateTimeExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import kotlin.test.Test

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/DateSubjectChangerSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.time.LocalDate

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/LocalDateExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/LocalDateExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/LocalDateTimeExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/LocalDateTimeExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.Month

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/PathExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/PathExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.specs.fileSystemSupportsPosixPermissions
 import ch.tutteli.niok.*
 import java.nio.file.FileSystems
@@ -87,7 +87,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun toExist() {
+    fun toBeExisting() {
         val dir = tempDir.newDirectory("test_dir")
 
         expect(dir) toBe existing
@@ -98,7 +98,7 @@ class PathExpectationSamples {
     }
 
     @Test
-    fun notToExist() {
+    fun notToBeExisting() {
         val dir = tempDir.newDirectory("test_dir")
 
         expect(Paths.get("non_existing_dir")) notToBe existing

--- a/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ZonedDateTimeExpectationSamples.kt
+++ b/apis/infix-en_GB/atrium-api-infix-en_GB/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/ZonedDateTimeExpectationSamples.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import java.time.*
 import kotlin.test.Test
 

--- a/apis/infix-en_GB/extensions/atrium-api-infix-en_GB-kotlin_1_3/build.gradle.kts
+++ b/apis/infix-en_GB/extensions/atrium-api-infix-en_GB-kotlin_1_3/build.gradle.kts
@@ -12,6 +12,8 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(prefixedProject("specs"))
+                // in order that we can use the correct import in the samples
+                implementation(prefixedProject("verbs"))
             }
         }
         val jvmTest by getting {

--- a/apis/infix-en_GB/extensions/atrium-api-infix-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/samples/ResultExpectationSamples.kt
+++ b/apis/infix-en_GB/extensions/atrium-api-infix-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/samples/ResultExpectationSamples.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3.*
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class ResultExpectationSamples {

--- a/apis/infix-en_GB/extensions/atrium-api-infix-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/samples/fails.kt
+++ b/apis/infix-en_GB/extensions/atrium-api-infix-en_GB-kotlin_1_3/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/kotlin_1_3/samples/fails.kt
@@ -1,6 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB.kotlin_1_3.samples
 
 import ch.tutteli.atrium.api.infix.en_GB.toThrow
-import ch.tutteli.atrium.api.verbs.internal.expect
+import ch.tutteli.atrium.api.verbs.expect
 
 fun fails(b: () -> Unit) = expect(b).toThrow<AssertionError>()


### PR DESCRIPTION
use the regular one so that a user copying it already has the correct import



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
