### PR TITLE
add samples for Iterable.toContain....entry

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
@@ -73,6 +73,8 @@ fun <E, T: IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.values(
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.entry
  */
 fun <E : Any, T: IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -69,6 +69,8 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.va
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.entry
  */
 fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -67,6 +67,8 @@ fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.entry
  */
 fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -32,6 +32,51 @@ class IterableLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
+    fun entry() {
+        expect(listOf("A", "B")).toContain.inAnyOrder.exactly(1).entry {
+            toEqual("A")
+        }
+
+        expect(listOf("A", null, null)).toContain.inAnyOrder.exactly(2).entry(null) // null is identified
+
+        expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.atLeast(2).entry {
+            toEqual("A")
+        }
+
+        expect(listOf("A", "B", "B")).toContain.inAnyOrder.atMost(2).entry {
+            toEqual("A")
+        }
+
+        fails { // because the count of "A" is not 2
+            expect(listOf("A", "B")).toContain.inAnyOrder.exactly(2).entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because all elements are not null
+            expect(listOf("A", "B", "C")).toContain.inAnyOrder.exactly(1).entry(null)
+        }
+
+        fails { // because assertionCreatorOrNull is non-null and has no expectation
+            expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.exactly(1).entry {
+                /* do nothing */
+            }
+        }
+
+        fails { // because the count of "A" is less than 3
+            expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.atLeast(3).entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because the count of "B" is more than 2
+            expect(listOf("A", "B", "B", "B")).toContain.inAnyOrder.atMost(2).entry {
+                toEqual("B")
+            }
+        }
+    }
+
+    @Test
     fun elementsOf() {
         expect(listOf("A", "B")).toContain.inAnyOrder.exactly(1).elementsOf(listOf("A", "B"))
         expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.atLeast(2).elementsOf(listOf("A", "B"))

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -9,11 +9,11 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
     fun value() {
         expect(listOf("A")).toContain.inAnyOrder.only.value("A")
 
-        fails { // because subject list does not contain expected value
+        fails { // because the List does not contain expected value
             expect(listOf("B")).toContain.inAnyOrder.only.value("A")
         }
 
-        fails { // because subject list contains multiple elements
+        fails { // because the List contains multiple elements
             expect(listOf("A", "A")).toContain.inAnyOrder.only.value("A")
         }
     }
@@ -34,6 +34,37 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
             expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.values(
                 "D", "C", "B", "A"
             )
+        }
+    }
+
+    @Test
+    fun entry() {
+        expect(listOf("A")).toContain.inAnyOrder.only.entry {
+            toEqual("A")
+        }
+
+        expect(listOf(null)).toContain.inAnyOrder.only.entry(null)
+
+        fails { // because the List does not contain "A"
+            expect(listOf("B")).toContain.inAnyOrder.only.entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because the List does not contain null
+            expect(listOf("A")).toContain.inAnyOrder.only.entry(null)
+        }
+
+        fails { // because the List contains multiple elements
+            expect(listOf("A", "A")).toContain.inAnyOrder.only.entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because assertionCreatorOrNull is non-null and has no expectation
+            expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entry {
+                /* do nothing */
+            }
         }
     }
 

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -9,11 +9,11 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
     fun value() {
         expect(listOf("A")).toContain.inOrder.only.value("A")
 
-        fails { // because subject list does not contain expected value
+        fails { // because the List does not contain expected value
             expect(listOf("B")).toContain.inOrder.only.value("A")
         }
 
-        fails { // because subject list contains multiple elements
+        fails { // because the List contains multiple elements
             expect(listOf("A", "A")).toContain.inOrder.only.value("A")
         }
     }
@@ -46,6 +46,37 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
             expect(listOf("A", "B")).toContain.inOrder.only.values(
                 "B", "A"
             )
+        }
+    }
+
+    @Test
+    fun entry() {
+        expect(listOf("A")).toContain.inOrder.only.entry {
+            toEqual("A")
+        }
+
+        expect(listOf(null)).toContain.inOrder.only.entry(null)
+
+        fails { // because the List does not contain "A"
+            expect(listOf("B")).toContain.inOrder.only.entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because the List does not contain null
+            expect(listOf("A")).toContain.inOrder.only.entry(null)
+        }
+
+        fails { // because the List contains multiple elements
+            expect(listOf("A", "A")).toContain.inOrder.only.entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because assertionCreatorOrNull is non-null and has no expectation
+            expect(listOf("A", "B", "C")).toContain.inOrder.only.entry {
+                /* do nothing */
+            }
         }
     }
 


### PR DESCRIPTION
Issue #1552 

_api-fluent_

- [x] add a entry method in IterableLikeToContainInAnyOrderCreatorSamples for Iterable.toContain.inAnyOrder.entry(...)
- [x] add a entry method in IterableLikeToContainInAnyOrderOnlyCreatorSamples for Iterable.toContain.inAnyOrder.only.entry(...)
- [x] add a entry method in IterableLikeToContainInOrderOnlyCreatorSamples for Iterable.toContain.inOrder.only.entry(...
- [x] link in the KDoc of the corresponding function in iterableLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
