### PR TITLE
add Map.toContain...entries infix samples

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderCreators.kt
@@ -43,6 +43,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderCreatorSamples.entries
+ *
  * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderSearchBehaviour>.the(

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInAnyOrderOnlyCreators.kt
@@ -40,6 +40,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehavi
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInAnyOrderOnlyCreatorSamples.entries
+ *
  * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InAnyOrderOnlySearchBehaviour>.the(

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/mapLikeToContainInOrderOnlyCreators.kt
@@ -44,6 +44,8 @@ infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.MapLikeToContainInOrderOnlyCreatorSamples.entries
+ *
  * @since 0.15.0
  */
 infix fun <K, V, T : MapLike> EntryPointStep<K, V, T, InOrderOnlySearchBehaviour>.the(

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderCreatorSamples.kt
@@ -29,6 +29,17 @@ class MapLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the pairs(
+            2 to "b"
+        )
+        
+        fails { // because the value ("b") of key 1 (which exists in the subject) is not "b"
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the pairs(1 to "b")
+        }
+    }
+
+    @Test
     fun entriesKeyValue() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order the entries(keyValue(2) { this toEqual "b" })
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -16,6 +16,17 @@ class MapLikeToContainInAnyOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only the pairs(
+            2 to "b", 1 to "a"
+        )
+
+        fails { // because subject has additional entries
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inAny order but only the pairs(1 to "a")
+        }
+    }
+
+    @Test
     fun entryKeyValue() {
         expect(mapOf(1 to "apple")) toContain o inAny order but only entry(
             keyValue(1) { this toStartWith "a"  }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/MapLikeToContainInOrderOnlyCreatorSamples.kt
@@ -29,6 +29,20 @@ class MapLikeToContainInOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entries() {
+        expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the pairs(
+            1 to "a", 2 to "b"
+        )
+
+        fails { // because the pair entries (which all exist in the subject) do not have the same order
+            expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the pairs(
+                2 to "b",
+                1 to "a",
+            )
+        }
+    }
+
+    @Test
     fun entriesKeyValue() {
         expect(mapOf(1 to "a", 2 to "b")) toContain o inGiven order and only the entries(
             keyValue(1) { this toEqual "a" },


### PR DESCRIPTION
Add `MapLikeToContain...CreatorSamples.kt` entries infix samples.

Thanks for highlighting that these were missing and providing an example @robstoll! I should have highlighted that the infix samples were mismatched compared to the fluent module.
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
