### PR TITLE
add Map.toContain...entriesOf samples

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -6,4 +6,37 @@ import kotlin.test.Test
 
 class MapLikeToContainInAnyOrderCreatorSamples {
 
+    @Test
+    fun entriesOf() {
+        expect(
+            mapOf(
+                1 to "a",
+                2 to "b",
+            )
+        )
+            .toContain
+            .inAnyOrder
+            .entriesOf(
+                mapOf(
+                    2 to "b",
+                )
+            )
+
+
+        fails {
+            expect(
+                mapOf(
+                    1 to "a",
+                    2 to "b",
+                )
+            )
+                .toContain
+                .inAnyOrder
+                .entriesOf(
+                    mapOf(
+                        1 to "b", // fails because subject does not have this entry
+                    )
+                )
+        }
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -8,35 +8,17 @@ class MapLikeToContainInAnyOrderCreatorSamples {
 
     @Test
     fun entriesOf() {
-        expect(
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(
             mapOf(
-                1 to "a",
                 2 to "b",
             )
         )
-            .toContain
-            .inAnyOrder
-            .entriesOf(
-                mapOf(
-                    2 to "b",
-                )
-            )
 
 
         fails {
-            expect(
-                mapOf(
-                    1 to "a",
-                    2 to "b",
-                )
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(
+                mapOf(1 to "b") // fails because subject does not have this entry
             )
-                .toContain
-                .inAnyOrder
-                .entriesOf(
-                    mapOf(
-                        1 to "b", // fails because subject does not have this entry
-                    )
-                )
         }
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -8,38 +8,15 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
 
     @Test
     fun entriesOf() {
-        expect(
-            mapOf(
-                1 to "a",
-                2 to "b",
-            )
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entriesOf(
+            mapOf(2 to "b", 1 to "a")
         )
-            .toContain
-            .inAnyOrder
-            .only
-            .entriesOf(
-                mapOf(
-                    2 to "b",
-                    1 to "a",
-                )
-            )
 
 
         fails {
-            expect(
-                mapOf(
-                    1 to "a",
-                    2 to "b",
-                )
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entriesOf(
+                mapOf(1 to "a") // fails because subject has additional entries
             )
-                .toContain
-                .inAnyOrder
-                .only
-                .entriesOf(
-                    mapOf(
-                        1 to "a", // fails because subject has additional entries
-                    )
-                )
         }
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -6,4 +6,40 @@ import kotlin.test.Test
 
 class MapLikeToContainInAnyOrderOnlyCreatorSamples {
 
+    @Test
+    fun entriesOf() {
+        expect(
+            mapOf(
+                1 to "a",
+                2 to "b",
+            )
+        )
+            .toContain
+            .inAnyOrder
+            .only
+            .entriesOf(
+                mapOf(
+                    2 to "b",
+                    1 to "a",
+                )
+            )
+
+
+        fails {
+            expect(
+                mapOf(
+                    1 to "a",
+                    2 to "b",
+                )
+            )
+                .toContain
+                .inAnyOrder
+                .only
+                .entriesOf(
+                    mapOf(
+                        1 to "a", // fails because subject has additional entries
+                    )
+                )
+        }
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -6,4 +6,41 @@ import kotlin.test.Test
 
 class MapLikeToContainInOrderOnlyCreatorSamples {
 
+    @Test
+    fun entriesOf() {
+        expect(
+            mapOf(
+                1 to "a",
+                2 to "b",
+            )
+        )
+            .toContain
+            .inOrder
+            .only
+            .entriesOf(
+                mapOf(
+                    1 to "a",
+                    2 to "b",
+                )
+            )
+
+
+        fails {
+            expect(
+                mapOf(
+                    1 to "a",
+                    2 to "b",
+                )
+            )
+                .toContain
+                .inOrder
+                .only
+                .entriesOf(
+                    mapOf(
+                        2 to "b", // fails because subject does not have the same order
+                        1 to "a",
+                    )
+                )
+        }
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -8,39 +8,18 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
 
     @Test
     fun entriesOf() {
-        expect(
-            mapOf(
-                1 to "a",
-                2 to "b",
-            )
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entriesOf(
+            mapOf(1 to "a", 2 to "b")
         )
-            .toContain
-            .inOrder
-            .only
-            .entriesOf(
-                mapOf(
-                    1 to "a",
-                    2 to "b",
-                )
-            )
 
 
         fails {
-            expect(
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entriesOf(
                 mapOf(
+                    2 to "b", // fails because subject does not have the same order
                     1 to "a",
-                    2 to "b",
                 )
             )
-                .toContain
-                .inOrder
-                .only
-                .entriesOf(
-                    mapOf(
-                        2 to "b", // fails because subject does not have the same order
-                        1 to "a",
-                    )
-                )
         }
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
@@ -113,6 +113,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -120,6 +120,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -183,6 +183,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  *   or it does not have elements (is empty).
  *
  * @since 0.18.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
     entriesOf: WithInOrderOnlyReportingOptions<MapLike>


### PR DESCRIPTION
Add sample usages of Map.toContain...entriesOf functions. Please advise if these samples meet standards. Thank you!

Issue #1557 

_api-fluent_

- [x] add a entriesOf method in MapLikeToContainInAnyOrderCreatorSamples for Map.toContain.inAnyOrder.only.entriesOf(...)
- [x] add a entriesOf method in MapLikeToContainInAnyOrderOnlyCreatorSamples for Map.toContain.inAnyOrder.entriesOf(...)
- [x] add a entriesOf method in MapLikeToContainInOrderOnlyCreatorSamples for Map.toContain.inOrder.only.entriesOf(...)
- [x] link in the KDoc of the corresponding function in mapLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
