### PR TITLE
add Map.toContain...entries and entriesKeyValue samples

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -37,6 +37,8 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
@@ -75,6 +77,8 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyO
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesKeyValue
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entries(
     keyValue: KeyValue<K, V>,
@@ -109,6 +113,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesOf
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
@@ -33,6 +33,8 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.e
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
@@ -67,6 +69,8 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyO
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesKeyValue
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entries(
     keyValue: KeyValue<K, V>,
@@ -100,6 +104,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesOf
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -40,6 +40,8 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
@@ -80,6 +82,8 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrde
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesKeyValue
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entries(
     keyValue: KeyValue<K, V>,
@@ -117,6 +121,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   since 0.18.0
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike,

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -21,13 +21,13 @@ class MapLikeToContainInAnyOrderCreatorSamples {
 
     @Test
     fun entriesKeyValue() {
-        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
-            KeyValue(2) { toEqual("b") }
+        expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.entries(
+            KeyValue(2) { toStartWith("b") }
         )
 
         fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
-                KeyValue(1) { toEqual("b") } // fails because subject does not have this entry
+            expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.entries(
+                KeyValue(1) { toStartWith("b") } // fails because subject does not have this entry
             )
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -7,13 +7,25 @@ import kotlin.test.Test
 class MapLikeToContainInAnyOrderCreatorSamples {
 
     @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
+            2 to "b"
+        )
+        
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
+                1 to "b" // fails because subject does not have this entry
+            )
+        }
+    }
+
+    @Test
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(
             mapOf(
                 2 to "b",
             )
         )
-
 
         fails {
             expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -20,6 +20,19 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
+    fun entriesKeyValue() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
+            KeyValue(2) { toEqual("b") }
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
+                KeyValue(1) { toEqual("b") } // fails because subject does not have this entry
+            )
+        }
+    }
+
+    @Test
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(
             mapOf(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -7,11 +7,23 @@ import kotlin.test.Test
 class MapLikeToContainInAnyOrderOnlyCreatorSamples {
 
     @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
+            2 to "b", 1 to "a"
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
+                1 to "a" // fails because subject has additional entries
+            )
+        }
+    }
+
+    @Test
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entriesOf(
             mapOf(2 to "b", 1 to "a")
         )
-
 
         fails {
             expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entriesOf(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -20,6 +20,20 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entriesKeyValue() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
+            KeyValue(2) { toEqual("b") },
+            KeyValue(1) { toEqual("a") },
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
+                KeyValue(1) { toEqual("a") }, // fails because subject has additional entries
+            )
+        }
+    }
+
+    @Test
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entriesOf(
             mapOf(2 to "b", 1 to "a")

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -21,14 +21,14 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
 
     @Test
     fun entriesKeyValue() {
-        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
-            KeyValue(2) { toEqual("b") },
-            KeyValue(1) { toEqual("a") },
+        expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.only.entries(
+            KeyValue(2) { toStartWith("b") },
+            KeyValue(1) { toStartWith("a") },
         )
 
         fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
-                KeyValue(1) { toEqual("a") }, // fails because subject has additional entries
+            expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.only.entries(
+                KeyValue(1) { toStartWith("a") }, // fails because subject has additional entries
             )
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -7,11 +7,24 @@ import kotlin.test.Test
 class MapLikeToContainInOrderOnlyCreatorSamples {
 
     @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
+            1 to "a", 2 to "b"
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
+                2 to "b", // fails because subject does not have the same order
+                1 to "a",
+            )
+        }
+    }
+
+    @Test
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entriesOf(
             mapOf(1 to "a", 2 to "b")
         )
