### PR TITLE
rewrite ambiguity tests for star and inOrder...grouped

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -45,6 +45,7 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
                 0 -> object : Group<(Expect<Double>.() -> Unit)?> {
                     override fun toList() = listOf<Expect<Double>.() -> Unit>()
                 }
+
                 1 -> Entry(groups[0])
                 else -> Entries(groups[0], *groups.drop(1).toTypedArray())
             }
@@ -60,29 +61,25 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
         list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}))
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}))
         subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}))
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Entry<Number> {}, Entries<Number>({}, {}))
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder<Any, Collection<Any?>>(Entry {}, Entry {})
 
         list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), report = {})
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), report = {})
         subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), report = {})
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
-            Entry<Number> {},
-            Entries<Number>({}, {}),
-            report = {}
-        )
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder<Any, Collection<Any?>>(Entry {},
+            Entries({}, {}),
+            report = {})
 
         list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), reportInGroup = {})
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry {}, Entries({}, {}), reportInGroup = {})
         subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(
             Entry {}, Entries({}, {}), reportInGroup = {})
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
-            Entry<Number> {},
-            Entries<Number>({}, {}),
-            reportInGroup = {}
-        )
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder<Any, Collection<Any?>>(Entry {},
+            Entries({}, {}),
+            reportInGroup = {})
 
         list = list.toContain.inOrder.only.grouped.within.inAnyOrder(
             Entry {},
@@ -102,19 +99,20 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             report = {},
             reportInGroup = {}
         )
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
-            Entry<Number> {},
-            Entries<Number>({}, {}),
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder<Any, Collection<*>>(
+            Entry {},
+            Entries({}, {}),
             report = {},
             reportInGroup = {}
         )
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry(null), Entries({}, null))
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
         star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Entry<Number>(null), Entries<Number>(null, {}))
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Entry(null), Entries({}, null), report = {})
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
         star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
             Entry<Number>(null),
             Entries<Number>(null, {}),
@@ -125,10 +123,10 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             Entries({}, null),
             reportInGroup = {}
         )
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
-            Entry<Number>(null),
-            Entries<Number>(null, {}),
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder<Any, Collection<Any?>>(
+            Entry(null),
+            Entries(null, {}),
             reportInGroup = {})
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(
@@ -136,10 +134,11 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
             Entries({}, null),
             report = {},
             reportInGroup = {})
-        //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(
-            Entry<Number>(null),
-            Entries<Number>(null, {}),
+
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder<Any, Collection<Any?>>(
+            Entry(null),
+            Entries(null, {}),
             report = {},
             reportInGroup = {})
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -94,9 +94,9 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
         var star: Expect<Collection<*>> = notImplemented()
 
         list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2))
-        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2))
-        subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2))
-        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2))
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1.2, 2))
+        subList = subList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1.2), Values(1, 2))
+        star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1f), Values(1L, 2, 'a', "hello"))
 
         list = list.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), report = {})
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(1), Values(1, 2), report = {})
@@ -129,7 +129,8 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
             report = {},
             reportInGroup = {})
 
-        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(1, null))
+        val value1 = Value<Int?>(null)
+        nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(value1, Values(1, null))
         star = star.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(null, 2))
 
         nList = nList.toContain.inOrder.only.grouped.within.inAnyOrder(Value(null), Values(1, null), report = {})

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
@@ -7,6 +7,6 @@ import ch.tutteli.atrium.logic.utils.Group
  *
  * Use the function `value(t)` to create this representation.
  */
