### PR TITLE
Restrict E at OptionalAssertions.isPresent with Any

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalExpectations.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalExpectations.kt
@@ -35,7 +35,7 @@ fun <T : Optional<*>> Expect<T>.toBeEmpty(): Expect<T> =
  *
  * @since 0.17.0
  */
-fun <E, T : Optional<E>> Expect<T>.toBePresent(): Expect<E> =
+fun <E: Any, T : Optional<E>> Expect<T>.toBePresent(): Expect<E> =
     _logic.isPresent().transform()
 
 /**
@@ -48,5 +48,5 @@ fun <E, T : Optional<E>> Expect<T>.toBePresent(): Expect<E> =
  *
  * @since 0.17.0
  */
-fun <E, T : Optional<E>> Expect<T>.toBePresent(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
+fun <E: Any, T : Optional<E>> Expect<T>.toBePresent(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
     _logic.isPresent().collectAndAppend(assertionCreator)

--- a/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/OptionalExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/OptionalExpectationsSpec.kt
@@ -21,11 +21,9 @@ class OptionalExpectationsSpec : OptionalExpectationsSpec(
         o1b = o1b.toBeEmpty()
         star = star.toBeEmpty()
         o1.toBePresent()
-        o1b.toBePresent()
         // the following is not supported on purpose as we don't know what type of the element is in such a case
         // star.toBePresent()
         o1.toBePresent {}
-        o1b.toBePresent {}
         // the following is not supported on purpose as we don't know what type of the element is in such a case
         // star.toBePresent {}
     }

--- a/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalExpectations.kt
+++ b/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalExpectations.kt
@@ -33,7 +33,7 @@ infix fun <T : Optional<*>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") empty: 
  *
  * @since 0.12.0
  */
-infix fun <E, T : Optional<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") present: present): FeatureExpect<T, E> =
+infix fun <E: Any, T : Optional<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") present: present): FeatureExpect<T, E> =
     _logic.isPresent().transform()
 
 /**
@@ -44,5 +44,5 @@ infix fun <E, T : Optional<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") pres
  *
  * @since 0.12.0
  */
-infix fun <E, T : Optional<E>> Expect<T>.toBe(present: PresentWithCreator<E>): Expect<T> =
+infix fun <E: Any, T : Optional<E>> Expect<T>.toBe(present: PresentWithCreator<E>): Expect<T> =
     _logic.isPresent().collectAndAppend(present.assertionCreator)

--- a/apis/infix/atrium-api-infix/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/OptionalExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/OptionalExpectationsSpec.kt
@@ -33,11 +33,9 @@ class OptionalExpectationsSpec : OptionalExpectationsSpec(
         o1b = o1b toBe empty
         star = star toBe empty
         o1 toBe present
-        o1b toBe present
         // following is not supported on purpose as we don't know what type the element is in this case
         //star toBe Present
         o1 toBe present {}
-        o1b toBe present {}
         // following is not supported on purpose as we don't know what type the element is in this case
         //star toBe present {}
     }

--- a/logic/atrium-logic/src/generated/jvmMain/ch/tutteli/atrium/logic/optional.kt
+++ b/logic/atrium-logic/src/generated/jvmMain/ch/tutteli/atrium/logic/optional.kt
@@ -14,7 +14,7 @@ import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.logic.impl.DefaultOptionalAssertions
 
 fun <T : Optional<*>> AssertionContainer<T>.isEmpty(): Assertion = impl.isEmpty(this)
-fun <E, T : Optional<E>> AssertionContainer<T>.isPresent(): FeatureExtractorBuilder.ExecutionStep<T, E> = impl.isPresent(this)
+fun <E: Any, T : Optional<E>> AssertionContainer<T>.isPresent(): FeatureExtractorBuilder.ExecutionStep<T, E> = impl.isPresent(this)
 
 @OptIn(ExperimentalNewExpectTypes::class)
 private inline val <T> AssertionContainer<T>.impl: OptionalAssertions

--- a/logic/atrium-logic/src/jvmMain/kotlin/ch/tutteli/atrium/logic/OptionalAssertions.kt
+++ b/logic/atrium-logic/src/jvmMain/kotlin/ch/tutteli/atrium/logic/OptionalAssertions.kt
@@ -10,6 +10,6 @@ import java.util.*
  */
 interface OptionalAssertions {
     fun <T : Optional<*>> isEmpty(container: AssertionContainer<T>): Assertion
-    fun <E, T : Optional<E>> isPresent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E>
+    fun <E: Any, T : Optional<E>> isPresent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E>
 }
 

--- a/logic/atrium-logic/src/jvmMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultOptionalAssertions.kt
+++ b/logic/atrium-logic/src/jvmMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultOptionalAssertions.kt
@@ -16,7 +16,7 @@ class DefaultOptionalAssertions : OptionalAssertions {
     override fun <T : Optional<*>> isEmpty(container: AssertionContainer<T>): Assertion =
         container.createDescriptiveAssertion(TO_BE, EMPTY) { !it.isPresent }
 
-    override fun <E, T : Optional<E>> isPresent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E> =
+    override fun <E: Any, T : Optional<E>> isPresent(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E> =
         container.extractFeature
             .withDescription(GET)
             .withRepresentationForFailure(IS_NOT_PRESENT)


### PR DESCRIPTION
Restricts E at OptionalAssertions.isPresent with Any.

Also adapts the `toBePresent` in `apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/optionalExpectations.kt` based on the previous added restriction and deletes tests that do not comply with the new restrictions since the receiver was Optional<Any?>.

Also adapts the `toBePresent` in `apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/optionalExpectations.kt` based on the previous added restriction and deletes tests that do not comply with the new restrictions since the receiver was Optional<Any?> as well.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
