### PR TITLE
samples for Iterable.toContain....entries

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderCreators.kt
@@ -96,6 +96,8 @@ fun <E : Any, T: IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBehaviour>
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.entries
  */
 fun <E : Any, T: IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBehaviour>.entries(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -103,6 +103,8 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBe
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.entries
  */
 fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.entries(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,

--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -93,6 +93,8 @@ fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehav
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.entries
  */
 fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.entries(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?,

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -77,6 +77,68 @@ class IterableLikeToContainInAnyOrderCreatorSamples {
     }
 
     @Test
+    fun entries() {
+        expect(listOf("A", "B")).toContain.inAnyOrder.exactly(1).entries(
+            { toEqual("B") },
+            { toEqual("A") }
+        )
+
+        expect(listOf("A", null, "A", null)).toContain.inAnyOrder.exactly(2).entries(
+            null,
+            { toEqual("A") }
+        )
+
+        expect(listOf(null, null)).toContain.inAnyOrder.exactly(2).entries(
+            null, null, null
+        )
+
+        expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.atLeast(2).entries(
+            { toEqual("B") },
+            { toEqual("A") }
+        )
+
+        expect(listOf("A", "B", "B")).toContain.inAnyOrder.atMost(2).entries(
+            { toEqual("B") },
+            { toEqual("A") }
+        )
+
+        fails { // because the count of "A" is not 2
+            expect(listOf("A", "B", "B")).toContain.inAnyOrder.exactly(2).entries(
+                { toEqual("A") },
+                { toEqual("B") }
+            )
+        }
+
+        fails { // because all elements are not null
+            expect(listOf("A", "B", "C")).toContain.inAnyOrder.exactly(1).entries(
+                { toEqual("A") },
+                null
+            )
+        }
+
+        fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
+            expect(listOf("A", "B")).toContain.inAnyOrder.exactly(1).entries(
+                { toEqual("A") },
+                {}
+            )
+        }
+
+        fails { // because the count of "A" is less than 2
+            expect(listOf("A", "B", "B")).toContain.inAnyOrder.atLeast(2).entries(
+                { toEqual("B") },
+                { toEqual("A") }
+            )
+        }
+
+        fails { // because the count of "B" is more than 2
+            expect(listOf("A", "B", "B", "B")).toContain.inAnyOrder.atMost(2).entries(
+                { toEqual("B") },
+                { toEqual("A") }
+            )
+        }
+    }
+
+    @Test
     fun elementsOf() {
         expect(listOf("A", "B")).toContain.inAnyOrder.exactly(1).elementsOf(listOf("A", "B"))
         expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.atLeast(2).elementsOf(listOf("A", "B"))

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -89,7 +89,7 @@ class IterableLikeToContainInAnyOrderCreatorSamples {
         )
 
         expect(listOf(null, null)).toContain.inAnyOrder.exactly(2).entries(
-            null, null, null
+            null
         )
 
         expect(listOf("A", "B", "A", "B")).toContain.inAnyOrder.atLeast(2).entries(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -119,7 +119,7 @@ class IterableLikeToContainInAnyOrderCreatorSamples {
         fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
             expect(listOf("A", "B")).toContain.inAnyOrder.exactly(1).entries(
                 { toEqual("A") },
-                {}
+                { /* do nothing */ }
             )
         }
 

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -83,7 +83,7 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
             { toEqual("A") }
         )
 
-        fails { // because the List contains an "A" that is not in entries
+        fails { // because the List contains additionally an "A" (not covered in entries)
             expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
                 { toEqual("C") },
                 { toEqual("B") }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -99,7 +99,7 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
             )
         }
 
-        fails { // because the List does not contain a null that is in entries
+        fails { // because the List does not contain a null
             expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
                 { toEqual("C") },
                 { toEqual("B") },

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -90,7 +90,7 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
             )
         }
 
-        fails { // because the List does not contain an "D" that is in entries
+        fails { // because the List does not contain a "D"
             expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
                 { toEqual("D") },
                 { toEqual("C") },

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -69,6 +69,46 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entries() {
+        expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
+            { toEqual("C") },
+            { toEqual("B") },
+            { toEqual("A") }
+        )
+
+        expect(listOf("A", null, "A", null)).toContain.inAnyOrder.only.entries(
+            null,
+            null,
+            { toEqual("A") },
+            { toEqual("A") }
+        )
+
+        fails { // because the List contains an "A" that is not in entries
+            expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
+                { toEqual("C") },
+                { toEqual("B") }
+            )
+        }
+
+        fails { // because the List does not contain an "D" that is in entries
+            expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
+                { toEqual("D") },
+                { toEqual("C") },
+                { toEqual("B") },
+                { toEqual("A") }
+            )
+        }
+
+        fails { // because the List does not contain a null that is in entries
+            expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.entries(
+                { toEqual("C") },
+                { toEqual("B") },
+                null
+            )
+        }
+    }
+
+    @Test
     fun elementsOf() {
         expect(listOf("A", "B", "C")).toContain.inAnyOrder.only.elementsOf(
             listOf("A", "B", "C")

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -106,6 +106,13 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
                 null
             )
         }
+
+        fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
+            expect(listOf("A", "B")).toContain.inAnyOrder.only.entries(
+                { toEqual("A") },
+                { /* do nothing */ }
+            )
+        }
     }
 
     @Test

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -102,7 +102,7 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
             )
         }
 
