### PR TITLE
update kbox to 2.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,12 +13,8 @@ plugins {
 
 // test
 val jacocoToolVersion by extra("0.8.9")
-val junitPlatformVersion by extra("1.9.2")
 // need to use an old version of spek as the newer contains a bug which causes that no tests are discovered and executed
 val spekVersion by extra("2.0.12")
-val spekExtensionsVersion by extra("1.2.1")
-val mockkVersion by extra("1.10.0")
-val mockitoKotlinVersion by extra("2.2.0")
 
 subprojects {
     group = rootProject.group

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kbox = "1.2.0"
+kbox = "2.0.0"
 niok = "1.5.0"
 
 # testing

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/impl/containsHelpers.kt
@@ -19,9 +19,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
 import ch.tutteli.atrium.reporting.translating.TranslatableWithArgs
 import ch.tutteli.atrium.translations.DescriptionAnyExpectation.TO_EQUAL
 import ch.tutteli.atrium.translations.DescriptionIterableLikeExpectation
-import ch.tutteli.kbox.WithIndex
 import ch.tutteli.kbox.identity
-import ch.tutteli.kbox.mapWithIndex
 
 internal fun <E : Any> allCreatedAssertionsHold(
     container: AssertionContainer<*>,
@@ -56,10 +54,10 @@ internal fun <E : Any> createExplanatoryAssertionGroup(
 
 internal fun <E> createIndexAssertions(
     list: List<E>,
-    predicate: (WithIndex<E>) -> Boolean
+    predicate: (IndexedValue<E>) -> Boolean
 ) = list
     .asSequence()
-    .mapWithIndex()
+    .withIndex()
     .filter { predicate(it) }
     .map { (index, element) ->
         assertionBuilder.createDescriptive(


### PR DESCRIPTION
moreover:
- use withIndex instead of kbox's mapWithIndex as it was removed with 2.0.0



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
