### PR TITLE
Add Iterable.toContain....elementsOf samples

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -5,5 +5,16 @@ import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableLikeToContainInAnyOrderCreatorSamples {
+    @Test
+    fun elementsOf(){
+        expect(listOf("A","B")).toContain.inAnyOrder.exactly(1).elementsOf(listOf("A","B"))
+        expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(2).elementsOf(listOf("A","B"))
+        expect(listOf("A","B","B")).toContain.inAnyOrder.atMost(2).elementsOf(listOf("A","B"))
 
+        fails {
+            expect(listOf("A","B")).toContain.inAnyOrder.exactly(2).elementsOf(listOf("A","B"))
+            expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(3).elementsOf(listOf("A","B"))
+            expect(listOf("A","B","B","B")).toContain.inAnyOrder.atMost(2).elementsOf(listOf("A","B"))
+        }
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -11,9 +11,15 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
             listOf("A","B","C")
         )
 
-        fails {
+        fails { // because not all elements found
             expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
-                listOf("A","B")
+                listOf("B", "A")
+            )
+        }
+        
+        fails { // because more elements expected than found
+            expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
+                listOf("B", "A", "C", "D")
             )
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -5,5 +5,16 @@ import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
+    @Test
+    fun elementsOf(){
+        expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
+            listOf("A","B","C")
+        )
 
+        fails {
+            expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
+                listOf("A","B")
+            )
+        }
+    }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -11,9 +11,21 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
             listOf("A","B","C")
         )
 
-        fails {
+        fails { // although same elements but not in same order
             expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
                 listOf("A","C","B")
+            )
+        }
+        
+         fails { // because not all elements found
+            expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
+                listOf("A","B")
+            )
+        }
+        
+        fails { // because more elements expected than found
+            expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
+                listOf("A","B","C","D")
             )
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -5,5 +5,16 @@ import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
 
 class IterableLikeToContainInOrderOnlyCreatorSamples {
+    @Test
+    fun elementsOf(){
+        expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
+            listOf("A","B","C")
+        )
 
+        fails {
+            expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
+                listOf("A","C","B")
+            )
+        }
+    }
 }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderCreators.kt
@@ -111,6 +111,8 @@ infix fun <E : Any, T : IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBeh
  *   or the given [expectedIterableLike] does not have elements (is empty).
  *
  * @since 0.13.0
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.elementsOf
  */
 inline infix fun <reified E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -146,6 +146,8 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  *   or the given [expectedIterableLike] does not have elements (is empty).
  *
  * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.elementsOf
  */
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -146,6 +146,8 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  *   or the given [expectedIterableLike] does not have elements (is empty).
  *
  * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.elementsOf
  */
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike


### PR DESCRIPTION
Add sample usages of Iterable.toContain....elementsOf functions. Please advise if these samples meet standards. Thank you!

Issue [#1554 ](https://github.com/robstoll/atrium/issues/1554)

_api-fluent_

- [x] add a elementsOf method in IterableLikeToContainInAnyOrderCreatorSamples for CharSequence.toContain.inAnyOrder.only.elementsOf(...)

- [x] add a elementsOf method in IterableLikeToContainInAnyOrderOnlyCreatorSamples for CharSequence.toContain.inAnyOrder.elementsOf(...)

- [x] add a elementsOf method in IterableLikeToContainInOrderOnlyCreatorSamples for CharSequence.toContain.inOrder.only.elementsOf(...

- [x] link in the KDoc of the corresponding function in iterableLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
