### PR TITLE
Issue/1555 map entry samples

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -21,6 +21,8 @@ import kotlin.reflect.KClass
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -59,6 +59,8 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entri
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entryKeyValue
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entry(
     keyValue: KeyValue<K, V>

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
@@ -21,6 +21,8 @@ import kotlin.reflect.KClass
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
@@ -55,6 +55,8 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.e
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entryKeyValue
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entry(
     keyValue: KeyValue<K, V>

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -64,6 +64,8 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entryKeyValue
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entry(
     keyValue: KeyValue<K, V>

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -25,6 +25,8 @@ import kotlin.reflect.KClass
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -7,6 +7,15 @@ import kotlin.test.Test
 class MapLikeToContainInAnyOrderCreatorSamples {
 
     @Test
+    fun entry() {
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entry(2 to "b")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entry(2 to "c")
+        }
+    }
+
+    @Test
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
             2 to "b"

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -16,6 +16,19 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
+    fun entryKeyValue() {
+        expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.entry(
+            KeyValue(2) { toStartWith("b") }
+        )
+
+        fails {
+            expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.entry(
+                KeyValue(1) { toStartWith("b") } // fails because subject does not have this entry
+            )
+        }
+    }
+
+    @Test
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
             2 to "b"

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -10,7 +10,7 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     fun entry() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entry(2 to "b")
 
-        fails {
+        fails { // because the value "b" of key 2 (which exists in the subject) is not equal to "c"
             expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entry(2 to "c")
         }
     }
@@ -21,9 +21,9 @@ class MapLikeToContainInAnyOrderCreatorSamples {
             KeyValue(2) { toStartWith("b") }
         )
 
-        fails {
+        fails { // because the value ("apple") of key 1 (which exists in the subject) does not start with "b"
             expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.entry(
-                KeyValue(1) { toStartWith("b") } // fails because subject does not have this entry
+                KeyValue(1) { toStartWith("b") }
             )
         }
     }
@@ -34,10 +34,8 @@ class MapLikeToContainInAnyOrderCreatorSamples {
             2 to "b"
         )
         
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(
-                1 to "b" // fails because subject does not have this entry
-            )
+        fails { // because the value ("b") of key 1 (which exists in the subject) is not "b"
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entries(1 to "b")
         }
     }
 
@@ -47,25 +45,19 @@ class MapLikeToContainInAnyOrderCreatorSamples {
             KeyValue(2) { toStartWith("b") }
         )
 
-        fails {
+        fails { // because the value ("apple") of key 1 (which exists in the subject) does not start with "b"
             expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.entries(
-                KeyValue(1) { toStartWith("b") } // fails because subject does not have this entry
+                KeyValue(1) { toStartWith("b") }
             )
         }
     }
 
     @Test
     fun entriesOf() {
-        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(
-            mapOf(
-                2 to "b",
-            )
-        )
+        expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(mapOf(2 to "b"))
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(
-                mapOf(1 to "b") // fails because subject does not have this entry
-            )
+        fails { // because the value ("a") of key 1 (which exists in the subject) is not "b"
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.entriesOf(mapOf(1 to "b"))
         }
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -7,6 +7,15 @@ import kotlin.test.Test
 class MapLikeToContainInAnyOrderOnlyCreatorSamples {
 
     @Test
+    fun entry() {
+        expect(mapOf(1 to "a")).toContain.inAnyOrder.only.entry(1 to "a")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entry(1 to "a")
+        }
+    }
+
+    @Test
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
             2 to "b", 1 to "a"

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -16,6 +16,19 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entryKeyValue() {
+        expect(mapOf(1 to "apple")).toContain.inAnyOrder.only.entry(
+            KeyValue(1) { toStartWith("a") },
+        )
+
+        fails {
+            expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.only.entry(
+                KeyValue(1) { toStartWith("a") }, // fails because subject has additional entries
+            )
+        }
+    }
+
+    @Test
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
             2 to "b", 1 to "a"

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -10,8 +10,9 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     fun entry() {
         expect(mapOf(1 to "a")).toContain.inAnyOrder.only.entry(1 to "a")
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entry(1 to "a")
+        fails { // because subject has additional entries
+            expect(mapOf(1 to "a", 2 to "b"))
+                .toContain.inAnyOrder.only.entry(1 to "a")
         }
     }
 
@@ -21,9 +22,9 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
             KeyValue(1) { toStartWith("a") },
         )
 
-        fails {
+        fails { // because subject has additional entries
             expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.only.entry(
-                KeyValue(1) { toStartWith("a") }, // fails because subject has additional entries
+                KeyValue(1) { toStartWith("a") },
             )
         }
     }
@@ -34,10 +35,8 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
             2 to "b", 1 to "a"
         )
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(
-                1 to "a" // fails because subject has additional entries
-            )
+        fails { // because subject has additional entries
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entries(1 to "a")
         }
     }
 
