### PR TITLE
add Map.toContain... infix samples

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToCntainInAnyOrderOnlyCreators.kt
@@ -23,6 +23,8 @@ import kotlin.reflect.KClass
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entry(
     keyValuePair: Pair<K, V>
@@ -61,6 +63,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entryKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entry(
     keyValue: KeyWithValueCreator<K, V>
@@ -81,6 +85,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.the(
     entries: KeyValues<K, V>
@@ -113,6 +119,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -23,6 +23,8 @@ import kotlin.reflect.KClass
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     this the pairs(keyValuePair)
@@ -64,6 +66,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entryKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entry(
     keyValue: KeyWithValueCreator<K, V>
@@ -88,6 +92,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.the(
     keyValues: KeyValues<K, V>
@@ -120,6 +126,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -29,6 +29,8 @@ import kotlin.reflect.KClass
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     this the pairs(keyValuePair)
@@ -85,6 +87,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entryKeyValue
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entry(
     keyValue: KeyWithValueCreator<K, V>
@@ -124,6 +128,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.18.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
  */
 @JvmName("theKeyValuesWithReportingOption")
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.the(
@@ -157,6 +163,8 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   or it does not have elements (is empty).
  *
  * @since 0.15.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -1,0 +1,52 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+class MapLikeToContainInAnyOrderCreatorSamples {
+
+    @Test
+    fun entry() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entry (2 to "b")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entry (2 to "c")
+        }
+    }
+
+    @Test
+    fun entryKeyValue() {
+        expect(mapOf(1 to "apple", 2 to "banana")) toContain o inAny order entry (
+            keyValue(2) { this toStartWith "b" }
+        )
+
+        fails {
+            expect(mapOf(1 to "apple", 2 to "banana")) toContain o inAny order entry (
+                keyValue(1) { this toStartWith "b" } // fails because subject does not have this entry
+            )
+        }
+    }
+
+    @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(2) { this toEqual "b" })
+        
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(1) { this toEqual "b" }) // fails because subject does not have this entry
+        }
+    }
+
+    @Test
+    fun entriesOf() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entriesOf(
+            mapOf(2 to "b")
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entriesOf(
+                mapOf(1 to "b") // fails because subject does not have this entry
+            )
+        }
+    }
+}

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -10,7 +10,7 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     fun entry() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entry (2 to "b")
 
-        fails {
+        fails { // because the value "b" of key 2 (which exists in the subject) is not equal to "c"
             expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entry (2 to "c")
         }
     }
@@ -21,9 +21,9 @@ class MapLikeToContainInAnyOrderCreatorSamples {
             keyValue(2) { this toStartWith "b" }
         )
 
-        fails {
+        fails { // because the value ("apple") of key 1 (which exists in the subject) does not start with "b"
             expect(mapOf(1 to "apple", 2 to "banana")) toContain o inAny order entry (
-                keyValue(1) { this toStartWith "b" } // fails because subject does not have this entry
+                keyValue(1) { this toStartWith "b" }
             )
         }
     }
@@ -32,21 +32,17 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     fun entries() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(2) { this toEqual "b" })
         
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(1) { this toEqual "b" }) // fails because subject does not have this entry
+        fails { // because the value ("b") of key 1 (which exists in the subject) is not "b"
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(1) { this toEqual "b" })
         }
     }
 
     @Test
     fun entriesOf() {
-        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entriesOf(
-            mapOf(2 to "b")
-        )
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entriesOf mapOf(2 to "b")
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entriesOf(
-                mapOf(1 to "b") // fails because subject does not have this entry
-            )
+        fails { // because the value ("a") of key 1 (which exists in the subject) is not "b"
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order entriesOf mapOf(1 to "b")
         }
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -10,7 +10,7 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     fun entry() {
         expect(mapOf(1 to "a")) toContain o inAny order but only entry (1 to "a")
 
-        fails {
+        fails { // because subject has additional entries
             expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entry (2 to "c")
         }
     }
@@ -21,9 +21,9 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
             keyValue(1) { this toStartWith "a"  }
         )
 
-        fails {
+        fails { // because subject has additional entries
             expect(mapOf(1 to "apple", 2 to "banana")) toContain o inAny order but only entry(
-                keyValue(1) { this toStartWith "a" } // fails because subject has additional entries
+                keyValue(1) { this toStartWith "a" }
             )
         }
     }
@@ -35,9 +35,9 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
             keyValue(1) { this toEqual "a" },
         )
 
-        fails {
+        fails { // because subject has additional entries
             expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only the entries(
-                keyValue(1) { this toEqual "a" } // fails because subject has additional entries
+                keyValue(1) { this toEqual "a" }
             )
         }
     }
