### PR TITLE
decide about bc-tests in 1.2.0, move val into when, move TODOs

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/FeatureExpectationsBoundedReferenceAlternativeSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/FeatureExpectationsBoundedReferenceAlternativeSpec.kt
@@ -87,13 +87,13 @@ class FeatureExpectationsBoundedReferenceAlternativeSpec : ch.tutteli.atrium.spe
         //@formatter:on
 
         val propertyLazyWithNestedImmediate: F = {
-            its feature { p(it::nonNullValue) } it {
+            its feature of({ p(it::nonNullValue) }) {
                 feature { p(it::length) } toEqual 12
             }
         }
         val propertyLazyWithNestedLazy: F = {
-            it feature { p(it::nonNullValue) } it {
-                feature { p(it::length) } it { this toEqual 12 }
+            it feature of({ p(it::nonNullValue) }) {
+                it feature of({ p(it::length) }) { this toEqual 12 }
             }
         }
 
@@ -115,12 +115,12 @@ class FeatureExpectationsBoundedReferenceAlternativeSpec : ch.tutteli.atrium.spe
         val star: Expect<Collection<*>> = notImplemented()
 
         a1 feature { p(it::size) }
-        a1 feature { p(it::size) } it {}
+        a1 feature of({ p(it::size) }) {}
 
         a1b feature { p(it::size) }
-        a1b feature { p(it::size) } it {}
+        a1b feature of({ p(it::size) }) {}
 
         star feature { p(it::size) }
-        star feature { p(it::size) } it {}
+        star feature of({ p(it::size) }) {}
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/FeatureExpectationsBoundedReferenceSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/FeatureExpectationsBoundedReferenceSpec.kt
@@ -95,7 +95,7 @@ class FeatureExpectationsBoundedReferenceSpec : ch.tutteli.atrium.specs.integrat
         }
         val propertyLazyWithNestedLazy: F = {
             its feature of<TestData, String>({ f(it::nonNullValue) }) {
-                feature { f(it::length) } it { it toEqual 12 }
+                it feature of({ f(it::length) }) { it toEqual 12 }
             }
         }
 
@@ -117,13 +117,13 @@ class FeatureExpectationsBoundedReferenceSpec : ch.tutteli.atrium.specs.integrat
         val star: Expect<Collection<*>> = notImplemented()
 
         a1 feature { f(it::size) }
-        a1 feature { f(it::size) } it {}
+        a1 feature of({ f(it::size) }) {}
 
         a1b feature { f(it::size) }
-        a1b feature { f(it::size) } it {}
+        a1b feature of({ f(it::size) }) {}
 
         star feature { f(it::size) }
-        star feature { f(it::size) } it {}
+        star feature of({ f(it::size) }) {}
     }
 }
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/FeatureExpectationsManualSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/FeatureExpectationsManualSpec.kt
@@ -92,7 +92,7 @@ class FeatureExpectationsManualSpec : ch.tutteli.atrium.specs.integration.Featur
         }
         val propertyLazyWithNestedLazy: F = {
             it feature of<TestData, String>({ f("nonNullValue", it.nonNullValue) }) {
-                feature { f("length", it.length) } it { it toEqual 12 }
+                it feature of({ f("length", it.length) }) { it toEqual 12 }
             }
         }
 

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/text/impl/TextExplanatoryAssertionGroupFormatter.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/text/impl/TextExplanatoryAssertionGroupFormatter.kt
@@ -54,9 +54,7 @@ class TextExplanatoryAssertionGroupFormatter(
             if (withIndent) withIndent(bulletPoint)
             else parameterObject.createForExplanatoryFilterAssertionGroup(bulletPoint)
 
-        //TODO 1.1.0 move val inside when
-        val assertionGroupType = assertionGroup.type
-        return when (assertionGroupType) {
+        return when (val assertionGroupType = assertionGroup.type) {
             is InformationAssertionGroupType -> withOrWithoutIndent(
                 informationBulletPoint,
                 assertionGroupType.withIndent

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator.kt
@@ -78,9 +78,7 @@ abstract class ArgumentsSupportingTranslator(
     private fun translateWithArgs(translatableWithArgs: TranslatableWithArgs): String {
         val result = translateWithoutArgs(translatableWithArgs.translatable)
         val arr = Array(translatableWithArgs.arguments.size) { index ->
-            //TODO 1.1.0 move arg into when with Kotlin 1.4 or later
-            val arg = translatableWithArgs.arguments[index]
-            when (arg) {
+            when (val arg = translatableWithArgs.arguments[index]) {
                 is Translatable -> translate(arg)
                 else -> arg
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ subprojects {
     version = rootProject.version
 }
 
-//TODO 1.1.0 re-introduce bcTests again? I am currently not sure if it is actually worth it
+//TODO 1.2.0 re-introduce bcTests again? I am currently not sure if it is actually worth it
 // did not have the need to be binary compatible for a while
 //val apiProjects = subprojects.filter {
 //    it.name.startsWith("${rootProject.name}-api")

--- a/gradle/build-logic/dev/src/main/kotlin/KotlinConfigurationExtensions.kt
+++ b/gradle/build-logic/dev/src/main/kotlin/KotlinConfigurationExtensions.kt
@@ -10,7 +10,7 @@ fun KotlinProjectExtension.configureKotlinJvm(){
 
 fun NamedDomainObjectContainer<KotlinSourceSet>.configureLanguageSettings() {
     configureEach {
-        // TODO 1.1.0 make this configurable so that we can use a higher version in Tests. This will reveal kotlin
+        // TODO 1.2.0 make this configurable so that we can use a higher version in Tests. This will reveal kotlin
         // regressions sooner which means we could already test beta versions in the hope that less regressions
         // are released in the end, because those bugs also hinder Atrium users to use Atrium at its full potential
         // in the end

--- a/gradle/build-logic/dev/src/main/kotlin/generation.kt
+++ b/gradle/build-logic/dev/src/main/kotlin/generation.kt
@@ -69,10 +69,10 @@ fun Project.createGenerateLogicTask(
             generateLogic.configure {
                 dependsOn(task)
             }
-            //TODO 1.1.0 build-logic, check if we no longer need this
-            tasks.withType<AbstractKotlinCompile<*>>{
-                dependsOn(task)
-            }
+//            //TODO 1.1.0 build-logic, check if we no longer need this
+//            tasks.withType<AbstractKotlinCompile<*>>{
+//                dependsOn(task)
+//            }
         }
     }
     return generateLogic

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator.kt
@@ -44,18 +44,24 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
         searchCriteria: List<SC>
     ): AssertionGroup {
         return LazyThreadUnsafeAssertionGroup {
-            //TODO 1.1.0 explicit type should not be necessary, report
-            val listFromWhichMatchesWillBeRemoved: MutableList<E?> = container.maybeSubject.fold({ mutableListOf<E?>() }) { converter(it).toMutableList() }
+            val listFromWhichMatchesWillBeRemoved: MutableList<E?> =
+                container.maybeSubject.fold({ mutableListOf() }) { converter(it).toMutableList() }
+
             val initialSize = listFromWhichMatchesWillBeRemoved.size
             val assertions = mutableListOf<Assertion>()
-            //TODO 1.1.0 could be moved out to a function, is also used in InOrderOnlyBaseAssertionCreator
+            //TODO 1.2.0 could be moved out to a function, is also used in InOrderOnlyBaseAssertionCreator
             val sizeAssertion = container.collectBasedOnSubject(Some(listFromWhichMatchesWillBeRemoved)) {
                 _logic
                     .size { it }
                     .collectAndLogicAppend { toBe(searchCriteria.size) }
             }
 
-            val mismatches = createAssertionsForAllSearchCriteria(container, searchCriteria, listFromWhichMatchesWillBeRemoved, assertions)
+            val mismatches = createAssertionsForAllSearchCriteria(
+                container,
+                searchCriteria,
+                listFromWhichMatchesWillBeRemoved,
+                assertions
+            )
             if (mismatches == 0 && listFromWhichMatchesWillBeRemoved.isNotEmpty()) {
                 assertions.add(LazyThreadUnsafeAssertionGroup {
                     createExplanatoryGroupForMismatchesEtc(
@@ -66,7 +72,7 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
             }
 
             val description = searchBehaviour.decorateDescription(TO_CONTAIN)
-            //TODO 1.1.0 could be moved out to a function, is also used in InOrderOnlyBaseAssertionCreator
+            //TODO 1.2.0 could be moved out to a function, is also used in InOrderOnlyBaseAssertionCreator
             val options = InAnyOrderOnlyReportingOptionsImpl().apply(reportingOptions)
             val assertionGroup = (if (searchCriteria.size <= options.maxNumberOfExpectedElementsForSummary) {
                 assertionBuilder.summary.withDescription(description)
@@ -76,7 +82,7 @@ abstract class InAnyOrderOnlyAssertionCreator<E, T : IterableLike, in SC>(
 
             if (mismatches != 0 && listFromWhichMatchesWillBeRemoved.isNotEmpty()) {
                 val warningDescription =
-                    if(listFromWhichMatchesWillBeRemoved.size == mismatches || initialSize < mismatches) WARNING_MISMATCHES
+                    if (listFromWhichMatchesWillBeRemoved.size == mismatches || initialSize < mismatches) WARNING_MISMATCHES
                     else WARNING_MISMATCHES_ADDITIONAL_ELEMENTS
 
                 assertionBuilder.invisibleGroup

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator.kt
@@ -33,9 +33,7 @@ abstract class InOrderOnlyBaseAssertionCreator<E, T : IterableLike, SC>(
         return LazyThreadUnsafeAssertionGroup {
             // TODO 1.1.0 more efficient and pragmatic than turnSubjectToList, use at other places too
             val maybeList = container.maybeSubject.map {
-                //TODO move into `when` with the update to Kotlin >= 1.3
-                val iterable = converter(it)
-                when (iterable) {
+                when (val iterable = converter(it)) {
                     is List -> iterable
                     else -> iterable.toList()
                 }

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher.kt
@@ -23,7 +23,7 @@ interface InOrderOnlyMatcher<E, SC> {
         }
         val elementAssertion = elementAssertionCreator(maybeElement, searchCriterion)
         val assertion = maybeElement.map { elementAssertion }.getOrElse {
-            //TODO 1.1.0: extract common pattern
+            //TODO 1.3.0: extract common pattern
             maybeSubject.fold({
                 // already in an explanatory assertion context, no need to wrap it again
                 elementAssertion

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor.kt
@@ -53,9 +53,9 @@ class DefaultFeatureExtractor : FeatureExtractor {
                     })
 
                 val subAssertions = maybeSubAssertions.fold({
-                    listOf<Assertion>()
+                    listOf()
                 }) { assertionCreator ->
-                    // TODO 1.1.0: factor out in common pattern, should not be the concern of the average expectation
+                    // TODO 1.3.0: factor out in common pattern, should not be the concern of the average expectation
                     // function writer
                     container.maybeSubject.fold({
                         // already in an explanatory expectation-group, no need to wrap again

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultAnyAssertions.kt
@@ -38,7 +38,7 @@ class DefaultAnyAssertions : AnyAssertions {
             val assertion = container.collectBasedOnSubject(collectSubject) {
                 _logic.appendAsGroup(assertionCreatorOrNull)
             }
-            //TODO 1.1.0 this is a pattern which occurs over and over again, maybe incorporate into collect?
+            //TODO 1.3.0 this is a pattern which occurs over and over again, maybe incorporate into collect?
             container.maybeSubject.fold(
                 {
                     // already in an explanatory assertion context, no need to wrap it again

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions.kt
@@ -76,10 +76,11 @@ internal fun <T : Comparable<T>> toBeWithErrorTolerance(
     assertionBuilder.descriptive
         .withTest(container.toExpect()) { absDiff(it) <= tolerance }
         .withHelpOnFailureBasedOnDefinedSubject(container.toExpect()) { subject ->
-            //TODO 1.1.0 that's not nice in case we use it in an Iterable contains assertion, for instance contains...entry { toBeWithErrorTolerance(x, 0.01) }
+            //TODO 1.3.0 that's not nice in case we use it in an Iterable contains assertion, for instance contains...entry { toBeWithErrorTolerance(x, 0.01) }
             //we do not want to see the failure nor the exact check in the 'an entry which...' part
             //same problematic applies to feature assertions within an identification lambda
             // => yet explanatory assertion should always hold
+            // see also https://github.com/robstoll/atrium/issues/1359
             assertionBuilder.explanatoryGroup
                 .withDefaultType
                 .withAssertions(explanatoryAssertionCreator(subject))

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions.kt
@@ -22,7 +22,7 @@ class DefaultThrowableAssertions : ThrowableAssertions {
         expectedType: KClass<TExpected>
     ):  SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
         container.manualFeature(DescriptionThrowableExpectation.CAUSE) { cause }.transform().let { previousExpect ->
-            //TODO 1.1.0 factor out a pattern, we are doing this more than once, in API we have withOptions
+            //TODO 1.3.0 factor out a pattern, we are doing this more than once, in API we have withOptions
             FeatureExpect(
                 previousExpect,
                 FeatureExpectOptions(representationInsteadOfFeature = {

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/CollectionExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/CollectionExpectationsSpec.kt
@@ -20,7 +20,7 @@ abstract class CollectionExpectationsSpec(
         describePrefix,
         isEmpty.forSubjectLess(),
         isNotEmpty.forSubjectLess(),
-        sizeFeature.forSubjectLess().adjustName { "$it feature" },
+        sizeFeature.forSubjectLess().withFeatureSuffix(),
         size.forSubjectLess { toBeGreaterThan(2) }
     ) {})
 

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/Fun0ExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/Fun0ExpectationsSpec.kt
@@ -21,20 +21,14 @@ abstract class Fun0ExpectationsSpec(
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
-    @Suppress("NAME_SHADOWING")
-    val toThrow = toThrow.adjustName { it.substringBefore(" (feature)") }
-
-    @Suppress("NAME_SHADOWING")
-    val notToThrow = notToThrow.adjustName { it.substringBefore(" (feature)") }
-
     include(object : SubjectLessSpec<() -> Any?>(
         "$describePrefix[toThrow] ",
-        toThrowFeature.forSubjectLess().adjustName { "$it feature" },
+        toThrowFeature.forSubjectLess(),
         toThrow.forSubjectLess { messageToContain("bla") }
     ) {})
 
     include(object : SubjectLessSpec<() -> Int>(describePrefix,
-        notToThrowFeature.forSubjectLess().adjustName { "$it feature" },
+        notToThrowFeature.forSubjectLess(),
         notToThrow.forSubjectLess { toEqual(2) }
     ) {})
 

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/IterableToContainInOrderOnlyGroupedValuesExpectationsSpec.kt
@@ -565,7 +565,7 @@ abstract class IterableToContainInOrderOnlyGroupedValuesExpectationsSpec(
                             indexSuccess(7, 8.0)
                             indexSuccess(
                                 8, 9, listOf(9.0, 10.0),
-                                //TODO 1.1.0: https://github.com/robstoll/atrium/issues/724 should not be shown, is enough to show the indices
+                                //TODO 1.2.0: https://github.com/robstoll/atrium/issues/724 should not be shown, is enough to show the indices
                                 sizeCheck(2, 2),
                                 successAfterSuccess(10.0),
                                 successAfterSuccess(9.0)

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/testUtils.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/testUtils.kt
@@ -253,9 +253,6 @@ internal inline fun <T, R, A1, A2, A3> Feature3<T, A1, A2, A3, R>.withSubAsserti
 //@formatter:off
 inline fun <T, R> property(f: KProperty1<Expect<T>, Expect<R>>): Feature0<T, R> = (f.name to f).withFeatureSuffix()
 
-//TODO 1.1.0 simplify further instead of adjustName { "$it nullable" } once https://youtrack.jetbrains.com/issue/KT-35992 is fixed
-//@JvmName("feature0Nullable")
-//inline fun <T, R> feature0(f: KFunction1<Expect<T>, Expect<R>>): Feature0<T, R> = "${f.name} (nullable feature)" to f
 inline fun <T, R> feature0(f: KFunction1<Expect<T>, Expect<R>>): Feature0<T, R> = (f.name to f).withFeatureSuffix()
 inline fun <T, A1, R> feature1(f: KFunction2<Expect<T>, A1, Expect<R>>): Feature1<T, A1, R> = (f.name to f).withFeatureSuffix()
 inline fun <T, A1, A2, R> feature2(f: KFunction3<Expect<T>, A1, A2, Expect<R>>): Feature2<T, A1, A2, R> = (f.name to f).withFeatureSuffix()

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/Fun0ExpectationsJvmSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/Fun0ExpectationsJvmSpec.kt
@@ -18,12 +18,6 @@ abstract class Fun0ExpectationsJvmSpec(
     describePrefix: String = "[Atrium] "
 ) : Spek({
 
-    @Suppress("NAME_SHADOWING")
-    val toThrow = toThrow.adjustName { it.substringBefore(" (feature)") }
-
-    @Suppress("NAME_SHADOWING")
-    val notToThrow = notToThrow.adjustName { it.substringBefore(" (feature)") }
-
     fun describeFun(vararg pairs: SpecPair<*>, body: Suite.() -> Unit) =
         describeFunTemplate(describePrefix, pairs.map { it.name }.toTypedArray(), body = body)
 

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/LocalDateExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/LocalDateExpectationsSpec.kt
@@ -24,13 +24,13 @@ abstract class LocalDateExpectationsSpec(
 ) : Spek({
 
     include(object : SubjectLessSpec<LocalDate>(describePrefix,
-        yearFeature.forSubjectLess().adjustName { "$it feature" },
+        yearFeature.forSubjectLess(),
         year.forSubjectLess { toBeGreaterThan(2000) },
-        monthFeature.forSubjectLess().adjustName { "$it feature" },
+        monthFeature.forSubjectLess(),
         month.forSubjectLess { toBeLessThan(12) },
-        dayFeature.forSubjectLess().adjustName { "$it feature" },
+        dayFeature.forSubjectLess(),
         day.forSubjectLess { toBeLessThanOrEqualTo(20) },
-        dayOfWeekFeature.forSubjectLess().adjustName { "$it feature" },
+        dayOfWeekFeature.forSubjectLess(),
         dayOfWeek.forSubjectLess { toBeLessThanOrEqualTo(DayOfWeek.SUNDAY) }
     ) {})
 

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/LocalDateTimeExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/LocalDateTimeExpectationsSpec.kt
@@ -23,13 +23,13 @@ abstract class LocalDateTimeExpectationsSpec(
 ) : Spek({
 
     include(object : SubjectLessSpec<LocalDateTime>(describePrefix,
-        yearFeature.forSubjectLess().adjustName { "$it feature" },
+        yearFeature.forSubjectLess(),
         year.forSubjectLess { toBeGreaterThan(2000) },
-        monthFeature.forSubjectLess().adjustName { "$it feature" },
+        monthFeature.forSubjectLess(),
         month.forSubjectLess { toBeLessThan(12) },
-        dayFeature.forSubjectLess().adjustName { "$it feature" },
+        dayFeature.forSubjectLess(),
         day.forSubjectLess { toBeLessThanOrEqualTo(20) },
-        dayOfWeekFeature.forSubjectLess().adjustName { "$it feature" },
+        dayOfWeekFeature.forSubjectLess(),
         dayOfWeek.forSubjectLess { toBeLessThanOrEqualTo(DayOfWeek.SUNDAY) }
     ) {})
 

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/OptionalExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/OptionalExpectationsSpec.kt
@@ -21,7 +21,7 @@ abstract class OptionalExpectationsSpec(
     include(object : SubjectLessSpec<Optional<Int>>(
         "$describePrefix[Path] ",
         toBeEmpty.forSubjectLess(),
-        toBePresentFeature.forSubjectLess().adjustName { "$it feature" },
+        toBePresentFeature.forSubjectLess(),
         toBePresent.forSubjectLess { toEqual(1) }
     ) {})
     include(object : AssertionCreatorSpec<Optional<Int>>(

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/PathExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/PathExpectationsSpec.kt
@@ -88,13 +88,13 @@ abstract class PathExpectationsSpec(
         toHaveTheSameBinaryContentAs.forSubjectLess(Paths.get("a")),
         toHaveTheSameTextualContentAs.forSubjectLess(Paths.get("a"), Charsets.ISO_8859_1, Charsets.ISO_8859_1),
         toHaveTheSameTextualContentAsDefaultArgs.forSubjectLess(Paths.get("a")),
-        parentFeature.forSubjectLess().adjustName { "$it feature" },
+        parentFeature.forSubjectLess(),
         parent.forSubjectLess { },
-        resolveFeature.forSubjectLess("test").adjustName { "$it feature" },
+        resolveFeature.forSubjectLess("test"),
         resolve.forSubjectLess("test") { toEqual(Paths.get("a/my.txt")) },
-        fileNameFeature.forSubjectLess().adjustName { "$it feature" },
+        fileNameFeature.forSubjectLess(),
         fileName.forSubjectLess { },
-        fileNameWithoutExtensionFeature.forSubjectLess().adjustName { "$it feature" },
+        fileNameWithoutExtensionFeature.forSubjectLess(),
         fileNameWithoutExtension.forSubjectLess { }
     ) {})
 

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/ZonedDateTimeExpectationsSpec.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/integration/ZonedDateTimeExpectationsSpec.kt
@@ -23,13 +23,13 @@ abstract class ZonedDateTimeExpectationsSpec(
 ) : Spek({
 
     include(object : SubjectLessSpec<ZonedDateTime>(describePrefix,
-        yearFeature.forSubjectLess().adjustName { "$it feature" },
+        yearFeature.forSubjectLess(),
         year.forSubjectLess { toBeGreaterThan(2000) },
-        monthFeature.forSubjectLess().adjustName { "$it feature" },
+        monthFeature.forSubjectLess(),
         month.forSubjectLess { toBeLessThan(12) },
-        dayFeature.forSubjectLess().adjustName { "$it feature" },
+        dayFeature.forSubjectLess(),
         day.forSubjectLess { toBeLessThanOrEqualTo(20) },
-        dayOfWeekFeature.forSubjectLess().adjustName { "$it feature" },
+        dayOfWeekFeature.forSubjectLess(),
         dayOfWeek.forSubjectLess { toBeLessThanOrEqualTo(DayOfWeek.SUNDAY) }
     ) {})
 

--- a/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -24,7 +24,7 @@ fun <T> expect(subject: T): RootExpect<T> =
     RootExpectBuilder.forSubject(subject)
         .withVerb("I expected subject")
         .withOptions {
-            //TODO 1.1.0 we could at least filter out the runner in most cases, even in tests
+            //TODO 1.2.0 we could at least filter out the runner in most cases, even in tests
             withComponent(AtriumErrorAdjuster::class) { _ -> NoOpAtriumErrorAdjuster }
         }
         .build()

--- a/misc/tools/bc-tests/build.gradle.kts
+++ b/misc/tools/bc-tests/build.gradle.kts
@@ -164,7 +164,7 @@ bcConfigs.forEach { (oldVersion, apis, pair) ->
                     doFirst {
                         if (this is AbstractCompile) {
                             // we don't want to see all the deprecation errors during compilation
-                            // TODO 1.1.0: Gradle's logging level is no longer writable
+                            // TODO 1.2.0: Gradle's logging level is no longer writable
                             // this.logging.level = LogLevel.QUIET
                         }
                     }
@@ -205,7 +205,7 @@ bcConfigs.forEach { (oldVersion, apis, pair) ->
                         api("io.mockk:mockk-dsl-js:$mockkVersion")
                         api("org.spekframework.spek2:spek-dsl-js:$spekVersion")
 
-                        //TODO 1.1.0 should no longer be necessary once updated to kotlin 1.4.x
+                        //TODO 1.2.0 should no longer be necessary once updated to kotlin 1.4.x
                         implementation(kotlin("stdlib-js"))
                     }
                 }
@@ -359,7 +359,7 @@ bcConfigs.forEach { (oldVersion, apis, pair) ->
                         // we want to run the samples as well
                         dependsOn(tasks.named("build"))
                     }
-                    //TODO 1.1.0 not yet sure if it makes more sense to include it into :check as well
+                    //TODO 1.2.0 not yet sure if it makes more sense to include it into :check as well
 //                    tasks.named("check").configure {
 //                        dependsOn(bcTest)
 //                    }
@@ -405,7 +405,7 @@ bcConfigs.forEach { (oldVersion, apis, pair) ->
                             api(project(":atrium-core-robstoll"))
                             api(project(":atrium-domain-robstolls"))
 
-                            //TODO 1.1.0 should no longer be necessary once updated to kotlin 1.4.x
+                            //TODO 1.2.0 should no longer be necessary once updated to kotlin 1.4.x
                             implementation(kotlin("stdlib-js"))
                         }
                     }
@@ -458,7 +458,7 @@ fun Project.createJacocoReportTask(
             else -> throw IllegalStateException("re-adjust jacoco task")
         }
         projects.forEach {
-            //TODO 1.1.0 simplify, all projects use now the new MPP plugin
+            //TODO 1.2.0 simplify, all projects use now the new MPP plugin
             val sourceSetContainer = it.extensions.findByType<SourceSetContainer>()
             if (sourceSetContainer != null) {
                 sourceSets(sourceSetContainer["main"])


### PR DESCRIPTION
moreover:
- use withFeatureSuffix instead of adjustName



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