@@ -48,9 +47,9 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
             KeyValue(1) { toStartWith("a") },
         )
 
-        fails {
+        fails { // because subject has additional entries
             expect(mapOf(1 to "apple", 2 to "banana")).toContain.inAnyOrder.only.entries(
-                KeyValue(1) { toStartWith("a") }, // fails because subject has additional entries
+                KeyValue(1) { toStartWith("a") },
             )
         }
     }
@@ -61,9 +60,9 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
             mapOf(2 to "b", 1 to "a")
         )
 
-        fails {
+        fails { // because subject has additional entries
             expect(mapOf(1 to "a", 2 to "b")).toContain.inAnyOrder.only.entriesOf(
-                mapOf(1 to "a") // fails because subject has additional entries
+                mapOf(1 to "a")
             )
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -10,10 +10,8 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     fun entry() {
         expect(mapOf(1 to "a")).toContain.inOrder.only.entry(1 to "a")
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entry(
-                1 to "a", // fails because subject does not have the same order
-            )
+        fails { // because the entry 1="a" (which exists in the subject) is not the only entry
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entry(1 to "a")
         }
     }
 
@@ -23,9 +21,9 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
             KeyValue(1) { toStartWith("a") },
         )
 
-        fails {
+        fails { // because the entry 2="b" (which exists in the subject) is not the only entry
             expect(mapOf(1 to "apple", 2 to "banana")).toContain.inOrder.only.entry(
-                KeyValue(2) { toStartWith("b") }, // fails because subject has more entries
+                KeyValue(2) { toStartWith("b") },
             )
         }
     }
@@ -36,9 +34,9 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
             1 to "a", 2 to "b"
         )
 
-        fails {
+        fails { // because the pair entries (which all exist in the subject) do not have the same order
             expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
-                2 to "b", // fails because subject does not have the same order
+                2 to "b",
                 1 to "a",
             )
         }
@@ -51,9 +49,9 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
             KeyValue(2) { toStartWith("b") },
         )
 
-        fails {
+        fails { // because the key-value entries (which all exist in the subject) do not have the same order
             expect(mapOf(1 to "apple", 2 to "banana")).toContain.inOrder.only.entries(
-                KeyValue(2) { toStartWith("b") }, // fails because subject does not have the same order
+                KeyValue(2) { toStartWith("b") },
                 KeyValue(1) { toStartWith("a") },
             )
         }
@@ -65,10 +63,10 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
             mapOf(1 to "a", 2 to "b")
         )
 
-        fails {
+        fails { // because the map entries (which all exist in the subject) do not have the same order
             expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entriesOf(
                 mapOf(
-                    2 to "b", // fails because subject does not have the same order
+                    2 to "b",
                     1 to "a",
                 )
             )

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -18,6 +18,19 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entryKeyValue() {
+        expect(mapOf(1 to "apple")).toContain.inOrder.only.entry(
+            KeyValue(1) { toStartWith("a") },
+        )
+
+        fails {
+            expect(mapOf(1 to "apple", 2 to "banana")).toContain.inOrder.only.entry(
+                KeyValue(2) { toStartWith("b") }, // fails because subject has more entries
+            )
+        }
+    }
+
+    @Test
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
             1 to "a", 2 to "b"

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -7,6 +7,17 @@ import kotlin.test.Test
 class MapLikeToContainInOrderOnlyCreatorSamples {
 
     @Test
+    fun entry() {
+        expect(mapOf(1 to "a")).toContain.inOrder.only.entry(1 to "a")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entry(
+                1 to "a", // fails because subject does not have the same order
+            )
+        }
+    }
+
+    @Test
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")).toContain.inOrder.only.entries(
             1 to "a", 2 to "b"


### PR DESCRIPTION
Issue #1555 

_api-fluent_

- [x] add a entry method in MapLikeToContainInAnyOrderCreatorSamples for Map.toContain.inAnyOrder.only.entry(...)
- [x] add a entry method in MapLikeToContainInAnyOrderOnlyCreatorSamples for Map.toContain.inAnyOrder.entry(...)
- [x] add a entry method in MapLikeToContainInOrderOnlyCreatorSamples for Map.toContain.inOrder.only.entry(...)
- [x] add a entryKeyValue method in MapLikeToContainInAnyOrderCreatorSamples for Map.toContain.inAnyOrder.only.entry(KeyValue(...){ ... })
- [x] add a entryKeyValue method in MapLikeToContainInAnyOrderOnlyCreatorSamples for Map.toContain.inAnyOrder.entry(KeyValue(...){ ... })
- [x] add a entryKeyValue method in MapLikeToContainInOrderOnlyCreatorSamples for Map.toContain.inOrder.only.entry(KeyValue(...){ ... })
- [x] link in the KDoc of the corresponding function in mapLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
