### PR TITLE
add samples for Iterable.toContain.notOrAtMost

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainCheckers.kt
@@ -114,6 +114,8 @@ fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.Ent
  * @throws IllegalArgumentException In case [times] is smaller than zero.
  * @throws IllegalArgumentException In case [times] is zero; use [notToContain] instead.
  *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainCheckerSamples.notOrAtMost
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 fun <E, T: IterableLike, S : InAnyOrderSearchBehaviour> IterableLikeContains.EntryPointStep<E, T, S>.notOrAtMost(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
@@ -27,4 +27,28 @@ class IterableLikeToContainCheckerSamples {
             }
         }
     }
+
+    @Test
+    fun notOrAtMost() {
+        expect(listOf("A", "A", "B", "C")).toContain.inAnyOrder.notOrAtMost(2).entry {
+            toEqual("A")
+        }
+
+        expect(listOf(1, 2, 3)).toContain.inAnyOrder.notOrAtMost(2).entry {
+            toBeGreaterThan(1)
+        }
+
+        fails {
+            expect(listOf("A", "B", "B", "B")).toContain.inAnyOrder.notOrAtMost(2).entry {
+                toEqual("B")
+            }
+        }
+
+        fails {
+            expect(listOf(1, 2, 3, 3)).toContain.inAnyOrder.notOrAtMost(2).entry {
+                toBeGreaterThan(1)
+            }
+        }
+
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainCheckerSamples.kt
@@ -35,16 +35,18 @@ class IterableLikeToContainCheckerSamples {
         }
 
         expect(listOf(1, 2, 3)).toContain.inAnyOrder.notOrAtMost(2).entry {
-            toBeGreaterThan(1)
+            // none fulfils the expectation which is fine because we use notOrAtMost
+            // use atMost if you want that at least one element matches
+            toBeGreaterThan(4)
         }
 
-        fails {
+        fails { // because "B" is 3 times in the List
             expect(listOf("A", "B", "B", "B")).toContain.inAnyOrder.notOrAtMost(2).entry {
                 toEqual("B")
             }
         }
 
-        fails {
+        fails { // because there are 3 items greater than 1
             expect(listOf(1, 2, 3, 3)).toContain.inAnyOrder.notOrAtMost(2).entry {
                 toBeGreaterThan(1)
             }


### PR DESCRIPTION
### Outline
Added samples for _Iterable.toContain.notOrAtMost_.

### Issue
#1549 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