-        fails { // because the List does not contain an "D" that is in entries
+        fails { // because the List does not contain a "D" at the end
             expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
                 { toEqual("A") },
                 { toEqual("B") },

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -134,6 +134,13 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
                 { toEqual("A") },
             )
         }
+
+        fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
+            expect(listOf("A", "B")).toContain.inOrder.only.entries(
+                { toEqual("A") },
+                { /* do nothing */ }
+            )
+        }
     }
 
     @Test

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -81,6 +81,62 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
     }
 
     @Test
+    fun entries() {
+        expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
+            { toEqual("A") },
+            { toEqual("B") },
+            { toEqual("C") }
+        )
+
+        expect(listOf(null, "A", null, "A")).toContain.inOrder.only.entries(
+            null,
+            { toEqual("A") },
+            null,
+            { toEqual("A") }
+        )
+
+        fails { // because the List contains an "A" that is not in entries
+            expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
+                { toEqual("B") },
+                { toEqual("C") }
+            )
+        }
+
+        fails { // because the List does not contain an "D" that is in entries
+            expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
+                { toEqual("A") },
+                { toEqual("B") },
+                { toEqual("C") },
+                { toEqual("D") }
+            )
+        }
+
+        fails { // because the List does not contain a null that is in entries
+            expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
+                { toEqual("A") },
+                { toEqual("B") },
+                null
+            )
+        }
+
+        fails { // because order is wrong
+            expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
+                { toEqual("C") },
+                { toEqual("B") },
+                { toEqual("A") }
+            )
+        }
+
+        fails { // because order is wrong
+            expect(listOf(null, "A", null)).toContain.inOrder.only.entries(
+                null,
+                null,
+                { toEqual("A") },
+            )
+        }
+    }
+
+    @Test
     fun elementsOf() {
         expect(listOf("A", "B", "C")).toContain.inOrder.only.elementsOf(
             listOf("A", "B", "C")

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -111,7 +111,7 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
             )
         }
 
-        fails { // because the List does not contain a null that is in entries
+        fails { // because the List contains a "C" and not null at the end
             expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
                 { toEqual("A") },
                 { toEqual("B") },

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -95,7 +95,7 @@ class IterableLikeToContainInOrderOnlyCreatorSamples {
             { toEqual("A") }
         )
 
-        fails { // because the List contains an "A" that is not in entries
+        fails { // because the List contains an additional "A" at the beginning
             expect(listOf("A", "B", "C")).toContain.inOrder.only.entries(
                 { toEqual("B") },
                 { toEqual("C") }


### PR DESCRIPTION
Issue #1553 

_api-fluent_

- [x] add a entries method in IterableLikeToContainInAnyOrderCreatorSamples for Iterable.toContain.inAnyOrder.entries(...)
- [x] add a entries method in IterableLikeToContainInAnyOrderOnlyCreatorSamples for Iterable.toContain.inAnyOrder.only.entries(...)
- [x] add a entries method in IterableLikeToContainInOrderOnlyCreatorSamples for Iterable.toContain.inOrder.only.entries(...
- [x] link in the KDoc of the corresponding function in iterableLikeToContain...Creators.kt to the samples via @sample (see charSequenceToContainCreators.kt)
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
