### PR TITLE
use bc-validator, apiDump based on tag v1.2.0

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -83,7 +83,7 @@ jobs:
       KOTLIN_VERSION: ${{ matrix.kotlin_version }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         kotlin_version: [ '1.5', '1.6', '1.7', '1.8', '1.9' ]
     steps:

--- a/apis/fluent/atrium-api-fluent/api/main/atrium-api-fluent.api
+++ b/apis/fluent/atrium-api-fluent/api/main/atrium-api-fluent.api
@@ -1,0 +1,580 @@
+public final class ch/tutteli/atrium/api/fluent/en_GB/AnyExpectationsKt {
+	public static final fun and (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getAnd (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNullButToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun notToEqualOneIn (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualOneOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun toBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNullIfNullGivenElse (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ArraySubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asListEOut (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/BigDecimalExpectationsKt {
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun notToEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNullable (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceExpectationsKt {
+	public static final fun getNotToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun getToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun notToBeBlank (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainRegex (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainRegex (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;[Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainCreatorsKt {
+	public static final fun elementsOf (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun matchFor (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/text/Regex;[Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/text/Regex;[Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valueIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainSearchBehavioursKt {
+	public static final fun getIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun getIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ChronoLocalDateExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ChronoLocalDateTimeExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ChronoZonedDateTimeExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CollectionExpectationsKt {
+	public static final fun notToBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveSize (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CollectionFeatureExtractorsKt {
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/DateSubjectChangersKt {
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/DocumentationUtilsKt {
+	public static final fun because (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Entries : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun <init> (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)V
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/jvm/functions/Function1;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public final fun getOtherAssertionCreatorsOrNulls ()[Lkotlin/jvm/functions/Function1;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/jvm/functions/Function1;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Entry : ch/tutteli/atrium/logic/utils/Group {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ExpectExtensionsKt {
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/api/fluent/en_GB/ExperimentalWithOptions : java/lang/annotation/Annotation {
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/FeatureExtractorsKt {
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun extractSubject$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/FileSubjectChangersKt {
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/FloatingPointExpectationsKt {
+	public static final fun toEqualWithErrorTolerance (Lch/tutteli/atrium/creating/Expect;DD)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualWithErrorTolerance (Lch/tutteli/atrium/creating/Expect;FF)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Fun0ExpectationsKt {
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/GroupingKt {
+	public static final fun group (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun group (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableExpectationsKt {
+	public static final fun getNotToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun getToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElements (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun toContainExactly$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun toContainExactly$default (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElements (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndNoDuplicates (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableFeatureExtractorsKt {
+	public static final fun getLast (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun last (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun values$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun values$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInOrderOnlyGroupedCreatorsKt {
+	public static final fun inAnyOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun inAnyOrder$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAnyOrderEntries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun inAnyOrderEntries$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainSearchBehavioursKt {
+	public static final fun andOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun butOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getWithin (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableSubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IteratorExpectationsKt {
+	public static final fun notToHaveNext (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveNext (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/KeyValue {
+	public fun <init> (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/fluent/en_GB/KeyValue;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/fluent/en_GB/KeyValue;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/fluent/en_GB/KeyValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public final fun getValueAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun toPair ()Lkotlin/Pair;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ListFeatureExtractorsKt {
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;ILkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/LocalDateFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/LocalDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapEntryExpectationsKt {
+	public static final fun toEqualKeyValue (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapEntryFeatureExtractorsKt {
+	public static final fun getKey (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValue (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun key (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapExpectationsKt {
+	public static final fun getToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun notToBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnly (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnlyEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapFeatureExtractorsKt {
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getKeys (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValues (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun keys (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entriesOf$default (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainSearchBehavioursKt {
+	public static final fun andOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun butOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapSubjectChangersKt {
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/OptionalExpectationsKt {
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBePresent (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBePresent (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/PairFeatureExtractorsKt {
+	public static final fun first (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFirst (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSecond (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun second (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/PathExpectationsKt {
+	public static final fun notToBeExecutable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeReadable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeWritable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToExist (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeADirectory (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeARegularFile (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeASymbolicLink (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAbsolute (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAnEmptyDirectory (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeExecutable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeReadable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeRelative (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeWritable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toExist (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheDirectoryEntries (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameBinaryContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameTextualContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun toHaveTheSameTextualContentAs$default (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/PathFeatureExtractorsKt {
+	public static final fun extension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileName (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileName (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getParent (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun parent (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ResultExpectationsKt {
+	public static final fun toBeASuccess (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeASuccess (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/SequenceSubjectChangersKt {
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ThirdPartyExpectationsKt {
+	public static final fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ThrowableFeatureExtractorsKt {
+	public static final fun causeToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun getMessage (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun message (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun messageToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Value : ch/tutteli/atrium/logic/utils/Group {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/api/fluent/en_GB/Value;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/fluent/en_GB/Value;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/fluent/en_GB/Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpected ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toList ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Values : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun <init> (Ljava/lang/Object;[Ljava/lang/Object;)V
+	public fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ZonedDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/creating/feature/MetaFeatureOption {
+	public fun <init> (Lch/tutteli/atrium/creating/Expect;)V
+	public final fun f (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f0 (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f1 (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f2 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f3 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f4 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f5 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun p (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+}
+

--- a/apis/fluent/atrium-api-fluent/api/using-kotlin-1.9-or-newer/atrium-api-fluent.api
+++ b/apis/fluent/atrium-api-fluent/api/using-kotlin-1.9-or-newer/atrium-api-fluent.api
@@ -1,0 +1,580 @@
+public final class ch/tutteli/atrium/api/fluent/en_GB/AnyExpectationsKt {
+	public static final fun and (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getAnd (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNullButToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun notToEqualOneIn (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualOneOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun toBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNullIfNullGivenElse (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ArraySubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asListEOut (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/BigDecimalExpectationsKt {
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun notToEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNullable (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceExpectationsKt {
+	public static final fun getNotToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun getToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun notToBeBlank (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainRegex (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainRegex (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;[Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainCreatorsKt {
+	public static final fun elementsOf (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun matchFor (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/text/Regex;[Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/text/Regex;[Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valueIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainSearchBehavioursKt {
+	public static final fun getIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun getIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ChronoLocalDateExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ChronoLocalDateTimeExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ChronoZonedDateTimeExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CollectionExpectationsKt {
+	public static final fun notToBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveSize (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/CollectionFeatureExtractorsKt {
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/DateSubjectChangersKt {
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/DocumentationUtilsKt {
+	public static final fun because (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Entries : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun <init> (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)V
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/jvm/functions/Function1;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public final fun getOtherAssertionCreatorsOrNulls ()[Lkotlin/jvm/functions/Function1;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/jvm/functions/Function1;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Entry : ch/tutteli/atrium/logic/utils/Group {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ExpectExtensionsKt {
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/api/fluent/en_GB/ExperimentalWithOptions : java/lang/annotation/Annotation {
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/FeatureExtractorsKt {
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun extractSubject$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/FileSubjectChangersKt {
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/FloatingPointExpectationsKt {
+	public static final fun toEqualWithErrorTolerance (Lch/tutteli/atrium/creating/Expect;DD)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualWithErrorTolerance (Lch/tutteli/atrium/creating/Expect;FF)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Fun0ExpectationsKt {
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/GroupingKt {
+	public static final fun group (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun group (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableExpectationsKt {
+	public static final fun getNotToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun getToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElements (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun toContainExactly$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun toContainExactly$default (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElements (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndNoDuplicates (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableFeatureExtractorsKt {
+	public static final fun getLast (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun last (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun values$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun values$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainInOrderOnlyGroupedCreatorsKt {
+	public static final fun inAnyOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun inAnyOrder$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAnyOrderEntries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun inAnyOrderEntries$default (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableLikeToContainSearchBehavioursKt {
+	public static final fun andOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun butOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getWithin (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IterableSubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/IteratorExpectationsKt {
+	public static final fun notToHaveNext (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveNext (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/KeyValue {
+	public fun <init> (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/fluent/en_GB/KeyValue;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/fluent/en_GB/KeyValue;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/fluent/en_GB/KeyValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public final fun getValueAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun toPair ()Lkotlin/Pair;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ListFeatureExtractorsKt {
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;ILkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/LocalDateFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/LocalDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapEntryExpectationsKt {
+	public static final fun toEqualKeyValue (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapEntryFeatureExtractorsKt {
+	public static final fun getKey (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValue (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun key (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapExpectationsKt {
+	public static final fun getToContain (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun notToBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnly (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnlyEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapFeatureExtractorsKt {
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getKeys (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValues (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun keys (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entries$default (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun entriesOf$default (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapLikeToContainSearchBehavioursKt {
+	public static final fun andOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun butOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/MapSubjectChangersKt {
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/OptionalExpectationsKt {
+	public static final fun toBeEmpty (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBePresent (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBePresent (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/PairFeatureExtractorsKt {
+	public static final fun first (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFirst (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSecond (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun second (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/PathExpectationsKt {
+	public static final fun notToBeExecutable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeReadable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeWritable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToExist (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeADirectory (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeARegularFile (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeASymbolicLink (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAbsolute (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAnEmptyDirectory (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeExecutable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeReadable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeRelative (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeWritable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toExist (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheDirectoryEntries (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameBinaryContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameTextualContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun toHaveTheSameTextualContentAs$default (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/PathFeatureExtractorsKt {
+	public static final fun extension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileName (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileName (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getParent (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun parent (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ResultExpectationsKt {
+	public static final fun toBeASuccess (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeASuccess (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/SequenceSubjectChangersKt {
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ThirdPartyExpectationsKt {
+	public static final fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ThrowableFeatureExtractorsKt {
+	public static final fun causeToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun getMessage (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun message (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun messageToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Value : ch/tutteli/atrium/logic/utils/Group {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/api/fluent/en_GB/Value;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/fluent/en_GB/Value;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/fluent/en_GB/Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpected ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toList ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/Values : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun <init> (Ljava/lang/Object;[Ljava/lang/Object;)V
+	public fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/ZonedDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/fluent/en_GB/creating/feature/MetaFeatureOption {
+	public fun <init> (Lch/tutteli/atrium/creating/Expect;)V
+	public final fun f (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f0 (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f1 (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f2 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f3 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f4 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f5 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun p (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+}
+

--- a/apis/infix/atrium-api-infix/api/main/atrium-api-infix.api
+++ b/apis/infix/atrium-api-infix/api/main/atrium-api-infix.api
@@ -1,0 +1,963 @@
+public final class ch/tutteli/atrium/api/infix/en_GB/AnyExpectationsKt {
+	public static final fun and (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun and (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getIt (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getIts (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Types;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNullButToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun notToEqualOneIn (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualOneOf (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun toBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNullIfNullGivenElse (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ArraySubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asListEOut (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/BigDecimalExpectationsKt {
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun notToEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNullable (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceExpectationsKt {
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/blank;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/All;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainRegex (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainCreatorsKt {
+	public static final fun elementsOf (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun matchFor (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/All;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun matchFor (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valueIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainSearchBehavioursKt {
+	public static final fun ignoring (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/case;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun ignoring (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;Lch/tutteli/atrium/api/infix/en_GB/case;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateTimeExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ChronoZonedDateTimeExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CollectionExpectationsKt {
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveSize (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CollectionFeatureExtractorsKt {
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/DateSubjectChangersKt {
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/DocumentationUtilsKt {
+	public static final fun because (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun because (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun of (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ExpectExtensionsKt {
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/api/infix/en_GB/ExperimentalWithOptions : java/lang/annotation/Annotation {
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/FeatureExtractorsKt {
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun f (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOption;Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun of (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun withFailureDescription (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/FileSubjectChangersKt {
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/Fun0ExpectationsKt {
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/GroupingKt {
+	public static final fun group (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun group (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/HelperFunctionsKt {
+	public static final fun aSuccess (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;
+	public static final fun all (Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/All;
+	public static final fun elementsOf (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static final fun elementsOf (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entries (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyValues;
+	public static final fun entries (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entries (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;
+	public static final fun entries (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static final fun entries (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entriesOf (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entry (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;
+	public static final fun keyValue (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public static final fun keyValues (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyValues;
+	public static final fun keyValues (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun pairs (Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;
+	public static final fun pairs (Lkotlin/Pair;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun present (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;
+	public static final fun regexPatterns (Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;
+	public static final fun types (Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;)Lch/tutteli/atrium/api/infix/en_GB/creating/Types;
+	public static final fun value (Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Value;
+	public static final fun values (Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Values;
+	public static final fun values (Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static final fun values (Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IIterableFeatureExtractorsKt {
+	public static final fun last (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun last (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableExpectationsKt {
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/elements;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactlyEntriesWithReportingOption (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactlyValuesWithReportingOption (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/elements;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAnd (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/noDuplicates;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theEntriesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theValuesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theEntriesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theValuesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInOrderOnlyGroupedCreatorsKt {
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAnyOrderEntries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAnyOrderEntries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun order (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order;
+	public static final fun order (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun order (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun orderWithReportInGroup (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainSearchBehavioursKt {
+	public static final fun and (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun but (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun grouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/entries;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun inGiven (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun within (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/group;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableSubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IteratorExpectationsKt {
+	public static final fun notToHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/next;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/next;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/api/infix/en_GB/Keyword {
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ListFeatureExtractorsKt {
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun index (ILkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/LocalDateFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/LocalDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapEntryExpectationsKt {
+	public static final fun toEqualKeyValue (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapEntryFeatureExtractorsKt {
+	public static final fun getKey (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValue (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun key (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapExpectationsKt {
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnly (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnly (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnlyEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapFeatureExtractorsKt {
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getKeys (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValues (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun key (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+	public static final fun keys (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun thePairsWithReportingOption (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainSearchBehavioursKt {
+	public static final fun and (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun but (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun inGiven (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapSubjectChangersKt {
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/OptionalExpectationsKt {
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/present;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/PairFeatureExtractorsKt {
+	public static final fun first (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFirst (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSecond (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun second (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/PathExpectationsKt {
+	public static final fun directoryEntries (Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/executable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/existing;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/readable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/writable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aDirectory;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aRegularFile;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aSymbolicLink;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/absolute;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/anEmptyDirectory;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/executable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/existing;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/readable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/relative;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/writable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameBinaryContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameTextualContentAs (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameTextualContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withEncoding (Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+	public static synthetic fun withEncoding$default (Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/PathFeatureExtractorsKt {
+	public static final fun extension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileName (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileName (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getParent (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun parent (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun path (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ResultExpectationsKt {
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aSuccess;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/SequenceSubjectChangersKt {
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ThirdPartyExpectationsKt {
+	public static final fun thirdPartyExpectation (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;
+	public static final fun toHold (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ThrowableFeatureExtractorsKt {
+	public static final fun causeToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun getMessage (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun message (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun messageToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun messageToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ZonedDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aDirectory : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aDirectory;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aRegularFile : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aRegularFile;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aSuccess : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aSuccess;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aSymbolicLink : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aSymbolicLink;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/absolute : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/absolute;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/anEmptyDirectory : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/anEmptyDirectory;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/blank : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/blank;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/case : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/case;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/All : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Entries : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/jvm/functions/Function1;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public final fun getOtherAssertionCreatorsOrNulls ()[Lkotlin/jvm/functions/Function1;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/jvm/functions/Function1;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Entry : ch/tutteli/atrium/logic/utils/Group {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toList ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator {
+	public final fun component1 ()I
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (ILkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator {
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getKey ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Pairs : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/Pair;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/Pair;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Ljava/lang/String;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Ljava/lang/String;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Types : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/reflect/KClass;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/reflect/KClass;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Value : ch/tutteli/atrium/logic/utils/Group {
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Value;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/Value;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpected ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toList ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Values : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getExtractor ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function2;
+	public final fun getFailureDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescriptionProvider ()Lkotlin/jvm/functions/Function1;
+	public final fun getExtractor ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getDescriptionProvider ()Lkotlin/jvm/functions/Function1;
+	public final fun getExtractor ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOption {
+	public fun <init> (Lch/tutteli/atrium/creating/Expect;)V
+	public final fun f (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f0 (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f1 (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f2 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f3 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f4 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f5 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun p (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getProvider ()Lkotlin/jvm/functions/Function2;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order {
+	public final fun getFirstGroup ()Lch/tutteli/atrium/logic/utils/Group;
+	public final fun getOtherExpectedGroups ()[Lch/tutteli/atrium/logic/utils/Group;
+	public final fun getSecondGroup ()Lch/tutteli/atrium/logic/utils/Group;
+	public final fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Lkotlin/jvm/functions/Function1;
+	public final fun getT ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Lkotlin/jvm/functions/Function1;
+	public final fun getT ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyValues : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun getExpected ()Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator {
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public final fun getValueAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun toPair ()Lkotlin/Pair;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun <init> (Ljava/lang/String;[Ljava/lang/String;)V
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Ljava/lang/String;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Ljava/lang/String;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding {
+	public final fun component1 ()Ljava/nio/file/Path;
+	public final fun component2 ()Ljava/nio/charset/Charset;
+	public final fun component3 ()Ljava/nio/charset/Charset;
+	public final fun copy (Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/nio/file/Path;
+	public final fun getSourceCharset ()Ljava/nio/charset/Charset;
+	public final fun getTargetCharset ()Ljava/nio/charset/Charset;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getExpectationExecutor ()Lkotlin/jvm/functions/Function1;
+	public final fun getRepresentation ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/elements : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/elements;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/empty : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/empty;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/entries : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/entries;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/executable : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/executable;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/existing : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/existing;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/group : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/group;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/next : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/next;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/noDuplicates : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/noDuplicates;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/o : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/o;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/only : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/only;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/order : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/order;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/present : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/present;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/readable : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/readable;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/relative : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/relative;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/writable : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/writable;
+}
+

--- a/apis/infix/atrium-api-infix/api/using-kotlin-1.9-or-newer/atrium-api-infix.api
+++ b/apis/infix/atrium-api-infix/api/using-kotlin-1.9-or-newer/atrium-api-infix.api
@@ -1,0 +1,963 @@
+public final class ch/tutteli/atrium/api/infix/en_GB/AnyExpectationsKt {
+	public static final fun and (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun and (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getIt (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getIts (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Types;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNullButToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun notToEqualOneIn (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualOneOf (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun toBeTheInstance (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNullIfNullGivenElse (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ArraySubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asListEOut (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun boolArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun byteArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun charArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun doubleArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun floatArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun intArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun longArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun shortArrAsList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/BigDecimalExpectationsKt {
+	public static final fun notToEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun notToEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNull (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Void;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeNullable (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqual (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Ljava/lang/Void;
+	public static final fun toEqualIncludingScale (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEqualNumerically (Lch/tutteli/atrium/creating/Expect;Ljava/math/BigDecimal;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceExpectationsKt {
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/blank;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/All;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainRegex (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toMatch (Lch/tutteli/atrium/creating/Expect;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/lang/CharSequence;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainCreatorsKt {
+	public static final fun elementsOf (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun elementsOfIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun matchFor (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/All;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun matchFor (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/text/Regex;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valueIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainSearchBehavioursKt {
+	public static final fun ignoring (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/case;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun ignoring (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;Lch/tutteli/atrium/api/infix/en_GB/case;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ChronoLocalDateTimeExpectationsKt {
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ChronoZonedDateTimeExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfter (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeAfterOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBefore (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeBeforeOrTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Ljava/lang/Void;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeTheSamePointInTimeAs (Lch/tutteli/atrium/creating/Expect;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CollectionExpectationsKt {
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveSize (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/CollectionFeatureExtractorsKt {
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsKt {
+	public static final fun notToBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeEqualComparingTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeGreaterThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThan (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBeLessThanOrEqualTo (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Comparable;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/DateSubjectChangersKt {
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDate (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asLocalDateTime (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/DocumentationUtilsKt {
+	public static final fun because (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun because (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun of (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ExpectExtensionsKt {
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withOptions (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/FeatureExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withRepresentation (Lch/tutteli/atrium/creating/RootExpect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/api/infix/en_GB/ExperimentalWithOptions : java/lang/annotation/Annotation {
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/FeatureExtractorsKt {
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun f (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOption;Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun feature (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun its (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun of (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KFunction;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun of (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static final fun withFailureDescription (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/FileSubjectChangersKt {
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asPath (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/Fun0ExpectationsKt {
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toThrow (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/GroupingKt {
+	public static final fun group (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun group (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static synthetic fun group$default (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/HelperFunctionsKt {
+	public static final fun aSuccess (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;
+	public static final fun all (Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/All;
+	public static final fun elementsOf (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static final fun elementsOf (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entries (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyValues;
+	public static final fun entries (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entries (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;
+	public static final fun entries (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static final fun entries (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entriesOf (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun entry (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;
+	public static final fun keyValue (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public static final fun keyValues (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyValues;
+	public static final fun keyValues (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun pairs (Lkotlin/Pair;[Lkotlin/Pair;)Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;
+	public static final fun pairs (Lkotlin/Pair;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun present (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;
+	public static final fun regexPatterns (Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns;
+	public static final fun types (Lkotlin/reflect/KClass;[Lkotlin/reflect/KClass;)Lch/tutteli/atrium/api/infix/en_GB/creating/Types;
+	public static final fun value (Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Value;
+	public static final fun values (Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Values;
+	public static final fun values (Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static final fun values (Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IIterableFeatureExtractorsKt {
+	public static final fun last (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun last (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun max (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun min (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableExpectationsKt {
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun notToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/elements;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToHaveElementsOrNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactly (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactlyEntriesWithReportingOption (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainExactlyValuesWithReportingOption (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/elements;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAnd (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/noDuplicates;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAll (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndAny (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveElementsAndNone (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainCheckersKt {
+	public static final fun atLeast (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;
+	public static final fun atMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep;
+	public static final fun notOrAtMost (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;I)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theEntriesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theValuesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Entries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theEntriesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun theValuesWithReportingOptions (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainInOrderOnlyGroupedCreatorsKt {
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAnyOrderEntries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun inAnyOrderEntries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun order (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order;
+	public static final fun order (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun order (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static final fun orderWithReportInGroup (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableLikeToContainSearchBehavioursKt {
+	public static final fun and (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun but (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun grouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/entries;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun inGiven (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun within (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/group;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IterableSubjectChangersKt {
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/IteratorExpectationsKt {
+	public static final fun notToHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/next;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/next;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/api/infix/en_GB/Keyword {
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ListFeatureExtractorsKt {
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;I)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun index (ILkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/LocalDateFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/LocalDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapEntryExpectationsKt {
+	public static final fun toEqualKeyValue (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapEntryFeatureExtractorsKt {
+	public static final fun getKey (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValue (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun key (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun value (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapExpectationsKt {
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun toContain (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainKey (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnly (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnly (Lch/tutteli/atrium/creating/Expect;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toContainOnlyEntriesOf (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapFeatureExtractorsKt {
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExisting (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getKeys (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSize (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getValues (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun key (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+	public static final fun keys (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun size (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun values (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainInAnyOrderCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainInAnyOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainInOrderOnlyCreatorsKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/reflect/KClass;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entriesOf (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun entry (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/Pair;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/Pairs;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun the (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun thePairsWithReportingOption (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapLikeToContainSearchBehavioursKt {
+	public static final fun and (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun but (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/only;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun inAny (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun inGiven (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lch/tutteli/atrium/api/infix/en_GB/order;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/MapSubjectChangersKt {
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asEntries (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/OptionalExpectationsKt {
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/empty;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/present;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/PairFeatureExtractorsKt {
+	public static final fun first (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFirst (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getSecond (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun second (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/PathExpectationsKt {
+	public static final fun directoryEntries (Ljava/lang/String;[Ljava/lang/String;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/executable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/existing;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/readable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/writable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun notToStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aDirectory;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aRegularFile;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aSymbolicLink;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/absolute;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/anEmptyDirectory;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/executable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/existing;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/readable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/relative;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/writable;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toEndWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHave (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameBinaryContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameTextualContentAs (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toHaveTheSameTextualContentAs (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toStartWith (Lch/tutteli/atrium/creating/Expect;Ljava/nio/file/Path;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun withEncoding (Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+	public static synthetic fun withEncoding$default (Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/PathFeatureExtractorsKt {
+	public static final fun extension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileName (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileName (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getFileNameWithoutExtension (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getParent (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun parent (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun path (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun resolve (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ResultExpectationsKt {
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/aSuccess;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toBe (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/SequenceSubjectChangersKt {
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asIterable (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/o;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ThirdPartyExpectationsKt {
+	public static final fun thirdPartyExpectation (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;
+	public static final fun toHold (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ThrowableFeatureExtractorsKt {
+	public static final fun causeToBeAnInstanceOf (Lch/tutteli/atrium/creating/Expect;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun getMessage (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun message (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun messageToContain (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/api/infix/en_GB/creating/Values;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun messageToContain (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/ZonedDateTimeFeatureExtractorsKt {
+	public static final fun day (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDay (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getDayOfWeek (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getMonth (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getYear (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun month (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun year (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aDirectory : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aDirectory;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aRegularFile : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aRegularFile;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aSuccess : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aSuccess;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/aSymbolicLink : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/aSymbolicLink;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/absolute : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/absolute;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/anEmptyDirectory : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/anEmptyDirectory;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/blank : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/blank;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/case : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/case;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/All : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Entries : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/jvm/functions/Function1;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public final fun getOtherAssertionCreatorsOrNulls ()[Lkotlin/jvm/functions/Function1;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/jvm/functions/Function1;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Entry : ch/tutteli/atrium/logic/utils/Group {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Entry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toList ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator {
+	public final fun component1 ()I
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (ILkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator {
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getKey ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Pairs : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/Pair;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/Pair;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/RegexPatterns : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Ljava/lang/String;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Ljava/lang/String;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Types : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Lkotlin/reflect/KClass;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Lkotlin/reflect/KClass;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Value : ch/tutteli/atrium/logic/utils/Group {
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Value;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/Value;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpected ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toList ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/Values : ch/tutteli/atrium/logic/utils/Group, ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getExtractor ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function2;
+	public final fun getFailureDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescriptionProvider ()Lkotlin/jvm/functions/Function1;
+	public final fun getExtractor ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getDescriptionProvider ()Lkotlin/jvm/functions/Function1;
+	public final fun getExtractor ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOption {
+	public fun <init> (Lch/tutteli/atrium/creating/Expect;)V
+	public final fun f (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f0 (Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f1 (Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f2 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f3 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f4 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun f5 (Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public final fun p (Lkotlin/reflect/KProperty0;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator {
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getProvider ()Lkotlin/jvm/functions/Function2;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/iterable/Order {
+	public final fun getFirstGroup ()Lch/tutteli/atrium/logic/utils/Group;
+	public final fun getOtherExpectedGroups ()[Lch/tutteli/atrium/logic/utils/Group;
+	public final fun getSecondGroup ()Lch/tutteli/atrium/logic/utils/Group;
+	public final fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Lkotlin/jvm/functions/Function1;
+	public final fun getT ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Lkotlin/jvm/functions/Function1;
+	public final fun getT ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyValues : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun getExpected ()Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public fun getOtherExpected ()[Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator {
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public final fun getValueAssertionCreatorOrNull ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun toPair ()Lkotlin/Pair;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/path/DirectoryEntries : ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public fun <init> (Ljava/lang/String;[Ljava/lang/String;)V
+	public synthetic fun getExpected ()Ljava/lang/Object;
+	public fun getExpected ()Ljava/lang/String;
+	public fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public synthetic fun getOtherExpected ()[Ljava/lang/Object;
+	public fun getOtherExpected ()[Ljava/lang/String;
+	public fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionCreator ()Lkotlin/jvm/functions/Function1;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding {
+	public final fun component1 ()Ljava/nio/file/Path;
+	public final fun component2 ()Ljava/nio/charset/Charset;
+	public final fun component3 ()Ljava/nio/charset/Charset;
+	public final fun copy (Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/nio/file/Path;
+	public final fun getSourceCharset ()Ljava/nio/charset/Charset;
+	public final fun getTargetCharset ()Ljava/nio/charset/Charset;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getExpectationExecutor ()Lkotlin/jvm/functions/Function1;
+	public final fun getRepresentation ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/elements : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/elements;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/empty : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/empty;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/entries : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/entries;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/executable : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/executable;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/existing : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/existing;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/group : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/group;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/next : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/next;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/noDuplicates : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/noDuplicates;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/o : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/o;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/only : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/only;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/order : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/order;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/present : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/present;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/readable : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/readable;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/relative : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/relative;
+}
+
+public final class ch/tutteli/atrium/api/infix/en_GB/writable : ch/tutteli/atrium/api/infix/en_GB/Keyword {
+	public static final field INSTANCE Lch/tutteli/atrium/api/infix/en_GB/writable;
+}
+

--- a/atrium-core/api/main/atrium-core.api
+++ b/atrium-core/api/main/atrium-core.api
@@ -1,0 +1,1309 @@
+public abstract interface class ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun holds ()Z
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/AssertionGroup : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getAssertions ()Ljava/util/List;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun holds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/AssertionGroup$DefaultImpls {
+	public static fun holds (Lch/tutteli/atrium/assertions/AssertionGroup;)Z
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/AssertionGroupType : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultExplanatoryAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultExplanatoryAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultFeatureAssertionGroupType : ch/tutteli/atrium/assertions/FeatureAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultFeatureAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultGroupingAssertionGroupType : ch/tutteli/atrium/assertions/GroupingAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultGroupingAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultListAssertionGroupType : ch/tutteli/atrium/assertions/ListAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultListAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultSummaryAssertionGroupType : ch/tutteli/atrium/assertions/SummaryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultSummaryAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/DescriptiveAssertion : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/DoNotFilterAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public abstract interface annotation class ch/tutteli/atrium/assertions/ExperimentalExpectationApi : java/lang/annotation/Annotation {
+	public abstract fun reason ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/ExplanatoryAssertion : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getExplanation ()Ljava/lang/Object;
+	public abstract fun holds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/ExplanatoryAssertion$DefaultImpls {
+	public static fun holds (Lch/tutteli/atrium/assertions/ExplanatoryAssertion;)Z
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType : ch/tutteli/atrium/assertions/DoNotFilterAssertionGroupType {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/FeatureAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/GroupingAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public final class ch/tutteli/atrium/assertions/HintAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/HintAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/InformationAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lch/tutteli/atrium/assertions/InformationAssertionGroupType;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/assertions/InformationAssertionGroupType;ZILjava/lang/Object;)Lch/tutteli/atrium/assertions/InformationAssertionGroupType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWithIndent ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/assertions/InvisibleAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/InvisibleAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/ListAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public final class ch/tutteli/atrium/assertions/PrefixFailingSummaryAssertion : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public final class ch/tutteli/atrium/assertions/PrefixFeatureAssertionGroupHeader : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public final class ch/tutteli/atrium/assertions/PrefixSuccessfulSummaryAssertion : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/RepresentationOnlyAssertion : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/RootAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/RootAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/SummaryAssertionGroupType : ch/tutteli/atrium/assertions/DoNotFilterAssertionGroupType {
+}
+
+public final class ch/tutteli/atrium/assertions/WarningAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/WarningAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionBuilder {
+	public abstract fun createDescriptive (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public abstract fun createDescriptive (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public abstract fun customType (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getDescriptive ()Lch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption;
+	public abstract fun getExplanatory ()Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;
+	public abstract fun getExplanatoryGroup ()Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption;
+	public abstract fun getFeature ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getList ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getRepresentationOnly ()Lch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep;
+	public abstract fun getSummary ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionBuilder$DefaultImpls {
+	public static fun createDescriptive (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public static fun createDescriptive (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public abstract fun build ()Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionBuilderKt {
+	public static final fun getAssertionBuilder ()Lch/tutteli/atrium/assertions/builders/AssertionBuilder;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption$Companion;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/Object;
+	public abstract fun withDescription (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lkotlin/jvm/functions/Function3;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption$DefaultImpls {
+	public static fun withDescription (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption;Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption$Companion;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun withDescriptionAndEmptyRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndEmptyRepresentation (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lkotlin/jvm/functions/Function3;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption$DefaultImpls {
+	public static fun withDescriptionAndEmptyRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/Object;
+	public static fun withDescriptionAndEmptyRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Ljava/lang/String;)Ljava/lang/Object;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/AssertionsOption$Companion;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun withAssertion (Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public abstract fun withAssertions (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public abstract fun withAssertions (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public abstract fun withAssertions (Ljava/util/List;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionsOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public final fun factoryWithDefaultFinalStep ()Lkotlin/jvm/functions/Function3;
+	public final fun withDefaultFinalStepAndEmptyDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public final fun withEmptyDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/AssertionGroupType;Lkotlin/jvm/functions/Function4;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionsOption$DefaultImpls {
+	public static fun withAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public static fun withAssertions (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public static fun withAssertions (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep$Companion;
+	public abstract fun getAssertions ()Ljava/util/List;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/util/List;)Lch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption$Companion;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption$DefaultImpls {
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Descriptive$FinalStep$Companion;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$FinalStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Descriptive$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption$Companion;
+	public abstract fun getFailing ()Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun getHolding ()Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun withTest (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun withTest (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption$DefaultImpls {
+	public static fun ifAbsent (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$DefinedOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep$Companion;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getFailureHintFactory ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getShowHint ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption$Companion;
+	public abstract fun getShowForAnyFailure ()Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showBasedOnDefinedSubjectOnlyIf (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showBasedOnSubjectOnlyIf (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showOnlyIf (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showOnlyIfSubjectDefined (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption$DefaultImpls {
+	public static fun showBasedOnDefinedSubjectOnlyIf (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static fun showBasedOnSubjectOnlyIf (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static fun showOnlyIfSubjectDefined (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption$DefaultImpls {
+	public static fun ifAbsent (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$DefinedOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveWithFailureHintKt {
+	public static final fun createShouldNotBeShownToUserWarning ()Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun withHelpOnFailure (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;
+	public static final fun withHelpOnFailureBasedOnDefinedSubject (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static synthetic fun withHelpOnFailureBasedOnDefinedSubject$default (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static final fun withHelpOnFailureBasedOnSubject (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Explanatory {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption$Companion;
+	public abstract fun withExplanation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+	public abstract fun withExplanation (Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+	public abstract fun withExplanation (Ljava/lang/String;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption$DefaultImpls {
+	public static fun withExplanation (Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+	public static fun withExplanation (Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;Ljava/lang/String;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Explanatory$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep$Companion;
+	public abstract fun getExplanation ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Explanatory$FinalStep$Companion {
+	public final fun create (Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$Companion;
+	public abstract fun getExplanatoryAssertions ()Ljava/util/List;
+	public abstract fun getFailing ()Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;Ljava/util/List;Z)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static synthetic fun create$default (Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$Companion;Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;Ljava/util/List;ZILjava/lang/Object;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$DefaultImpls {
+	public static fun getFailing (Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption$Companion;
+	public abstract fun getWithDefaultType ()Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun getWithHintType ()Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun getWithWarningType ()Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun withInformationType (Z)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun withType (Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroupKt {
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep : ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep$Companion;
+	public abstract fun getHolds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/util/List;Z)Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption$DefaultImpls {
+	public static fun getWithFeatureType (Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public static fun getWithListType (Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroupKt {
+	public static final fun getFixedClaimGroup (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption {
+	public abstract fun getWithFeatureType ()Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public abstract fun getWithListType ()Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public abstract fun withType (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption$DefaultImpls {
+	public static fun getWithFeatureType (Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public static fun getWithListType (Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption {
+	public abstract fun getFailing ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun getHolding ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun withClaim (Z)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/InvisibleGroupKt {
+	public static final fun getInvisibleGroup (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep : ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep$Companion;
+	public abstract fun getPreTransformationHolds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/util/List;Z)Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption$DefaultImpls {
+	public static fun getWithFeatureType (Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public static fun getWithListType (Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroupKt {
+	public static final fun getPartiallyFixedClaimGroup (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep$Companion;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep : ch/tutteli/atrium/assertions/builders/common/HoldsStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep$Companion;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+	public abstract fun withRepresentation (Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RootKt {
+	public static final fun getRoot (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/SubjectBasedOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/SubjectBasedOption$Companion;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption {
+	public abstract fun getIfDefined ()Lkotlin/jvm/functions/Function1;
+	public abstract fun ifAbsent (Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption$DefaultImpls {
+	public static fun ifAbsent (Lch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$DefinedOption {
+	public abstract fun ifDefined (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/common/HoldsStep {
+	public abstract fun getFailing ()Ljava/lang/Object;
+	public abstract fun getHolding ()Ljava/lang/Object;
+	public abstract fun withTest (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun withTest (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/impl/representationOnly/RepresentationOnlyAssertionImpl : ch/tutteli/atrium/assertions/RepresentationOnlyAssertion {
+	public fun <init> (Lkotlin/jvm/functions/Function0;Ljava/lang/Object;)V
+	public fun getRepresentation ()Ljava/lang/Object;
+	public fun holds ()Z
+}
+
+public final class ch/tutteli/atrium/core/BooleanProviderKt {
+	public static final fun getFalseProvider ()Lkotlin/jvm/functions/Function0;
+	public static final fun getTrueProvider ()Lkotlin/jvm/functions/Function0;
+}
+
+public abstract class ch/tutteli/atrium/core/Either {
+	public final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun map (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Either;
+	public final fun toOption ()Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/core/EitherKt {
+	public static final fun flatMap (Lch/tutteli/atrium/core/Either;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Either;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/core/ExperimentalNewExpectTypes : java/lang/annotation/Annotation {
+}
+
+public final class ch/tutteli/atrium/core/Left : ch/tutteli/atrium/core/Either {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/core/Left;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/core/Left;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/core/Left;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getL ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/None : ch/tutteli/atrium/core/Option {
+	public static final field INSTANCE Lch/tutteli/atrium/core/None;
+}
+
+public abstract class ch/tutteli/atrium/core/Option {
+	public static final field Companion Lch/tutteli/atrium/core/Option$Companion;
+	public final fun filter (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+	public final fun flatMap (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+	public final fun fold (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun isDefined ()Z
+	public final fun map (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/core/Option$Companion {
+	public final fun someIf (ZLkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/core/OptionKt {
+	public static final fun getOrElse (Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/core/Right : ch/tutteli/atrium/core/Either {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/core/Right;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/core/Right;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/core/Right;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getR ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/Some : ch/tutteli/atrium/core/Option {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/core/Some;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/core/Some;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/core/Some;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/FormatFloatingPointNumberKt {
+	public static final fun formatFloatingPointNumber (Ljava/lang/Number;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/KClassExtensionsKt {
+	public static final fun cast (Lkotlin/reflect/KClass;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun fullName (Lkotlin/reflect/KClass;Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun getFullName (Lkotlin/reflect/KClass;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/StringBuilderExtensionKt {
+	public static final fun appendln (Ljava/lang/StringBuilder;)Ljava/lang/StringBuilder;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/StringExtensionsKt {
+	public static final fun format (Ljava/lang/String;Lch/tutteli/atrium/reporting/translating/Locale;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun format (Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/ThrowableExtensionsKt {
+	public static final fun getStackBacktrace (Ljava/lang/Throwable;)Ljava/util/List;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/AssertionContainer {
+	public abstract fun append (Lch/tutteli/atrium/assertions/Assertion;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun appendAsGroup (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun createAndAppend (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun createAndAppend (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun getComponents ()Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+	public abstract fun getImpl (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun getMaybeSubject ()Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/creating/AssertionContainer$DefaultImpls {
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/CollectingExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/CollectingExpect$Companion;
+	public abstract fun appendAsGroup (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/CollectingExpect;
+	public abstract fun getAssertions ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/creating/CollectingExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/creating/ComponentFactoryContainer;)Lch/tutteli/atrium/creating/CollectingExpect;
+}
+
+public final class ch/tutteli/atrium/creating/ComponentFactory {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Z)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Z
+	public final fun copy (Lkotlin/jvm/functions/Function1;Z)Lch/tutteli/atrium/creating/ComponentFactory;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/creating/ComponentFactory;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lch/tutteli/atrium/creating/ComponentFactory;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuild ()Lkotlin/jvm/functions/Function1;
+	public final fun getProducesSingleton ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/ComponentFactoryContainer {
+	public static final field Companion Lch/tutteli/atrium/creating/ComponentFactoryContainer$Companion;
+	public abstract fun buildChainedOrNull (Lkotlin/reflect/KClass;)Lkotlin/sequences/Sequence;
+	public abstract fun buildOrNull (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public abstract fun getFactoryForChainedOrNull (Lkotlin/reflect/KClass;)Lkotlin/sequences/Sequence;
+	public abstract fun getFactoryOrNull (Lkotlin/reflect/KClass;)Lch/tutteli/atrium/creating/ComponentFactory;
+	public abstract fun merge (Lch/tutteli/atrium/creating/ComponentFactoryContainer;)Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+}
+
+public final class ch/tutteli/atrium/creating/ComponentFactoryContainer$Companion {
+	public final fun createIfNotEmpty (Ljava/util/Map;Ljava/util/Map;)Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/DelegatingExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/DelegatingExpect$Companion;
+}
+
+public final class ch/tutteli/atrium/creating/DelegatingExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/creating/ErrorMessages : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field AT_LEAST_ONE_EXPECTATION_DEFINED Lch/tutteli/atrium/creating/ErrorMessages;
+	public static final field FORGOT_DO_DEFINE_EXPECTATION Lch/tutteli/atrium/creating/ErrorMessages;
+	public static final field HINT_AT_LEAST_ONE_EXPECTATION_DEFINED Lch/tutteli/atrium/creating/ErrorMessages;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/creating/ErrorMessages;
+	public static fun values ()[Lch/tutteli/atrium/creating/ErrorMessages;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/Expect {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/ExpectGrouping {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/ExpectInternal : ch/tutteli/atrium/creating/AssertionContainer, ch/tutteli/atrium/creating/Expect, ch/tutteli/atrium/creating/ExpectGrouping {
+}
+
+public final class ch/tutteli/atrium/creating/ExpectInternal$DefaultImpls {
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/ExpectInternal;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/ExpectInternal;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/creating/ExperimentalComponentFactoryContainer : java/lang/annotation/Annotation {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/FeatureExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/FeatureExpect$Companion;
+}
+
+public final class ch/tutteli/atrium/creating/FeatureExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public final fun invoke (Lch/tutteli/atrium/creating/FeatureExpect;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public final class ch/tutteli/atrium/creating/FeatureExpectOptions {
+	public fun <init> ()V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/creating/FeatureExpectOptions;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun getRepresentationInsteadOfFeature ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun merge (Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/creating/PleaseUseReplacementException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class ch/tutteli/atrium/creating/RootExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/RootExpect$Companion;
+}
+
+public final class ch/tutteli/atrium/creating/RootExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/RootExpect;
+	public final fun invoke (Lch/tutteli/atrium/creating/RootExpect;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/RootExpect;
+}
+
+public final class ch/tutteli/atrium/creating/RootExpectOptions {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/ComponentFactoryContainer;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun component3 ()Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/ComponentFactoryContainer;)Lch/tutteli/atrium/creating/RootExpectOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/creating/RootExpectOptions;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/ComponentFactoryContainer;ILjava/lang/Object;)Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComponentFactoryContainer ()Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+	public final fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun getRepresentationInsteadOfSubject ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun merge (Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/creating/feature/ExperimentalFeatureInfo : java/lang/annotation/Annotation {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/feature/FeatureInfo {
+	public abstract fun determine (Lkotlin/jvm/functions/Function1;I)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/creating/feature/impl/StackTraceBasedFeatureInfo : ch/tutteli/atrium/creating/feature/FeatureInfo {
+	public fun <init> ()V
+	public fun determine (Lkotlin/jvm/functions/Function1;I)Ljava/lang/String;
+}
+
+public abstract class ch/tutteli/atrium/creating/impl/BaseExpectImpl : ch/tutteli/atrium/creating/ExpectInternal {
+	public static final field Companion Lch/tutteli/atrium/creating/impl/BaseExpectImpl$Companion;
+	public fun <init> (Lch/tutteli/atrium/core/Option;)V
+	protected final fun appendAsGroup (Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public fun appendAsGroup (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public fun createAndAppend (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public fun createAndAppend (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public fun getImpl (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getMaybeSubject ()Lch/tutteli/atrium/core/Option;
+	public final fun registerImpl (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/creating/impl/BaseExpectImpl$Companion {
+	public final fun determineRepresentation (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/core/Option;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionFormatter {
+	public static final field Companion Lch/tutteli/atrium/reporting/AssertionFormatter$Companion;
+	public abstract fun canFormat (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public abstract fun formatGroup (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lkotlin/jvm/functions/Function2;)V
+	public abstract fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatter$Companion {
+	public final fun getCALL_FORMAT_GROUP ()Ljava/lang/String;
+	public final fun throwNotIntendedForAssertionGroups ()V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatter$DefaultImpls {
+	public static fun format (Lch/tutteli/atrium/reporting/AssertionFormatter;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionFormatterController {
+	public static final field Companion Lch/tutteli/atrium/reporting/AssertionFormatterController$Companion;
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public abstract fun isExplanatoryAssertionGroup (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public abstract fun register (Lch/tutteli/atrium/reporting/AssertionFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterController$Companion {
+	public final fun noSuitableAssertionFormatterFound (Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Void;
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterController$DefaultImpls {
+	public static fun isExplanatoryAssertionGroup (Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/assertions/Assertion;)Z
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionFormatterFacade {
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun register (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterParameterObject {
+	public static final field Companion Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject$Companion;
+	public synthetic fun <init> (Ljava/lang/StringBuilder;Ljava/lang/String;ILkotlin/jvm/functions/Function1;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun appendLnAndIndent ()V
+	public final fun appendLnIndentAndPrefix ()V
+	public final fun createChildWithNewPrefix (Ljava/lang/String;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createChildWithNewPrefixAndAdditionalIndent (Ljava/lang/String;I)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createForDoNotFilterAssertionGroup ()Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createForExplanatoryFilterAssertionGroup (Ljava/lang/String;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public static synthetic fun createForExplanatoryFilterAssertionGroup$default (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Ljava/lang/String;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createWithNewPrefix (Ljava/lang/String;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun getAssertionFilter ()Lkotlin/jvm/functions/Function1;
+	public final fun getPrefix ()Ljava/lang/String;
+	public final fun getSb ()Ljava/lang/StringBuilder;
+	public final fun indent (I)V
+	public final fun isNotInDoNotFilterGroup ()Z
+	public final fun isNotInExplanatoryFilterGroup ()Z
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterParameterObject$Companion {
+	public final fun new (Ljava/lang/StringBuilder;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionPairFormatter {
+	public abstract fun format (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public abstract fun formatGroupHeader (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AtriumError : java/lang/AssertionError {
+	public static final field Companion Lch/tutteli/atrium/reporting/AtriumError$Companion;
+	public fun getLocalizedMessage ()Ljava/lang/String;
+	public fun getMessage ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/AtriumError$Companion {
+	public final fun create (Ljava/lang/String;Lch/tutteli/atrium/reporting/AtriumErrorAdjuster;)Lch/tutteli/atrium/reporting/AtriumError;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AtriumErrorAdjuster : ch/tutteli/atrium/reporting/AtriumErrorAdjusterCommon {
+	public abstract fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AtriumErrorAdjusterCommon {
+	public abstract fun adjust (Ljava/lang/Throwable;)V
+	public abstract fun adjustOtherThanStacks (Ljava/lang/Throwable;)V
+}
+
+public final class ch/tutteli/atrium/reporting/ConstantsKt {
+	public static final field BUG_REPORT_URL Ljava/lang/String;
+	public static final field SHOULD_NOT_BE_SHOWN_TO_THE_USER_BUG Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/LazyRepresentation {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public final fun eval ()Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/MethodCallFormatter {
+	public abstract fun formatArgument (Ljava/lang/Object;)Ljava/lang/String;
+	public abstract fun formatCall (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/ObjectFormatter {
+	public abstract fun format (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/Reporter {
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;)V
+}
+
+public final class ch/tutteli/atrium/reporting/Text {
+	public static final field Companion Lch/tutteli/atrium/reporting/Text$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lch/tutteli/atrium/reporting/Text;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/reporting/Text;Ljava/lang/String;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/Text$Companion {
+	public final fun getEMPTY ()Lch/tutteli/atrium/reporting/Text;
+	public final fun getEMPTY_PROVIDER ()Lkotlin/jvm/functions/Function0;
+	public final fun getNULL ()Lch/tutteli/atrium/reporting/Text;
+	public final fun invoke (Ljava/lang/String;)Lch/tutteli/atrium/reporting/Text;
+}
+
+public abstract class ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public fun <init> ()V
+	public final fun adjust (Ljava/lang/Throwable;)V
+	public fun adjustOtherThanStacks (Ljava/lang/Throwable;)V
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/MultiAtriumErrorAdjuster : ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster, ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public fun <init> (Lch/tutteli/atrium/reporting/AtriumErrorAdjuster;Lch/tutteli/atrium/reporting/AtriumErrorAdjuster;Ljava/util/List;)V
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjuster : ch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjusterCommon, ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjuster;
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public abstract class ch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjusterCommon : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public fun <init> ()V
+	public fun adjust (Ljava/lang/Throwable;)V
+	public fun adjustOtherThanStacks (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/erroradjusters/RemoveAtriumFromAtriumError : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/erroradjusters/RemoveRunnerFromAtriumError : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/impl/RemoveAtriumFromAtriumErrorImpl : ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster, ch/tutteli/atrium/reporting/erroradjusters/RemoveAtriumFromAtriumError {
+	public fun <init> ()V
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/impl/RemoveRunnerFromAtriumErrorImpl : ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster, ch/tutteli/atrium/reporting/erroradjusters/RemoveRunnerFromAtriumError {
+	public fun <init> ()V
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public final class ch/tutteli/atrium/reporting/impl/AssertionFormatterControllerBasedFacade : ch/tutteli/atrium/reporting/AssertionFormatterFacade {
+	public fun <init> (Lch/tutteli/atrium/reporting/AssertionFormatterController;)V
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;Lkotlin/jvm/functions/Function1;)V
+	public fun register (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/reporting/impl/DefaultAssertionFormatterController : ch/tutteli/atrium/reporting/AssertionFormatterController {
+	public fun <init> ()V
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public fun isExplanatoryAssertionGroup (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public fun register (Lch/tutteli/atrium/reporting/AssertionFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/impl/OnlyFailureReporter : ch/tutteli/atrium/reporting/Reporter {
+	public fun <init> (Lch/tutteli/atrium/reporting/AssertionFormatterFacade;)V
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/BulletPointProvider {
+	public abstract fun getBulletPoints ()Ljava/util/Map;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextAssertionFormatter : ch/tutteli/atrium/reporting/AssertionFormatter {
+}
+
+public final class ch/tutteli/atrium/reporting/text/TextAssertionFormatter$DefaultImpls {
+	public static fun format (Lch/tutteli/atrium/reporting/text/TextAssertionFormatter;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter : ch/tutteli/atrium/reporting/AssertionPairFormatter {
+	public static final field Companion Lch/tutteli/atrium/reporting/text/TextAssertionPairFormatter$Companion;
+}
+
+public final class ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter$Companion {
+	public final fun newNextLine (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)Lch/tutteli/atrium/reporting/text/TextAssertionPairFormatter;
+	public final fun newSameLine (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)Lch/tutteli/atrium/reporting/text/TextAssertionPairFormatter;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextMethodCallFormatter : ch/tutteli/atrium/reporting/MethodCallFormatter {
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextObjectFormatter : ch/tutteli/atrium/reporting/ObjectFormatter {
+}
+
+public final class ch/tutteli/atrium/reporting/text/UsingDefaultBulletPoints : ch/tutteli/atrium/reporting/text/BulletPointProvider {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/text/UsingDefaultBulletPoints;
+	public fun getBulletPoints ()Ljava/util/Map;
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/AbstractTextObjectFormatter : ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public final fun format (Ljava/lang/Object;)Ljava/lang/String;
+	protected final fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
+	protected fun identityHash (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/DefaultTextMethodCallFormatter : ch/tutteli/atrium/reporting/text/TextMethodCallFormatter {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/text/impl/DefaultTextMethodCallFormatter;
+	public fun formatArgument (Ljava/lang/Object;)Ljava/lang/String;
+	public fun formatCall (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter : ch/tutteli/atrium/reporting/text/impl/AbstractTextObjectFormatter, ch/tutteli/atrium/reporting/text/TextObjectFormatter {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter : ch/tutteli/atrium/reporting/text/impl/SingleAssertionGroupTypeFormatter {
+	public fun <init> (Lkotlin/reflect/KClass;Lch/tutteli/atrium/reporting/AssertionFormatterController;)V
+	protected final fun formatGroupAssertions (Lkotlin/jvm/functions/Function2;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/SingleAssertionGroupTypeFormatter : ch/tutteli/atrium/reporting/AssertionFormatter {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public final fun canFormat (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public final fun formatGroup (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lkotlin/jvm/functions/Function2;)V
+	protected abstract fun formatGroupAssertions (Lkotlin/jvm/functions/Function2;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	protected abstract fun formatGroupHeaderAndGetChildParameterObject (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Ljava/lang/Void;
+	public synthetic fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory {
+	public static final field Companion Lch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory$Companion;
+	public abstract fun build (Lch/tutteli/atrium/reporting/AssertionFormatterController;)Lch/tutteli/atrium/reporting/text/TextAssertionFormatter;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextExplanatoryAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextFallbackAssertionFormatter : ch/tutteli/atrium/reporting/AssertionFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lch/tutteli/atrium/reporting/ObjectFormatter;)V
+	public fun canFormat (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public fun formatGroup (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lkotlin/jvm/functions/Function2;)V
+	public fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextFeatureAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextGroupingAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextListAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/TextListBasedAssertionGroupFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/TextListBasedAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/lang/String;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lkotlin/reflect/KClass;)V
+	protected fun formatGroupHeaderAndGetChildParameterObject (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextNextLineAssertionPairFormatter : ch/tutteli/atrium/reporting/AssertionPairFormatter, ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter {
+	public fun <init> (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public fun format (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun formatGroupHeader (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon : ch/tutteli/atrium/reporting/text/TextObjectFormatter {
+	public static final field Companion Lch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon$Companion;
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public fun format (Ljava/lang/Object;)Ljava/lang/String;
+	protected abstract fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
+	protected abstract fun identityHash (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon$Companion {
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextPrefixBasedAssertionGroupFormatter {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun formatAfterAppendLnEtc (Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun formatWithGroupName (Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextSameLineAssertionPairFormatter : ch/tutteli/atrium/reporting/AssertionPairFormatter, ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter {
+	public fun <init> (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public fun format (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun formatGroupHeader (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextSummaryAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/SingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator : ch/tutteli/atrium/reporting/translating/Translator {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)V
+	protected final fun getFallbackLocales ()Ljava/util/List;
+	protected final fun getPrimaryLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+	public final fun translate (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+	protected abstract fun translateWithoutArgs (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Locale {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lch/tutteli/atrium/reporting/translating/Locale;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/translating/Locale;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getScript ()Ljava/lang/String;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/LocaleKt {
+	public static final fun getDefaultLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+	public static final fun toJavaLocale (Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/util/Locale;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/LocaleOrderDecider {
+	public abstract fun determineOrder (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/LocaleProvider {
+	public abstract fun getFallbackLocales ()Ljava/util/List;
+	public abstract fun getPrimaryLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+}
+
+public abstract class ch/tutteli/atrium/reporting/translating/PropertiesBasedTranslationSupplier : ch/tutteli/atrium/reporting/translating/TranslationSupplier {
+	public fun <init> ()V
+	protected final fun getFileNameFor (Ljava/lang/String;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+	protected final fun getOrLoadProperties (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/PropertiesPerEntityAndLocaleTranslationSupplier : ch/tutteli/atrium/reporting/translating/PropertiesBasedTranslationSupplier {
+	public fun <init> ()V
+	public fun get (Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/PropertiesPerLocaleTranslationSupplier : ch/tutteli/atrium/reporting/translating/PropertiesBasedTranslationSupplier {
+	public fun <init> ()V
+	public fun get (Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/StringBasedTranslatable : ch/tutteli/atrium/reporting/translating/Translatable {
+	public abstract fun getDefault ()Ljava/lang/String;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/StringBasedTranslatable$DefaultImpls {
+	public static fun getDefault (Lch/tutteli/atrium/reporting/translating/StringBasedTranslatable;)Ljava/lang/String;
+	public static fun getId (Lch/tutteli/atrium/reporting/translating/StringBasedTranslatable;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/Translatable {
+	public static final field Companion Lch/tutteli/atrium/reporting/translating/Translatable$Companion;
+	public static final field ID_SEPARATOR Ljava/lang/String;
+	public abstract fun getDefault ()Ljava/lang/String;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Translatable$Companion {
+	public static final field ID_SEPARATOR Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Translatable$DefaultImpls {
+	public static fun getId (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/TranslatableWithArgs : ch/tutteli/atrium/reporting/translating/Translatable {
+	public static final field Companion Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs$Companion;
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;)Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/util/List;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getTranslatable ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/TranslatableWithArgs$Companion {
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/TranslationSupplier {
+	public abstract fun get (Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/Translator {
+	public abstract fun translate (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Untranslatable : ch/tutteli/atrium/reporting/translating/Translatable {
+	public static final field Companion Lch/tutteli/atrium/reporting/translating/Untranslatable$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Untranslatable$Companion {
+	public final fun getEMPTY ()Lch/tutteli/atrium/reporting/translating/Untranslatable;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/UseDefaultLocaleAsPrimary : ch/tutteli/atrium/reporting/translating/LocaleProvider {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/translating/UseDefaultLocaleAsPrimary;
+	public fun getFallbackLocales ()Ljava/util/List;
+	public fun getPrimaryLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/UsingDefaultTranslator : ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator {
+	public fun <init> ()V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Locale;)V
+	public synthetic fun <init> (Lch/tutteli/atrium/reporting/translating/Locale;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class ch/tutteli/atrium/reporting/translating/impl/ResourceBundleInspiredLocaleOrderDecider : ch/tutteli/atrium/reporting/translating/LocaleOrderDecider {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/translating/impl/ResourceBundleInspiredLocaleOrderDecider;
+	public fun determineOrder (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/impl/TranslationSupplierBasedTranslator : ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/TranslationSupplier;Lch/tutteli/atrium/reporting/translating/LocaleOrderDecider;Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)V
+}
+

--- a/atrium-core/api/using-kotlin-1.9-or-newer/atrium-core.api
+++ b/atrium-core/api/using-kotlin-1.9-or-newer/atrium-core.api
@@ -1,0 +1,1310 @@
+public abstract interface class ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun holds ()Z
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/AssertionGroup : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getAssertions ()Ljava/util/List;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun holds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/AssertionGroup$DefaultImpls {
+	public static fun holds (Lch/tutteli/atrium/assertions/AssertionGroup;)Z
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/AssertionGroupType : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultExplanatoryAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultExplanatoryAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultFeatureAssertionGroupType : ch/tutteli/atrium/assertions/FeatureAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultFeatureAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultGroupingAssertionGroupType : ch/tutteli/atrium/assertions/GroupingAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultGroupingAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultListAssertionGroupType : ch/tutteli/atrium/assertions/ListAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultListAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/DefaultSummaryAssertionGroupType : ch/tutteli/atrium/assertions/SummaryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/DefaultSummaryAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/DescriptiveAssertion : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/DoNotFilterAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public abstract interface annotation class ch/tutteli/atrium/assertions/ExperimentalExpectationApi : java/lang/annotation/Annotation {
+	public abstract fun reason ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/ExplanatoryAssertion : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getExplanation ()Ljava/lang/Object;
+	public abstract fun holds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/ExplanatoryAssertion$DefaultImpls {
+	public static fun holds (Lch/tutteli/atrium/assertions/ExplanatoryAssertion;)Z
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType : ch/tutteli/atrium/assertions/DoNotFilterAssertionGroupType {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/FeatureAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/GroupingAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public final class ch/tutteli/atrium/assertions/HintAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/HintAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/InformationAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lch/tutteli/atrium/assertions/InformationAssertionGroupType;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/assertions/InformationAssertionGroupType;ZILjava/lang/Object;)Lch/tutteli/atrium/assertions/InformationAssertionGroupType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWithIndent ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/assertions/InvisibleAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/InvisibleAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/ListAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+}
+
+public final class ch/tutteli/atrium/assertions/PrefixFailingSummaryAssertion : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public final class ch/tutteli/atrium/assertions/PrefixFeatureAssertionGroupHeader : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public final class ch/tutteli/atrium/assertions/PrefixSuccessfulSummaryAssertion : ch/tutteli/atrium/assertions/BulletPointIdentifier {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/RepresentationOnlyAssertion : ch/tutteli/atrium/assertions/Assertion {
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/RootAssertionGroupType : ch/tutteli/atrium/assertions/AssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/RootAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/SummaryAssertionGroupType : ch/tutteli/atrium/assertions/DoNotFilterAssertionGroupType {
+}
+
+public final class ch/tutteli/atrium/assertions/WarningAssertionGroupType : ch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType {
+	public static final field INSTANCE Lch/tutteli/atrium/assertions/WarningAssertionGroupType;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionBuilder {
+	public abstract fun createDescriptive (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public abstract fun createDescriptive (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public abstract fun customType (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getDescriptive ()Lch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption;
+	public abstract fun getExplanatory ()Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;
+	public abstract fun getExplanatoryGroup ()Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption;
+	public abstract fun getFeature ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getList ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getRepresentationOnly ()Lch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep;
+	public abstract fun getSummary ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionBuilder$DefaultImpls {
+	public static fun createDescriptive (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public static fun createDescriptive (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public abstract fun build ()Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionBuilderKt {
+	public static final fun getAssertionBuilder ()Lch/tutteli/atrium/assertions/builders/AssertionBuilder;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption$Companion;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/Object;
+	public abstract fun withDescription (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lkotlin/jvm/functions/Function3;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption$DefaultImpls {
+	public static fun withDescription (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndEmptyRepresentationOption;Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption$Companion;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun withDescriptionAndEmptyRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndEmptyRepresentation (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lkotlin/jvm/functions/Function3;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption$DefaultImpls {
+	public static fun withDescriptionAndEmptyRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/Object;
+	public static fun withDescriptionAndEmptyRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Ljava/lang/String;)Ljava/lang/Object;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/AssertionsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/AssertionsOption$Companion;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun withAssertion (Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public abstract fun withAssertions (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public abstract fun withAssertions (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public abstract fun withAssertions (Ljava/util/List;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionsOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public final fun factoryWithDefaultFinalStep ()Lkotlin/jvm/functions/Function3;
+	public final fun withDefaultFinalStepAndEmptyDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public final fun withEmptyDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/AssertionGroupType;Lkotlin/jvm/functions/Function4;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/AssertionsOption$DefaultImpls {
+	public static fun withAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public static fun withAssertions (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+	public static fun withAssertions (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep$Companion;
+	public abstract fun getAssertions ()Ljava/util/List;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/util/List;)Lch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption$Companion;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption$DefaultImpls {
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Descriptive$FinalStep$Companion;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$FinalStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Descriptive$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption$Companion;
+	public abstract fun getFailing ()Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun getHolding ()Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun withTest (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun withTest (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/Descriptive$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption$DefaultImpls {
+	public static fun ifAbsent (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectAbsentOption;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$DefinedOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FailureHintSubjectDefinedOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep$Companion;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getFailureHintFactory ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getShowHint ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption$Companion;
+	public abstract fun getShowForAnyFailure ()Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showBasedOnDefinedSubjectOnlyIf (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showBasedOnSubjectOnlyIf (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showOnlyIf (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public abstract fun showOnlyIfSubjectDefined (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption$DefaultImpls {
+	public static fun showBasedOnDefinedSubjectOnlyIf (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static fun showBasedOnSubjectOnlyIf (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static fun showOnlyIfSubjectDefined (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption$DefaultImpls {
+	public static fun ifAbsent (Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectAbsentOption;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption : ch/tutteli/atrium/assertions/builders/SubjectBasedOption$DefinedOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowSubjectDefinedOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/DescriptiveWithFailureHintKt {
+	public static final fun createShouldNotBeShownToUserWarning ()Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun withHelpOnFailure (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;
+	public static final fun withHelpOnFailureBasedOnDefinedSubject (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static synthetic fun withHelpOnFailureBasedOnDefinedSubject$default (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static final fun withHelpOnFailureBasedOnSubject (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/DescriptiveAssertionWithFailureHint$ShowOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Explanatory {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption$Companion;
+	public abstract fun withExplanation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+	public abstract fun withExplanation (Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+	public abstract fun withExplanation (Ljava/lang/String;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption$DefaultImpls {
+	public static fun withExplanation (Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+	public static fun withExplanation (Lch/tutteli/atrium/assertions/builders/Explanatory$ExplanationOption;Ljava/lang/String;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/Explanatory$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep$Companion;
+	public abstract fun getExplanation ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/Explanatory$FinalStep$Companion {
+	public final fun create (Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/Explanatory$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$Companion;
+	public abstract fun getExplanatoryAssertions ()Ljava/util/List;
+	public abstract fun getFailing ()Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;Ljava/util/List;Z)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static synthetic fun create$default (Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$Companion;Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;Ljava/util/List;ZILjava/lang/Object;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep$DefaultImpls {
+	public static fun getFailing (Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption$Companion;
+	public abstract fun getWithDefaultType ()Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun getWithHintType ()Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun getWithWarningType ()Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun withInformationType (Z)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+	public abstract fun withType (Lch/tutteli/atrium/assertions/ExplanatoryAssertionGroupType;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$GroupTypeOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/ExplanatoryGroupKt {
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+	public static final fun withExplanatoryAssertion (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep : ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep$Companion;
+	public abstract fun getHolds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/util/List;Z)Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption$DefaultImpls {
+	public static fun getWithFeatureType (Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public static fun getWithListType (Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$HoldsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimGroupKt {
+	public static final fun getFixedClaimGroup (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/FixedClaimGroup$GroupTypeOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption {
+	public abstract fun getWithFeatureType ()Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public abstract fun getWithListType ()Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public abstract fun withType (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption$DefaultImpls {
+	public static fun getWithFeatureType (Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public static fun getWithListType (Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption {
+	public abstract fun getFailing ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun getGroupType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public abstract fun getHolding ()Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+	public abstract fun withClaim (Z)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/InvisibleGroupKt {
+	public static final fun getInvisibleGroup (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/AssertionsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep : ch/tutteli/atrium/assertions/builders/BasicAssertionGroupFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep$Companion;
+	public abstract fun getPreTransformationHolds ()Z
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/util/List;Z)Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$GroupTypeOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption$DefaultImpls {
+	public static fun getWithFeatureType (Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+	public static fun getWithListType (Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;)Lch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption : ch/tutteli/atrium/assertions/builders/FixedClaimLikeGroup$HoldsOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption$Companion {
+	public final fun create (Lch/tutteli/atrium/assertions/AssertionGroupType;)Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$HoldsOption;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroupKt {
+	public static final fun getPartiallyFixedClaimGroup (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/PartiallyFixedClaimGroup$GroupTypeOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly {
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep : ch/tutteli/atrium/assertions/builders/AssertionBuilderFinalStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep$Companion;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep : ch/tutteli/atrium/assertions/builders/common/HoldsStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep$Companion;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep$Companion {
+	public final fun create ()Lch/tutteli/atrium/assertions/builders/RepresentationOnly$HoldsStep;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep$Companion;
+	public abstract fun getTest ()Lkotlin/jvm/functions/Function0;
+	public abstract fun withRepresentation (Ljava/lang/Object;)Lch/tutteli/atrium/assertions/builders/RepresentationOnly$FinalStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/builders/RepresentationOnly$RepresentationStep;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/RootKt {
+	public static final fun getRoot (Lch/tutteli/atrium/assertions/builders/AssertionBuilder;)Lch/tutteli/atrium/assertions/builders/AssertionGroupDescriptionAndRepresentationOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/SubjectBasedOption {
+	public static final field Companion Lch/tutteli/atrium/assertions/builders/SubjectBasedOption$Companion;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption {
+	public abstract fun getIfDefined ()Lkotlin/jvm/functions/Function1;
+	public abstract fun ifAbsent (Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption$DefaultImpls {
+	public static fun ifAbsent (Lch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption;Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/SubjectBasedOption$DefinedOption {
+	public abstract fun ifDefined (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/SubjectBasedOption$AbsentOption;
+}
+
+public abstract interface class ch/tutteli/atrium/assertions/builders/common/HoldsStep {
+	public abstract fun getFailing ()Ljava/lang/Object;
+	public abstract fun getHolding ()Ljava/lang/Object;
+	public abstract fun withTest (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun withTest (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/assertions/builders/impl/representationOnly/RepresentationOnlyAssertionImpl : ch/tutteli/atrium/assertions/RepresentationOnlyAssertion {
+	public fun <init> (Lkotlin/jvm/functions/Function0;Ljava/lang/Object;)V
+	public fun getRepresentation ()Ljava/lang/Object;
+	public fun holds ()Z
+}
+
+public final class ch/tutteli/atrium/core/BooleanProviderKt {
+	public static final fun getFalseProvider ()Lkotlin/jvm/functions/Function0;
+	public static final fun getTrueProvider ()Lkotlin/jvm/functions/Function0;
+}
+
+public abstract class ch/tutteli/atrium/core/Either {
+	public final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun map (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Either;
+	public final fun toOption ()Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/core/EitherKt {
+	public static final fun flatMap (Lch/tutteli/atrium/core/Either;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Either;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/core/ExperimentalNewExpectTypes : java/lang/annotation/Annotation {
+}
+
+public final class ch/tutteli/atrium/core/Left : ch/tutteli/atrium/core/Either {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/core/Left;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/core/Left;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/core/Left;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getL ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/None : ch/tutteli/atrium/core/Option {
+	public static final field INSTANCE Lch/tutteli/atrium/core/None;
+}
+
+public abstract class ch/tutteli/atrium/core/Option {
+	public static final field Companion Lch/tutteli/atrium/core/Option$Companion;
+	public final fun filter (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+	public final fun flatMap (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+	public final fun fold (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun isDefined ()Z
+	public final fun map (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/core/Option$Companion {
+	public final fun someIf (ZLkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/core/OptionKt {
+	public static final fun getOrElse (Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/core/Right : ch/tutteli/atrium/core/Either {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/core/Right;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/core/Right;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/core/Right;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getR ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/Some : ch/tutteli/atrium/core/Option {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lch/tutteli/atrium/core/Some;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/core/Some;Ljava/lang/Object;ILjava/lang/Object;)Lch/tutteli/atrium/core/Some;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/FormatFloatingPointNumberKt {
+	public static final fun formatFloatingPointNumber (Ljava/lang/Number;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/KClassExtensionsKt {
+	public static final fun cast (Lkotlin/reflect/KClass;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun fullName (Lkotlin/reflect/KClass;Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun getFullName (Lkotlin/reflect/KClass;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/StringBuilderExtensionKt {
+	public static final fun appendln (Ljava/lang/StringBuilder;)Ljava/lang/StringBuilder;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/StringExtensionsKt {
+	public static final fun format (Ljava/lang/String;Lch/tutteli/atrium/reporting/translating/Locale;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun format (Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/core/polyfills/ThrowableExtensionsKt {
+	public static final fun getStackBacktrace (Ljava/lang/Throwable;)Ljava/util/List;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/AssertionContainer {
+	public abstract fun append (Lch/tutteli/atrium/assertions/Assertion;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun appendAsGroup (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun createAndAppend (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun createAndAppend (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun getComponents ()Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+	public abstract fun getImpl (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun getMaybeSubject ()Lch/tutteli/atrium/core/Option;
+}
+
+public final class ch/tutteli/atrium/creating/AssertionContainer$DefaultImpls {
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/CollectingExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/CollectingExpect$Companion;
+	public abstract fun appendAsGroup (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/CollectingExpect;
+	public abstract fun getAssertions ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/creating/CollectingExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/creating/ComponentFactoryContainer;)Lch/tutteli/atrium/creating/CollectingExpect;
+}
+
+public final class ch/tutteli/atrium/creating/ComponentFactory {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Z)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Z
+	public final fun copy (Lkotlin/jvm/functions/Function1;Z)Lch/tutteli/atrium/creating/ComponentFactory;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/creating/ComponentFactory;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lch/tutteli/atrium/creating/ComponentFactory;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuild ()Lkotlin/jvm/functions/Function1;
+	public final fun getProducesSingleton ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/ComponentFactoryContainer {
+	public static final field Companion Lch/tutteli/atrium/creating/ComponentFactoryContainer$Companion;
+	public abstract fun buildChainedOrNull (Lkotlin/reflect/KClass;)Lkotlin/sequences/Sequence;
+	public abstract fun buildOrNull (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public abstract fun getFactoryForChainedOrNull (Lkotlin/reflect/KClass;)Lkotlin/sequences/Sequence;
+	public abstract fun getFactoryOrNull (Lkotlin/reflect/KClass;)Lch/tutteli/atrium/creating/ComponentFactory;
+	public abstract fun merge (Lch/tutteli/atrium/creating/ComponentFactoryContainer;)Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+}
+
+public final class ch/tutteli/atrium/creating/ComponentFactoryContainer$Companion {
+	public final fun createIfNotEmpty (Ljava/util/Map;Ljava/util/Map;)Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/DelegatingExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/DelegatingExpect$Companion;
+}
+
+public final class ch/tutteli/atrium/creating/DelegatingExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/creating/ErrorMessages : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field AT_LEAST_ONE_EXPECTATION_DEFINED Lch/tutteli/atrium/creating/ErrorMessages;
+	public static final field FORGOT_DO_DEFINE_EXPECTATION Lch/tutteli/atrium/creating/ErrorMessages;
+	public static final field HINT_AT_LEAST_ONE_EXPECTATION_DEFINED Lch/tutteli/atrium/creating/ErrorMessages;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/creating/ErrorMessages;
+	public static fun values ()[Lch/tutteli/atrium/creating/ErrorMessages;
+}
+
+public abstract interface class ch/tutteli/atrium/creating/Expect {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/ExpectGrouping {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/ExpectInternal : ch/tutteli/atrium/creating/AssertionContainer, ch/tutteli/atrium/creating/Expect, ch/tutteli/atrium/creating/ExpectGrouping {
+}
+
+public final class ch/tutteli/atrium/creating/ExpectInternal$DefaultImpls {
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/ExpectInternal;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static fun createAndAppend (Lch/tutteli/atrium/creating/ExpectInternal;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/creating/ExperimentalComponentFactoryContainer : java/lang/annotation/Annotation {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/FeatureExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/FeatureExpect$Companion;
+}
+
+public final class ch/tutteli/atrium/creating/FeatureExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/Expect;Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public final fun invoke (Lch/tutteli/atrium/creating/FeatureExpect;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public final class ch/tutteli/atrium/creating/FeatureExpectOptions {
+	public fun <init> ()V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/creating/FeatureExpectOptions;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun getRepresentationInsteadOfFeature ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun merge (Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/creating/PleaseUseReplacementException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class ch/tutteli/atrium/creating/RootExpect : ch/tutteli/atrium/creating/Expect {
+	public static final field Companion Lch/tutteli/atrium/creating/RootExpect$Companion;
+}
+
+public final class ch/tutteli/atrium/creating/RootExpect$Companion {
+	public final fun invoke (Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/RootExpect;
+	public final fun invoke (Lch/tutteli/atrium/creating/RootExpect;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/RootExpect;
+}
+
+public final class ch/tutteli/atrium/creating/RootExpectOptions {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/ComponentFactoryContainer;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun component3 ()Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/ComponentFactoryContainer;)Lch/tutteli/atrium/creating/RootExpectOptions;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/creating/RootExpectOptions;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/ComponentFactoryContainer;ILjava/lang/Object;)Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComponentFactoryContainer ()Lch/tutteli/atrium/creating/ComponentFactoryContainer;
+	public final fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun getRepresentationInsteadOfSubject ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun merge (Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class ch/tutteli/atrium/creating/feature/ExperimentalFeatureInfo : java/lang/annotation/Annotation {
+}
+
+public abstract interface class ch/tutteli/atrium/creating/feature/FeatureInfo {
+	public abstract fun determine (Lkotlin/jvm/functions/Function1;I)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/creating/feature/impl/StackTraceBasedFeatureInfo : ch/tutteli/atrium/creating/feature/FeatureInfo {
+	public fun <init> ()V
+	public fun determine (Lkotlin/jvm/functions/Function1;I)Ljava/lang/String;
+}
+
+public abstract class ch/tutteli/atrium/creating/impl/BaseExpectImpl : ch/tutteli/atrium/creating/ExpectInternal {
+	public static final field Companion Lch/tutteli/atrium/creating/impl/BaseExpectImpl$Companion;
+	public fun <init> (Lch/tutteli/atrium/core/Option;)V
+	protected final fun appendAsGroup (Ljava/util/List;)Lch/tutteli/atrium/creating/Expect;
+	public fun appendAsGroup (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public fun createAndAppend (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public fun createAndAppend (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public fun getImpl (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getMaybeSubject ()Lch/tutteli/atrium/core/Option;
+	public final fun registerImpl (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/creating/impl/BaseExpectImpl$Companion {
+	public final fun determineRepresentation (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/core/Option;)Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionFormatter {
+	public static final field Companion Lch/tutteli/atrium/reporting/AssertionFormatter$Companion;
+	public abstract fun canFormat (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public abstract fun formatGroup (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lkotlin/jvm/functions/Function2;)V
+	public abstract fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatter$Companion {
+	public final fun getCALL_FORMAT_GROUP ()Ljava/lang/String;
+	public final fun throwNotIntendedForAssertionGroups ()V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatter$DefaultImpls {
+	public static fun format (Lch/tutteli/atrium/reporting/AssertionFormatter;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionFormatterController {
+	public static final field Companion Lch/tutteli/atrium/reporting/AssertionFormatterController$Companion;
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public abstract fun isExplanatoryAssertionGroup (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public abstract fun register (Lch/tutteli/atrium/reporting/AssertionFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterController$Companion {
+	public final fun noSuitableAssertionFormatterFound (Lch/tutteli/atrium/assertions/Assertion;)Ljava/lang/Void;
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterController$DefaultImpls {
+	public static fun isExplanatoryAssertionGroup (Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/assertions/Assertion;)Z
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionFormatterFacade {
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun register (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterParameterObject {
+	public static final field Companion Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject$Companion;
+	public synthetic fun <init> (Ljava/lang/StringBuilder;Ljava/lang/String;ILkotlin/jvm/functions/Function1;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun appendLnAndIndent ()V
+	public final fun appendLnIndentAndPrefix ()V
+	public final fun createChildWithNewPrefix (Ljava/lang/String;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createChildWithNewPrefixAndAdditionalIndent (Ljava/lang/String;I)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createForDoNotFilterAssertionGroup ()Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createForExplanatoryFilterAssertionGroup (Ljava/lang/String;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public static synthetic fun createForExplanatoryFilterAssertionGroup$default (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Ljava/lang/String;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun createWithNewPrefix (Ljava/lang/String;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun getAssertionFilter ()Lkotlin/jvm/functions/Function1;
+	public final fun getPrefix ()Ljava/lang/String;
+	public final fun getSb ()Ljava/lang/StringBuilder;
+	public final fun indent (I)V
+	public final fun isNotInDoNotFilterGroup ()Z
+	public final fun isNotInExplanatoryFilterGroup ()Z
+}
+
+public final class ch/tutteli/atrium/reporting/AssertionFormatterParameterObject$Companion {
+	public final fun new (Ljava/lang/StringBuilder;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AssertionPairFormatter {
+	public abstract fun format (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public abstract fun formatGroupHeader (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/AtriumError : java/lang/AssertionError {
+	public static final field Companion Lch/tutteli/atrium/reporting/AtriumError$Companion;
+	public fun getLocalizedMessage ()Ljava/lang/String;
+	public fun getMessage ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/AtriumError$Companion {
+	public final fun create (Ljava/lang/String;Lch/tutteli/atrium/reporting/AtriumErrorAdjuster;)Lch/tutteli/atrium/reporting/AtriumError;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AtriumErrorAdjuster : ch/tutteli/atrium/reporting/AtriumErrorAdjusterCommon {
+	public abstract fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/AtriumErrorAdjusterCommon {
+	public abstract fun adjust (Ljava/lang/Throwable;)V
+	public abstract fun adjustOtherThanStacks (Ljava/lang/Throwable;)V
+}
+
+public final class ch/tutteli/atrium/reporting/ConstantsKt {
+	public static final field BUG_REPORT_URL Ljava/lang/String;
+	public static final field SHOULD_NOT_BE_SHOWN_TO_THE_USER_BUG Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/LazyRepresentation {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public final fun eval ()Ljava/lang/Object;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/MethodCallFormatter {
+	public abstract fun formatArgument (Ljava/lang/Object;)Ljava/lang/String;
+	public abstract fun formatCall (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/ObjectFormatter {
+	public abstract fun format (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/Reporter {
+	public abstract fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;)V
+}
+
+public final class ch/tutteli/atrium/reporting/Text {
+	public static final field Companion Lch/tutteli/atrium/reporting/Text$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lch/tutteli/atrium/reporting/Text;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/reporting/Text;Ljava/lang/String;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/Text$Companion {
+	public final fun getEMPTY ()Lch/tutteli/atrium/reporting/Text;
+	public final fun getEMPTY_PROVIDER ()Lkotlin/jvm/functions/Function0;
+	public final fun getNULL ()Lch/tutteli/atrium/reporting/Text;
+	public final fun invoke (Ljava/lang/String;)Lch/tutteli/atrium/reporting/Text;
+}
+
+public abstract class ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public fun <init> ()V
+	public final fun adjust (Ljava/lang/Throwable;)V
+	public fun adjustOtherThanStacks (Ljava/lang/Throwable;)V
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/MultiAtriumErrorAdjuster : ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster, ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public fun <init> (Lch/tutteli/atrium/reporting/AtriumErrorAdjuster;Lch/tutteli/atrium/reporting/AtriumErrorAdjuster;Ljava/util/List;)V
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjuster : ch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjusterCommon, ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjuster;
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public abstract class ch/tutteli/atrium/reporting/erroradjusters/NoOpAtriumErrorAdjusterCommon : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+	public fun <init> ()V
+	public fun adjust (Ljava/lang/Throwable;)V
+	public fun adjustOtherThanStacks (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/erroradjusters/RemoveAtriumFromAtriumError : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/erroradjusters/RemoveRunnerFromAtriumError : ch/tutteli/atrium/reporting/AtriumErrorAdjuster {
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/impl/RemoveAtriumFromAtriumErrorImpl : ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster, ch/tutteli/atrium/reporting/erroradjusters/RemoveAtriumFromAtriumError {
+	public fun <init> ()V
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public final class ch/tutteli/atrium/reporting/erroradjusters/impl/RemoveRunnerFromAtriumErrorImpl : ch/tutteli/atrium/reporting/erroradjusters/FilterAtriumErrorAdjuster, ch/tutteli/atrium/reporting/erroradjusters/RemoveRunnerFromAtriumError {
+	public fun <init> ()V
+	public fun adjustStackTrace (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+}
+
+public final class ch/tutteli/atrium/reporting/impl/AssertionFormatterControllerBasedFacade : ch/tutteli/atrium/reporting/AssertionFormatterFacade {
+	public fun <init> (Lch/tutteli/atrium/reporting/AssertionFormatterController;)V
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;Lkotlin/jvm/functions/Function1;)V
+	public fun register (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/reporting/impl/DefaultAssertionFormatterController : ch/tutteli/atrium/reporting/AssertionFormatterController {
+	public fun <init> ()V
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public fun isExplanatoryAssertionGroup (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public fun register (Lch/tutteli/atrium/reporting/AssertionFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/impl/OnlyFailureReporter : ch/tutteli/atrium/reporting/Reporter {
+	public fun <init> (Lch/tutteli/atrium/reporting/AssertionFormatterFacade;)V
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Ljava/lang/StringBuilder;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/BulletPointProvider {
+	public abstract fun getBulletPoints ()Ljava/util/Map;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextAssertionFormatter : ch/tutteli/atrium/reporting/AssertionFormatter {
+}
+
+public final class ch/tutteli/atrium/reporting/text/TextAssertionFormatter$DefaultImpls {
+	public static fun format (Lch/tutteli/atrium/reporting/text/TextAssertionFormatter;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter : ch/tutteli/atrium/reporting/AssertionPairFormatter {
+	public static final field Companion Lch/tutteli/atrium/reporting/text/TextAssertionPairFormatter$Companion;
+}
+
+public final class ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter$Companion {
+	public final fun newNextLine (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)Lch/tutteli/atrium/reporting/text/TextAssertionPairFormatter;
+	public final fun newSameLine (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)Lch/tutteli/atrium/reporting/text/TextAssertionPairFormatter;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextMethodCallFormatter : ch/tutteli/atrium/reporting/MethodCallFormatter {
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/TextObjectFormatter : ch/tutteli/atrium/reporting/ObjectFormatter {
+}
+
+public final class ch/tutteli/atrium/reporting/text/UsingDefaultBulletPoints : ch/tutteli/atrium/reporting/text/BulletPointProvider {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/text/UsingDefaultBulletPoints;
+	public fun getBulletPoints ()Ljava/util/Map;
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/AbstractTextObjectFormatter : ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public final fun format (Ljava/lang/Object;)Ljava/lang/String;
+	protected final fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
+	protected fun identityHash (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/DefaultTextMethodCallFormatter : ch/tutteli/atrium/reporting/text/TextMethodCallFormatter {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/text/impl/DefaultTextMethodCallFormatter;
+	public fun formatArgument (Ljava/lang/Object;)Ljava/lang/String;
+	public fun formatCall (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter : ch/tutteli/atrium/reporting/text/impl/AbstractTextObjectFormatter, ch/tutteli/atrium/reporting/text/TextObjectFormatter {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter : ch/tutteli/atrium/reporting/text/impl/SingleAssertionGroupTypeFormatter {
+	public fun <init> (Lkotlin/reflect/KClass;Lch/tutteli/atrium/reporting/AssertionFormatterController;)V
+	protected final fun formatGroupAssertions (Lkotlin/jvm/functions/Function2;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/SingleAssertionGroupTypeFormatter : ch/tutteli/atrium/reporting/AssertionFormatter {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public final fun canFormat (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public final fun formatGroup (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lkotlin/jvm/functions/Function2;)V
+	protected abstract fun formatGroupAssertions (Lkotlin/jvm/functions/Function2;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	protected abstract fun formatGroupHeaderAndGetChildParameterObject (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Ljava/lang/Void;
+	public synthetic fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory {
+	public static final field Companion Lch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory$Companion;
+	public abstract fun build (Lch/tutteli/atrium/reporting/AssertionFormatterController;)Lch/tutteli/atrium/reporting/text/TextAssertionFormatter;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/reporting/text/impl/TextAssertionFormatterFactory;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextExplanatoryAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextFallbackAssertionFormatter : ch/tutteli/atrium/reporting/AssertionFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lch/tutteli/atrium/reporting/ObjectFormatter;)V
+	public fun canFormat (Lch/tutteli/atrium/assertions/Assertion;)Z
+	public fun format (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+	public fun formatGroup (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lkotlin/jvm/functions/Function2;)V
+	public fun formatNonGroup (Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextFeatureAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextGroupingAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextListAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/TextListBasedAssertionGroupFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/TextListBasedAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/NoSpecialChildFormattingSingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/lang/String;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lkotlin/reflect/KClass;)V
+	protected fun formatGroupHeaderAndGetChildParameterObject (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextNextLineAssertionPairFormatter : ch/tutteli/atrium/reporting/AssertionPairFormatter, ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter {
+	public fun <init> (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public fun format (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun formatGroupHeader (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon : ch/tutteli/atrium/reporting/text/TextObjectFormatter {
+	public static final field Companion Lch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon$Companion;
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public fun format (Ljava/lang/Object;)Ljava/lang/String;
+	protected abstract fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
+	protected abstract fun identityHash (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon$Companion {
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextPrefixBasedAssertionGroupFormatter {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun formatAfterAppendLnEtc (Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+	public final fun formatWithGroupName (Lch/tutteli/atrium/reporting/AssertionPairFormatter;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextSameLineAssertionPairFormatter : ch/tutteli/atrium/reporting/AssertionPairFormatter, ch/tutteli/atrium/reporting/text/TextAssertionPairFormatter {
+	public fun <init> (Lch/tutteli/atrium/reporting/ObjectFormatter;Lch/tutteli/atrium/reporting/translating/Translator;)V
+	public fun format (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun formatGroupHeader (Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/reporting/AssertionFormatterParameterObject;)V
+}
+
+public final class ch/tutteli/atrium/reporting/text/impl/TextSummaryAssertionGroupFormatter : ch/tutteli/atrium/reporting/text/impl/SingleAssertionGroupTypeFormatter, ch/tutteli/atrium/reporting/text/TextAssertionFormatter {
+	public fun <init> (Ljava/util/Map;Lch/tutteli/atrium/reporting/AssertionFormatterController;Lch/tutteli/atrium/reporting/AssertionPairFormatter;)V
+}
+
+public abstract class ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator : ch/tutteli/atrium/reporting/translating/Translator {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)V
+	protected final fun getFallbackLocales ()Ljava/util/List;
+	protected final fun getPrimaryLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+	public final fun translate (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+	protected abstract fun translateWithoutArgs (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Locale {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lch/tutteli/atrium/reporting/translating/Locale;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/translating/Locale;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getScript ()Ljava/lang/String;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/LocaleKt {
+	public static final fun getDefaultLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+	public static final fun toJavaLocale (Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/util/Locale;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/LocaleOrderDecider {
+	public abstract fun determineOrder (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/LocaleProvider {
+	public abstract fun getFallbackLocales ()Ljava/util/List;
+	public abstract fun getPrimaryLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+}
+
+public abstract class ch/tutteli/atrium/reporting/translating/PropertiesBasedTranslationSupplier : ch/tutteli/atrium/reporting/translating/TranslationSupplier {
+	public fun <init> ()V
+	protected final fun getFileNameFor (Ljava/lang/String;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+	protected final fun getOrLoadProperties (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/PropertiesPerEntityAndLocaleTranslationSupplier : ch/tutteli/atrium/reporting/translating/PropertiesBasedTranslationSupplier {
+	public fun <init> ()V
+	public fun get (Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/PropertiesPerLocaleTranslationSupplier : ch/tutteli/atrium/reporting/translating/PropertiesBasedTranslationSupplier {
+	public fun <init> ()V
+	public fun get (Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/StringBasedTranslatable : ch/tutteli/atrium/reporting/translating/Translatable {
+	public abstract fun getDefault ()Ljava/lang/String;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/StringBasedTranslatable$DefaultImpls {
+	public static fun getDefault (Lch/tutteli/atrium/reporting/translating/StringBasedTranslatable;)Ljava/lang/String;
+	public static fun getId (Lch/tutteli/atrium/reporting/translating/StringBasedTranslatable;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/Translatable {
+	public static final field Companion Lch/tutteli/atrium/reporting/translating/Translatable$Companion;
+	public static final field ID_SEPARATOR Ljava/lang/String;
+	public abstract fun getDefault ()Ljava/lang/String;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Translatable$Companion {
+	public static final field ID_SEPARATOR Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Translatable$DefaultImpls {
+	public static fun getId (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/TranslatableWithArgs : ch/tutteli/atrium/reporting/translating/Translatable {
+	public static final field Companion Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs$Companion;
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;)Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/util/List;ILjava/lang/Object;)Lch/tutteli/atrium/reporting/translating/TranslatableWithArgs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/util/List;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getTranslatable ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/TranslatableWithArgs$Companion {
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/TranslationSupplier {
+	public abstract fun get (Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/reporting/translating/Locale;)Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/reporting/translating/Translator {
+	public abstract fun translate (Lch/tutteli/atrium/reporting/translating/Translatable;)Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Untranslatable : ch/tutteli/atrium/reporting/translating/Translatable {
+	public static final field Companion Lch/tutteli/atrium/reporting/translating/Untranslatable$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/Untranslatable$Companion {
+	public final fun getEMPTY ()Lch/tutteli/atrium/reporting/translating/Untranslatable;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/UseDefaultLocaleAsPrimary : ch/tutteli/atrium/reporting/translating/LocaleProvider {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/translating/UseDefaultLocaleAsPrimary;
+	public fun getFallbackLocales ()Ljava/util/List;
+	public fun getPrimaryLocale ()Lch/tutteli/atrium/reporting/translating/Locale;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/UsingDefaultTranslator : ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator {
+	public fun <init> ()V
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Locale;)V
+	public synthetic fun <init> (Lch/tutteli/atrium/reporting/translating/Locale;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class ch/tutteli/atrium/reporting/translating/impl/ResourceBundleInspiredLocaleOrderDecider : ch/tutteli/atrium/reporting/translating/LocaleOrderDecider {
+	public static final field INSTANCE Lch/tutteli/atrium/reporting/translating/impl/ResourceBundleInspiredLocaleOrderDecider;
+	public fun determineOrder (Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+
+public final class ch/tutteli/atrium/reporting/translating/impl/TranslationSupplierBasedTranslator : ch/tutteli/atrium/reporting/translating/ArgumentsSupportingTranslator {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/TranslationSupplier;Lch/tutteli/atrium/reporting/translating/LocaleOrderDecider;Lch/tutteli/atrium/reporting/translating/Locale;Ljava/util/List;)V
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
 
 plugins {
     id("build-logic.root-build")
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+    alias(libs.plugins.nexus)
 }
 
 

--- a/gradle/build-logic/root-build/build.gradle.kts
+++ b/gradle/build-logic/root-build/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
     api(buildLibs.bundles.dokka)
     api(buildLibs.tutteli.dokka)
+    api(buildLibs.bc.validator)
 }

--- a/gradle/buildLibs.versions.toml
+++ b/gradle/buildLibs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+bc-validator="0.15.0-Beta.2"
 dokka = "1.9.20"
 jacocoTool = "0.8.9"
 kotlin = "1.9.24"
@@ -7,6 +8,7 @@ tutteli = "5.0.1"
 vlsi = "1.90"
 
 [libraries]
+bc-validator = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version.ref = "bc-validator" }
 dokka-plugin = { module = "org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin", version.ref = "dokka" }
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -20,7 +22,6 @@ tutteli-spek = { module = "ch.tutteli.gradle.plugins.spek:ch.tutteli.gradle.plug
 
 vlsi-crlf = { module = "com.github.vlsi.crlf:com.github.vlsi.crlf.gradle.plugin", version.ref = "vlsi" }
 vlsi-gradle = { module = "com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin", version.ref = "vlsi" }
-
 
 [bundles]
 dokka = ["dokka-base", "dokka-plugin"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,9 @@ spekExtensions = "1.2.1"
 mockk = "1.11.0"
 mockitoKotlin = "2.2.0"
 
+# gradle
+nexus="2.0.0"
+
 [libraries]
 assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJ" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
@@ -29,3 +32,6 @@ spek-runner = { module = "org.spekframework.spek2:spek-runner-junit5", version.r
 spek-runtime = { module = "org.spekframework.spek2:spek-runtime-jvm", version.ref = "spek" }
 spek-js = { module = "org.spekframework.spek2:spek-dsl-js", version.ref = "spek" }
 tutteli-spek = { module = "ch.tutteli.spek:tutteli-spek-extensions", version.ref = "spekExtensions" }
+
+[plugins]
+nexus = { id = "io.github.gradle-nexus.publish-plugin", version.ref="nexus" }

--- a/logic/atrium-logic/api/main/atrium-logic.api
+++ b/logic/atrium-logic/api/main/atrium-logic.api
@@ -1,0 +1,2228 @@
+public abstract interface class ch/tutteli/atrium/logic/AnyAssertions {
+	public abstract fun because (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun isNotIn (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Iterable;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun notToBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun notToBeNullButOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun toBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun toBeNullIfNullGivenElse (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/AnyKt {
+	public static final fun because (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun isNotIn (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Iterable;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun notToBeNullButOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun toBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun toBeNullIfNullGivenElse (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/BigDecimalAssertions {
+	public abstract fun isEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/BigDecimalKt {
+	public static final fun isEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/CharSequenceAssertions {
+	public abstract fun containsBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public abstract fun containsNotBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public abstract fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotBlank (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun matches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun mismatches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/CharSequenceKt {
+	public static final fun containsBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun containsNotBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotBlank (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun matches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun mismatches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ChronoLocalDateAssertions {
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ChronoLocalDateKt {
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ChronoLocalDateTimeAssertions {
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ChronoLocalDateTimeKt {
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ChronoZonedDateTimeAssertions {
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ChronoZonedDateTimeKt {
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/CollectionLikeAssertions {
+	public abstract fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun size (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/CollectionLikeKt {
+	public static final fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun size (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ComparableAssertions {
+	public abstract fun isEqualComparingTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isGreaterThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isLessThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ComparableKt {
+	public static final fun isEqualComparingTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isGreaterThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isLessThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/FeatureAssertions {
+	public abstract fun extractSubject (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun f0 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f1 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f2 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f3 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f4 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f5 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun property (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/FeatureExtensionsKt {
+	public static final fun genericSubjectBasedFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/FeatureKt {
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun f0 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f1 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f2 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f3 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f4 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f5 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun property (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/FloatingPointAssertions {
+	public abstract fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;DD)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;FF)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/FloatingPointJvmAssertions {
+	public abstract fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/FloatingPointJvmKt {
+	public static final fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/FloatingPointKt {
+	public static final fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;DD)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;FF)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/Fun0Assertions {
+	public abstract fun notToThrow (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun toThrow (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/Fun0Kt {
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun toThrow (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/GroupingAssertions {
+	public abstract fun group (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun grouping (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/GroupingKt {
+	public static final fun group (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun grouping (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/IterableLikeAssertions {
+	public abstract fun all (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun builderContainsInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public abstract fun builderContainsNotInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public abstract fun containsNoDuplicates (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNextOrAll (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNextOrAny (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNextOrNone (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun last (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun max (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun min (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/IterableLikeKt {
+	public static final fun all (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun builderContainsInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun builderContainsNotInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun containsNoDuplicates (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNextOrAll (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNextOrAny (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNextOrNone (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun last (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun max (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun min (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/IteratorAssertions {
+	public abstract fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/IteratorKt {
+	public static final fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ListAssertions {
+	public abstract fun get (Lch/tutteli/atrium/creating/AssertionContainer;I)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ListKt {
+	public static final fun get (Lch/tutteli/atrium/creating/AssertionContainer;I)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/LocalDateAssertions {
+	public abstract fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/LocalDateKt {
+	public static final fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/LocalDateTimeAssertions {
+	public abstract fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/LocalDateTimeKt {
+	public static final fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/LogicCharSequenceContainsKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/LogicIterableLikeContainsKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/LogicKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun _logicAppend (Lch/tutteli/atrium/creating/ExpectGrouping;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static final fun get_logic (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/AssertionContainer;
+	public static final fun get_logic (Lch/tutteli/atrium/creating/ExpectGrouping;)Lch/tutteli/atrium/creating/AssertionContainer;
+}
+
+public final class ch/tutteli/atrium/logic/LogicMapLikeContainsKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/MapEntryAssertions {
+	public abstract fun isKeyValue (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun key (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun value (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/MapEntryKt {
+	public static final fun isKeyValue (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun key (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun value (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/MapLikeAssertions {
+	public abstract fun builderContainsInMapLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public abstract fun containsKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun containsNotKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun getExisting (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/MapLikeKt {
+	public static final fun builderContainsInMapLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun containsKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun containsNotKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun getExisting (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/OptionalAssertions {
+	public abstract fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isPresent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/OptionalKt {
+	public static final fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isPresent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/PairAssertions {
+	public abstract fun first (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun second (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/PairKt {
+	public static final fun first (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun second (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/PathAssertions {
+	public abstract fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun exists (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun existsNot (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun extension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun fileName (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun hasDirectoryEntry (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasSameBinaryContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasSameTextualContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAbsolute (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEmptyDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isRegularFile (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isRelative (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isSymbolicLink (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun parent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun resolve (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/PathAssertions$DefaultImpls {
+	public static synthetic fun exists$default (Lch/tutteli/atrium/logic/PathAssertions;Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static synthetic fun existsNot$default (Lch/tutteli/atrium/logic/PathAssertions;Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/PathKt {
+	public static final fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun exists (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public static synthetic fun exists$default (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun existsNot (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public static synthetic fun existsNot$default (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun extension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun fileName (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun hasDirectoryEntry (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasSameBinaryContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasSameTextualContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAbsolute (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEmptyDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isRegularFile (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isRelative (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isSymbolicLink (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun parent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun resolve (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ResultAssertions {
+	public abstract fun isFailureOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun isSuccess (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ResultKt {
+	public static final fun isFailureOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun isSuccess (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ThirdPartyAssertions {
+	public abstract fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ThirdPartyKt {
+	public static final fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ThrowableAssertions {
+	public abstract fun causeIsA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ThrowableKt {
+	public static final fun causeIsA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/UtilsCollectKt {
+	public static final fun collect (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun collectAndLogicAppend (Lch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun collectBasedOnSubject (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun collectForComposition (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun collectForCompositionBasedOnSubject (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/UtilsKt {
+	public static final fun createDescriptiveAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun getChangeSubject (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep;
+	public static final fun getExtractFeature (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;
+	public static final fun toAssertionContainer (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/AssertionContainer;
+	public static final fun toAssertionCreator (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static final fun toExpect (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toExpectGrouping (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ZonedDateTimeAssertions {
+	public abstract fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ZonedDateTimeKt {
+	public static final fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/assertions/impl/LazyThreadUnsafeAssertionGroup : ch/tutteli/atrium/assertions/AssertionGroup {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun getAssertions ()Ljava/util/List;
+	public fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getRepresentation ()Ljava/lang/Object;
+	public fun getType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public fun holds ()Z
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser$Companion;
+	public abstract fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public abstract fun withDescription (Ljava/lang/String;)V
+	public abstract fun withRepresentation (Ljava/lang/String;)V
+	public abstract fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+}
+
+public final class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser$DefaultImpls {
+	public static fun withDescription (Lch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser;Ljava/lang/String;)V
+	public static fun withRepresentation (Lch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser;Ljava/lang/String;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsKt {
+	public static final fun FeatureExpectOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$Companion {
+	public final fun forSubject (Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep {
+	public abstract fun getSubject ()Ljava/lang/Object;
+	public abstract fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+	public abstract fun withVerb (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep$DefaultImpls {
+	public static fun withVerb (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/creating/RootExpect;
+	public abstract fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getOptions ()Lch/tutteli/atrium/creating/RootExpectOptions;
+	public abstract fun getSubject ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep$Companion {
+	public final fun invoke (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser$Companion;
+	public abstract fun prependChainedComponents (Lkotlin/reflect/KClass;Lkotlin/sequences/Sequence;)V
+	public abstract fun withComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withRepresentation (Ljava/lang/String;)V
+	public abstract fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withSingletonComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public abstract fun withVerb (Ljava/lang/String;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/RootExpectOptions;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser$DefaultImpls {
+	public static fun withRepresentation (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser;Ljava/lang/String;)V
+	public static fun withVerb (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser;Ljava/lang/String;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep$Companion;
+	public abstract fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getSubject ()Ljava/lang/Object;
+	public abstract fun withOptions (Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public abstract fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public abstract fun withoutOptions ()Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep$Companion {
+	public final fun invoke (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep$DefaultImpls {
+	public static fun withOptions (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectOptionsKt {
+	public static final fun RootExpectOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/RootExpectOptions;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+	public abstract fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStepLogic {
+	public abstract fun getCheckers ()Ljava/util/List;
+	public abstract fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+	public abstract fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getSearchBehaviour ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker {
+	public abstract fun getAtLeastCall ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker {
+	public abstract fun getAtMostCall ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/ExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker {
+	public abstract fun getExactlyCall ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/NotChecker : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public final class ch/tutteli/atrium/logic/creating/basic/contains/checkers/TimesValidatorsKt {
+	public static final fun validateAtMost (ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static final fun validateButAtMost (IILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+	public abstract fun getTimes ()I
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	protected final fun createDescriptiveAssertion (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public final fun getTimes ()I
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;Ljava/util/List;)V
+	public final fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	protected fun decorateInAnyOrderAssertion (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	protected abstract fun getDescriptionNotFound ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected abstract fun getDescriptionNumberOfElementsFound ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected abstract fun getDescriptionToContain ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected final fun getSearchBehaviour ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;
+	protected abstract fun makeSubjectMultipleTimesConsumable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/creating/AssertionContainer;
+	protected abstract fun searchAndCreateAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;Ljava/util/List;)V
+	protected abstract fun getDescriptionNumberOfOccurrences ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected abstract fun getGroupDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected fun mismatchesForNotSearchBehaviour (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/util/List;
+	protected abstract fun search (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)I
+	protected fun searchAndCreateAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun getSearchBehaviour ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Creator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepInternal : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour : ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public abstract fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtLeastChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtMostChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/ExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/ExactlyChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/NotChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/NotChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultAtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtLeastChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtLeastCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultAtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtMostChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtMostCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/ExactlyChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getExactlyCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultNotChecker : ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/NotChecker {
+	public fun <init> ()V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/CharSequenceContainsAssertions {
+	public abstract fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public abstract fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public abstract fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public abstract fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/CharSequenceContainsKt {
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static final fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/StringRegexKt {
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Creator {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher;Ljava/util/List;Lch/tutteli/atrium/reporting/translating/Translatable;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/DefaultCharSequenceContainsAssertions : ch/tutteli/atrium/logic/creating/charsequence/contains/creators/CharSequenceContainsAssertions {
+	public fun <init> ()V
+	public fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/IgnoringCaseSearchBehaviour : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour {
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/impl/IgnoringCaseSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/IgnoringCaseSearchBehaviour {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour;)V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/impl/NoOpSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/impl/NotSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IgnoringCaseIndexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IgnoringCaseRegexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public synthetic fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+	public fun search (Ljava/lang/CharSequence;Ljava/lang/String;)I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IndexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/RegexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public synthetic fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+	public fun search (Ljava/lang/CharSequence;Lkotlin/text/Regex;)I
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ImplsKt {
+	public static final fun atLeastCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;
+	public static final fun atMostCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactlyCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep;
+	public static final fun getIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun notCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun notOrAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepInternal : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic {
+	public abstract fun getTimes ()I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/AtMostCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/ButAtMostCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep {
+	public fun <init> (ILch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepInternal {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/GenericTimesCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepInternal {
+	public fun <init> (ILch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;Ljava/util/List;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+	public fun getTimes ()I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/NotCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/NotOrAtMostCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/SharedCheckersKt {
+	public static final fun atLeastChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtLeastChecker;
+	public static final fun atMostChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtMostChecker;
+}
+
+public final class ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensionsKt {
+	public static final fun collectAssertions (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/feature/MetaFeature {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lch/tutteli/atrium/core/Option;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/logic/creating/feature/MetaFeature;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;ILjava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun getMaybeSubject ()Lch/tutteli/atrium/core/Option;
+	public final fun getRepresentation ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/Failure : ch/tutteli/atrium/logic/creating/filesystem/IoResult {
+	public fun <init> (Ljava/nio/file/Path;Ljava/io/IOException;)V
+	public final fun getException ()Ljava/io/IOException;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/filesystem/IoResult {
+	public synthetic fun <init> (Ljava/nio/file/Path;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPath ()Ljava/nio/file/Path;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/IoResultKt {
+	public static final fun runCatchingIo (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/filesystem/IoResult;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/Success : ch/tutteli/atrium/logic/creating/filesystem/IoResult {
+	public fun <init> (Ljava/nio/file/Path;Ljava/lang/Object;)V
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/hints/HintsKt {
+	public static final fun explainForResolvedLink (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun findHintForProblemWithParent (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForAccessDenied (Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForClosestExistingParent (Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForExistsButMissingPermission (Ljava/nio/file/Path;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForIoException (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/io/IOException;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForOwnersAndPermissions (Ljava/nio/file/Path;)Ljava/util/List;
+	public static final fun withHelpOnFileAttributesFailure (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static final fun withHelpOnIOExceptionFailure (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/ExpectationVerbStepImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun getSubject ()Ljava/lang/Object;
+	public fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+	public fun withVerb (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/FeatureExpectOptionsChooserImpl : ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser {
+	public fun <init> ()V
+	public final fun build ()Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public fun withDescription (Ljava/lang/String;)V
+	public fun withRepresentation (Ljava/lang/String;)V
+	public fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/FinalStepImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep {
+	public fun <init> (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/creating/RootExpectOptions;)V
+	public fun build ()Lch/tutteli/atrium/creating/RootExpect;
+	public fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getOptions ()Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun getSubject ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/OptionsStepImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep {
+	public fun <init> (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getSubject ()Ljava/lang/Object;
+	public fun withOptions (Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public fun withoutOptions ()Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/RootExpectOptionsChooserImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser {
+	public fun <init> ()V
+	public final fun build ()Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun prependChainedComponents (Lkotlin/reflect/KClass;Lkotlin/sequences/Sequence;)V
+	public fun withComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun withRepresentation (Ljava/lang/String;)V
+	public fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+	public fun withSingletonComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public fun withVerb (Ljava/lang/String;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepInternal : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public abstract fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public abstract fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour : ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtLeastChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtMostChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/ExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/ExactlyChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/NotChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/NotChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtLeastCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtMostChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtMostCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/iterable/contains/checkers/ExactlyChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getExactlyCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultNotChecker : ch/tutteli/atrium/logic/creating/iterable/contains/checkers/NotChecker {
+	public fun <init> ()V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions {
+	public abstract fun entriesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun entriesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun entriesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun valuesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun valuesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun valuesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderAssertions {
+	public abstract fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsKt {
+	public static final fun entriesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun entriesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun entriesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun valuesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun valuesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun valuesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/DefaultIterableLikeContainsAssertions : ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions {
+	public fun <init> ()V
+	public fun entriesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun entriesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun entriesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun valuesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun valuesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun valuesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/DefaultIterableLikeContainsInAnyOrderAssertions : ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderAssertions {
+	public fun <init> ()V
+	public fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun searchAndCreateAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected abstract fun createAssertionForSearchCriterionAndRemoveMatchFromList (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/util/List;)Lkotlin/Pair;
+	public final fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun createAssertionForSearchCriterionAndRemoveMatchFromList (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/util/List;)Lkotlin/Pair;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour;Ljava/util/List;Ljava/lang/String;)V
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected fun addAssertionsAndReturnIndex (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)I
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected abstract fun addAssertionsAndReturnIndex (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)I
+	public final fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILkotlin/jvm/functions/Function1;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public synthetic fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesMatcher : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> ()V
+	public synthetic fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILkotlin/jvm/functions/Function1;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public synthetic fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected final fun addAssertionsAndReturnIndex (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)I
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	protected abstract fun addSublistAssertion (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILkotlin/jvm/functions/Function1;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public synthetic fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedValuesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public abstract fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public abstract fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher$DefaultImpls {
+	public static fun addSingleEntryAssertion (Lch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher;Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValueMatcher : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> ()V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValuesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/IterableMultiConsumableKt {
+	public static final fun extractSubjectTurnToList (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+	public static final fun mapSubjectToList (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/AssertionContainer;
+	public static final fun turnSubjectToList (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/AssertionContainer;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedWithinSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NotSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InAnyOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InAnyOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderOnlyGroupedSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderOnlyGroupedWithinSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedWithinSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/NoOpSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/NotSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NotSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/ImplsKt {
+	public static final fun atLeastCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;
+	public static final fun atMostCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactlyCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep;
+	public static final fun getAndOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getButOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getWithin (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun notCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun notOrAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/NoOpCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepInternal {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepInternal : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep, ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic {
+	public abstract fun getTimes ()I
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)V
+	public fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/impl/SharedCheckersKt {
+	public static final fun atLeastChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker;
+	public static final fun atMostChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtMostChecker;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions : ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions$DefaultImpls {
+	public static fun showAlwaysSummary (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions;)V
+	public static fun showOnlyFailing (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions : ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions$DefaultImpls {
+	public static fun showAlwaysSummary (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions;)V
+	public static fun showOnlyFailing (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions {
+	public abstract fun getMaxNumberOfExpectedElementsForSummary ()I
+	public abstract fun showAlwaysSummary ()V
+	public abstract fun showOnlyFailing ()V
+	public abstract fun showOnlyFailingIfMoreExpectedElementsThan (I)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions$DefaultImpls {
+	public static fun showAlwaysSummary (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions;)V
+	public static fun showOnlyFailing (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$Creator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep, ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic {
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal;Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public abstract fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public abstract fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour : ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsAssertions {
+	public abstract fun keyValuePairsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyValuePairsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyValuePairsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyWithValueAssertionsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyWithValueAssertionsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyWithValueAssertionsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsKt {
+	public static final fun keyValuePairsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyValuePairsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyValuePairsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyWithValueAssertionsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyWithValueAssertionsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyWithValueAssertionsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions : ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsAssertions {
+	public fun <init> ()V
+	public fun keyValuePairsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyValuePairsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyValuePairsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyWithValueAssertionsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyWithValueAssertionsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyWithValueAssertionsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InAnyOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InAnyOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/NoOpSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/steps/ImplsKt {
+	public static final fun getAndOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getButOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl, ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)V
+	public fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FailureHandlerAdapter : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+	public final fun getFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;
+	public final fun getMap ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractor {
+	public abstract fun extract (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun methodCall (Ljava/lang/String;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public abstract fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public abstract fun withDescription (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep$DefaultImpls {
+	public static fun methodCall (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;Ljava/lang/String;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public static fun withDescription (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep : ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentationForFailure ()Ljava/lang/Object;
+	public abstract fun withFeatureExtraction (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun getFeatureExpectOptions ()Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public abstract fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep$Companion;
+	public abstract fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+	public abstract fun withOptions (Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public abstract fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public abstract fun withoutOptions ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep$DefaultImpls {
+	public static fun withOptions (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun withRepresentationForFailure (Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+	public abstract fun withRepresentationForFailure (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep$DefaultImpls {
+	public static fun withRepresentationForFailure (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/ImplsKt {
+	public static final fun getFeatureExtractor (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractor;
+	public static final fun getSubjectChanger (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChanger {
+	public abstract fun reported (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun unreported (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public abstract fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep$Companion;
+	public abstract fun downCastTo (Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep$DefaultImpls {
+	public static fun downCastTo (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep : ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public abstract fun withDefaultFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public abstract fun withFailureHandler (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public abstract fun withFailureHandlerAdapter (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep$DefaultImpls {
+	public static fun build (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static fun withFailureHandlerAdapter (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun getFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;
+	public abstract fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep {
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun reportBuilder ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;
+	public abstract fun unreported (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep$DefaultImpls {
+	public static fun unreported (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun withTransformation (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public abstract fun collect (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun collectAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun transform ()Lch/tutteli/atrium/creating/Expect;
+	public abstract fun transformAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep : ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+	public final fun collect (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public final fun collectAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	protected final fun getAction ()Lkotlin/jvm/functions/Function1;
+	protected final fun getActionAndApply ()Lkotlin/jvm/functions/Function2;
+	protected final fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public final fun transform ()Lch/tutteli/atrium/creating/Expect;
+	public final fun transformAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/CreateAdditionalHintsKt {
+	public static final fun createAdditionalHints (Ljava/lang/Throwable;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractor {
+	public fun <init> ()V
+	public fun extract (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/DefaultSubjectChanger : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger {
+	public fun <init> ()V
+	public fun reported (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/creating/Expect;
+	public fun unreported (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler$Companion;
+	public fun <init> ()V
+	public fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler$Companion {
+	public final fun createChildHint (Ljava/lang/Throwable;Ljava/lang/Throwable;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public final fun propertiesOfThrowable (Ljava/lang/Throwable;Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static synthetic fun propertiesOfThrowable$default (Lch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler$Companion;Ljava/lang/Throwable;Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/DescriptionStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun methodCall (Ljava/lang/String;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public fun withDescription (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/ExecutionStepImpl : ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep, ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/FeatureExtractionStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getRepresentationForFailure ()Ljava/lang/Object;
+	public fun withFeatureExtraction (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/FinalStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/FeatureExpectOptions;)V
+	public fun build ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun getFeatureExpectOptions ()Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/OptionsStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;)V
+	public fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+	public fun withOptions (Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public fun withoutOptions ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/DefaultFailureHandlerImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public fun <init> ()V
+	public fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/DescriptionRepresentationStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun downCastTo (Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/ExecutionStepImpl : ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep, ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/FailureHandlerStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;)V
+	public fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public fun withDefaultFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public fun withFailureHandler (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public fun withFailureHandlerAdapter (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/FinalStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)V
+	public fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun getFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;
+	public fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/KindStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun reportBuilder ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;
+	public fun unreported (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/TransformationStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getRepresentation ()Ljava/lang/Object;
+	public fun withTransformation (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/typeutils/ImplsKt {
+	public static final fun getIterableLikeToIterableTransformer (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/typeutils/IterableLikeToIterableTransformer;
+	public static final fun getMapLikeToMapTransformer (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/typeutils/MapLikeToIterablePairTransformer;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/typeutils/IterableLikeToIterableTransformer {
+	public abstract fun supportedTypes ()Ljava/util/List;
+	public abstract fun unsafeTransform (Ljava/lang/Object;)Ljava/lang/Iterable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/typeutils/MapLikeToIterablePairTransformer {
+	public abstract fun supportedTypes ()Ljava/util/List;
+	public abstract fun unsafeTransform (Ljava/lang/Object;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/creating/typeutils/impl/DefaultIterableLikeToIterableTransformer : ch/tutteli/atrium/logic/creating/typeutils/IterableLikeToIterableTransformer {
+	public fun <init> ()V
+	public fun supportedTypes ()Ljava/util/List;
+	public fun unsafeTransform (Ljava/lang/Object;)Ljava/lang/Iterable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/typeutils/impl/DefaultMapLikeToIterablePairTransformer : ch/tutteli/atrium/logic/creating/typeutils/MapLikeToIterablePairTransformer {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun supportedTypes ()Ljava/util/List;
+	public fun unsafeTransform (Ljava/lang/Object;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultAnyAssertions : ch/tutteli/atrium/logic/AnyAssertions {
+	public fun <init> ()V
+	public fun because (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun isNotIn (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Iterable;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun notToBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun notToBeNullButOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun toBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun toBeNullIfNullGivenElse (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultBigDecimalAssertions : ch/tutteli/atrium/logic/BigDecimalAssertions {
+	public fun <init> ()V
+	public fun isEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultCharSequenceAssertions : ch/tutteli/atrium/logic/CharSequenceAssertions {
+	public fun <init> ()V
+	public fun containsBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public fun containsNotBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotBlank (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun matches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun mismatches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultChronoLocalDateAssertions : ch/tutteli/atrium/logic/ChronoLocalDateAssertions {
+	public fun <init> ()V
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultChronoLocalDateTimeAssertions : ch/tutteli/atrium/logic/ChronoLocalDateTimeAssertions {
+	public fun <init> ()V
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultChronoZonedDateTimeAssertions : ch/tutteli/atrium/logic/ChronoZonedDateTimeAssertions {
+	public fun <init> ()V
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultCollectionLikeAssertions : ch/tutteli/atrium/logic/CollectionLikeAssertions {
+	public fun <init> ()V
+	public fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun size (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultComparableAssertions : ch/tutteli/atrium/logic/ComparableAssertions {
+	public fun <init> ()V
+	public fun isEqualComparingTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isGreaterThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isLessThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFeatureAssertions : ch/tutteli/atrium/logic/FeatureAssertions {
+	public fun <init> ()V
+	public fun extractSubject (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public fun f0 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f1 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f2 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f3 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f4 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f5 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun property (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions : ch/tutteli/atrium/logic/FloatingPointAssertions {
+	public fun <init> ()V
+	public fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;DD)Lch/tutteli/atrium/assertions/Assertion;
+	public fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;FF)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFloatingPointJvmAssertions : ch/tutteli/atrium/logic/FloatingPointJvmAssertions {
+	public fun <init> ()V
+	public fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFun0Assertions : ch/tutteli/atrium/logic/Fun0Assertions {
+	public fun <init> ()V
+	public fun notToThrow (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun toThrow (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultGroupingAssertions : ch/tutteli/atrium/logic/GroupingAssertions {
+	public fun <init> ()V
+	public fun group (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun grouping (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions : ch/tutteli/atrium/logic/IterableLikeAssertions {
+	public fun <init> ()V
+	public fun all (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun builderContainsInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public fun builderContainsNotInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public fun containsNoDuplicates (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNextOrAll (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNextOrAny (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNextOrNone (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun last (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun max (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun min (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultIteratorAssertions : ch/tutteli/atrium/logic/IteratorAssertions {
+	public fun <init> ()V
+	public fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultListAssertions : ch/tutteli/atrium/logic/ListAssertions {
+	public fun <init> ()V
+	public fun get (Lch/tutteli/atrium/creating/AssertionContainer;I)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultLocalDateAssertions : ch/tutteli/atrium/logic/LocalDateAssertions {
+	public fun <init> ()V
+	public fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultLocalDateTimeAssertions : ch/tutteli/atrium/logic/LocalDateTimeAssertions {
+	public fun <init> ()V
+	public fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultMapEntryAssertions : ch/tutteli/atrium/logic/MapEntryAssertions {
+	public fun <init> ()V
+	public fun isKeyValue (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun key (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun value (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultMapLikeAssertions : ch/tutteli/atrium/logic/MapLikeAssertions {
+	public fun <init> ()V
+	public fun builderContainsInMapLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public fun containsKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun containsNotKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getExisting (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultOptionalAssertions : ch/tutteli/atrium/logic/OptionalAssertions {
+	public fun <init> ()V
+	public fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isPresent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultPairAssertions : ch/tutteli/atrium/logic/PairAssertions {
+	public fun <init> ()V
+	public fun first (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun second (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultPathAssertions : ch/tutteli/atrium/logic/PathAssertions {
+	public fun <init> ()V
+	public fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun exists (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun existsNot (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun extension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun fileName (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun hasDirectoryEntry (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasSameBinaryContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasSameTextualContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAbsolute (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEmptyDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isRegularFile (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isRelative (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isSymbolicLink (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun parent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun resolve (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultResultAssertions : ch/tutteli/atrium/logic/ResultAssertions {
+	public fun <init> ()V
+	public fun isFailureOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun isSuccess (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultThirdPartyAssertions : ch/tutteli/atrium/logic/ThirdPartyAssertions {
+	public fun <init> ()V
+	public fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions : ch/tutteli/atrium/logic/ThrowableAssertions {
+	public fun <init> ()V
+	public fun causeIsA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultZonedDateTimeAssertions : ch/tutteli/atrium/logic/ZonedDateTimeAssertions {
+	public fun <init> ()V
+	public fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/utils/ArgumentMapperBuilder {
+	public final fun getFirst ()Ljava/lang/Object;
+	public final fun getOthers ()[Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/utils/ArgumentToNullOrMapperBuilder {
+	public fun <init> (Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;)V
+	public final fun getArgumentMapperBuilder ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public final fun toExpect (Lkotlin/jvm/functions/Function2;)Lkotlin/Pair;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/utils/Group {
+	public abstract fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/GroupsToListKt {
+	public static final fun groupsToList (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/LambdaHelpersKt {
+	public static final fun expectLambda (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+}
+
+public final class ch/tutteli/atrium/logic/utils/MapArgumentsKt {
+	public static final fun mapArguments (B[B)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (C[C)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (D[D)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (F[F)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (I[I)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (J[J)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (S[S)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (Z[Z)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun toNullOr (Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;)Lch/tutteli/atrium/logic/utils/ArgumentToNullOrMapperBuilder;
+}
+
+public final class ch/tutteli/atrium/logic/utils/NullableKt {
+	public static final fun nullable (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun nullable (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable1 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable2 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable3 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable4 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable5 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullableContainer (Ljava/lang/Iterable;)Ljava/lang/Iterable;
+	public static final fun nullableContainer ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun nullableKeyMap (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun nullableKeyValueMap (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun nullableValueMap (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public abstract fun getExpected ()Ljava/lang/Object;
+	public abstract fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public abstract fun getOtherExpected ()[Ljava/lang/Object;
+	public abstract fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/VarArgHelper$DefaultImpls {
+	public static fun getMapArguments (Lch/tutteli/atrium/logic/utils/VarArgHelper;)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static fun toList (Lch/tutteli/atrium/logic/utils/VarArgHelper;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/VarArgHelpersKt {
+	public static final fun iterableLikeToIterable (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/lang/Iterable;
+	public static final fun iterableLikeToIterableWithoutCheckForElements (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/lang/Iterable;
+	public static final fun mapLikeToIterablePair (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/util/List;
+	public static final fun mapLikeToVarArgPairs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun toVarArgPairs (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/lang/Object;)Lkotlin/Pair;
+}
+

--- a/logic/atrium-logic/api/using-kotlin-1.9-or-newer/atrium-logic.api
+++ b/logic/atrium-logic/api/using-kotlin-1.9-or-newer/atrium-logic.api
@@ -1,0 +1,2228 @@
+public abstract interface class ch/tutteli/atrium/logic/AnyAssertions {
+	public abstract fun because (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun isNotIn (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Iterable;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun notToBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun notToBeNullButOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun toBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun toBeNullIfNullGivenElse (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/AnyKt {
+	public static final fun because (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun isNotIn (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Iterable;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun notToBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun notToBeNullButOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun toBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun toBeNullIfNullGivenElse (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/BigDecimalAssertions {
+	public abstract fun isEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/BigDecimalKt {
+	public static final fun isEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/CharSequenceAssertions {
+	public abstract fun containsBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public abstract fun containsNotBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public abstract fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotBlank (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun matches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun mismatches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/CharSequenceKt {
+	public static final fun containsBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun containsNotBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotBlank (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun matches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun mismatches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ChronoLocalDateAssertions {
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ChronoLocalDateKt {
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ChronoLocalDateTimeAssertions {
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ChronoLocalDateTimeKt {
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ChronoZonedDateTimeAssertions {
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ChronoZonedDateTimeKt {
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/CollectionLikeAssertions {
+	public abstract fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun size (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/CollectionLikeKt {
+	public static final fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun size (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ComparableAssertions {
+	public abstract fun isEqualComparingTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isGreaterThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isLessThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ComparableKt {
+	public static final fun isEqualComparingTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isGreaterThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isLessThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/FeatureAssertions {
+	public abstract fun extractSubject (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun f0 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f1 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f2 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f3 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f4 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun f5 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun property (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/FeatureExtensionsKt {
+	public static final fun genericSubjectBasedFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/FeatureKt {
+	public static final fun extractSubject (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun f0 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f1 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f2 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f3 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f4 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun f5 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun property (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/FloatingPointAssertions {
+	public abstract fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;DD)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;FF)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/FloatingPointJvmAssertions {
+	public abstract fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/FloatingPointJvmKt {
+	public static final fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/FloatingPointKt {
+	public static final fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;DD)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;FF)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/Fun0Assertions {
+	public abstract fun notToThrow (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun toThrow (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/Fun0Kt {
+	public static final fun notToThrow (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun toThrow (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/GroupingAssertions {
+	public abstract fun group (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun grouping (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/GroupingKt {
+	public static final fun group (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun grouping (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/IterableLikeAssertions {
+	public abstract fun all (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun builderContainsInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public abstract fun builderContainsNotInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public abstract fun containsNoDuplicates (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNextOrAll (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNextOrAny (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNextOrNone (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun last (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun max (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun min (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/IterableLikeKt {
+	public static final fun all (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun builderContainsInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun builderContainsNotInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun containsNoDuplicates (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNextOrAll (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNextOrAny (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNextOrNone (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun last (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun max (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun min (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/IteratorAssertions {
+	public abstract fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/IteratorKt {
+	public static final fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ListAssertions {
+	public abstract fun get (Lch/tutteli/atrium/creating/AssertionContainer;I)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ListKt {
+	public static final fun get (Lch/tutteli/atrium/creating/AssertionContainer;I)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/LocalDateAssertions {
+	public abstract fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/LocalDateKt {
+	public static final fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/LocalDateTimeAssertions {
+	public abstract fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/LocalDateTimeKt {
+	public static final fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/LogicCharSequenceContainsKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/LogicIterableLikeContainsKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/LogicKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun _logicAppend (Lch/tutteli/atrium/creating/ExpectGrouping;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static final fun get_logic (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/AssertionContainer;
+	public static final fun get_logic (Lch/tutteli/atrium/creating/ExpectGrouping;)Lch/tutteli/atrium/creating/AssertionContainer;
+}
+
+public final class ch/tutteli/atrium/logic/LogicMapLikeContainsKt {
+	public static final fun _logicAppend (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun get_logic (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/MapEntryAssertions {
+	public abstract fun isKeyValue (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun key (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun value (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/MapEntryKt {
+	public static final fun isKeyValue (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun key (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun value (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/MapLikeAssertions {
+	public abstract fun builderContainsInMapLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public abstract fun containsKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun containsNotKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun getExisting (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/MapLikeKt {
+	public static final fun builderContainsInMapLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun containsKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun containsNotKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun getExisting (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/OptionalAssertions {
+	public abstract fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isPresent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/OptionalKt {
+	public static final fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isPresent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/PairAssertions {
+	public abstract fun first (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun second (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/PairKt {
+	public static final fun first (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun second (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/PathAssertions {
+	public abstract fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun exists (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun existsNot (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun extension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun fileName (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun hasDirectoryEntry (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasSameBinaryContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun hasSameTextualContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isAbsolute (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isEmptyDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isNotWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isRegularFile (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isRelative (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isSymbolicLink (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun isWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun parent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun resolve (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/PathAssertions$DefaultImpls {
+	public static synthetic fun exists$default (Lch/tutteli/atrium/logic/PathAssertions;Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static synthetic fun existsNot$default (Lch/tutteli/atrium/logic/PathAssertions;Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/PathKt {
+	public static final fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun exists (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public static synthetic fun exists$default (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun existsNot (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public static synthetic fun existsNot$default (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun extension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun fileName (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun hasDirectoryEntry (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasSameBinaryContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hasSameTextualContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isAbsolute (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isEmptyDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isNotWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isRegularFile (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isRelative (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isSymbolicLink (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun isWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun parent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun resolve (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ResultAssertions {
+	public abstract fun isFailureOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun isSuccess (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ResultKt {
+	public static final fun isFailureOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static final fun isSuccess (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ThirdPartyAssertions {
+	public abstract fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/ThirdPartyKt {
+	public static final fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ThrowableAssertions {
+	public abstract fun causeIsA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ThrowableKt {
+	public static final fun causeIsA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/UtilsCollectKt {
+	public static final fun collect (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun collectAndLogicAppend (Lch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun collectBasedOnSubject (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun collectForComposition (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun collectForCompositionBasedOnSubject (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/UtilsKt {
+	public static final fun createDescriptiveAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun getChangeSubject (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep;
+	public static final fun getExtractFeature (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;
+	public static final fun toAssertionContainer (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/AssertionContainer;
+	public static final fun toAssertionCreator (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static final fun toExpect (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun toExpectGrouping (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/ZonedDateTimeAssertions {
+	public abstract fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/ZonedDateTimeKt {
+	public static final fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public static final fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/assertions/impl/LazyThreadUnsafeAssertionGroup : ch/tutteli/atrium/assertions/AssertionGroup {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun getAssertions ()Ljava/util/List;
+	public fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getRepresentation ()Ljava/lang/Object;
+	public fun getType ()Lch/tutteli/atrium/assertions/AssertionGroupType;
+	public fun holds ()Z
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser$Companion;
+	public abstract fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public abstract fun withDescription (Ljava/lang/String;)V
+	public abstract fun withRepresentation (Ljava/lang/String;)V
+	public abstract fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+}
+
+public final class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser$DefaultImpls {
+	public static fun withDescription (Lch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser;Ljava/lang/String;)V
+	public static fun withRepresentation (Lch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser;Ljava/lang/String;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/FeatureExpectOptionsKt {
+	public static final fun FeatureExpectOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/FeatureExpectOptions;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$Companion {
+	public final fun forSubject (Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep {
+	public abstract fun getSubject ()Ljava/lang/Object;
+	public abstract fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+	public abstract fun withVerb (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep$DefaultImpls {
+	public static fun withVerb (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/creating/RootExpect;
+	public abstract fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getOptions ()Lch/tutteli/atrium/creating/RootExpectOptions;
+	public abstract fun getSubject ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep$Companion {
+	public final fun invoke (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser$Companion;
+	public abstract fun prependChainedComponents (Lkotlin/reflect/KClass;Lkotlin/sequences/Sequence;)V
+	public abstract fun withComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withRepresentation (Ljava/lang/String;)V
+	public abstract fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withSingletonComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public abstract fun withVerb (Ljava/lang/String;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/RootExpectOptions;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser$DefaultImpls {
+	public static fun withRepresentation (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser;Ljava/lang/String;)V
+	public static fun withVerb (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser;Ljava/lang/String;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep$Companion;
+	public abstract fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getSubject ()Ljava/lang/Object;
+	public abstract fun withOptions (Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public abstract fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public abstract fun withoutOptions ()Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep$Companion {
+	public final fun invoke (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep$DefaultImpls {
+	public static fun withOptions (Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/RootExpectOptionsKt {
+	public static final fun RootExpectOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/RootExpectOptions;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+	public abstract fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStepLogic {
+	public abstract fun getCheckers ()Ljava/util/List;
+	public abstract fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+	public abstract fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getSearchBehaviour ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker {
+	public abstract fun getAtLeastCall ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker {
+	public abstract fun getAtMostCall ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/ExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker {
+	public abstract fun getExactlyCall ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/NotChecker : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public final class ch/tutteli/atrium/logic/creating/basic/contains/checkers/TimesValidatorsKt {
+	public static final fun validateAtMost (ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static final fun validateButAtMost (IILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/basic/contains/checkers/WithTimesChecker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+	public abstract fun getTimes ()I
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	protected final fun createDescriptiveAssertion (Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/assertions/DescriptiveAssertion;
+	public final fun getTimes ()I
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;Ljava/util/List;)V
+	public final fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	protected fun decorateInAnyOrderAssertion (Lch/tutteli/atrium/assertions/AssertionGroup;Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	protected abstract fun getDescriptionNotFound ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected abstract fun getDescriptionNumberOfElementsFound ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected abstract fun getDescriptionToContain ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected final fun getSearchBehaviour ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;
+	protected abstract fun makeSubjectMultipleTimesConsumable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/creating/AssertionContainer;
+	protected abstract fun searchAndCreateAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;Ljava/util/List;)V
+	protected abstract fun getDescriptionNumberOfOccurrences ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected abstract fun getGroupDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	protected fun mismatchesForNotSearchBehaviour (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/util/List;
+	protected abstract fun search (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)I
+	protected fun searchAndCreateAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun getSearchBehaviour ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Creator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepInternal : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour : ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public abstract fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtLeastChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtMostChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/ExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/ExactlyChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/NotChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/NotChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Checker {
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultAtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtLeastChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtLeastCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultAtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtMostChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtMostCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/ExactlyChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getExactlyCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/impl/DefaultNotChecker : ch/tutteli/atrium/logic/creating/charsequence/contains/checkers/NotChecker {
+	public fun <init> ()V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/CharSequenceContainsAssertions {
+	public abstract fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public abstract fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public abstract fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public abstract fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/CharSequenceContainsKt {
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static final fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static final fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/StringRegexKt {
+	public static final fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/CharSequenceContainsAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Creator {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher;Ljava/util/List;Lch/tutteli/atrium/reporting/translating/Translatable;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/creators/impl/DefaultCharSequenceContainsAssertions : ch/tutteli/atrium/logic/creating/charsequence/contains/creators/CharSequenceContainsAssertions {
+	public fun <init> ()V
+	public fun regex (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public fun regexIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public fun values (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public fun valuesIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/IgnoringCaseSearchBehaviour : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour {
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/impl/IgnoringCaseSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/IgnoringCaseSearchBehaviour {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour;)V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/impl/NoOpSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NoOpSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/impl/NotSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/searchbehaviours/NotSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IgnoringCaseIndexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IgnoringCaseRegexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public synthetic fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+	public fun search (Ljava/lang/CharSequence;Ljava/lang/String;)I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IndexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/RegexSearcher : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$Searcher {
+	public fun <init> ()V
+	public synthetic fun search (Ljava/lang/CharSequence;Ljava/lang/Object;)I
+	public fun search (Ljava/lang/CharSequence;Lkotlin/text/Regex;)I
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep {
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ImplsKt {
+	public static final fun atLeastCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep;
+	public static final fun atMostCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactlyCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep;
+	public static final fun getIgnoringCase (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public static final fun notCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public static final fun notOrAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepInternal : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepLogic {
+	public abstract fun getTimes ()I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/AtMostCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtMostCheckerStep {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/ButAtMostCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep {
+	public fun <init> (ILch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepLogic;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl, ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepInternal {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$SearchBehaviour;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/GenericTimesCheckerStep : ch/tutteli/atrium/logic/creating/charsequence/contains/steps/AtLeastCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ButAtMostCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/ExactlyCheckerStep, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/WithTimesCheckerStepInternal {
+	public fun <init> (ILch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;Ljava/util/List;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+	public fun getTimes ()I
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/NotCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/NotOrAtMostCheckerStepImpl : ch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotOrAtMostCheckerStep {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStepLogic;
+}
+
+public final class ch/tutteli/atrium/logic/creating/charsequence/contains/steps/impl/SharedCheckersKt {
+	public static final fun atLeastChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtLeastChecker;
+	public static final fun atMostChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/charsequence/contains/checkers/AtMostChecker;
+}
+
+public final class ch/tutteli/atrium/logic/creating/collectors/AssertionsOptionExplantoryExtensionsKt {
+	public static final fun collectAssertions (Lch/tutteli/atrium/assertions/builders/AssertionsOption;Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/builders/ExplanatoryGroup$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/feature/MetaFeature {
+	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;)V
+	public final fun component1 ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lch/tutteli/atrium/core/Option;
+	public final fun copy (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public static synthetic fun copy$default (Lch/tutteli/atrium/logic/creating/feature/MetaFeature;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lch/tutteli/atrium/core/Option;ILjava/lang/Object;)Lch/tutteli/atrium/logic/creating/feature/MetaFeature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public final fun getMaybeSubject ()Lch/tutteli/atrium/core/Option;
+	public final fun getRepresentation ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/Failure : ch/tutteli/atrium/logic/creating/filesystem/IoResult {
+	public fun <init> (Ljava/nio/file/Path;Ljava/io/IOException;)V
+	public final fun getException ()Ljava/io/IOException;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/filesystem/IoResult {
+	public synthetic fun <init> (Ljava/nio/file/Path;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPath ()Ljava/nio/file/Path;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/IoResultKt {
+	public static final fun runCatchingIo (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/filesystem/IoResult;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/Success : ch/tutteli/atrium/logic/creating/filesystem/IoResult {
+	public fun <init> (Ljava/nio/file/Path;Ljava/lang/Object;)V
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/creating/filesystem/hints/HintsKt {
+	public static final fun explainForResolvedLink (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun findHintForProblemWithParent (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForAccessDenied (Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForClosestExistingParent (Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForExistsButMissingPermission (Ljava/nio/file/Path;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForIoException (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/io/IOException;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun hintForOwnersAndPermissions (Ljava/nio/file/Path;)Ljava/util/List;
+	public static final fun withHelpOnFileAttributesFailure (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+	public static final fun withHelpOnIOExceptionFailure (Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/builders/Descriptive$DescriptionOption;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/ExpectationVerbStepImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$ExpectationVerbStep {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun getSubject ()Ljava/lang/Object;
+	public fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+	public fun withVerb (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/FeatureExpectOptionsChooserImpl : ch/tutteli/atrium/logic/creating/FeatureExpectOptionsChooser {
+	public fun <init> ()V
+	public final fun build ()Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public fun withDescription (Ljava/lang/String;)V
+	public fun withRepresentation (Ljava/lang/String;)V
+	public fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/FinalStepImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep {
+	public fun <init> (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;Lch/tutteli/atrium/creating/RootExpectOptions;)V
+	public fun build ()Lch/tutteli/atrium/creating/RootExpect;
+	public fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getOptions ()Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun getSubject ()Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/OptionsStepImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsStep {
+	public fun <init> (Ljava/lang/Object;Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public fun getExpectationVerb ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getSubject ()Ljava/lang/Object;
+	public fun withOptions (Lch/tutteli/atrium/creating/RootExpectOptions;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+	public fun withoutOptions ()Lch/tutteli/atrium/logic/creating/RootExpectBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/impl/RootExpectOptionsChooserImpl : ch/tutteli/atrium/logic/creating/RootExpectBuilder$OptionsChooser {
+	public fun <init> ()V
+	public final fun build ()Lch/tutteli/atrium/creating/RootExpectOptions;
+	public fun prependChainedComponents (Lkotlin/reflect/KClass;Lkotlin/sequences/Sequence;)V
+	public fun withComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun withRepresentation (Ljava/lang/String;)V
+	public fun withRepresentation (Lkotlin/jvm/functions/Function1;)V
+	public fun withSingletonComponent (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun withVerb (Lch/tutteli/atrium/reporting/translating/Translatable;)V
+	public fun withVerb (Ljava/lang/String;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepInternal : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$CheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public abstract fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public abstract fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour : ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtLeastChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/AtMostChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/ExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/ExactlyChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/NotChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/NotChecker, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Checker {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtLeastChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtLeastCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultAtMostChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtMostChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getAtMostCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultExactlyChecker : ch/tutteli/atrium/logic/creating/basic/contains/checkers/impl/ContainsChecker, ch/tutteli/atrium/logic/creating/iterable/contains/checkers/ExactlyChecker {
+	public fun <init> (ILjava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getExactlyCall ()Lkotlin/jvm/functions/Function1;
+	public fun getNameContainsNotFun ()Ljava/lang/String;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/checkers/impl/DefaultNotChecker : ch/tutteli/atrium/logic/creating/iterable/contains/checkers/NotChecker {
+	public fun <init> ()V
+	public fun createAssertion (I)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions {
+	public abstract fun entriesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun entriesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun entriesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun valuesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun valuesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun valuesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderAssertions {
+	public abstract fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderKt {
+	public static final fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsKt {
+	public static final fun entriesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun entriesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun entriesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun valuesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun valuesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun valuesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/DefaultIterableLikeContainsAssertions : ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsAssertions {
+	public fun <init> ()V
+	public fun entriesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun entriesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun entriesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun valuesInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun valuesInOrderOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun valuesInOrderOnlyGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/DefaultIterableLikeContainsInAnyOrderAssertions : ch/tutteli/atrium/logic/creating/iterable/contains/creators/IterableLikeContainsInAnyOrderAssertions {
+	public fun <init> ()V
+	public fun entries (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun values (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic;Ljava/util/List;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun searchAndCreateAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected abstract fun createAssertionForSearchCriterionAndRemoveMatchFromList (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/util/List;)Lkotlin/Pair;
+	public final fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun createAssertionForSearchCriterionAndRemoveMatchFromList (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/util/List;)Lkotlin/Pair;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyValuesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderOnlyAssertionCreator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InAnyOrderValuesAssertionCreator : ch/tutteli/atrium/logic/creating/basic/contains/creators/impl/ContainsObjectsAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour;Ljava/util/List;Ljava/lang/String;)V
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected fun addAssertionsAndReturnIndex (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)I
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$Creator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected abstract fun addAssertionsAndReturnIndex (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)I
+	public final fun createAssertionGroup (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILkotlin/jvm/functions/Function1;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public synthetic fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyEntriesMatcher : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> ()V
+	public synthetic fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILkotlin/jvm/functions/Function1;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public synthetic fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyBaseAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	protected final fun addAssertionsAndReturnIndex (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)I
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	protected abstract fun addSublistAssertion (Lch/tutteli/atrium/creating/Expect;Ljava/util/List;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedEntriesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILkotlin/jvm/functions/Function1;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public synthetic fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedValuesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyGroupedAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public abstract fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public abstract fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher$DefaultImpls {
+	public static fun addSingleEntryAssertion (Lch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher;Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValueMatcher : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> ()V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyValuesAssertionCreator : ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyAssertionCreator, ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/InOrderOnlyMatcher {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour;Lkotlin/jvm/functions/Function1;)V
+	public fun addSingleEntryAssertion (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/Object;Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;)V
+	public fun elementAssertionCreator (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/core/Option;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/creators/impl/IterableMultiConsumableKt {
+	public static final fun extractSubjectTurnToList (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/core/Option;
+	public static final fun mapSubjectToList (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/AssertionContainer;
+	public static final fun turnSubjectToList (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/AssertionContainer;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedWithinSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NotSearchBehaviour : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InAnyOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InAnyOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InAnyOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderOnlyGroupedSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderOnlyGroupedWithinSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlyGroupedWithinSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/InOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/InOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/NoOpSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NoOpSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/impl/NotSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/iterable/contains/searchbehaviours/NotSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/ImplsKt {
+	public static final fun atLeastCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtLeastCheckerStep;
+	public static final fun atMostCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/AtMostCheckerStep;
+	public static final fun butAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ButAtMostCheckerStep;
+	public static final fun exactlyCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/ExactlyCheckerStep;
+	public static final fun getAndOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getButOnly (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getGrouped (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun getWithin (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public static final fun notCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public static final fun notOrAtMostCheckerStep (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/NoOpCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepInternal {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;)V
+	public fun getCheckers ()Ljava/util/List;
+	public synthetic fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic;
+	public fun getEntryPointStepLogic ()Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepLogic;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/NotOrAtMostCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepInternal : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepInternal, ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStep, ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterable/contains/steps/WithTimesCheckerStepLogic : ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$CheckerStepLogic {
+	public abstract fun getTimes ()I
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl, ch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStepInternal {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)V
+	public fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterable/contains/steps/impl/SharedCheckersKt {
+	public static final fun atLeastChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtLeastChecker;
+	public static final fun atMostChecker (Lch/tutteli/atrium/creating/AssertionContainer;ILjava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/checkers/AtMostChecker;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions : ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions$DefaultImpls {
+	public static fun showAlwaysSummary (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions;)V
+	public static fun showOnlyFailing (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InAnyOrderOnlyReportingOptions;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions : ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions {
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions$DefaultImpls {
+	public static fun showAlwaysSummary (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions;)V
+	public static fun showOnlyFailing (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/InOrderOnlyReportingOptions;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions {
+	public abstract fun getMaxNumberOfExpectedElementsForSummary ()I
+	public abstract fun showAlwaysSummary ()V
+	public abstract fun showOnlyFailing ()V
+	public abstract fun showOnlyFailingIfMoreExpectedElementsThan (I)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions$DefaultImpls {
+	public static fun showAlwaysSummary (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions;)V
+	public static fun showOnlyFailing (Lch/tutteli/atrium/logic/creating/iterablelike/contains/reporting/OnlyReportingOptions;)V
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$Creator : ch/tutteli/atrium/logic/creating/basic/contains/Contains$Creator {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStep {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep, ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic {
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal;Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic : ch/tutteli/atrium/logic/creating/basic/contains/Contains$EntryPointStepLogic {
+	public abstract fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public abstract fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic$DefaultImpls {
+	public static fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour : ch/tutteli/atrium/logic/creating/basic/contains/Contains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsAssertions {
+	public abstract fun keyValuePairsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyValuePairsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyValuePairsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyWithValueAssertionsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyWithValueAssertionsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun keyWithValueAssertionsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsKt {
+	public static final fun keyValuePairsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyValuePairsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyValuePairsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyWithValueAssertionsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyWithValueAssertionsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public static final fun keyWithValueAssertionsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/creators/impl/DefaultMapLikeContainsAssertions : ch/tutteli/atrium/logic/creating/maplike/contains/creators/MapLikeContainsAssertions {
+	public fun <init> ()V
+	public fun keyValuePairsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyValuePairsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyValuePairsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyWithValueAssertionsInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyWithValueAssertionsInAnyOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun keyWithValueAssertionsInOrderOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Lkotlin/reflect/KClass;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderOnlySearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderSearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour : ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour {
+	public abstract fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour$DefaultImpls {
+	public static fun decorateDescription (Lch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InAnyOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InAnyOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InAnyOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InOrderOnlySearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderOnlySearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/InOrderSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/InOrderSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/impl/NoOpSearchBehaviourImpl : ch/tutteli/atrium/logic/creating/maplike/contains/searchbehaviours/NoOpSearchBehaviour {
+	public fun <init> ()V
+	public fun decorateDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/reporting/translating/Translatable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/steps/ImplsKt {
+	public static final fun getAndOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getButOnly (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInAnyOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public static final fun getInOrder (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/maplike/contains/steps/impl/EntryPointStepImpl : ch/tutteli/atrium/logic/creating/basic/contains/steps/impl/EntryPointStepImpl, ch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepInternal {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)V
+	public fun getConverter ()Lkotlin/jvm/functions/Function1;
+	public fun withSearchBehaviour (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$SearchBehaviour;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FailureHandlerAdapter : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)V
+	public fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+	public final fun getFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;
+	public final fun getMap ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractor {
+	public abstract fun extract (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun methodCall (Ljava/lang/String;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public abstract fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public abstract fun withDescription (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep$DefaultImpls {
+	public static fun methodCall (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;Ljava/lang/String;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public static fun withDescription (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep : ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentationForFailure ()Ljava/lang/Object;
+	public abstract fun withFeatureExtraction (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public abstract fun getFeatureExpectOptions ()Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public abstract fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep$Companion;
+	public abstract fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+	public abstract fun withOptions (Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public abstract fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public abstract fun withoutOptions ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep$DefaultImpls {
+	public static fun withOptions (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun withRepresentationForFailure (Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+	public abstract fun withRepresentationForFailure (Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep$DefaultImpls {
+	public static fun withRepresentationForFailure (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/ImplsKt {
+	public static final fun getFeatureExtractor (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractor;
+	public static final fun getSubjectChanger (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChanger {
+	public abstract fun reported (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun unreported (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public abstract fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep$Companion;
+	public abstract fun downCastTo (Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public abstract fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep$DefaultImpls {
+	public static fun downCastTo (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+	public static fun withDescriptionAndRepresentation (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep : ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep$Companion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public abstract fun withDefaultFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public abstract fun withFailureHandler (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public abstract fun withFailureHandlerAdapter (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep$DefaultImpls {
+	public static fun build (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public static fun withFailureHandlerAdapter (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep$Companion;
+	public abstract fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public abstract fun getFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;
+	public abstract fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep {
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun reportBuilder ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;
+	public abstract fun unreported (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep$DefaultImpls {
+	public static fun unreported (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep$Companion;
+	public abstract fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public abstract fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public abstract fun getRepresentation ()Ljava/lang/Object;
+	public abstract fun withTransformation (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep$Companion {
+	public final fun invoke (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public abstract fun collect (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public abstract fun collectAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public abstract fun transform ()Lch/tutteli/atrium/creating/Expect;
+	public abstract fun transformAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public abstract class ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep : ch/tutteli/atrium/logic/creating/transformers/TransformationExecutionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+	public final fun collect (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public final fun collectAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	protected final fun getAction ()Lkotlin/jvm/functions/Function1;
+	protected final fun getActionAndApply ()Lkotlin/jvm/functions/Function2;
+	protected final fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public final fun transform ()Lch/tutteli/atrium/creating/Expect;
+	public final fun transformAndAppend (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/CreateAdditionalHintsKt {
+	public static final fun createAdditionalHints (Ljava/lang/Throwable;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/DefaultFeatureExtractor : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractor {
+	public fun <init> ()V
+	public fun extract (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/core/Option;Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/creating/FeatureExpect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/DefaultSubjectChanger : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger {
+	public fun <init> ()V
+	public fun reported (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/creating/Expect;
+	public fun unreported (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public static final field Companion Lch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler$Companion;
+	public fun <init> ()V
+	public fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler$Companion {
+	public final fun createChildHint (Ljava/lang/Throwable;Ljava/lang/Throwable;Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public final fun propertiesOfThrowable (Ljava/lang/Throwable;Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;)Lch/tutteli/atrium/assertions/AssertionGroup;
+	public static synthetic fun propertiesOfThrowable$default (Lch/tutteli/atrium/logic/creating/transformers/impl/ThrowableThrownFailureHandler$Companion;Ljava/lang/Throwable;Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;ILjava/lang/Object;)Lch/tutteli/atrium/assertions/AssertionGroup;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/DescriptionStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$DescriptionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun methodCall (Ljava/lang/String;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public fun withDescription (Lch/tutteli/atrium/reporting/translating/Translatable;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+	public fun withDescription (Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$RepresentationInCaseOfFailureStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/ExecutionStepImpl : ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep, ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/FeatureExtractionStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getRepresentationForFailure ()Ljava/lang/Object;
+	public fun withFeatureExtraction (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/FinalStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/creating/FeatureExpectOptions;)V
+	public fun build ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun getFeatureExpectOptions ()Lch/tutteli/atrium/creating/FeatureExpectOptions;
+	public fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/featureextractor/OptionsStepImpl : ch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$OptionsStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;Lkotlin/jvm/functions/Function1;)V
+	public fun getFeatureExtraction ()Lkotlin/jvm/functions/Function1;
+	public fun getFeatureExtractionStep ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FeatureExtractionStep;
+	public fun withOptions (Lch/tutteli/atrium/creating/FeatureExpectOptions;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public fun withOptions (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+	public fun withoutOptions ()Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/DefaultFailureHandlerImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler {
+	public fun <init> ()V
+	public fun createAssertion (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/assertions/Assertion;Lch/tutteli/atrium/core/Option;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/DescriptionRepresentationStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun downCastTo (Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun withDescriptionAndRepresentation (Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public fun withDescriptionAndRepresentation (Ljava/lang/String;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/ExecutionStepImpl : ch/tutteli/atrium/logic/creating/transformers/impl/BaseTransformationExecutionStep, ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/FailureHandlerStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;)V
+	public fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+	public fun withDefaultFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public fun withFailureHandler (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+	public fun withFailureHandlerAdapter (Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/FinalStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FinalStep {
+	public fun <init> (Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;Lkotlin/jvm/functions/Function1;Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;)V
+	public fun build ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun getFailureHandler ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChanger$FailureHandler;
+	public fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public fun getTransformationStep ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/KindStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$KindStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun reportBuilder ()Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$DescriptionRepresentationStep;
+	public fun unreported (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
+public final class ch/tutteli/atrium/logic/creating/transformers/impl/subjectchanger/TransformationStepImpl : ch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$TransformationStep {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Ljava/lang/Object;)V
+	public fun getContainer ()Lch/tutteli/atrium/creating/AssertionContainer;
+	public fun getDescription ()Lch/tutteli/atrium/reporting/translating/Translatable;
+	public fun getRepresentation ()Ljava/lang/Object;
+	public fun withTransformation (Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$FailureHandlerStep;
+}
+
+public final class ch/tutteli/atrium/logic/creating/typeutils/ImplsKt {
+	public static final fun getIterableLikeToIterableTransformer (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/typeutils/IterableLikeToIterableTransformer;
+	public static final fun getMapLikeToMapTransformer (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/typeutils/MapLikeToIterablePairTransformer;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/typeutils/IterableLikeToIterableTransformer {
+	public abstract fun supportedTypes ()Ljava/util/List;
+	public abstract fun unsafeTransform (Ljava/lang/Object;)Ljava/lang/Iterable;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/creating/typeutils/MapLikeToIterablePairTransformer {
+	public abstract fun supportedTypes ()Ljava/util/List;
+	public abstract fun unsafeTransform (Ljava/lang/Object;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/creating/typeutils/impl/DefaultIterableLikeToIterableTransformer : ch/tutteli/atrium/logic/creating/typeutils/IterableLikeToIterableTransformer {
+	public fun <init> ()V
+	public fun supportedTypes ()Ljava/util/List;
+	public fun unsafeTransform (Ljava/lang/Object;)Ljava/lang/Iterable;
+}
+
+public final class ch/tutteli/atrium/logic/creating/typeutils/impl/DefaultMapLikeToIterablePairTransformer : ch/tutteli/atrium/logic/creating/typeutils/MapLikeToIterablePairTransformer {
+	public fun <init> (Lch/tutteli/atrium/creating/AssertionContainer;)V
+	public fun supportedTypes ()Ljava/util/List;
+	public fun unsafeTransform (Ljava/lang/Object;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultAnyAssertions : ch/tutteli/atrium/logic/AnyAssertions {
+	public fun <init> ()V
+	public fun because (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun isNotIn (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Iterable;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isSameAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun notToBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun notToBeAnInstanceOf (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun notToBeNullButOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun toBe (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun toBeNullIfNullGivenElse (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultBigDecimalAssertions : ch/tutteli/atrium/logic/BigDecimalAssertions {
+	public fun <init> ()V
+	public fun isEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotEqualIncludingScale (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNumericallyEqualTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultCharSequenceAssertions : ch/tutteli/atrium/logic/CharSequenceAssertions {
+	public fun <init> ()V
+	public fun containsBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/CharSequenceContains$EntryPointStep;
+	public fun containsNotBuilder (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/charsequence/contains/steps/NotCheckerStep;
+	public fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotBlank (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun matches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun mismatches (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/text/Regex;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/CharSequence;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultChronoLocalDateAssertions : ch/tutteli/atrium/logic/ChronoLocalDateAssertions {
+	public fun <init> ()V
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDate;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultChronoLocalDateTimeAssertions : ch/tutteli/atrium/logic/ChronoLocalDateTimeAssertions {
+	public fun <init> ()V
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoLocalDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultChronoZonedDateTimeAssertions : ch/tutteli/atrium/logic/ChronoZonedDateTimeAssertions {
+	public fun <init> ()V
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfter (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAfterOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBefore (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isBeforeOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/time/chrono/ChronoZonedDateTime;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultCollectionLikeAssertions : ch/tutteli/atrium/logic/CollectionLikeAssertions {
+	public fun <init> ()V
+	public fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotEmpty (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun size (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultComparableAssertions : ch/tutteli/atrium/logic/ComparableAssertions {
+	public fun <init> ()V
+	public fun isEqualComparingTo (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isGreaterThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isLessThanOrEqual (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotGreaterThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotLessThan (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFeatureAssertions : ch/tutteli/atrium/logic/FeatureAssertions {
+	public fun <init> ()V
+	public fun extractSubject (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lch/tutteli/atrium/creating/Expect;
+	public fun f0 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f1 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f2 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f3 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f4 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun f5 (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KFunction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun manualFeature (Lch/tutteli/atrium/creating/AssertionContainer;Lch/tutteli/atrium/reporting/translating/Translatable;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun property (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KProperty1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFloatingPointAssertions : ch/tutteli/atrium/logic/FloatingPointAssertions {
+	public fun <init> ()V
+	public fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;DD)Lch/tutteli/atrium/assertions/Assertion;
+	public fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;FF)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFloatingPointJvmAssertions : ch/tutteli/atrium/logic/FloatingPointJvmAssertions {
+	public fun <init> ()V
+	public fun toBeWithErrorTolerance (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultFun0Assertions : ch/tutteli/atrium/logic/Fun0Assertions {
+	public fun <init> ()V
+	public fun notToThrow (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun toThrow (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultGroupingAssertions : ch/tutteli/atrium/logic/GroupingAssertions {
+	public fun <init> ()V
+	public fun group (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun grouping (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultIterableLikeAssertions : ch/tutteli/atrium/logic/IterableLikeAssertions {
+	public fun <init> ()V
+	public fun all (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun builderContainsInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/IterableLikeContains$EntryPointStep;
+	public fun builderContainsNotInIterableLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/iterable/contains/steps/NotCheckerStep;
+	public fun containsNoDuplicates (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNextOrAll (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNextOrAny (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNextOrNone (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun last (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun max (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun min (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultIteratorAssertions : ch/tutteli/atrium/logic/IteratorAssertions {
+	public fun <init> ()V
+	public fun hasNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasNotNext (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultListAssertions : ch/tutteli/atrium/logic/ListAssertions {
+	public fun <init> ()V
+	public fun get (Lch/tutteli/atrium/creating/AssertionContainer;I)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultLocalDateAssertions : ch/tutteli/atrium/logic/LocalDateAssertions {
+	public fun <init> ()V
+	public fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultLocalDateTimeAssertions : ch/tutteli/atrium/logic/LocalDateTimeAssertions {
+	public fun <init> ()V
+	public fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultMapEntryAssertions : ch/tutteli/atrium/logic/MapEntryAssertions {
+	public fun <init> ()V
+	public fun isKeyValue (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun key (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun value (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultMapLikeAssertions : ch/tutteli/atrium/logic/MapLikeAssertions {
+	public fun <init> ()V
+	public fun builderContainsInMapLike (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStep;
+	public fun containsKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun containsNotKey (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun getExisting (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultOptionalAssertions : ch/tutteli/atrium/logic/OptionalAssertions {
+	public fun <init> ()V
+	public fun isEmpty (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isPresent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultPairAssertions : ch/tutteli/atrium/logic/PairAssertions {
+	public fun <init> ()V
+	public fun first (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun second (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultPathAssertions : ch/tutteli/atrium/logic/PathAssertions {
+	public fun <init> ()V
+	public fun endsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun endsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun exists (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun existsNot (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/LinkOption;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun extension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun fileName (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun fileNameWithoutExtension (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun hasDirectoryEntry (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/util/List;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasSameBinaryContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun hasSameTextualContentAs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;Ljava/nio/charset/Charset;Ljava/nio/charset/Charset;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isAbsolute (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isEmptyDirectory (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotExecutable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isNotWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isReadable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isRegularFile (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isRelative (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isSymbolicLink (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun isWritable (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun parent (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun resolve (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun startsNotWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+	public fun startsWith (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/nio/file/Path;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultResultAssertions : ch/tutteli/atrium/logic/ResultAssertions {
+	public fun <init> ()V
+	public fun isFailureOfType (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+	public fun isSuccess (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultThirdPartyAssertions : ch/tutteli/atrium/logic/ThirdPartyAssertions {
+	public fun <init> ()V
+	public fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/assertions/Assertion;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultThrowableAssertions : ch/tutteli/atrium/logic/ThrowableAssertions {
+	public fun <init> ()V
+	public fun causeIsA (Lch/tutteli/atrium/creating/AssertionContainer;Lkotlin/reflect/KClass;)Lch/tutteli/atrium/logic/creating/transformers/SubjectChangerBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/impl/DefaultZonedDateTimeAssertions : ch/tutteli/atrium/logic/ZonedDateTimeAssertions {
+	public fun <init> ()V
+	public fun day (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun dayOfWeek (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun month (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+	public fun year (Lch/tutteli/atrium/creating/AssertionContainer;)Lch/tutteli/atrium/logic/creating/transformers/FeatureExtractorBuilder$ExecutionStep;
+}
+
+public final class ch/tutteli/atrium/logic/utils/ArgumentMapperBuilder {
+	public final fun getFirst ()Ljava/lang/Object;
+	public final fun getOthers ()[Ljava/lang/Object;
+}
+
+public final class ch/tutteli/atrium/logic/utils/ArgumentToNullOrMapperBuilder {
+	public fun <init> (Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;)V
+	public final fun getArgumentMapperBuilder ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public final fun toExpect (Lkotlin/jvm/functions/Function2;)Lkotlin/Pair;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/utils/Group {
+	public abstract fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/GroupsToListKt {
+	public static final fun groupsToList (Lch/tutteli/atrium/logic/utils/Group;Lch/tutteli/atrium/logic/utils/Group;[Lch/tutteli/atrium/logic/utils/Group;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/LambdaHelpersKt {
+	public static final fun expectLambda (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+}
+
+public final class ch/tutteli/atrium/logic/utils/MapArgumentsKt {
+	public static final fun mapArguments (B[B)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (C[C)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (D[D)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (F[F)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (I[I)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (J[J)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (Ljava/lang/Object;[Ljava/lang/Object;)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (S[S)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun mapArguments (Z[Z)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static final fun toNullOr (Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;)Lch/tutteli/atrium/logic/utils/ArgumentToNullOrMapperBuilder;
+}
+
+public final class ch/tutteli/atrium/logic/utils/NullableKt {
+	public static final fun nullable (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun nullable (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable1 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable2 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable3 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable4 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullable5 (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public static final fun nullableContainer (Ljava/lang/Iterable;)Ljava/lang/Iterable;
+	public static final fun nullableContainer ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun nullableKeyMap (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun nullableKeyValueMap (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun nullableValueMap (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public abstract interface class ch/tutteli/atrium/logic/utils/VarArgHelper {
+	public abstract fun getExpected ()Ljava/lang/Object;
+	public abstract fun getMapArguments ()Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public abstract fun getOtherExpected ()[Ljava/lang/Object;
+	public abstract fun toList ()Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/VarArgHelper$DefaultImpls {
+	public static fun getMapArguments (Lch/tutteli/atrium/logic/utils/VarArgHelper;)Lch/tutteli/atrium/logic/utils/ArgumentMapperBuilder;
+	public static fun toList (Lch/tutteli/atrium/logic/utils/VarArgHelper;)Ljava/util/List;
+}
+
+public final class ch/tutteli/atrium/logic/utils/VarArgHelpersKt {
+	public static final fun iterableLikeToIterable (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/lang/Iterable;
+	public static final fun iterableLikeToIterableWithoutCheckForElements (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/lang/Iterable;
+	public static final fun mapLikeToIterablePair (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Ljava/util/List;
+	public static final fun mapLikeToVarArgPairs (Lch/tutteli/atrium/creating/AssertionContainer;Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun toVarArgPairs (Lch/tutteli/atrium/logic/creating/maplike/contains/MapLikeContains$EntryPointStepLogic;Ljava/lang/Object;)Lkotlin/Pair;
+}
+

--- a/misc/atrium-verbs/api/main/atrium-verbs.api
+++ b/misc/atrium-verbs/api/main/atrium-verbs.api
@@ -1,0 +1,24 @@
+public final class ch/tutteli/atrium/api/verbs/AssertionVerb : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EXPECT Lch/tutteli/atrium/api/verbs/AssertionVerb;
+	public static final field EXPECT_GROUPED Lch/tutteli/atrium/api/verbs/AssertionVerb;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/api/verbs/AssertionVerb;
+	public static fun values ()[Lch/tutteli/atrium/api/verbs/AssertionVerb;
+}
+
+public final class ch/tutteli/atrium/api/verbs/ExpectKt {
+	public static final fun expect (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun expect (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expect (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expect (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expect (Ljava/lang/Object;)Lch/tutteli/atrium/creating/RootExpect;
+	public static final fun expect (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expectGrouped (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static final fun expectGrouped (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun expectGrouped$default (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun expectGrouped$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+

--- a/misc/atrium-verbs/api/using-kotlin-1.9-or-newer/atrium-verbs.api
+++ b/misc/atrium-verbs/api/using-kotlin-1.9-or-newer/atrium-verbs.api
@@ -1,0 +1,25 @@
+public final class ch/tutteli/atrium/api/verbs/AssertionVerb : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EXPECT Lch/tutteli/atrium/api/verbs/AssertionVerb;
+	public static final field EXPECT_GROUPED Lch/tutteli/atrium/api/verbs/AssertionVerb;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/api/verbs/AssertionVerb;
+	public static fun values ()[Lch/tutteli/atrium/api/verbs/AssertionVerb;
+}
+
+public final class ch/tutteli/atrium/api/verbs/ExpectKt {
+	public static final fun expect (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun expect (Lch/tutteli/atrium/creating/Expect;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expect (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/Object;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expect (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expect (Ljava/lang/Object;)Lch/tutteli/atrium/creating/RootExpect;
+	public static final fun expect (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun expectGrouped (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static final fun expectGrouped (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun expectGrouped$default (Lch/tutteli/atrium/creating/ExpectGrouping;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+	public static synthetic fun expectGrouped$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lch/tutteli/atrium/creating/ExpectGrouping;
+}
+

--- a/translations/atrium-translations-de_CH/api/main/atrium-translations-de_CH.api
+++ b/translations/atrium-translations-de_CH/api/main/atrium-translations-de_CH.api
@@ -1,0 +1,314 @@
+public final class ch/tutteli/atrium/translations/DescriptionAnyExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field BECAUSE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_NULL_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_ONE_IN Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBasic : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NONE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field WAS Lch/tutteli/atrium/translations/DescriptionBasic;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBasic;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBigDecimalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_IS_EQUAL_INCLUDING_SCALE_BUT_NUMERICALLY_EQUAL Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCharSequenceExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field BLANK Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field IGNORING_CASE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field STRING_MATCHING_REGEX Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCollectionExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static final field SIZE Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionComparableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NOT_TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field NOT_TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_EQUAL_COMPARING_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DAY Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field DAY_OF_WEEK Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field MONTH Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_DAY_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field YEAR Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFloatingPointExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_DUE_TO_FLOATING_POINT_NUMBER Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE_EXPLAINED Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFunLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NO_EXCEPTION_OCCURRED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THREW Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THROWN_EXCEPTION_WHEN_CALLED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionIterableLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ALL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_EQUALS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_NEEDS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field A_NEXT_ELEMENT Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATED_BY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATE_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_NOT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_WITH_INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX_FROM_TO Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY_GROUPED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NEITHER_EMPTY_NOR_ELEMENT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ALL Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ANY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NO_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_ELEMENTS_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_SUCH_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field SIZE_EXCEEDED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field USE_NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionListLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field INDEX_OUT_OF_BOUNDS Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionMapLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ENTRY_WITH_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field KEY_DOES_NOT_EXIST Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field NOT_TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ENTRIES Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionOptionalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field GET Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field IS_NOT_PRESENT Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionPathAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ABSOLUTE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field AN_EMPTY_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_UNKNOWN_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DIRECTORY_CONTAINS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DOES_NOT_HAVE_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXECUTABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXIST Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_DENIED Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_EXCEPTION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_LINK_LOOP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_NO_SUCH_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PERMISSION_FILE_TYPE_HINT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_WRONG_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME_WITHOUT_EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_BINARY_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_TEXTUAL_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_ACL_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_POSIX_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_CLOSEST_EXISTING_PARENT_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_FOLLOWED_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER_AND_GROUP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field READABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field RELATIVE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field WRITABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionResultExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EXCEPTION Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_FAILURE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_SUCCESS Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionThrowableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field HAS_NO_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_MESSAGE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_PROPERTIES Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_STACKTRACE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_SUPPRESSED Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/ErrorMessages : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DESCRIPTION_BASED_ON_SUBJECT Lch/tutteli/atrium/translations/ErrorMessages;
+	public static final field REPRESENTATION_BASED_ON_SUBJECT_NOT_DEFINED Lch/tutteli/atrium/translations/ErrorMessages;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/ErrorMessages;
+	public static fun values ()[Lch/tutteli/atrium/translations/ErrorMessages;
+}
+

--- a/translations/atrium-translations-de_CH/api/using-kotlin-1.9-or-newer/atrium-translations-de_CH.api
+++ b/translations/atrium-translations-de_CH/api/using-kotlin-1.9-or-newer/atrium-translations-de_CH.api
@@ -1,0 +1,331 @@
+public final class ch/tutteli/atrium/translations/DescriptionAnyExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field BECAUSE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_NULL_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_ONE_IN Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBasic : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NONE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field WAS Lch/tutteli/atrium/translations/DescriptionBasic;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBasic;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBigDecimalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_IS_EQUAL_INCLUDING_SCALE_BUT_NUMERICALLY_EQUAL Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCharSequenceExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field BLANK Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field IGNORING_CASE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field STRING_MATCHING_REGEX Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCollectionExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static final field SIZE Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionComparableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NOT_TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field NOT_TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_EQUAL_COMPARING_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DAY Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field DAY_OF_WEEK Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field MONTH Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_DAY_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field YEAR Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFloatingPointExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_DUE_TO_FLOATING_POINT_NUMBER Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE_EXPLAINED Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFloatingPointExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFunLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NO_EXCEPTION_OCCURRED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THREW Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THROWN_EXCEPTION_WHEN_CALLED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionIterableLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ALL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_EQUALS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_NEEDS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field A_NEXT_ELEMENT Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATED_BY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATE_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_NOT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_WITH_INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX_FROM_TO Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY_GROUPED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NEITHER_EMPTY_NOR_ELEMENT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ALL Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ANY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NO_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_ELEMENTS_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_SUCH_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field SIZE_EXCEEDED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field USE_NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionListLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field INDEX_OUT_OF_BOUNDS Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionMapLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ENTRY_WITH_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field KEY_DOES_NOT_EXIST Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field NOT_TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ENTRIES Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionOptionalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field GET Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field IS_NOT_PRESENT Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionPathAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ABSOLUTE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field AN_EMPTY_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_UNKNOWN_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DIRECTORY_CONTAINS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DOES_NOT_HAVE_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXECUTABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXIST Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_DENIED Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_EXCEPTION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_LINK_LOOP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_NO_SUCH_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PERMISSION_FILE_TYPE_HINT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_WRONG_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME_WITHOUT_EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_BINARY_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_TEXTUAL_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_ACL_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_POSIX_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_CLOSEST_EXISTING_PARENT_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_FOLLOWED_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER_AND_GROUP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field READABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field RELATIVE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field WRITABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionResultExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EXCEPTION Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_FAILURE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_SUCCESS Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionThrowableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field HAS_NO_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_MESSAGE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_PROPERTIES Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_STACKTRACE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_SUPPRESSED Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/ErrorMessages : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DESCRIPTION_BASED_ON_SUBJECT Lch/tutteli/atrium/translations/ErrorMessages;
+	public static final field REPRESENTATION_BASED_ON_SUBJECT_NOT_DEFINED Lch/tutteli/atrium/translations/ErrorMessages;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/ErrorMessages;
+	public static fun values ()[Lch/tutteli/atrium/translations/ErrorMessages;
+}
+

--- a/translations/atrium-translations-en_GB/api/main/atrium-translations-en_GB.api
+++ b/translations/atrium-translations-en_GB/api/main/atrium-translations-en_GB.api
@@ -1,0 +1,314 @@
+public final class ch/tutteli/atrium/translations/DescriptionAnyExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field BECAUSE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_NULL_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_ONE_IN Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBasic : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NONE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field WAS Lch/tutteli/atrium/translations/DescriptionBasic;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBasic;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBigDecimalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_IS_EQUAL_INCLUDING_SCALE_BUT_NUMERICALLY_EQUAL Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCharSequenceExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field BLANK Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field IGNORING_CASE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field STRING_MATCHING_REGEX Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCollectionExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static final field SIZE Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionComparableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NOT_TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field NOT_TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_EQUAL_COMPARING_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DAY Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field DAY_OF_WEEK Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field MONTH Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_DAY_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field YEAR Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFloatingPointException : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_DUE_TO_FLOATING_POINT_NUMBER Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE_EXPLAINED Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFunLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NO_EXCEPTION_OCCURRED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THREW Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THROWN_EXCEPTION_WHEN_CALLED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionIterableLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ALL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_EQUALS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_NEEDS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field A_NEXT_ELEMENT Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATED_BY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATE_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_NOT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_WITH_INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX_FROM_TO Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY_GROUPED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NEITHER_EMPTY_NOR_ELEMENT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ALL Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ANY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NO_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_ELEMENTS_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_SUCH_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field SIZE_EXCEEDED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field USE_NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionListLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field INDEX_OUT_OF_BOUNDS Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionMapLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ENTRY_WITH_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field KEY_DOES_NOT_EXIST Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field NOT_TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ENTRIES Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionOptionalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field GET Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field IS_NOT_PRESENT Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionPathAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ABSOLUTE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field AN_EMPTY_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_UNKNOWN_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DIRECTORY_CONTAINS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DOES_NOT_HAVE_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXECUTABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXIST Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_DENIED Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_EXCEPTION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_LINK_LOOP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_NO_SUCH_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PERMISSION_FILE_TYPE_HINT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_WRONG_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME_WITHOUT_EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_BINARY_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_TEXTUAL_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_ACL_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_POSIX_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_CLOSEST_EXISTING_PARENT_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_FOLLOWED_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER_AND_GROUP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field READABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field RELATIVE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field WRITABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionResultExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EXCEPTION Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_FAILURE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_SUCCESS Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionThrowableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field HAS_NO_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_MESSAGE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_PROPERTIES Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_STACKTRACE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_SUPPRESSED Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/ErrorMessages : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DESCRIPTION_BASED_ON_SUBJECT Lch/tutteli/atrium/translations/ErrorMessages;
+	public static final field REPRESENTATION_BASED_ON_SUBJECT_NOT_DEFINED Lch/tutteli/atrium/translations/ErrorMessages;
+	public fun getDefault ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/ErrorMessages;
+	public static fun values ()[Lch/tutteli/atrium/translations/ErrorMessages;
+}
+

--- a/translations/atrium-translations-en_GB/api/using-kotlin-1.9-or-newer/atrium-translations-en_GB.api
+++ b/translations/atrium-translations-en_GB/api/using-kotlin-1.9-or-newer/atrium-translations-en_GB.api
@@ -1,0 +1,331 @@
+public final class ch/tutteli/atrium/translations/DescriptionAnyExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field BECAUSE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_NULL_TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field NOT_TO_EQUAL_ONE_IN Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_AN_INSTANCE_OF Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_BE_THE_INSTANCE Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static final field TO_EQUAL Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionAnyExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBasic : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NONE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field NOT_TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_BE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field TO_HAVE Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static final field WAS Lch/tutteli/atrium/translations/DescriptionBasic;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBasic;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBasic;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionBigDecimalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_IS_EQUAL_INCLUDING_SCALE_BUT_NUMERICALLY_EQUAL Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_EQUAL_INCLUDING_SCALE Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NOT_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static final field IS_NUMERICALLY_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionBigDecimalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCharSequenceExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field BLANK Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field IGNORING_CASE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NOT_TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field NUMBER_OF_MATCHES_FOUND Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field STRING_MATCHING_REGEX Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_END_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_MATCH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field TO_START_WITH Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCharSequenceExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionCollectionExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static final field SIZE Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionCollectionExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionComparableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NOT_TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field NOT_TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_EQUAL_COMPARING_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_GREATER_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static final field TO_BE_LESS_THAN_OR_EQUAL_TO Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionComparableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DAY Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field DAY_OF_WEEK Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field MONTH Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_AFTER_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_BEFORE_OR_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_DAY_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field TO_BE_THE_SAME_POINT_IN_TIME_AS Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static final field YEAR Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionDateTimeLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFloatingPointException : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field FAILURE_DUE_TO_FLOATING_POINT_NUMBER Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public static final field TO_EQUAL_WITH_ERROR_TOLERANCE_EXPLAINED Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFloatingPointException;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionFunLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field NO_EXCEPTION_OCCURRED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THREW Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static final field THROWN_EXCEPTION_WHEN_CALLED Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionFunLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionIterableLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ALL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_EQUALS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AN_ELEMENT_WHICH_NEEDS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_LEAST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field AT_MOST Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field A_NEXT_ELEMENT Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATED_BY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field DUPLICATE_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_NOT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field ELEMENT_WITH_INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field EXACTLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field INDEX_FROM_TO Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field IN_ORDER_ONLY_GROUPED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NEITHER_EMPTY_NOR_ELEMENT_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ALL Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_ANY Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NO_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_ELEMENTS_FOUND Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field NUMBER_OF_SUCH_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field SIZE_EXCEEDED Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field USE_NOT_TO_HAVE_ELEMENTS_OR_NONE Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static final field WARNING_MISMATCHES_ADDITIONAL_ELEMENTS Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionIterableLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionListLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field INDEX_OUT_OF_BOUNDS Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionListLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionMapLikeExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ENTRY_WITH_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ANY_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field IN_ORDER_ONLY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field KEY_DOES_NOT_EXIST Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field NOT_TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field TO_CONTAIN_KEY Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static final field WARNING_ADDITIONAL_ENTRIES Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionMapLikeExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionOptionalAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EMPTY Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field GET Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static final field IS_NOT_PRESENT Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionOptionalAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionPathAssertion : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field ABSOLUTE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field AN_EMPTY_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field A_UNKNOWN_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DIRECTORY_CONTAINS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field DOES_NOT_HAVE_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field ENDS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXECUTABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXIST Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_DENIED Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_ACCESS_EXCEPTION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_LINK_LOOP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_NO_SUCH_FILE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_PERMISSION_FILE_TYPE_HINT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FAILURE_DUE_TO_WRONG_FILE_TYPE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field FILE_NAME_WITHOUT_EXTENSION Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_BINARY_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HAS_SAME_TEXTUAL_CONTENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_ACL_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_ACTUAL_POSIX_PERMISSIONS Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_CLOSEST_EXISTING_PARENT_DIRECTORY Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_FOLLOWED_SYMBOLIC_LINK Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field HINT_OWNER_AND_GROUP Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field PARENT Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field READABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field RELATIVE_PATH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_NOT_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field STARTS_WITH Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static final field WRITABLE Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionPathAssertion;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionResultExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field EXCEPTION Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_FAILURE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field IS_NOT_SUCCESS Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static final field VALUE Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionResultExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/DescriptionThrowableExpectation : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field HAS_NO_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_CAUSE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_MESSAGE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_PROPERTIES Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_STACKTRACE Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static final field OCCURRED_EXCEPTION_SUPPRESSED Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+	public static fun values ()[Lch/tutteli/atrium/translations/DescriptionThrowableExpectation;
+}
+
+public final class ch/tutteli/atrium/translations/ErrorMessages : java/lang/Enum, ch/tutteli/atrium/reporting/translating/StringBasedTranslatable {
+	public static final field DESCRIPTION_BASED_ON_SUBJECT Lch/tutteli/atrium/translations/ErrorMessages;
+	public static final field REPRESENTATION_BASED_ON_SUBJECT_NOT_DEFINED Lch/tutteli/atrium/translations/ErrorMessages;
+	public fun getDefault ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Ljava/lang/String;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lch/tutteli/atrium/translations/ErrorMessages;
+	public static fun values ()[Lch/tutteli/atrium/translations/ErrorMessages;
+}
+


### PR DESCRIPTION
we are producing two dumps, once for main and once when using Kotlin 1.9 or newer for the forward-compatibility tests. Kotlin outputs `entries` for Enums since Kotlin 1.9



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
