### PR TITLE
workaround for the double exception msg printing problem in JS

### DIFF
--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
@@ -22,8 +22,7 @@ expect class AtriumError internal constructor(message: String) : AssertionError 
     }
 }
 
-internal fun createAtriumError(message: String, errorAdjuster: AtriumErrorAdjuster): AtriumError {
-    val err = AtriumError(message)
-    errorAdjuster.adjust(err)
-    return err
-}
+internal fun createAtriumError(message: String, errorAdjuster: AtriumErrorAdjuster): AtriumError =
+    AtriumError(message).also {
+        errorAdjuster.adjust(it)
+    }

--- a/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
+++ b/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
@@ -1,5 +1,7 @@
 package ch.tutteli.atrium.reporting
 
+import ch.tutteli.atrium.core.polyfills.stackBacktrace
+
 /**
  * Indicates that an assertion made by Atrium failed.
  *
@@ -11,7 +13,34 @@ package ch.tutteli.atrium.reporting
  *
  * To create such an error you need to use the [AtriumError.Companion.create][Companion.create] function.
  */
-actual class AtriumError internal actual constructor(message: String) : AssertionError(message) {
+actual class AtriumError private constructor(
+    private val internalMessage: String,
+    @Suppress("UNUSED_PARAMETER") dummyUnit: Unit
+) : AssertionError(internalMessage) {
+    internal actual constructor(message: String) : this(message, Unit)
+
+    override val message: String?
+        get() {
+            val process = js("process.env._") as? String
+            return if (process?.contains("idea") == true) {
+                "".also {
+                    // if the process contains idea, then we assume we deal with intellij-idea and that it suffers
+                    // from the double print exception message problem by outputting the message once as message and
+                    // once as part of the stack-trace (no idea why they do it).
+                    // Currently, kotlin calls `message` twice, once when populating the stacktrace and once when
+                    // reporting the failure. To work around the bug we return an empty string for the `message`
+                    // and instead print it when intellij most likely wants to report the failure
+                    //
+                    // we tried to sneak it into the stack (as it is a String) but it looks like intellij-idea does a
+                    // post-processing of the stack and double prints it again *sight*
+                    if (Error().stackBacktrace.first().contains("AtriumError")) {
+                        println("\n" + internalMessage)
+                    }
+                }
+            } else {
+                internalMessage
+            }
+        }
 
     actual companion object {
         /**


### PR DESCRIPTION
fixes #1803 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
