### PR TITLE
add ignoringCaseWithNotChecker sample

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceToContainCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceToContainCreators.kt
@@ -92,8 +92,7 @@ fun <T : CharSequence> CheckerStep<T, NoOpSearchBehaviour>.values(
  * @return an [Expect] for the subject of `this` expectation.
  * @throws IllegalArgumentException in case [expected] is not a [CharSequence], [Number] or [Char].
  *
- *  @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceToContainCreatorSamples.valueIgnoringCaseWithChecker
- *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceToContainCreatorSamples.valueIgnoringCaseWithChecker
  */
 @JvmName("valueIgnoringCase")
 fun <T : CharSequence> CheckerStep<T, IgnoringCaseSearchBehaviour>.value(

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceToContainSearchBehaviours.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/charSequenceToContainSearchBehaviours.kt
@@ -23,6 +23,8 @@ val <T : CharSequence> EntryPointStep<T, NoOpSearchBehaviour>.ignoringCase: Entr
  * Defines that the search behaviour `ignore case` shall be applied to this sophisticated `contains not` assertion.
  *
  * @return The newly created builder.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.CharSequenceToContainSearchBehaviourSamples.ignoringCaseWithNotChecker
  */
 val <T : CharSequence> NotCheckerStep<T, NotSearchBehaviour>.ignoringCase: NotCheckerStep<T, IgnoringCaseSearchBehaviour>
     get() = _logic.entryPointStepLogic.ignoringCase._logic.notCheckerStep()

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -20,9 +20,9 @@ import kotlin.reflect.KClass
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)
@@ -38,9 +38,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
@@ -58,9 +58,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entri
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entryKeyValue
+ *
+ * @since 0.15.0
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entry(
     keyValue: KeyValue<K, V>
@@ -80,9 +80,9 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyO
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesKeyValue
+ *
+ * @since 0.15.0
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entries(
     keyValue: KeyValue<K, V>,
@@ -116,9 +116,9 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesOf
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
@@ -20,9 +20,9 @@ import kotlin.reflect.KClass
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)
@@ -34,9 +34,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.e
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
@@ -54,9 +54,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.e
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entryKeyValue
+ *
+ * @since 0.15.0
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entry(
     keyValue: KeyValue<K, V>
@@ -72,9 +72,9 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyO
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesKeyValue
+ *
+ * @since 0.15.0
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entries(
     keyValue: KeyValue<K, V>,
@@ -107,9 +107,9 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesOf
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -24,9 +24,9 @@ import kotlin.reflect.KClass
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     entries(keyValuePair)
@@ -41,9 +41,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entries(
     keyValuePair: Pair<K, V>,
@@ -63,9 +63,9 @@ fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entr
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entryKeyValue
+ *
+ * @since 0.15.0
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entry(
     keyValue: KeyValue<K, V>
@@ -85,9 +85,9 @@ inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrde
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesKeyValue
+ *
+ * @since 0.15.0
  */
 inline fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entries(
     keyValue: KeyValue<K, V>,
@@ -124,9 +124,9 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   the default [InOrderOnlyReportingOptions] apply if not specified.
  *   since 0.18.0
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
+ *
+ * @since 0.15.0
  */
 fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike,

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainSearchBehaviours.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/mapLikeToContainSearchBehaviours.kt
@@ -13,9 +13,12 @@ import kotlin.jvm.JvmName
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-val <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inAnyOrder: EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
+val <K, V, T : MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inAnyOrder: EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
     get() = _logic.inAnyOrder
 
 /**
@@ -24,9 +27,11 @@ val <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inAnyOrder: 
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-val <K, V, T: MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.only: EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>
+val <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.only: EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>
     @JvmName("butOnly")
     get() = _logic.butOnly
 
@@ -36,9 +41,11 @@ val <K, V, T: MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.only: 
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-val <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inOrder: EntryPointStep<K, V, T, InOrderSearchBehaviour>
+val <K, V, T : MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inOrder: EntryPointStep<K, V, T, InOrderSearchBehaviour>
     get() = _logic.inOrder
 
 /**
@@ -47,8 +54,10 @@ val <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inOrder: Ent
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-val <K, V, T: MapLike> EntryPointStep<K, V, T, InOrderSearchBehaviour>.only: EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>
+val <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderSearchBehaviour>.only: EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>
     @JvmName("andOnly")
     get() = _logic.andOnly

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/resultExpectations.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/resultExpectations.kt
@@ -11,12 +11,11 @@ import ch.tutteli.atrium.logic.isSuccess
  *
  * @return The newly created [Expect] if the given assertion is a success.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.samples.ResultExpectationSamples.toBeASuccessFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ResultExpectationSamples.toBeASuccessFeature
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
-fun <E, T : Result<E>> Expect<T>.toBeASuccess(): Expect<E> =
-    _logic.isSuccess().transform()
+fun <E, T : Result<E>> Expect<T>.toBeASuccess(): Expect<E> = _logic.isSuccess().transform()
 
 /**
  * Expects that the subject of `this` expectation (a [Result]) is a success ([Result.isSuccess]) and
@@ -24,9 +23,9 @@ fun <E, T : Result<E>> Expect<T>.toBeASuccess(): Expect<E> =
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.samples.ResultExpectationSamples.toBeASuccess
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ResultExpectationSamples.toBeASuccess
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
 fun <E, T : Result<E>> Expect<T>.toBeASuccess(assertionCreator: Expect<E>.() -> Unit): Expect<T> =
     _logic.isSuccess().collectAndAppend(assertionCreator)
@@ -37,9 +36,9 @@ fun <E, T : Result<E>> Expect<T>.toBeASuccess(assertionCreator: Expect<E>.() -> 
  *
  * @return An [Expect] with the new type [TExpected]
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.samples.ResultExpectationSamples.toBeAFailureFeature
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ResultExpectationSamples.toBeAFailureFeature
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
 inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(): Expect<TExpected> =
     _logic.isFailureOfType(TExpected::class).transform()
@@ -51,9 +50,9 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure():
  *
  * @return An [Expect] with the new type [TExpected]
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.kotlin_1_3.samples.ResultExpectationSamples.toBeAFailure
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.ResultExpectationSamples.toBeAFailure
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
 inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(
     noinline assertionCreator: Expect<TExpected>.() -> Unit

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceSubjectChangers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sequenceSubjectChangers.kt
@@ -39,9 +39,9 @@ fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<
  *
  * @return The newly created [Expect] for the transformed subject.
  *
- * @since 0.14.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SequenceSubjectChangerSamples.asListFeature
+ *
+ * @since 0.14.0
  */
 fun <E, T : Sequence<E>> Expect<T>.asList(): Expect<List<E>> = _logic.changeSubject.unreported { it.toList() }
 
@@ -54,9 +54,9 @@ fun <E, T : Sequence<E>> Expect<T>.asList(): Expect<List<E>> = _logic.changeSubj
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.14.0
- *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SequenceSubjectChangerSamples.asList
+ *
+ * @since 0.14.0
  */
 fun <E, T : Sequence<E>> Expect<T>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<T> =
     apply { asList()._logic.appendAsGroup(assertionCreator) }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CharSequenceToContainSearchBehaviourSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/CharSequenceToContainSearchBehaviourSamples.kt
@@ -15,4 +15,13 @@ class CharSequenceToContainSearchBehaviourSamples {
             expect("AAAaaa").toContain.ignoringCase.atMost(3).value("a")
         }
     }
+
+    @Test
+    fun ignoringCaseWithNotChecker() {
+        expect("ABC").notToContain.ignoringCase.value("d")
+
+        fails { // because it contains a `d` which is the same as a `D` when case is ignored
+            expect("abcd").notToContain.ignoringCase.value("D")
+        }
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableFeatureExtractorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableFeatureExtractorSamples.kt
@@ -1,0 +1,9 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+class IterableFeatureExtractorSamples {
+
+}

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyExpectations.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/anyExpectations.kt
@@ -299,7 +299,7 @@ inline infix fun <T> Expect<T>.and(@Suppress("UNUSED_PARAMETER") o: o): Expect<T
  * For instance `expect(1) toBeLessThan 3 and { it toBe even; it toBeGreaterThan 1 }` creates
  * two assertions where the second one consists of two sub-assertions. In case the first assertion holds, then the
  * second one is evaluated as a whole. Meaning, even though 1 is not even, it still evaluates that 1 is greater than 1.
- * Hence the reporting might (depending on the configured [Reporter]) contain both failing sub-assertions.
+ * Hence, the reporting might (depending on the configured [Reporter]) contain both failing sub-assertions.
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -314,15 +314,15 @@ infix fun <T> Expect<T>.and(assertionCreator: Expect<T>.() -> Unit): Expect<T> =
  * For instance, instead of:
  * ```
  * expect("hello world") {
- *   this startsWith "hello"
- *   this endsWith "world"
+ *   this toStartWith "hello"
+ *   this toEndWith "world"
  * }
  * ```
  * You can write
  * ```
  * expect("hello world") {
- *   it startsWith "hello"
- *   it endsWith "world"
+ *   it toStartWith "hello"
+ *   it toEndWith "world"
  * }
  * ```
  *
@@ -337,14 +337,18 @@ inline val <T> Expect<T>.it: Expect<T> get() : Expect<T> = this
  *
  * For instance, instead of:
  * ```
- * expect(person) {
- *   this name toEqual 1
+ * expect {
+ *   ...
+ * }.toThrow<...>{
+ *    this messageToContain "oho"
  * }
  * ```
  * You can write
  * ```
- * expect("hello world") {
- *   its name toEqual 1
+ * expect {
+ *   ...
+ * }.toThrow<...>{
+ *    its messageToContain "oho"
  * }
  * ```
  *

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -20,11 +20,11 @@ import kotlin.reflect.KClass
  *
  * Delegates to `the pairs(keyValuePair)`.
  *
- * @return an [Expect] for the subject of `this` expectation.
- *
- * @since 0.15.0
+ * @return an [Expect] for the subject of `this` expectation
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     this the pairs(keyValuePair)
@@ -63,11 +63,11 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  *   or needs to be `null` in case [KeyWithValueCreator.valueAssertionCreatorOrNull] is defined as `null`
  *   -- use the function `keyValue(x) { ... }` to create a [KeyWithValueCreator].
  *
- * @return an [Expect] for the subject of `this` expectation.
- *
- * @since 0.15.0
+ * @return an [Expect] for the subject of `this` expectation
  *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entryKeyValue
+ *
+ * @since 0.15.0
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.entry(
     keyValue: KeyWithValueCreator<K, V>
@@ -89,11 +89,11 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @param keyValues The [KeyWithValueCreator]s -- use the function
  *   `keyValues(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
  *
- * @return an [Expect] for the subject of `this` expectation.
+ * @return an [Expect] for the subject of `this` expectation
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesKeyValue
  *
  * @since 0.15.0
- *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSearchBehaviour>.the(
     keyValues: KeyValues<K, V>
@@ -125,9 +125,9 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderSe
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entriesOf
+ *
+ * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
@@ -22,9 +22,9 @@ import kotlin.reflect.KClass
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
+ * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entry(
     keyValuePair: Pair<K, V>
@@ -62,9 +62,9 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entryKeyValue
+ *
+ * @since 0.15.0
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.entry(
     keyValue: KeyWithValueCreator<K, V>
@@ -84,9 +84,9 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesKeyValue
  *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
+ * @since 0.15.0
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOnlySearchBehaviour>.the(
     entries: KeyValues<K, V>
@@ -118,9 +118,9 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InAnyOrderOn
  *   a [Map], [Sequence] or one of the [Array] types
  *   or the given [expectedMapLike] does not have elements (is empty).
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entriesOf
+ *
+ * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -28,9 +28,9 @@ import kotlin.reflect.KClass
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entry(keyValuePair: Pair<K, V>): Expect<T> =
     this the pairs(keyValuePair)
@@ -86,9 +86,9 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entryKeyValue
+ *
+ * @since 0.15.0
  */
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.entry(
     keyValue: KeyWithValueCreator<K, V>
@@ -106,6 +106,8 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  *   `entries(keyValue(key1) { ... }, keyValue(key2) { ... }, ...)` to create a [KeyValues].
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesKeyValue
  *
  * @since 0.15.0
  */
@@ -128,8 +130,6 @@ inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, 
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.18.0
- *
- * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
  */
 @JvmName("theKeyValuesWithReportingOption")
 inline infix fun <K, reified V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlySearchBehaviour>.the(
@@ -162,9 +162,9 @@ internal fun <K, V : Any, T : MapLike> EntryPointStep<K, out V?, T, InOrderOnlyS
  *   if the transformation from the given [MapLike] to `Iterable<Pair<K, V>>` fails,
  *   or it does not have elements (is empty).
  *
- * @since 0.15.0
- *
  * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entriesOf
+ *
+ * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.entriesOf(
     expectedMapLike: MapLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainSearchBehaviours.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainSearchBehaviours.kt
@@ -13,9 +13,12 @@ import kotlin.jvm.JvmName
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entry
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inAny(
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inAny(
     @Suppress("UNUSED_PARAMETER") order: order
 ): EntryPointStep<K, V, T, InAnyOrderSearchBehaviour> = _logic.inAnyOrder
 
@@ -25,10 +28,12 @@ infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inAny(
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.but(
-@Suppress("UNUSED_PARAMETER") only: only
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.but(
+    @Suppress("UNUSED_PARAMETER") only: only
 ): EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour> = _logic.butOnly
 
 /**
@@ -37,10 +42,12 @@ infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inGiven(
-@Suppress("UNUSED_PARAMETER") order: order
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inGiven(
+    @Suppress("UNUSED_PARAMETER") order: order
 ): EntryPointStep<K, V, T, InOrderSearchBehaviour> = _logic.inOrder
 
 /**
@@ -49,8 +56,10 @@ infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, NoOpSearchBehaviour>.inGive
  *
  * @return The newly created builder.
  *
-* @since 0.15.0
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entry
+ *
+ * @since 0.15.0
  */
-infix fun <K, V, T: MapLike> EntryPointStep<K, V, T, InOrderSearchBehaviour>.and(
-@Suppress("UNUSED_PARAMETER") only: only
+infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderSearchBehaviour>.and(
+    @Suppress("UNUSED_PARAMETER") only: only
 ): EntryPointStep<K, V, T, InOrderOnlySearchBehaviour> = _logic.andOnly

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/resultExpectations.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/resultExpectations.kt
@@ -12,7 +12,9 @@ import ch.tutteli.atrium.logic.isSuccess
  *
  * @return The newly created [Expect] if the given assertion is success.
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ResultExpectationSamples.toBeASuccessFeature
+ *
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
 infix fun <E, T : Result<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aSuccess: aSuccess): Expect<E> =
     _logic.isSuccess().transform()
@@ -25,7 +27,9 @@ infix fun <E, T : Result<E>> Expect<T>.toBe(@Suppress("UNUSED_PARAMETER") aSucce
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.12.0)
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ResultExpectationSamples.toBeASuccess
+ *
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.12.0)
  */
 infix fun <E, T : Result<E>> Expect<T>.toBe(success: SuccessWithCreator<E>): Expect<T> =
     _logic.isSuccess().collectAndAppend(success.assertionCreator)
@@ -34,9 +38,11 @@ infix fun <E, T : Result<E>> Expect<T>.toBe(success: SuccessWithCreator<E>): Exp
  * Expects that the subject of `this` expectation (a [Result]) is a failure ([Result.isFailure]) and
  * that it encapsulates an exception of type [TExpected].
  *
-* @return An [Expect] with the new type [TExpected]
+ * @return An [Expect] with the new type [TExpected]
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ResultExpectationSamples.toBeAFailureFeature
+ *
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
 inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(): Expect<TExpected> =
     _logic.isFailureOfType(TExpected::class).transform()
@@ -48,7 +54,9 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure():
  *
  * @return An [Expect] with the new type [TExpected]
  *
- *  @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.ResultExpectationSamples.toBeAFailure
+ *
+ * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
 inline infix fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(
     noinline assertionCreator: Expect<TExpected>.() -> Unit

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceSubjectChangers.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/sequenceSubjectChangers.kt
@@ -11,6 +11,8 @@ import ch.tutteli.atrium.logic.changeSubject
  * Use `feature { f(it::asIterable) }` if you want to show the transformation in reporting.
  *
  * @return The newly created [Expect] for the transformed subject.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.SequenceSubjectChangerSamples.asIterableFeature
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asIterable(
     @Suppress("UNUSED_PARAMETER") o: o
@@ -24,6 +26,8 @@ infix fun <E, T : Sequence<E>> Expect<T>.asIterable(
  * Use `feature of({ f(it::asIterable) }, assertionCreator)` if you want to show the transformation in reporting.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.SequenceSubjectChangerSamples.asIterable
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Iterable<E>>.() -> Unit): Expect<T> =
     apply { asIterable(o)._logic.appendAsGroup(assertionCreator) }
@@ -37,6 +41,8 @@ infix fun <E, T : Sequence<E>> Expect<T>.asIterable(assertionCreator: Expect<Ite
  * @return The newly created [Expect] for the transformed subject.
  *
  * @since 0.14.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.SequenceSubjectChangerSamples.asList
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asList(
     @Suppress("UNUSED_PARAMETER") o: o
@@ -52,6 +58,8 @@ infix fun <E, T : Sequence<E>> Expect<T>.asList(
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.SequenceSubjectChangerSamples.asListFeature
  */
 infix fun <E, T : Sequence<E>> Expect<T>.asList(assertionCreator: Expect<List<E>>.() -> Unit): Expect<T> =
     apply { asList(o)._logic.appendAsGroup(assertionCreator) }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableExpectations.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableExpectations.kt
@@ -1,2 +1,0 @@
-package ch.tutteli.atrium.api.infix.en_GB
-

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -29,9 +29,9 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
-    fun entries() {
+    fun entriesKeyValue() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(2) { this toEqual "b" })
-        
+
         fails { // because the value ("b") of key 1 (which exists in the subject) is not "b"
             expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(1) { this toEqual "b" })
         }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapLikeToContainInAnyOrderOnlyCreatorSamples {
-    
+
     @Test
     fun entry() {
         expect(mapOf(1 to "a")) toContain o inAny order but only entry (1 to "a")
@@ -29,7 +29,7 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     }
 
     @Test
-    fun entries() {
+    fun entriesKeyValue() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only the entries(
             keyValue(2) { this toEqual "b" },
             keyValue(1) { this toEqual "a" },

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -5,7 +5,7 @@ import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class MapLikeToContainInOrderOnlyCreatorSamples {
-    
+
     @Test
     fun entry() {
         expect(mapOf(1 to "a")) toContain o inGiven order and only entry (1 to "a")
@@ -29,7 +29,7 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     }
 
     @Test
-    fun entries() {
+    fun entriesKeyValue() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the entries(
             keyValue(1) { this toEqual "a" },
             keyValue(2) { this toEqual "b" },


### PR DESCRIPTION
moreover:
- make sure we use the order `@return...@sample...@since` in KDOC
- add samples to mapLikeToContainSearchBehaviours.kt
- fix type on mapLikeToCntain => mapLikeToContain (is a BC break)
- fix linking to ResultExpectationSamples (pointed to the deprecated extension module) in api-fluent
- add links to ResultExpectationSamples in api-infix
- add links to SequenceSubjectChangerSamples in api-infix



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
