### PR TITLE
setup jdk17 again by using setup-java

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     env:
       android-version: 26
+      JAVA_VERSION: ${{ matrix.java_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -22,8 +23,6 @@ jobs:
           cache: 'gradle'
 
       - name: "build using jdk ${{ matrix.java_version }}"
-        env:
-          JAVA_VERSION: ${{ matrix.java_version }}
         run: ./gradlew build
 
       - name: Cache android jar
@@ -59,8 +58,7 @@ jobs:
       - name: Upload build code coverage
         uses: codecov/codecov-action@v3.1.4
         if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        env:
-          JAVA_VERSION: ${{ matrix.java_version }}
+
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: current

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -4,6 +4,8 @@ on: [ push, pull_request ]
 
 jobs:
   build:
+    env:
+      android-version: 26
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -12,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: "Set up JDK 11"
+      - name: "Set up JDK ${{ matrix.java_version }}"
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -23,6 +25,31 @@ jobs:
         env:
           JAVA_VERSION: ${{ matrix.java_version }}
         run: ./gradlew build
+
+      - name: Cache android jar
+        id: android-cache
+        uses: actions/cache@v3
+        with:
+          path: android-jar-cache
+          key: ${{ runner.os }}-android-version-${{ env.android-version }}
+
+      - name: download Android SDK's android.jar (or use cached file)
+        if: steps.android-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir android-jar-cache
+          cd android-jar-cache
+          curl -o android.jar -L "https://github.com/Sable/android-platforms/blob/master/android-${{ env.android-version }}/android.jar?raw=true"
+          echo "cdc1846376a14b0370cc63454a129606b4a52cc50ada75ef0d4cf956b1ad2daa  android.jar" >android.sha256
+          if ! sha256sum -c android.sha256; then
+            echo >&2 "wrong sha256 for android.jar, expected:"
+            cat >&2 android.sha256
+            echo >&2 "actual:"
+            sha256sum android.jar
+            exit 1;
+          fi
+
+      - name: check Atrium's -jvm.jar can be dexed
+        run: ATRIUM_ANDROID_JAR="$PWD/android-jar-cache/android.jar" ./gradlew checkDexer
 
       # TODO 1.3.0 re-activate scala API
       #            -   name: composite build atrium-scala2

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: ${{ matrix.java_version }}
           cache: 'gradle'
 
       - name: "build using jdk ${{ matrix.java_version }}"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: ${{ matrix.java_version }}
           cache: 'gradle'
 
       - name: "build using jdk ${{ matrix.java_version }}"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,8 +4,6 @@ on: [ push, pull_request ]
 
 jobs:
   build:
-    env:
-      android-version: 26
     runs-on: windows-latest
     strategy:
       fail-fast: true
@@ -25,31 +23,6 @@ jobs:
         env:
           JAVA_VERSION: ${{ matrix.java_version }}
         run: ./gradlew build
-
-      - name: Cache android jar
-        id: android-cache
-        uses: actions/cache@v3
-        with:
-          path: android-jar-cache
-          key: ${{ runner.os }}-android-version-${{ env.android-version }}
-
-      - name: download Android SDK's android.jar (or use cached file)
-        if: steps.android-cache.outputs.cache-hit != 'true'
-        run: |
-          md android-jar-cache
-          cd android-jar-cache
-          curl -o android.jar -L "https://github.com/Sable/android-platforms/blob/master/android-${{ env.android-version }}/android.jar?raw=true"
-          $file_sha256 = $(certutil -hashfile android.jar sha256)[1] -replace " ",""
-          $expected_sha256 = "cdc1846376a14b0370cc63454a129606b4a52cc50ada75ef0d4cf956b1ad2daa"
-          if ($file_sha256 -Ne $expected_sha256) {
-              echo "wrong sha256 for android.jar: $file_sha256";
-              echo "                    expected: $expected_sha256";
-              exit -1
-          }
-
-      - name: check Atrium's -jvm.jar can be dexed
-        run: ATRIUM_ANDROID_JAR="$PWD/android-jar-cache/android.jar" ./gradlew checkDexer
-        shell: bash
 
       # TODO 1.5.0 re-activate scala API
       #            -   name: composite build atrium-scala2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,6 +4,8 @@ on: [ push, pull_request ]
 
 jobs:
   build:
+    env:
+      JAVA_VERSION: ${{ matrix.java_version }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
@@ -12,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: "Set up JDK 11"
+      - name: "Set up JDK ${{ matrix.java_version }}"
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -20,8 +22,6 @@ jobs:
           cache: 'gradle'
 
       - name: "build using jdk ${{ matrix.java_version }}"
-        env:
-          JAVA_VERSION: ${{ matrix.java_version }}
         run: ./gradlew build
 
       # TODO 1.5.0 re-activate scala API
@@ -32,8 +32,6 @@ jobs:
       - name: Upload windows build code coverage
         uses: codecov/codecov-action@v3.1.4
         if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        env:
-          JAVA_VERSION: ${{ matrix.java_version }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: current_windows

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import java.io.IOException
 import java.net.URL
 
@@ -549,11 +550,13 @@ subprojects {
     }
 }
 
-//TODO 2.0.0 remove if we use kotlin 1.7.x should no longer be necessary
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        freeCompilerArgs += "-Xsuppress-version-warnings"
+allprojects {
+    tasks.withType<KotlinCompilationTask<*>>().configureEach {
+        compilerOptions {
+            //TODO 1.1.0 re-activate again if possible
+//            allWarningsAsErrors.set(true)
+            freeCompilerArgs.add("-Xsuppress-version-warnings")
+        }
     }
 }
 

--- a/samples/jvm/junit5/build.gradle.kts
+++ b/samples/jvm/junit5/build.gradle.kts
@@ -41,12 +41,3 @@ tasks.test {
         showStackTraces = true
     }
 }
-
-kotlin {
-    target.compilations.all {
-        // Atrium requires at least jdk 11
-        kotlinOptions.jvmTarget = "11"
-
-    }
-}
-java.targetCompatibility = JavaVersion.VERSION_11

--- a/samples/jvm/maven/pom.xml
+++ b/samples/jvm/maven/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <!-- @formatter:off -->
-        <atrium.version>1.0.0-RC2</atrium.version>
+        <atrium.version>1.0.0</atrium.version>
         <java.charset>UTF-8</java.charset>
         <java.version>11</java.version>
         <junit.version>5.9.2</junit.version>

--- a/samples/jvm/spek/build.gradle.kts
+++ b/samples/jvm/spek/build.gradle.kts
@@ -42,11 +42,4 @@ tasks.test {
     }
 }
 
-// Atrium requires at least jdk 11
-kotlin {
-    target.compilations.all {
-        kotlinOptions.jvmTarget = "11"
-    }
-}
-java.targetCompatibility = JavaVersion.VERSION_11
 

--- a/samples/multiplatform/kotlin-test/build.gradle.kts
+++ b/samples/multiplatform/kotlin-test/build.gradle.kts
@@ -21,13 +21,11 @@ repositories {
 }
 
 kotlin {
-    jvm().compilations.all {
-        // Atrium requires at least jdk 11
-        kotlinOptions.jvmTarget = "11"
-    }
-    java.targetCompatibility = JavaVersion.VERSION_11
+    jvm()
+
     // atrium only supports LEGACY for now
     js(LEGACY).nodejs()
+
     sourceSets {
         val commonTest by getting {
             dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,12 +4,6 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-plugins {
-    if (System.getenv("CI")?.toBoolean() == true) {
-        id("org.gradle.toolchains.foojay-resolver-convention") version ("0.4.0")
-    }
-}
-
 
 rootProject.name = "atrium"
 


### PR DESCRIPTION
We used jdk11 before because gradle 6.9.3 did not support jdk17.
setting up jdk17 via CI seems like the better idea because we already run into timeouts when installing via gradle in CI



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