-data class Value<T> internal constructor(val expected: T) : Group<T> {
+data class Value<out T> internal constructor(val expected: T) : Group<T> {
     override fun toList() = listOf(expected)
 }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Values.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Values.kt
@@ -10,9 +10,6 @@ import ch.tutteli.atrium.logic.utils.VarArgHelper
  *
  * Note, [Values] will be made invariant once Kotlin 1.4 is out and Atrium depends on it (most likely with 1.0.0)
  */
-// TODO remove `out` with Kotlin 1.4 (most likely with Atrium 1.1.0)
-// but check infix-api, things like `the values("A", 1)` where the subject is List<Number> should be prevented
-// on the other hand, we don't want to need to specify `the values<Number?>(1, 1.2)` in case the subject is List<Number?>
 class Values<out T> internal constructor(
     override val expected: T,
     override val otherExpected: Array<out T>

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyEntriesExpectationsSpec.kt
@@ -1,18 +1,15 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.logic._logicAppend
-import ch.tutteli.atrium.logic.creating.iterable.contains.creators.entriesInOrderOnly
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
+import ch.tutteli.atrium.specs.notImplemented
 import org.spekframework.spek2.Spek
 import kotlin.reflect.KFunction2
 
 class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
-
     include(BuilderSpec)
     include(ShortcutSpec)
-
 }) {
     object BuilderSpec : ch.tutteli.atrium.specs.integration.IterableToContainInOrderOnlyEntriesExpectationsSpec(
         getToContainPair(),
@@ -92,5 +89,83 @@ class IterableToContainInOrderOnlyEntriesExpectationsSpec : Spek({
                     expect toContainExactly entries(a, *aX)
                 }
             } else expect toContainExactly entries(a, *aX, reportOptionsInOrderOnly = report)
+    }
+
+    @Suppress("unused", "UNUSED_VALUE")
+    private fun ambiguityTest() {
+        var list: Expect<List<Number>> = notImplemented()
+        var nList: Expect<Set<Number?>> = notImplemented()
+        var subList: Expect<ArrayList<Number>> = notImplemented()
+        var star: Expect<Collection<*>> = notImplemented()
+
+        list = list toContain o inGiven order and only entry {}
+        nList = nList toContain o inGiven order and only entry {}
+        subList = subList toContain o inGiven order and only entry {}
+        star = star toContain o inGiven order and only entry {}
+
+        nList = nList toContain o inGiven order and only entry (null)
+        star = star toContain o inGiven order and only entry (null)
+
+        list = list toContain o inGiven order and only the entries({}, {})
+        nList = nList toContain o inGiven order and only the entries({}, {})
+        subList = subList toContain o inGiven order and only the entries({}, {})
+        star = star toContain o inGiven order and only the entries({}, {})
+
+        nList toContain o inGiven order and only the entries(null, {})
+        star toContain o inGiven order and only the entries(null, {})
+
+        nList toContain o inGiven order and only the entries({}, null)
+        star toContain o inGiven order and only the entries({}, null)
+
+        nList toContain o inGiven order and only the entries(null, null)
+        star toContain o inGiven order and only the entries(null, null)
+
+        nList = nList toContain o inGiven order and only the entries(null, {}, null)
+        star = star toContain o inGiven order and only the entries(null, {}, null)
+
+        list = list toContain o inGiven order and only the entries({}, {}, reportOptionsInOrderOnly = { })
+        nList = nList toContain o inGiven order and only the entries({}, {}, reportOptionsInOrderOnly = { })
+        subList = subList toContain o inGiven order and only the entries({}, {}, reportOptionsInOrderOnly = { })
+        star = star toContain o inGiven order and only the entries({}, {}, reportOptionsInOrderOnly = { })
+
+        nList = nList toContain o inGiven order and only the entries(null, {}, null, reportOptionsInOrderOnly = { })
+        star = star toContain o inGiven order and only the entries(null, {}, null, reportOptionsInOrderOnly = { })
+
+        list = list toContainExactly {}
+        nList = nList toContainExactly {}
+        subList = subList toContainExactly {}
+        star = star toContainExactly {}
+
+        nList = nList toContainExactly null
+        star = star toContainExactly null
+
+        list = list toContainExactly entries({}, {})
+        nList = nList toContainExactly entries({}, {})
+        subList = subList toContainExactly entries({}, {})
+        star = star toContainExactly entries({}, {})
+
+        list = list toContainExactly entries(
+            {},
+            {},
+            reportOptionsInOrderOnly = { showOnlyFailingIfMoreExpectedElementsThan(20) }
+        )
+        nList = nList toContainExactly entries({}, {}, reportOptionsInOrderOnly = { showOnlyFailing() })
+        subList = subList toContainExactly entries({}, {}, reportOptionsInOrderOnly = { showAlwaysSummary() })
+        star = star toContainExactly entries({}, {}, reportOptionsInOrderOnly = { })
+
+        nList = nList toContainExactly entries(null, {})
+        star = star toContainExactly entries(null, {})
+
+        nList = nList toContainExactly entries({}, null)
+        star = star toContainExactly entries({}, null)
+
+        nList = nList toContainExactly entries(null, null)
+        star = star toContainExactly entries(null, null)
+
+        nList = nList toContainExactly entries(null, {}, null)
+        star = star toContainExactly entries(null, {}, null)
+
+        nList = nList toContainExactly entries(null, {}, null, reportOptionsInOrderOnly = {})
+        star = star toContainExactly entries(null, {}, null, reportOptionsInOrderOnly = {})
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -48,6 +48,7 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
                 0 -> object : Group<(Expect<Double>.() -> Unit)?> {
                     override fun toList() = listOf<Expect<Double>.() -> Unit>()
                 }
+
                 1 -> entry(groups[0])
                 else -> entries(groups[0], *groups.drop(1).toTypedArray())
             }
@@ -62,155 +63,139 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
         var star: Expect<Collection<*>> = notImplemented()
 
         list = list toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {})
         )
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {})
         )
         subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {})
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry {},
             entries({}, {})
