### PR TITLE
Solved issue "samples for Iterable.toContain.atLeast"

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
@@ -18,6 +18,8 @@ import ch.tutteli.atrium.logic.creating.iterable.contains.steps.*
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] is zero; use [notToContain] instead.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainCheckerSamples.atLeast
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.EntryPointStep<E, T, S>.atLeast(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
@@ -3,6 +3,7 @@ package ch.tutteli.atrium.api.fluent.en_GB.samples
 import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
+import kotlin.collections.*
 
 class IterableLikeToContainCheckerSamples {
     @Test
@@ -24,6 +25,23 @@ class IterableLikeToContainCheckerSamples {
         fails {
             expect(listOf(1, 2, 3)).toContain.inAnyOrder.exactly(2).entry {
                 toBeLessThanOrEqualTo(1)
+            }
+        }
+    }
+
+    @Test
+    fun atLeast() {
+        expect(listOf("A,B,C,A,B,B")).toContain.inAnyOrder.atLeast(3).entry{
+            toEqual("B")
+        }
+
+        expect(listOf(1,2,3,4,5,6,4)).toContain.inAnyOrder.atLeast(2).entry{
+            toEqual(4)
+        }
+
+        fails {
+            expect(listOf("A,B,C")).toContain.inAnyOrder.atLeast(2).entry{
+                toEqual("A")
             }
         }
     }


### PR DESCRIPTION
Added atLeast method to IterableLikeToContainCheckerSamples.kt and added @sample annotation to the corresponding function's KDoc in iterableLikeToContainCheckers.kt

CI needs to ensured as passing upon submission of Pull Request

Resolves #1545



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
