### PR TITLE
specify Xmx1g as min requirement for gradle to build the project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ kotlin.code.style=official
 # com.github.vlsi.gradle-extensions prints only failing or slow test results
 slowTestLogThreshold=500
 slowSuiteLogThreshold=5000
+
+# the project requires at least the following memory to not run into OOM in github actions
+org.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
Looks like the default settings used by github-actions are not enough any more to build the project. Locally, I can build the project with 500m, on github-actions this seems not to be enough, hence I specified 1g so that the issue will not pop up soonish. I will try to decrease the build-configuration time (and maybe memory consumption) by creating publishing tasks only when env PUB is given. But in a subsequent PR
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