-
 
         fails {
             expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entriesOf(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -22,15 +22,15 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
 
     @Test
     fun entriesKeyValue() {
-        expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
-            KeyValue(1) { toEqual("a") },
-            KeyValue(2) { toEqual("b") },
+        expect(mapOf(1 to "apple", 2 to "banana")).toContain.inOrder.only.entries(
+            KeyValue(1) { toStartWith("a") },
+            KeyValue(2) { toStartWith("b") },
         )
 
         fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
-                KeyValue(2) { toEqual("b") }, // fails because subject does not have the same order
-                KeyValue(1) { toEqual("a") },
+            expect(mapOf(1 to "apple", 2 to "banana")).toContain.inOrder.only.entries(
+                KeyValue(2) { toStartWith("b") }, // fails because subject does not have the same order
+                KeyValue(1) { toStartWith("a") },
             )
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -21,6 +21,21 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entriesKeyValue() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
+            KeyValue(1) { toEqual("a") },
+            KeyValue(2) { toEqual("b") },
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
+                KeyValue(2) { toEqual("b") }, // fails because subject does not have the same order
+                KeyValue(1) { toEqual("a") },
+            )
+        }
+    }
+
+    @Test
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entriesOf(
             mapOf(1 to "a", 2 to "b")

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
@@ -86,6 +86,10 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
     entries: KeyValues<K, V>
 ): Expect<T> = entries(V::class, entries.toList())
 
+/**
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
+ */
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entries(
     kClass: KClass<V>,

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
@@ -81,6 +81,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.the(
     entries: KeyValues<K, V>

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
@@ -81,17 +81,11 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.the(
     entries: KeyValues<K, V>
 ): Expect<T> = entries(V::class, entries.toList())
 
-/**
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
- */
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entries(
     kClass: KClass<V>,
@@ -119,8 +113,6 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -88,17 +88,11 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.the(
     keyValues: KeyValues<K, V>
 ): Expect<T> = entries(V::class, keyValues.toList())
 
-/**
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
- */
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entries(
     kClass: KClass<V>,
@@ -126,8 +120,6 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -93,6 +93,10 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
     keyValues: KeyValues<K, V>
 ): Expect<T> = entries(V::class, keyValues.toList())
 
+/**
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
+ */
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entries(
     kClass: KClass<V>,

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -88,6 +88,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.the(
     keyValues: KeyValues<K, V>

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -104,6 +104,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.the(
     entries: KeyValues<K, V>

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -157,6 +157,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   or it does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike
@@ -183,8 +185,6 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  *   or it does not have elements (is empty).
  *
  * @since 0.18.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(
     entriesOf: WithInOrderOnlyReportingOptions<MapLike>

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -104,8 +104,6 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.the(
     entries: KeyValues<K, V>
@@ -132,10 +130,6 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
     entries: WithInOrderOnlyReportingOptions<KeyValues<K, V>>
 ): Expect<T> = entries(V::class, entries)
 
-/**
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
- */
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entries(
     kClass: KClass<V>,
@@ -163,8 +157,6 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   or it does not have elements (is empty).
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -130,6 +130,10 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
     entries: WithInOrderOnlyReportingOptions<KeyValues<K, V>>
 ): Expect<T> = entries(V::class, entries)
 
+/**
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
+ */
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
 internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entries(
     kClass: KClass<V>,


### PR DESCRIPTION
Issue #1556 
_api-fluent_
- [x] add a entries method in MapLikeToContainInAnyOrderCreatorSamples for Map.toContain.inAnyOrder.only.entries(...)
- [x] add a entries method in MapLikeToContainInAnyOrderOnlyCreatorSamples for Map.toContain.inAnyOrder.entries(...)
- [x] add a entries method in MapLikeToContainInOrderOnlyCreatorSamples for Map.toContain.inOrder.only.entries(...)
- [x] add a entriesKeyValue method in MapLikeToContainInAnyOrderCreatorSamples for Map.toContain.inAnyOrder.only.entries(KeyValue(...){...}, ...)
- [x] add a entriesKeyValue method in MapLikeToContainInAnyOrderOnlyCreatorSamples for Map.toContain.inAnyOrder.entries(KeyValue(...){...}, ...)
- [x] add a entriesKeyValue method in MapLikeToContainInOrderOnlyCreatorSamples for Map.toContain.inOrder.only.entries(KeyValue(...){...}, ...)
- [x] link in the KDoc of the corresponding function in mapLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
