### PR TITLE
add samples for Iterable.toContain....values

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
@@ -51,6 +51,8 @@ fun <E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.value(expe
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.values
  */
 fun <E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.values(
     expected: E,

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -46,6 +46,8 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.va
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.values
  */
 fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.values(
     expected: E,

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -44,6 +44,8 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.values
  */
 fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.values(
     expected: E,

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -19,6 +19,19 @@ class IterableLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
+    fun values(){
+        expect(listOf("A","B")).toContain.inAnyOrder.exactly(1).values("B", "A")
+        expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(2).values("B", "A")
+        expect(listOf("A","B","B")).toContain.inAnyOrder.atMost(2).values("B", "A")
+
+        fails {
+            expect(listOf("A","B")).toContain.inAnyOrder.exactly(2).values("B", "A")
+            expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(3).values("B", "A")
+            expect(listOf("A","B","B","B")).toContain.inAnyOrder.atMost(2).values("B", "A")
+        }
+    }
+
+    @Test
     fun elementsOf(){
         expect(listOf("A","B")).toContain.inAnyOrder.exactly(1).elementsOf(listOf("A","B"))
         expect(listOf("A","B","A","B")).toContain.inAnyOrder.atLeast(2).elementsOf(listOf("A","B"))

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -19,6 +19,25 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun values(){
+        expect(listOf("A","B","C")).toContain.inAnyOrder.only.values(
+            "C", "B", "A"
+        )
+
+        fails { // because not all elements found
+            expect(listOf("A","B","C")).toContain.inAnyOrder.only.values(
+                "B","A"
+            )
+        }
+
+        fails { // because more elements expected than found
+            expect(listOf("A","B","C")).toContain.inAnyOrder.only.values(
+                "D","C","B","A"
+            )
+        }
+    }
+
+    @Test
     fun elementsOf(){
         expect(listOf("A","B","C")).toContain.inAnyOrder.only.elementsOf(
             listOf("A","B","C")

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -23,6 +23,31 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun values(){
+        expect(listOf("A","B","C")).toContain.inOrder.only.values(
+            "A","B","C"
+        )
+
+        fails { // although same elements but not in same order
+            expect(listOf("A","B","C")).toContain.inOrder.only.values(
+                "A","C","B"
+            )
+        }
+
+        fails { // because not all elements found
+            expect(listOf("A","B","C")).toContain.inOrder.only.values(
+                "A","B"
+            )
+        }
+
+        fails { // because more elements expected than found
+            expect(listOf("A","B","C")).toContain.inOrder.only.values(
+                "A","B","C","D"
+            )
+        }
+    }
+
+    @Test
     fun elementsOf(){
         expect(listOf("A","B","C")).toContain.inOrder.only.elementsOf(
             listOf("A","B","C")


### PR DESCRIPTION
Issue #1551 

_api-fluent_

- [x] add a values method in IterableLikeToContainInAnyOrderCreatorSamples for Iterable.toContain.inAnyOrder.values(...)
- [x] add a values method in IterableLikeToContainInAnyOrderOnlyCreatorSamples for Iterable.toContain.inAnyOrder.only.values(...)
- [x]  add a values method in IterableLikeToContainInOrderOnlyCreatorSamples for Iterable.toContain.inOrder.only.values(...
- [x]  link in the KDoc of the corresponding function in iterableLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
