### PR TITLE
apply publishing plugins, esp. tutteli-dokka only if env PUB is true

### DIFF
--- a/gradle/build-logic/basics/src/main/kotlin/extensions.kt
+++ b/gradle/build-logic/basics/src/main/kotlin/extensions.kt
@@ -8,3 +8,14 @@ fun Project.prefixedProject(name: String): Project = project(":${rootProject.nam
 // copied from com.github.vlsi.gradle.dsl.configureEach, using this instead so that we don't have to import
 inline fun <reified S : Any> DomainObjectCollection<in S>.configureEach(noinline configuration: S.() -> Unit) =
     withType().configureEach(configuration)
+
+fun isPublishing() = isEnvVariableTrue("PUB")
+fun ifIsPublishing(action: () -> Unit) = ifEnvVariableTrue("PUB", action)
+
+fun ifEnvVariableTrue(name: String, action: () -> Unit) {
+    if (isEnvVariableTrue(name)) {
+        action()
+    }
+}
+
+fun isEnvVariableTrue(name: String) = System.getenv(name).toBoolean()

--- a/gradle/build-logic/publishing/src/main/kotlin/build-logic.dokka.gradle.kts
+++ b/gradle/build-logic/publishing/src/main/kotlin/build-logic.dokka.gradle.kts
@@ -2,20 +2,23 @@ import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
 
 plugins {
     id("build-logic.gradle-conventions")
-    id("ch.tutteli.gradle.plugins.dokka")
+    id("ch.tutteli.gradle.plugins.dokka") apply isPublishing()
 }
 
-val kdocDir = rootProject.projectDir.resolve("misc/kdoc")
+ifIsPublishing {
 
-tasks.configureEach<AbstractDokkaLeafTask> {
-    dokkaSourceSets.configureEach {
-        reportUndocumented.set(true)
-        jdkVersion.set(buildParameters.defaultJdkVersion)
-        perPackageOption {
-            matchingRegex.set("io.mockk")
-            suppress.set(true)
+    val kdocDir = rootProject.projectDir.resolve("misc/kdoc")
+
+    tasks.configureEach<AbstractDokkaLeafTask> {
+        dokkaSourceSets.configureEach {
+            reportUndocumented.set(true)
+            jdkVersion.set(buildParameters.defaultJdkVersion)
+            perPackageOption {
+                matchingRegex.set("io.mockk")
+                suppress.set(true)
+            }
+            includes.from(kdocDir.resolve("packages.md"))
         }
-        includes.from(kdocDir.resolve("packages.md"))
+        configurePlugins()
     }
-    configurePlugins()
 }

--- a/gradle/build-logic/publishing/src/main/kotlin/build-logic.published-kotlin-multiplatform.gradle.kts
+++ b/gradle/build-logic/publishing/src/main/kotlin/build-logic.published-kotlin-multiplatform.gradle.kts
@@ -1,10 +1,12 @@
 plugins {
     id("build-logic.kotlin-multiplatform")
-    id("ch.tutteli.gradle.plugins.publish")
+    id("ch.tutteli.gradle.plugins.publish") apply isPublishing()
     id("build-logic.publish-to-tmp-maven-repo")
     id("build-logic.dokka")
 }
 
-tutteliPublish {
-    resetLicenses("EUPL-1.2")
+ifIsPublishing {
+    tutteliPublish {
+        resetLicenses("EUPL-1.2")
+    }
 }

--- a/gradle/build-logic/root-build/src/main/kotlin/build-logic.root-build.gradle.kts
+++ b/gradle/build-logic/root-build/src/main/kotlin/build-logic.root-build.gradle.kts
@@ -8,46 +8,49 @@ import java.net.URL
 plugins {
     id("build-logic.gradle-conventions")
     id("org.jetbrains.dokka")
-    id("ch.tutteli.gradle.plugins.dokka")
-}
-
-tutteliDokka {
-    writeToDocs.set(false)
+    id("ch.tutteli.gradle.plugins.dokka") apply isPublishing()
 }
 
 val rootProject = this
 
-val modulesNotInGhPages = listOf(
-    // deprecated modules only clutter kdoc
-    "api-fluent-kotlin_1_3",
-    "api-infix-kotlin_1_3",
-    "logic-kotlin_1_3",
-    // internal modules are not of interest
-    "specs",
-    "verbs-internal",
-    // a user will most likely never look up translations, only clutter the search
-    "translations-de_CH", "translations-en_GB"
-)
-modulesNotInGhPages.forEach { projectName ->
-    prefixedProject(projectName).afterEvaluate {
-        val subproject = this
-        rootProject.tasks.configureEach<DokkaMultiModuleTask> {
-            dependsOn(subproject.tasks.named("cleanDokkaHtmlPartial"))
-        }
-    }
-}
-tasks.configureEach<DokkaMultiModuleTask> {
-    moduleName.set("Atrium")
-    configurePlugins()
-}
+ifIsPublishing {
 
-gradle.taskGraph.whenReady {
-    if (hasTask(":dokkaHtmlMultiModule")) {
+    tutteliDokka {
+        writeToDocs.set(false)
+
+        val modulesNotInGhPages = listOf(
+            // deprecated modules only clutter kdoc
+            "api-fluent-kotlin_1_3",
+            "api-infix-kotlin_1_3",
+            "logic-kotlin_1_3",
+            // internal modules are not of interest
+            "specs",
+            "verbs-internal",
+            // a user will most likely never look up translations, only clutter the search
+            "translations-de_CH", "translations-en_GB"
+        )
         modulesNotInGhPages.forEach { projectName ->
-            prefixedProject(projectName)
-                .tasks.configureEach<DokkaTaskPartial> {
-                    enabled = false
+            prefixedProject(projectName).afterEvaluate {
+                val subproject = this
+                rootProject.tasks.configureEach<DokkaMultiModuleTask> {
+                    dependsOn(subproject.tasks.named("cleanDokkaHtmlPartial"))
                 }
+            }
+        }
+        tasks.configureEach<DokkaMultiModuleTask> {
+            moduleName.set("Atrium")
+            configurePlugins()
+        }
+
+        gradle.taskGraph.whenReady {
+            if (hasTask(":dokkaHtmlMultiModule")) {
+                modulesNotInGhPages.forEach { projectName ->
+                    prefixedProject(projectName)
+                        .tasks.configureEach<DokkaTaskPartial> {
+                            enabled = false
+                        }
+                }
+            }
         }
     }
 }

--- a/translations/atrium-translations-de_CH/build.gradle.kts
+++ b/translations/atrium-translations-de_CH/build.gradle.kts
@@ -16,8 +16,10 @@ kotlin {
     }
 }
 
-tasks.configureEach<AbstractDokkaLeafTask> {
-    dokkaSourceSets.configureEach {
-        reportUndocumented.set(false)
+ifIsPublishing {
+    tasks.configureEach<AbstractDokkaLeafTask> {
+        dokkaSourceSets.configureEach {
+            reportUndocumented.set(false)
+        }
     }
 }

--- a/translations/atrium-translations-en_GB/build.gradle.kts
+++ b/translations/atrium-translations-en_GB/build.gradle.kts
@@ -16,8 +16,10 @@ kotlin {
     }
 }
 
-tasks.configureEach<AbstractDokkaLeafTask> {
-    dokkaSourceSets.configureEach {
-        reportUndocumented.set(false)
+ifIsPublishing {
+    tasks.configureEach<AbstractDokkaLeafTask> {
+        dokkaSourceSets.configureEach {
+            reportUndocumented.set(false)
+        }
     }
 }


### PR DESCRIPTION
since the update to tutteli-dokka 5.0.0 we sometimes run into an OutOfMemoryException in github_actions. the main change is that we now create one dokkaHtml task per kotlin platform and my guess is, that they have memory leaks (as dkoka had in the past). Hence, we only apply dokka and tutteli-dokka when ENV PUB is given. On my local machine I don't have any problems publishing.



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
