### PR TITLE
Solved issue "samples for Iterable.toContain.atMost"

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
@@ -91,6 +91,8 @@ fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.Ent
  * @throws IllegalArgumentException In case [times] is zero; use [notToContain] instead.
  * @throws IllegalArgumentException In case [times] equals to one; use [exactly] instead.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainCheckerSamples.atMost
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.EntryPointStep<E, T, S>.atMost(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
@@ -27,4 +27,27 @@ class IterableLikeToContainCheckerSamples {
             }
         }
     }
+
+    @Test
+    fun atMost() {
+        expect(listOf("A,A,B,C,A,B,B")).toContain.inAnyOrder.atMost(2).entry{
+            toEqual("C")
+        }
+
+        expect(listOf(1,2,3,2,3,3)).toContain.inAnyOrder.atMost(2).entry{
+            toBeLessThanOrEqualTo(2)
+        }
+
+        fails {
+            expect(listOf("A,A,B,B,C,C")).toContain.inAnyOrder.atMost(1).entry{
+                toEqual("A")
+            }
+        }
+
+        fails {
+            expect(listOf(1,2,3,2,3,3)).toContain.inAnyOrder.atMost(2).entry{
+                toBeGreaterThan(2)
+            }
+        }
+    }
 }


### PR DESCRIPTION
added atMost method to IterableLikeToContainCheckerSamples.kt and added @sample annotation to the corresponding function's KDoc in iterableLikeToContainCheckers.kt

CI needs to ensured as passing upon submission of Pull Request

Resolves #1548



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
