### PR TITLE
Added samples for functions which are not deprecated in ch.tutteli.at…

### DIFF
--- a/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/bigDecimalExpectations.kt
+++ b/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/bigDecimalExpectations.kt
@@ -124,6 +124,8 @@ infix fun <T : BigDecimal> Expect<T?>.notToEqual(expected: Nothing?): Expect<T> 
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.BigDecimalExpectationSamples.toEqualNumerically
+ *
  * @since 0.17.0
  */
 infix fun <T : BigDecimal> Expect<T>.toEqualNumerically(expected: T): Expect<T> =
@@ -143,6 +145,8 @@ infix fun <T : BigDecimal> Expect<T>.toEqualNumerically(expected: T): Expect<T> 
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.BigDecimalExpectationSamples.notToEqualNumerically
+ *
  * @since 0.17.0
  */
 infix fun <T : BigDecimal> Expect<T>.notToEqualNumerically(expected: T): Expect<T> =
@@ -160,6 +164,8 @@ infix fun <T : BigDecimal> Expect<T>.notToEqualNumerically(expected: T): Expect<
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.BigDecimalExpectationSamples.toEqualIncludingScale
+ *
  * @since 0.17.0
  */
 infix fun <T : BigDecimal> Expect<T>.toEqualIncludingScale(expected: T): Expect<T> =
@@ -175,6 +181,8 @@ infix fun <T : BigDecimal> Expect<T>.toEqualIncludingScale(expected: T): Expect<
  * - `expect(BigDecimal("10")).notToEqualNumerically(BigDecimal("10.0"))`  does not hold.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.BigDecimalExpectationSamples.notToEqualIncludingScale
  *
  * @since 0.17.0
  */

--- a/apis/infix/atrium-api-infix/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/BigDecimalExpectationSamples.kt
+++ b/apis/infix/atrium-api-infix/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/BigDecimalExpectationSamples.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.api.infix.en_GB.samples
 import ch.tutteli.atrium.api.infix.en_GB.*
 import ch.tutteli.atrium.api.verbs.expect
 import java.math.BigDecimal
+import java.math.MathContext
 import kotlin.test.Test
 
 class BigDecimalExpectationSamples {
@@ -26,6 +27,46 @@ class BigDecimalExpectationSamples {
 
         fails {
             expect(null as BigDecimal?) notToEqual null
+        }
+    }
+
+    @Test
+    fun toEqualNumerically(){
+        // Use toEqualNumerically to compare subject and target are numerically equal
+        expect(BigDecimal("-12345.67890")) toEqualNumerically BigDecimal("-12345.6789")
+
+        fails{
+            expect(BigDecimal("-12345.678")) toEqualNumerically BigDecimal("-12345.6789")
+        }
+    }
+
+    @Test
+    fun notToEqualNumerically(){
+        // Use notToEqualNumerically to compare subject and target are not numerically equal
+        expect(BigDecimal("-12345.678")) notToEqualNumerically BigDecimal("-12345.6789")
+
+        fails{
+            expect(BigDecimal("-12345.67890")) notToEqualNumerically BigDecimal("-12345.6789")
+        }
+    }
+
+    @Test
+    fun toEqualIncludingScale(){
+        // Use toEqualIncludingScale to compare subject and target are numerically equal including scale
+        expect(BigDecimal("-12345.678912", MathContext(9))) toEqualIncludingScale BigDecimal("-12345.6789")
+
+        fails{
+            expect(BigDecimal("-12345.67890")) toEqualIncludingScale BigDecimal("-12345.6789")
+        }
+    }
+
+    @Test
+    fun notToEqualIncludingScale(){
+        // Use notToEqualIncludingScale to compare subject and target are not numerically and scaling equal
+        expect(BigDecimal("-12345.67890")) notToEqualIncludingScale BigDecimal("-12345.6789")
+
+        fails{
+            expect(BigDecimal("-12345.678912", MathContext(9))) notToEqualIncludingScale BigDecimal("-12345.6789")
         }
     }
 }


### PR DESCRIPTION
…rium.api.infix.en_GB.samples.BigDecimalExpectationSamples



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