-        )
+        ))
 
         list = list toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             report = {}
         )
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             report = {}
         )
         subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             report = {}
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry {},
             entries({}, {}),
             report = {}
-        )
+        ))
 
         list = list toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             reportInGroup = {}
         )
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             reportInGroup = {}
         )
         subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             reportInGroup = {}
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry {},
             entries({}, {}),
             reportInGroup = {}
-        )
+        ))
 
         list = list toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             report = {},
             reportInGroup = {}
         )
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             report = {},
             reportInGroup = {}
         )
         subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+            entry {},
             entries({}, {}),
             report = {},
             reportInGroup = {}
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number> {},
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry {},
             entries({}, {}),
             report = {},
             reportInGroup = {}
-        )
+        ))
 
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+            entry(null),
             entries({}, null)
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry(null),
             entries(null, {})
-        )
+        ))
 
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+            entry(null),
             entries({}, null),
             report = {}
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry(null),
             entries(null, {}),
             report = {}
-        )
+        ))
 
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+            entry(null),
             entries({}, null),
             reportInGroup = {}
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry(null),
             entries(null, {}),
             reportInGroup = {}
-        )
+        ))
 
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+            entry(null),
             entries({}, null),
             report = {},
             reportInGroup = {}
         )
-        star = star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            entry<Number>(null),
+        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
+        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
+            entry(null),
             entries(null, {}),
             report = {},
             reportInGroup = {}