@@ -46,9 +46,8 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entriesOf mapOf(2 to "b", 1 to "a")
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entriesOf mapOf(1 to "a") // fails because subject has additional entries
+        fails { // because subject has additional entries
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entriesOf mapOf(1 to "a")
         }
     }
-
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -1,0 +1,54 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+class MapLikeToContainInAnyOrderOnlyCreatorSamples {
+    
+    @Test
+    fun entry() {
+        expect(mapOf(1 to "a")) toContain o inAny order but only entry (1 to "a")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entry (2 to "c")
+        }
+    }
+
+    @Test
+    fun entryKeyValue() {
+        expect(mapOf(1 to "apple")) toContain o inAny order but only entry(
+            keyValue(1) { this toStartWith "a"  }
+        )
+
+        fails {
+            expect(mapOf(1 to "apple", 2 to "banana")) toContain o inAny order but only entry(
+                keyValue(1) { this toStartWith "a" } // fails because subject has additional entries
+            )
+        }
+    }
+
+    @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only the entries(
+            keyValue(2) { this toEqual "b" },
+            keyValue(1) { this toEqual "a" },
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only the entries(
+                keyValue(1) { this toEqual "a" } // fails because subject has additional entries
+            )
+        }
+    }
+
+    @Test
+    fun entriesOf() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entriesOf mapOf(2 to "b", 1 to "a")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only entriesOf mapOf(1 to "a") // fails because subject has additional entries
+        }
+    }
+
+}

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -1,0 +1,57 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+class MapLikeToContainInOrderOnlyCreatorSamples {
+    
+    @Test
+    fun entry() {
+        expect(mapOf(1 to "a")) toContain o inGiven order and only entry (1 to "a")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entry (1 to "a") // fails because subject does not have the same order
+        }
+    }
+
+    @Test
+    fun entryKeyValue() {
+        expect(mapOf(1 to "apple")) toContain o inGiven order and only entry(
+            keyValue(1) { this toStartWith "a" }
+        )
+
+        fails {
+            expect(mapOf(1 to "apple", 2 to "banana")) toContain o inGiven order and only entry(
+                keyValue(2) { this toStartWith "b" } // fails because subject has more entries
+            )
+        }
+    }
+
+    @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the entries(
+            keyValue(1) { this toEqual "a" },
+            keyValue(2) { this toEqual "b" },
+        )
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the entries(
+                keyValue(2) { this toEqual "b" }, // fails because subject does not have the same order
+                keyValue(1) { this toEqual "a" },
+            )
+        }
+    }
+
+    @Test
+    fun entriesOf() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entriesOf mapOf(1 to "a", 2 to "b")
+
+        fails {
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entriesOf mapOf(
+                2 to "b", // fails because subject does not have the same order
+                1 to "a",
+            )
+        }
+    }
+}

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -10,8 +10,8 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     fun entry() {
         expect(mapOf(1 to "a")) toContain o inGiven order and only entry (1 to "a")
 
-        fails {
-            expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entry (1 to "a") // fails because subject does not have the same order
+        fails { // because the entry 1="a" (which exists in the subject) is not the only entry
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entry (1 to "a")
         }
     }
 
@@ -21,9 +21,9 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
             keyValue(1) { this toStartWith "a" }
         )
 
-        fails {
+        fails { // because the entry 2="b" (which exists in the subject) is not the only entry
             expect(mapOf(1 to "apple", 2 to "banana")) toContain o inGiven order and only entry(
-                keyValue(2) { this toStartWith "b" } // fails because subject has more entries
+                keyValue(2) { this toStartWith "b" }
             )
         }
     }
@@ -35,9 +35,9 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
             keyValue(2) { this toEqual "b" },
         )
 
-        fails {
+        fails { // because the pair entries (which all exist in the subject) do not have the same order
             expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the entries(
-                keyValue(2) { this toEqual "b" }, // fails because subject does not have the same order
+                keyValue(2) { this toEqual "b" },
                 keyValue(1) { this toEqual "a" },
             )
         }
@@ -47,9 +47,9 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     fun entriesOf() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entriesOf mapOf(1 to "a", 2 to "b")
 
-        fails {
+        fails { // because the map entries (which all exist in the subject) do not have the same order
             expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only entriesOf mapOf(
-                2 to "b", // fails because subject does not have the same order
+                2 to "b",
                 1 to "a",
             )
         }


### PR DESCRIPTION
These are the map infix samples. Please let me know if the samples are what is expected. It wasn't clear to me when certain filler words were required (`o`, `the`), but they were in order to compile and have the tests pass. Thank you!
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
