### PR TITLE
add Iterable.toContain....value samples

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
@@ -24,6 +24,8 @@ import ch.tutteli.kbox.glue
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.value
  */
 fun <E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.value(expected: E): Expect<T> =
     values(expected)

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -26,6 +26,8 @@ import ch.tutteli.kbox.glue
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.value
  */
 fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
     values(expected)

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -24,6 +24,8 @@ import ch.tutteli.kbox.glue
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.value
  */
 fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
     values(expected)

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -6,6 +6,19 @@ import kotlin.test.Test
 
 class IterableLikeToContainInAnyOrderCreatorSamples {
     @Test
+    fun value(){
+        expect(listOf("A","B")).toContain.inAnyOrder.exactly(1).value("A")
+        expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(2).value("A")
+        expect(listOf("A","B","B")).toContain.inAnyOrder.atMost(2).value("B")
+
+        fails {
+            expect(listOf("A","B")).toContain.inAnyOrder.exactly(2).value("A")
+            expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(3).value("A")
+            expect(listOf("A","B","B","B")).toContain.inAnyOrder.atMost(2).value("B")
+        }
+    }
+
+    @Test
     fun elementsOf(){
         expect(listOf("A","B")).toContain.inAnyOrder.exactly(1).elementsOf(listOf("A","B"))
         expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(2).elementsOf(listOf("A","B"))

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -6,6 +6,19 @@ import kotlin.test.Test
 
 class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
     @Test
+    fun value(){
+        expect(listOf("A")).toContain.inAnyOrder.only.value("A")
+
+        fails { // because subject list does not contain expected value
+            expect(listOf("B")).toContain.inAnyOrder.only.value("A")
+        }
+
+        fails { // because subject list contains multiple elements
+            expect(listOf("A","A")).toContain.inAnyOrder.only.value("A")
+        }
+    }
+
+    @Test
     fun elementsOf(){
         expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
             listOf("A","B","C")
@@ -16,7 +29,7 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
                 listOf("B", "A")
             )
         }
-        
+
         fails { // because more elements expected than found
             expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
                 listOf("B", "A", "C", "D")

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -6,6 +6,19 @@ import kotlin.test.Test
 
 class IterableLikeToContainInOrderOnlyCreatorSamples {
     @Test
+    fun value(){
+        expect(listOf("A")).toContain.inOrder.only.value("A")
+
+        fails { // because subject list does not contain expected value
+            expect(listOf("B")).toContain.inOrder.only.value("A")
+        }
+
+        fails { // because subject list contains multiple elements
+            expect(listOf("A","A")).toContain.inOrder.only.value("A")
+        }
+    }
+
+    @Test
     fun elementsOf(){
         expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
             listOf("A","B","C")
@@ -16,13 +29,13 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
                 listOf("A","C","B")
             )
         }
-        
+
          fails { // because not all elements found
             expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
                 listOf("A","B")
             )
         }
-        
+
         fails { // because more elements expected than found
             expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
                 listOf("A","B","C","D")

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -16,6 +16,10 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
         fails { // because subject list contains multiple elements
             expect(listOf("A","A")).toContain.inOrder.only.value("A")
         }
+
+        fails { // because the order is wrong
+            expect(listOf("B","A")).toContain.inOrder.only.value("A")
+        }
     }
 
     @Test


### PR DESCRIPTION
Issue #1550 

_api-fluent_

- [x] add a value method in IterableLikeToContainInAnyOrderCreatorSamples for Iterable.toContain.inAnyOrder.value(...)
- [x] add a value method in IterableLikeToContainInAnyOrderOnlyCreatorSamples for Iterable.toContain.inAnyOrder.only.value(...)
- [x] add a value method in IterableLikeToContainInOrderOnlyCreatorSamples for Iterable.toContain.inOrder.only.value(...
- [x] link in the KDoc of the corresponding function in iterableLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