-        )
+        ))
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -97,23 +97,19 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
 
         list = list toContain o inGiven order and only grouped entries within group inAny order(
             value(1),
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            values<Number>(1, 2.2)
+            values(1, 2.2)
         )
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
             value(1),
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            values<Number>(1, 2.2)
+            values(1, 2.2)
         )
         subList = subList toContain o inGiven order and only grouped entries within group inAny order(
             value(1),
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            values<Number>(1, 2.2)
+            values(1, 2.2)
         )
         star = star toContain o inGiven order and only grouped entries within group inAny order(
             value(1),
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            values<Number>(1, 2.2)
+            values(1, 2.2)
         )
 
         list = list toContain o inGiven order and only grouped entries within group inAny order(
@@ -186,8 +182,7 @@ class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec :
         nList = nList toContain o inGiven order and only grouped entries within group inAny order(
             value(null),
             values(1, null),
-            //TODO check if <Number> is still necessary with kotlin 1.4, if so, report a bug
-            values<Number?>(1.2, null)
+            values(1.2, null)
         )
         star = star toContain o inGiven order and only grouped entries within group inAny order(
             value(null),

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainSpecBase.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainSpecBase.kt
@@ -69,6 +69,7 @@ abstract class IterableToContainSpecBase {
         Expect<Iterable<Int>>::notToContain
     protected val notToContain = "${notToContainProp.name} $Values"
 
+    //TODO move to specific specs
     @Suppress("unused")
     private fun ambiguityTest() {
         val list: Expect<List<Number>> = notImplemented()
@@ -138,31 +139,18 @@ abstract class IterableToContainSpecBase {
 
         list toContainExactly 1
         list toContainExactly values(1, 2f)
-        list toContainExactly {}
-        list toContainExactly entries({}, {})
 
         subList toContainExactly 1
         subList toContainExactly values(1, 2f)
-        subList toContainExactly {}
-        subList toContainExactly entries({}, {})
 
         nullableList toContainExactly 1
         nullableList toContainExactly values(1, 2f)
-        nullableList toContainExactly {}
-        nullableList toContainExactly entries({}, {})
         nullableList toContainExactly null
-        nullableList toContainExactly entries({}, null)
-        nullableList toContainExactly entries(null, {})
-        nullableList toContainExactly entries(null, null)
 
         star toContainExactly 1
         star toContainExactly values(1, 2f)
-        star toContainExactly {}
-        star toContainExactly entries({}, {})
         star toContainExactly null
-        star toContainExactly entries({}, null)
-        star toContainExactly entries(null, {})
-        star toContainExactly entries(null, null)
+
 
         list toContain o inAny order atLeast 1 value 1
         list toContain o inAny order atLeast 1 the values(2, 1)
@@ -240,107 +228,30 @@ abstract class IterableToContainSpecBase {
 
         list toContain o inGiven order and only value 1
         list toContain o inGiven order and only the values(2, 1)
-        list toContain o inGiven order and only entry {}
-        list toContain o inGiven order and only the entries({}, {})
+
         list toContain o inGiven order and only elementsOf listOf(1, 2)
         subList toContain o inGiven order and only value 1
         subList toContain o inGiven order and only the values(2, 1)
-        subList toContain o inGiven order and only entry {}
-        subList toContain o inGiven order and only the entries({}, {})
+
         subList toContain o inGiven order and only elementsOf listOf(1, 2)
         nullableList toContain o inGiven order and only value 1
         nullableList toContain o inGiven order and only the values(2, 1)
-        nullableList toContain o inGiven order and only entry {}
-        nullableList toContain o inGiven order and only the entries({}, {})
+
         nullableList toContain o inGiven order and only elementsOf listOf(1, 2)
         nullableList toContain o inGiven order and only value null
         nullableList toContain o inGiven order and only the values(null, 1)
         nullableList toContain o inGiven order and only the values(2, null)
         nullableList toContain o inGiven order and only the values(null, null)
-        nullableList toContain o inGiven order and only entry null
-        nullableList toContain o inGiven order and only the entries(null, {})
-        nullableList toContain o inGiven order and only the entries({}, null)
-        nullableList toContain o inGiven order and only the entries(null, null)
+
         star toContain o inGiven order and only value 1
         star toContain o inGiven order and only the values(2, 1)
-        star toContain o inGiven order and only entry {}
-        star toContain o inGiven order and only the entries({}, {})
+
+
         star toContain o inGiven order and only elementsOf listOf(1, 2)
         star toContain o inGiven order and only value null
         star toContain o inGiven order and only the values(null, 1)
         star toContain o inGiven order and only the values(2, null)
         star toContain o inGiven order and only the values(null, null)
-        star toContain o inGiven order and only entry null
-        star toContain o inGiven order and only the entries(null, {})
-        star toContain o inGiven order and only the entries({}, null)
-        star toContain o inGiven order and only the entries(null, null)
 
-        list toContain o inGiven order and only grouped entries within group inAny order(
-            value(1),
-            values(1f),
-            values(1f, 1)
-        )
-        subList toContain o inGiven order and only grouped entries within group inAny order(
-            value(1),
-            values(1f),
-            values<Number>(1f, 1)
-        )
-        nullableList toContain o inGiven order and only grouped entries within group inAny order(
-            value(null),
-            values(null),
-            values(null, 2),
-            values(1, null),
-            values(null, null)
-        )
-        star toContain o inGiven order and only grouped entries within group inAny order(
-            value(null),
-            values(null),
-            values(null, 2),
-            values(1, null),
-            values(null, null)
-        )
-        any toContain o inGiven order and only grouped entries within group inAny order(
-            value(1),
-            values(2),
-            values(1f, 2),
-            values(1, 1),
-            values("je", 'a')
-        )
-
-        list toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}),
-            entries({}, {})
-        )
-        subList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}),
-            entries({}, {})
-        )
-        nullableList toContain o inGiven order and only grouped entries within group inAny order(
-            entry(null),
-            entries(null),
-            entries(null, {}),
-            entries({}, null),
-            entries(null, null)
-        )
-        star toContain o inGiven order and only grouped entries within group inAny order(
-            //TODO 1.1.0 this should fail IMO
-            // re-check don't remember why I thought this but most likely I was thinking about it being invariant
-            // which means we should need to to provide Any and not Number (or Int or any other sub-type of Any)
-            // as type argument. Right now we cannot pass Any or leave it out which is strange
-            entry<Number>(null),
-            entries(null),
-            entries(null, {}),
-            entries({}, null),
-            entries(null, null)
-        )
-        any toContain o inGiven order and only grouped entries within group inAny order(
-            entry(null),
-            entries(null),
-            entries(null, {}),
-            entries({}, null),
-            entries(null, null)
-        )
     }
 }

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/core/polyfills/stringBuilderExtensions.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/core/polyfills/stringBuilderExtensions.kt
@@ -3,5 +3,4 @@ package ch.tutteli.atrium.core.polyfills
 /**
  * Appends a line separator to this StringBuilder.
  */
