### PR TITLE
Solved issue "samples for Iterable.toContain.butAtMost"

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
@@ -40,6 +40,8 @@ fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.Ent
  * @throws IllegalArgumentException In case [times] of this `at most` restriction equals to the number of the
  *   `at least` restriction; use the [exactly] restriction instead.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainCheckerSamples.butAtMost
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> AtLeastCheckerStep<E, T, S>.butAtMost(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
@@ -27,4 +27,21 @@ class IterableLikeToContainCheckerSamples {
             }
         }
     }
+
+    @Test
+    fun butAtMost() {
+        expect(listOf("A,B,C,A,B,B")).toContain.inAnyOrder.atLeast(2).butAtMost(2).entry{
+            toEqual("A")
+        }
+
+        expect(listOf(1,2,3,4,5,6,4,5,5,7,7,7,7)).toContain.inAnyOrder.atLeast(3).butAtMost(4).entry{
+            toEqual(5)
+        }
+
+        fails {
+            expect(listOf("A,B,B,B,B,B,C,C")).toContain.inAnyOrder.atLeast(3).butAtMost(4).entry{
+                toEqual("A")
+            }
+        }
+    }
 }


### PR DESCRIPTION
added butAtMost method to IterableLikeToContainCheckerSamples.kt and added @sample annotation to the corresponding function's KDoc in iterableLikeToContainCheckers.kt

CI needs to ensured as passing upon submission of Pull Request

Resolves #1546



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
