### PR TITLE
feat: add default variance to Expect<out T>, AssertionContainer<out T>, FeatureExpect<out T, out R>

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arraySubjectChangers.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/arraySubjectChangers.kt
@@ -17,7 +17,7 @@ import kotlin.jvm.JvmName
  *
  * @since 0.9.0
  */
-fun <E> Expect<out Array<out E>>.asList(): Expect<List<E>> =
+fun <E> Expect<Array<out E>>.asList(): Expect<List<E>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fun0Expectations.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/fun0Expectations.kt
@@ -19,11 +19,11 @@ import kotlin.reflect.KClass
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.Fun0ExpectationSamples.toThrowFeature
  */
-inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(): Expect<TExpected> =
+inline fun <reified TExpected : Throwable> Expect<() -> Any?>.toThrow(): Expect<TExpected> =
     toThrow(TExpected::class).transform()
 
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
-internal fun <TExpected : Throwable> Expect<out () -> Any?>.toThrow(
+internal fun <TExpected : Throwable> Expect<() -> Any?>.toThrow(
     kClass: KClass<TExpected>
 ): SubjectChangerBuilder.ExecutionStep<*, TExpected> = _logic.toThrow(kClass)
 
@@ -61,7 +61,7 @@ internal fun <TExpected : Throwable> Expect<out () -> Any?>.toThrow(
  *
  * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.Fun0ExpectationSamples.toThrow
  */
-inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
+inline fun <reified TExpected : Throwable> Expect<() -> Any?>.toThrow(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> = toThrow(TExpected::class).transformAndAppend(assertionCreator)
 

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/resultExpectations.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/resultExpectations.kt
@@ -40,7 +40,7 @@ fun <E, T : Result<E>> Expect<T>.toBeASuccess(assertionCreator: Expect<E>.() -> 
  *
  * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
-inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(): Expect<TExpected> =
+inline fun <reified TExpected : Throwable> Expect<Result<*>>.toBeAFailure(): Expect<TExpected> =
     _logic.isFailureOfType(TExpected::class).transform()
 
 /**
@@ -54,6 +54,6 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure():
  *
  * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
-inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(
+inline fun <reified TExpected : Throwable> Expect<Result<*>>.toBeAFailure(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> = _logic.isFailureOfType(TExpected::class).transformAndAppend(assertionCreator)

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableFeatureExtractors.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/throwableFeatureExtractors.kt
@@ -60,11 +60,11 @@ fun <T : Throwable> Expect<T>.messageToContain(
  *
  * @since 0.10.0
  */
-inline fun <reified TExpected : Throwable> Expect<out Throwable>.cause(): Expect<TExpected> =
+inline fun <reified TExpected : Throwable> Expect<Throwable>.cause(): Expect<TExpected> =
     causeToBeAnInstanceOf(TExpected::class).transform()
 
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
-internal fun <TExpected : Throwable> Expect<out Throwable>.causeToBeAnInstanceOf(
+internal fun <TExpected : Throwable> Expect<Throwable>.causeToBeAnInstanceOf(
     kClass: KClass<TExpected>
 ): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = _logic.causeIsA(kClass)
 
@@ -82,6 +82,6 @@ internal fun <TExpected : Throwable> Expect<out Throwable>.causeToBeAnInstanceOf
  *
  * @since 0.10.0
  */
-inline fun <reified TExpected : Throwable> Expect<out Throwable>.cause(
+inline fun <reified TExpected : Throwable> Expect<Throwable>.cause(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> = causeToBeAnInstanceOf(TExpected::class).transformAndAppend(assertionCreator)

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/AnyExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/AnyExpectationsSpec.kt
@@ -59,29 +59,29 @@ class AnyExpectationsSpec : ch.tutteli.atrium.specs.integration.AnyExpectationsS
     companion object {
         private fun toEqualNull(expect: Expect<Int?>) = expect.toEqual(null)
 
-        private fun toBeAnInstanceOfIntFeature(expect: Expect<out Any?>): Expect<Int> =
+        private fun toBeAnInstanceOfIntFeature(expect: Expect<Any?>): Expect<Int> =
             expect.toBeAnInstanceOf<Int>()
 
         private fun toBeAnInstanceOfInt(
-            expect: Expect<out Any?>,
+            expect: Expect<Any?>,
             assertionCreator: Expect<Int>.() -> Unit
         ): Expect<Int> =
             expect.toBeAnInstanceOf<Int> { assertionCreator() }
 
-        private fun toBeAnInstanceOfSuperTypeFeature(expect: Expect<out Any?>): Expect<SuperType> =
+        private fun toBeAnInstanceOfSuperTypeFeature(expect: Expect<Any?>): Expect<SuperType> =
             expect.toBeAnInstanceOf<SuperType>()
 
         private fun toBeAnInstanceOfSuperType(
-            expect: Expect<out Any?>,
+            expect: Expect<Any?>,
             assertionCreator: Expect<SuperType>.() -> Unit
         ): Expect<SuperType> =
             expect.toBeAnInstanceOf<SuperType> { assertionCreator() }
 
-        private fun toBeAnInstanceOfSubTypeFeature(expect: Expect<out Any?>): Expect<SubType> =
+        private fun toBeAnInstanceOfSubTypeFeature(expect: Expect<Any?>): Expect<SubType> =
             expect.toBeAnInstanceOf<SubType>()
 
         private fun toBeAnInstanceOfSubType(
-            expect: Expect<out Any?>,
+            expect: Expect<Any?>,
             assertionCreator: Expect<SubType>.() -> Unit
         ): Expect<SubType> =
             expect.toBeAnInstanceOf<SubType> { assertionCreator() }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/Fun0ExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/Fun0ExpectationsSpec.kt
@@ -13,11 +13,11 @@ class Fun0ExpectationsSpec : ch.tutteli.atrium.specs.integration.Fun0Expectation
     feature1<() -> Int, Expect<Int>.() -> Unit, Int>(Expect<() -> Int>::notToThrow)
 ) {
     companion object {
-        private fun toThrowFeature(expect: Expect<out () -> Any?>) =
+        private fun toThrowFeature(expect: Expect<() -> Any?>) =
             expect.toThrow<IllegalArgumentException>()
 
         private fun toThrow(
-            expect: Expect<out () -> Any?>,
+            expect: Expect<() -> Any?>,
             assertionCreator: Expect<IllegalArgumentException>.() -> Unit
         ) = expect.toThrow<IllegalArgumentException> { assertionCreator() }
     }
@@ -25,7 +25,7 @@ class Fun0ExpectationsSpec : ch.tutteli.atrium.specs.integration.Fun0Expectation
     @Suppress("unused", "UNUSED_VALUE", "UNUSED_VARIABLE")
     private fun ambiguityTest() {
         val a1: Expect<() -> Any?> = notImplemented()
-        val a2: Expect<out () -> Int> = notImplemented()
+        val a2: Expect<() -> Int> = notImplemented()
 
         val r1: Expect<IllegalArgumentException> = a1.toThrow<IllegalArgumentException>()
         val r2: Expect<IllegalArgumentException> = a2.toThrow<IllegalArgumentException>()

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ResultExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ResultExpectationsSpec.kt
@@ -15,7 +15,7 @@ class ResultExpectationsSpec : ch.tutteli.atrium.specs.integration.ResultExpecta
         private fun toBeAFailureFeature(expect: Expect<Result<Int>>) = expect.toBeAFailure<IllegalArgumentException>()
 
         private fun toBeAFailure(
-            expect: Expect<out Result<*>>,
+            expect: Expect<Result<*>>,
             assertionCreator: Expect<IllegalArgumentException>.() -> Unit
         ) = expect.toBeAFailure<IllegalArgumentException> { assertionCreator() }
 

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ThrowableExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ThrowableExpectationsSpec.kt
@@ -13,13 +13,11 @@ class ThrowableExpectationsSpec : ch.tutteli.atrium.specs.integration.ThrowableE
 
     companion object {
 
-        @Suppress("RemoveExplicitTypeArguments")
-        private fun causeFeature(expect: Expect<out Throwable>): Expect<IllegalArgumentException> =
+        private fun causeFeature(expect: Expect<Throwable>): Expect<IllegalArgumentException> =
             expect.cause<IllegalArgumentException>()
 
-        @Suppress("RemoveExplicitTypeArguments")
         private fun cause(
-            expect: Expect<out Throwable>,
+            expect: Expect<Throwable>,
             assertionCreator: Expect<IllegalArgumentException>.() -> Unit
         ) = expect.cause<IllegalArgumentException>(assertionCreator)
 

--- a/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/BigDecimalExpectationsSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/BigDecimalExpectationsSpec.kt
@@ -14,7 +14,7 @@ class BigDecimalExpectationsSpec : Spek({
         @Suppress("DEPRECATION") fun1<BigDecimal?, BigDecimal?>(Expect<BigDecimal?>::toEqual).withNullableSuffix(),
         fun1<BigDecimal?, Nothing?>(Expect<BigDecimal?>::toEqual).withNullableSuffix(),
         Expect<Any>::toEqual,
-        @Suppress("DEPRECATION") (Expect<BigDecimal>::notToEqual.name to  Expect<BigDecimal>::notToEqual),
+        @Suppress("DEPRECATION") (Expect<BigDecimal>::notToEqual.name to { notToEqual(it) }),
         Expect<Any>::notToEqual,
         Expect<BigDecimal>::toEqualNumerically.name to Expect<BigDecimal>::toEqualNumerically,
         Expect<BigDecimal>::notToEqualNumerically.name to Expect<BigDecimal>::notToEqualNumerically,

--- a/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/Fun0ExpectationsJvmSpec.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/Fun0ExpectationsJvmSpec.kt
@@ -13,8 +13,8 @@ class Fun0ExpectationsJvmSpec : ch.tutteli.atrium.specs.integration.Fun0Expectat
 ) {
 
     companion object {
-        fun toThrowFeature(expect: Expect<out () -> Any?>) = expect.toThrow<IllegalArgumentException>()
-        fun toThrow(expect: Expect<out () -> Any?>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
+        fun toThrowFeature(expect: Expect<() -> Any?>) = expect.toThrow<IllegalArgumentException>()
+        fun toThrow(expect: Expect<() -> Any?>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
             expect.toThrow<IllegalArgumentException> { assertionCreator() }
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/arraySubjectChangers.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/arraySubjectChangers.kt
@@ -17,7 +17,7 @@ import kotlin.jvm.JvmName
  *
  * @since 0.12.0
  */
-infix fun <E> Expect<out Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<E>> =
+infix fun <E> Expect<Array<out E>>.asList(@Suppress("UNUSED_PARAMETER") o: o): Expect<List<E>> =
     _logic.changeSubject.unreported { it.asList() }
 
 /**

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/fun0Expectations.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/fun0Expectations.kt
@@ -17,11 +17,11 @@ import kotlin.reflect.KClass
  *
  * @return An [Expect] with the new type [TExpected].
  */
-inline fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(): Expect<TExpected> =
+inline fun <reified TExpected : Throwable> Expect<() -> Any?>.toThrow(): Expect<TExpected> =
     toThrow(TExpected::class).transform()
 
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
-internal fun <TExpected : Throwable> Expect<out () -> Any?>.toThrow(
+internal fun <TExpected : Throwable> Expect<() -> Any?>.toThrow(
     kClass: KClass<TExpected>
 ): SubjectChangerBuilder.ExecutionStep<*, TExpected> = _logic.toThrow(kClass)
 
@@ -57,7 +57,7 @@ internal fun <TExpected : Throwable> Expect<out () -> Any?>.toThrow(
  *
  * @return An [Expect] with the new type [TExpected].
  */
-inline infix fun <reified TExpected : Throwable> Expect<out () -> Any?>.toThrow(
+inline infix fun <reified TExpected : Throwable> Expect<() -> Any?>.toThrow(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> = toThrow(TExpected::class).transformAndAppend(assertionCreator)
 

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/resultExpectations.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/resultExpectations.kt
@@ -44,7 +44,7 @@ infix fun <E, T : Result<E>> Expect<T>.toBe(success: SuccessWithCreator<E>): Exp
  *
  * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
-inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(): Expect<TExpected> =
+inline fun <reified TExpected : Throwable> Expect<Result<*>>.toBeAFailure(): Expect<TExpected> =
     _logic.isFailureOfType(TExpected::class).transform()
 
 /**
@@ -58,6 +58,6 @@ inline fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure():
  *
  * @since 1.1.0 (was in kotlin_1_3 extension since 0.17.0)
  */
-inline infix fun <reified TExpected : Throwable> Expect<out Result<*>>.toBeAFailure(
+inline infix fun <reified TExpected : Throwable> Expect<Result<*>>.toBeAFailure(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> = _logic.isFailureOfType(TExpected::class).transformAndAppend(assertionCreator)

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableFeatureExtractors.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/throwableFeatureExtractors.kt
@@ -78,11 +78,11 @@ infix fun <T : Throwable> Expect<T>.messageToContain(values: Values<Any>): Expec
  *
  * @since 0.12.0
  */
-inline fun <reified TExpected : Throwable> Expect<out Throwable>.cause(): Expect<TExpected> =
+inline fun <reified TExpected : Throwable> Expect<Throwable>.cause(): Expect<TExpected> =
     causeToBeAnInstanceOf(TExpected::class).transform()
 
 @PublishedApi // in order that _logic does not become part of the API we have this extra function
-internal fun <TExpected : Throwable> Expect<out Throwable>.causeToBeAnInstanceOf(
+internal fun <TExpected : Throwable> Expect<Throwable>.causeToBeAnInstanceOf(
     kClass: KClass<TExpected>
 ): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = _logic.causeIsA(kClass)
 
@@ -101,6 +101,6 @@ internal fun <TExpected : Throwable> Expect<out Throwable>.causeToBeAnInstanceOf
  *
  * @since 0.12.0
  */
-inline infix fun <reified TExpected : Throwable> Expect<out Throwable>.cause(
+inline infix fun <reified TExpected : Throwable> Expect<Throwable>.cause(
     noinline assertionCreator: Expect<TExpected>.() -> Unit
 ): Expect<TExpected> = causeToBeAnInstanceOf(TExpected::class).transformAndAppend(assertionCreator)

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/AnyExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/AnyExpectationsSpec.kt
@@ -59,26 +59,26 @@ class AnyExpectationsSpec : ch.tutteli.atrium.specs.integration.AnyExpectationsS
     companion object {
         private fun toEqualNull(expect: Expect<Int?>) = expect toEqual null
 
-        private fun toBeAnInstanceOfIntFeature(expect: Expect<out Any?>): Expect<Int> =
+        private fun toBeAnInstanceOfIntFeature(expect: Expect<Any?>): Expect<Int> =
             expect.toBeAnInstanceOf()
 
-        private fun toBeAnInstanceOfInt(expect: Expect<out Any?>, assertionCreator: Expect<Int>.() -> Unit): Expect<Int> =
+        private fun toBeAnInstanceOfInt(expect: Expect<Any?>, assertionCreator: Expect<Int>.() -> Unit): Expect<Int> =
             expect.toBeAnInstanceOf<Int> { assertionCreator() }
 
-        private fun toBeAnInstanceOfSuperTypeFeature(expect: Expect<out Any?>): Expect<SuperType> =
+        private fun toBeAnInstanceOfSuperTypeFeature(expect: Expect<Any?>): Expect<SuperType> =
             expect.toBeAnInstanceOf<SuperType>()
 
         private fun toBeAnInstanceOfSuperType(
-            expect: Expect<out Any?>,
+            expect: Expect<Any?>,
             assertionCreator: Expect<SuperType>.() -> Unit
         ): Expect<SuperType> =
             expect.toBeAnInstanceOf<SuperType> { assertionCreator() }
 
-        private fun toBeAnInstanceOfSubTypeFeature(expect: Expect<out Any?>): Expect<SubType> =
+        private fun toBeAnInstanceOfSubTypeFeature(expect: Expect<Any?>): Expect<SubType> =
             expect.toBeAnInstanceOf<SubType>()
 
         private fun toBeAnInstanceOfSubType(
-            expect: Expect<out Any?>,
+            expect: Expect<Any?>,
             assertionCreator: Expect<SubType>.() -> Unit
         ): Expect<SubType> =
             expect.toBeAnInstanceOf<SubType> { assertionCreator() }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/Fun0ExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/Fun0ExpectationsSpec.kt
@@ -13,11 +13,11 @@ class Fun0ExpectationsSpec : ch.tutteli.atrium.specs.integration.Fun0Expectation
     feature1<() -> Int, Expect<Int>.() -> Unit, Int>(Expect<() -> Int>::notToThrow)
 ) {
     companion object {
-        private fun toThrowFeature(expect: Expect<out () -> Any?>) =
+        private fun toThrowFeature(expect: Expect<() -> Any?>) =
             expect.toThrow<IllegalArgumentException>()
 
         private fun toThrow(
-            expect: Expect<out () -> Any?>,
+            expect: Expect<() -> Any?>,
             assertionCreator: Expect<IllegalArgumentException>.() -> Unit
         ) = expect.toThrow<IllegalArgumentException> { assertionCreator() }
     }
@@ -25,7 +25,7 @@ class Fun0ExpectationsSpec : ch.tutteli.atrium.specs.integration.Fun0Expectation
     @Suppress("unused", "UNUSED_VALUE", "UNUSED_VARIABLE")
     private fun ambiguityTest() {
         val a1: Expect<() -> Any?> = notImplemented()
-        val a2: Expect<out () -> Int> = notImplemented()
+        val a2: Expect<() -> Int> = notImplemented()
 
         val r1: Expect<IllegalArgumentException> = a1.toThrow<IllegalArgumentException>()
         val r2: Expect<IllegalArgumentException> = a2.toThrow<IllegalArgumentException>()

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ResultExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ResultExpectationsSpec.kt
@@ -32,7 +32,7 @@ class ResultExpectationsSpec : ResultExpectationsSpec(
         ) = expect toBe aSuccess { assertionCreator() }
 
         private fun toBeAFailure(
-            expect: Expect<out Result<*>>,
+            expect: Expect<Result<*>>,
             assertionCreator: Expect<IllegalArgumentException>.() -> Unit
         ) = expect.toBeAFailure<IllegalArgumentException> { assertionCreator() }
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ThrowableExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ThrowableExpectationsSpec.kt
@@ -24,13 +24,11 @@ class ThrowableExpectationsSpec : ch.tutteli.atrium.specs.integration.ThrowableE
                 *otherExpected
             )
 
-        @Suppress("RemoveExplicitTypeArguments")
-        private fun causeFeature(expect: Expect<out Throwable>): Expect<IllegalArgumentException> =
+        private fun causeFeature(expect: Expect<Throwable>): Expect<IllegalArgumentException> =
             expect.cause<IllegalArgumentException>()
 
-        @Suppress("RemoveExplicitTypeArguments")
         private fun cause(
-            expect: Expect<out Throwable>,
+            expect: Expect<Throwable>,
             assertionCreator: Expect<IllegalArgumentException>.() -> Unit
         ) = expect.cause<IllegalArgumentException>(assertionCreator)
     }

--- a/apis/infix/atrium-api-infix/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/Fun0ExpectationsJvmSpec.kt
+++ b/apis/infix/atrium-api-infix/src/jvmTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/Fun0ExpectationsJvmSpec.kt
@@ -13,8 +13,8 @@ class Fun0ExpectationsJvmSpec : ch.tutteli.atrium.specs.integration.Fun0Expectat
 ) {
 
     companion object {
-        fun toThrowFeature(expect: Expect<out () -> Any?>) = expect.toThrow<IllegalArgumentException>()
-        fun toThrow(expect: Expect<out () -> Any?>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
+        fun toThrowFeature(expect: Expect<() -> Any?>) = expect.toThrow<IllegalArgumentException>()
+        fun toThrow(expect: Expect<() -> Any?>, assertionCreator: Expect<IllegalArgumentException>.() -> Unit) =
             expect.toThrow<IllegalArgumentException> { assertionCreator() }
     }
 }

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  * @param T The type of the subject of `this` expectation.
  */
 //TODO 1.3.0 introduce ProofContainer
-interface AssertionContainer<T> {
+interface AssertionContainer<out T> {
     /**
      * Either [Some] wrapping the subject of an [Assertion] or [None] in case a previous subject transformation
      * could not be carried out.

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/CollectingExpect.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/CollectingExpect.kt
@@ -11,7 +11,7 @@ import ch.tutteli.atrium.creating.impl.CollectingExpectImpl
  *
  * @param T The type of the subject of this [Expect].
  */
-interface CollectingExpect<T> : Expect<T> {
+interface CollectingExpect<out T> : Expect<T> {
 
     /**
      * Returns the [Assertion]s which have been [appended][append] to this container.

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/DelegatingExpect.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/DelegatingExpect.kt
@@ -8,7 +8,7 @@ import ch.tutteli.atrium.creating.impl.DelegatingExpectImpl
 /**
  * Represents an [Expect] which passes on appended [Assertion]s to a given [Expect].
  */
-interface DelegatingExpect<T> : Expect<T> {
+interface DelegatingExpect<out T> : Expect<T> {
     companion object {
         @OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
         operator fun <T> invoke(expect: AssertionContainer<*>, maybeSubject: Option<T>): Expect<T> =

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/Expect.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/Expect.kt
@@ -16,14 +16,14 @@ import ch.tutteli.atrium.assertions.Assertion
  * not relevant for newcomers to Atrium (see [https://github.com/robstoll/atrium-roadmap/wiki/Requirements#personas](https://github.com/robstoll/atrium-roadmap/wiki/Requirements#personas)
  * for more information about the personas).
  */
-interface ExpectInternal<T> : Expect<T>, AssertionContainer<T>, ExpectGrouping
+interface ExpectInternal<out T> : Expect<T>, AssertionContainer<T>, ExpectGrouping
 
 /**
  * Represents the extension point for expectation functions and sophisticated builders for subjects of type [T].
  *
  * @param T The type of the subject of `this` expectation.
  */
-interface Expect<T>
+interface Expect<out T>
 typealias ExpectationCreator<T> = Expect<T>.() -> Unit
 
 /**

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/FeatureExpect.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/FeatureExpect.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
 /**
  * Represents an [Expect] which results due to a feature extraction from he subject of the expectation.
  */
-interface FeatureExpect<T, R> : Expect<R> {
+interface FeatureExpect<out T, out R> : Expect<R> {
 
     companion object {
 

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/RootExpect.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/RootExpect.kt
@@ -10,7 +10,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  * Represents the root of an [Expect] chain, intended as extension point for functionality
  * which should only be available on the root.
  */
-interface RootExpect<T> : Expect<T> {
+interface RootExpect<out T> : Expect<T> {
 
     companion object {
         @ExperimentalNewExpectTypes

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/Fun0Assertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/Fun0Assertions.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KClass
 interface Fun0Assertions {
 
     fun <TExpected : Throwable> toThrow(
-        container: AssertionContainer<out () -> Any?>,
+        container: AssertionContainer<() -> Any?>,
         expectedType: KClass<TExpected>
     ): SubjectChangerBuilder.ExecutionStep<*, TExpected>
 

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/ResultAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/ResultAssertions.kt
@@ -12,7 +12,7 @@ interface ResultAssertions {
     fun <E, T : Result<E>> isSuccess(container: AssertionContainer<T>): FeatureExtractorBuilder.ExecutionStep<T, E>
 
     fun <TExpected : Throwable> isFailureOfType(
-        container: AssertionContainer<out Result<*>>,
+        container: AssertionContainer<Result<*>>,
         expectedType: KClass<TExpected>
     ): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected>
 }

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/ThrowableAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/ThrowableAssertions.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
 interface ThrowableAssertions {
 
     fun <TExpected : Throwable> causeIsA(
-        container: AssertionContainer<out Throwable>,
+        container: AssertionContainer<Throwable>,
         expectedType: KClass<TExpected>
     ): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected>
 }

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions.kt
@@ -67,7 +67,7 @@ internal fun <T> createToBeWithErrorToleranceExplained(
     .build()
 
 internal fun <T : Comparable<T>> toBeWithErrorTolerance(
-    container: AssertionContainer<out T>,
+    container: AssertionContainer<T>,
     expected: T,
     tolerance: T,
     absDiff: (T) -> T,

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultFun0Assertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultFun0Assertions.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
 class DefaultFun0Assertions : Fun0Assertions {
 
     override fun <TExpected : Throwable> toThrow(
-        container: AssertionContainer<out () -> Any?>,
+        container: AssertionContainer<() -> Any?>,
         expectedType: KClass<TExpected>
     ): SubjectChangerBuilder.ExecutionStep<*, TExpected> {
         // we use manualFeature and not extractFeature since we never want to fail the feature extraction

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultResultAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultResultAssertions.kt
@@ -27,7 +27,7 @@ class DefaultResultAssertions : ResultAssertions {
 
     @OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
     override fun <TExpected : Throwable> isFailureOfType(
-        container: AssertionContainer<out Result<*>>,
+        container: AssertionContainer<Result<*>>,
         expectedType: KClass<TExpected>
     ): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
         container.manualFeature(EXCEPTION) {

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions.kt
@@ -18,7 +18,7 @@ class DefaultThrowableAssertions : ThrowableAssertions {
 
     @OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
     override fun <TExpected : Throwable> causeIsA(
-        container: AssertionContainer<out Throwable>,
+        container: AssertionContainer<Throwable>,
         expectedType: KClass<TExpected>
     ):  SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> =
         container.manualFeature(DescriptionThrowableExpectation.CAUSE) { cause }.transform().let { previousExpect ->

--- a/logic/atrium-logic/src/generated/commonMain/ch/tutteli/atrium/logic/fun0.kt
+++ b/logic/atrium-logic/src/generated/commonMain/ch/tutteli/atrium/logic/fun0.kt
@@ -14,7 +14,7 @@ import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.logic.impl.DefaultFun0Assertions
 
 
-fun <TExpected : Throwable> AssertionContainer<out () -> Any?>.toThrow(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<*, TExpected> = impl.toThrow(this, expectedType)
+fun <TExpected : Throwable> AssertionContainer<() -> Any?>.toThrow(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<*, TExpected> = impl.toThrow(this, expectedType)
 
 fun <R, T : () -> R> AssertionContainer<T>.notToThrow(): FeatureExtractorBuilder.ExecutionStep<*, R> = impl.notToThrow(this)
 

--- a/logic/atrium-logic/src/generated/commonMain/ch/tutteli/atrium/logic/result.kt
+++ b/logic/atrium-logic/src/generated/commonMain/ch/tutteli/atrium/logic/result.kt
@@ -15,7 +15,7 @@ import ch.tutteli.atrium.logic.impl.DefaultResultAssertions
 
 fun <E, T : Result<E>> AssertionContainer<T>.isSuccess(): FeatureExtractorBuilder.ExecutionStep<T, E> = impl.isSuccess(this)
 
-fun <TExpected : Throwable> AssertionContainer<out Result<*>>.isFailureOfType(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = impl.isFailureOfType(this, expectedType)
+fun <TExpected : Throwable> AssertionContainer<Result<*>>.isFailureOfType(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = impl.isFailureOfType(this, expectedType)
 
 @OptIn(ExperimentalNewExpectTypes::class)
 private inline val <T> AssertionContainer<T>.impl: ResultAssertions

--- a/logic/atrium-logic/src/generated/commonMain/ch/tutteli/atrium/logic/throwable.kt
+++ b/logic/atrium-logic/src/generated/commonMain/ch/tutteli/atrium/logic/throwable.kt
@@ -13,7 +13,7 @@ import ch.tutteli.atrium.core.ExperimentalNewExpectTypes
 import ch.tutteli.atrium.logic.impl.DefaultThrowableAssertions
 
 
-fun <TExpected : Throwable> AssertionContainer<out Throwable>.causeIsA(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = impl.causeIsA(this, expectedType)
+fun <TExpected : Throwable> AssertionContainer<Throwable>.causeIsA(expectedType: KClass<TExpected>): SubjectChangerBuilder.ExecutionStep<Throwable?, TExpected> = impl.causeIsA(this, expectedType)
 
 @OptIn(ExperimentalNewExpectTypes::class)
 private inline val <T> AssertionContainer<T>.impl: ThrowableAssertions

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AnyExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AnyExpectationsSpec.kt
@@ -599,7 +599,7 @@ abstract class AnyExpectationsSpec(
 
 
     describeFun(notToEqualNullFeature, notToEqualNull) {
-        val notToEqualNullFunctions = unifySignatures(notToEqualNullFeature, notToEqualNull)
+        val notToEqualNullFunctions = unifySignatures<Int?, Int>(notToEqualNullFeature, notToEqualNull)
 
         context("subject is null") {
             notToEqualNullFunctions.forEach { (name, notToEqualNullFun, hasExtraHint) ->

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ThrowableExpectationsSpec.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ThrowableExpectationsSpec.kt
@@ -160,7 +160,7 @@ abstract class ThrowableExpectationsSpec(
     }
 
     describeFun(causeFeature, cause) {
-        val causeFunctions = unifySignatures(causeFeature, cause)
+        val causeFunctions = unifySignatures<Throwable, IllegalArgumentException>(causeFeature, cause)
 
         context("Throwable.cause is not null") {
             val exceptionCause = IllegalArgumentException("Hello from the Clause")

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/testUtils.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/testUtils.kt
@@ -182,20 +182,6 @@ fun <T, R> unifySignatures(
     )
 }
 
-// TODO I cant make this work any way I try, it seems to me like I wont be able to unify like this
-//@JvmName("unifySignatures0Feature")
-//fun <T, R> unifySignatures(
-//    f0: Feature0<T, T>,
-//    f1: Feature1<T, Expect<R>.() -> Unit, T>
-//): List<Triple<String, Expect<T>.(Expect<R>.() -> Unit) -> Expect<T>, Boolean>> {
-//    val f0WithSubAssertion: Expect<T>.(Expect<R>.() -> Unit) -> Expect<T> =
-//        { f: Expect<R>.() -> Unit -> (f0.lambda)() }
-//    return listOf(
-//        Triple(f0.name, f0WithSubAssertion, false),
-//        Triple(f1.name, f1.lambda, true)
-//    )
-//}
-
 @JvmName("unifySignatures1Feature")
 fun <T, A1, R> unifySignatures(
     f0: Feature1<T, A1, R>,
@@ -208,16 +194,6 @@ fun <T, A1, R> unifySignatures(
         Triple(f1.name, f1.lambda, true)
     )
 }
-
-@JvmName("unifySignaturesSameReturn0")
-fun <T> unifySignatures(
-    f0: Feature0<T, T>,
-    f1: Fun1<T, Expect<T>.() -> Unit>
-): List<Triple<String, Expect<T>.(Expect<T>.() -> Unit) -> Expect<T>, Boolean>> =
-    listOf(
-        Triple(f0.name, f0.withSubAssertion(), false),
-        Triple(f1.name, f1.lambda, true)
-    )
 
 @JvmName("unifySignaturesSameReturn1")
 fun <T, A1> unifySignatures(


### PR DESCRIPTION
It enables usages as follows:

```kotlin
    val Expect<Number>.numberOfDigits: FeatureExpect<Number, Int>
        get() = feature("Number of digits") {
            toString().length
        }

    expect(42).numberOfDigits.toEqual(2)
```

Another usage pattern:

```kotlin
interface Named {
    val name: String
}

data class Item(override val name: String, ...): Named
data class Person(override val name: String, ...): Named

val Expect<Named>.name: FeatureExpect<Named, String>
    get() = feature("name") { name }

...

expect(Person("Fred")).name.toEqual("Fred")
```

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