-//TODO 1.1.0 rename to appendLine once we migrate to Kotlin 1.4 or higher
 expect fun StringBuilder.appendln(): StringBuilder

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/AssertionFormatterParameterObject.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/AssertionFormatterParameterObject.kt
@@ -12,13 +12,13 @@ import ch.tutteli.atrium.core.polyfills.appendln
  * @property sb The [StringBuilder] to which the formatted [Assertion] will be appended.
  * @property prefix The current prefix per assertion.
  * @property indentLevel The current indentation level.
- * @property assertionFilter Can be used used to filter out [Assertion]s which should not be formatted.
+ * @property assertionFilter Can be used to filter out [Assertion]s which should not be formatted.
  *
  * @constructor A parameter object used for interactions between [AssertionFormatterController] and [AssertionFormatter].
  * @param sb The [StringBuilder] to which the formatted [Assertion] will be appended.
  * @param prefix The current prefix per assertion.
  * @param indentLevel The current indentation level.
- * @param assertionFilter Can be used used to filter out [Assertion]s which should not be formatted.
+ * @param assertionFilter Can be used to filter out [Assertion]s which should not be formatted.
  */
 class AssertionFormatterParameterObject private constructor(
     val sb: StringBuilder,


### PR DESCRIPTION
the Number type parameter is wrong (wrong overload is chosen). Kotlin bug reported, rewrite TODOs.
This also means:
- keep `out` for infix Values and
- add `out` to Value



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
