### PR TITLE
Add samples for Iterable.toContain.exactly

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
@@ -66,6 +66,8 @@ fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> AtLeastCheckerStep<E, T,
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] is zero; use [notToContain] instead.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainCheckerSamples.exactly
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.EntryPointStep<E, T, S>.exactly(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
@@ -5,6 +5,26 @@ import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableLikeToContainCheckerSamples {
+    @Test
+    fun exactly() {
+        expect(listOf("A", "B", "A")).toContain.inAnyOrder.exactly(2).entry {
+            toEqual("A")
+        }
 
+        expect(listOf(1, 2, 3)).toContain.inAnyOrder.exactly(2).entry {
+            toBeGreaterThan(1)
+        }
 
+        fails {
+            expect(listOf("A", "B", "A", "C")).toContain.inAnyOrder.exactly(2).entry {
+                toEqual("B")
+            }
+        }
+
+        fails {
+            expect(listOf(1, 2, 3)).toContain.inAnyOrder.exactly(2).entry {
+                toBeLessThanOrEqualTo(1)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds samples for Iterable.toContain.exactly

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
