### PR TITLE
###Feature/Add extractors and test samples for SQLException (Took over)

### DIFF
--- a/apis/fluent/atrium-api-fluent/api/main/atrium-api-fluent.api
+++ b/apis/fluent/atrium-api-fluent/api/main/atrium-api-fluent.api
@@ -523,6 +523,13 @@ public final class ch/tutteli/atrium/api/fluent/en_GB/SequenceSubjectChangersKt 
 	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
 }
 
+public final class ch/tutteli/atrium/api/fluent/en_GB/SqlExceptionFeatureExtractorsKt {
+	public static final fun errorCode (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getErrorCode (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun getSqlState (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun sqlState (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
 public final class ch/tutteli/atrium/api/fluent/en_GB/ThirdPartyExpectationsKt {
 	public static final fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
 }

--- a/apis/fluent/atrium-api-fluent/api/using-kotlin-1.9-or-newer/atrium-api-fluent.api
+++ b/apis/fluent/atrium-api-fluent/api/using-kotlin-1.9-or-newer/atrium-api-fluent.api
@@ -523,6 +523,13 @@ public final class ch/tutteli/atrium/api/fluent/en_GB/SequenceSubjectChangersKt 
 	public static final fun asList (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
 }
 
+public final class ch/tutteli/atrium/api/fluent/en_GB/SqlExceptionFeatureExtractorsKt {
+	public static final fun errorCode (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+	public static final fun getErrorCode (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun getSqlState (Lch/tutteli/atrium/creating/Expect;)Lch/tutteli/atrium/creating/FeatureExpect;
+	public static final fun sqlState (Lch/tutteli/atrium/creating/Expect;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
+}
+
 public final class ch/tutteli/atrium/api/fluent/en_GB/ThirdPartyExpectationsKt {
 	public static final fun toHoldThirdPartyExpectation (Lch/tutteli/atrium/creating/Expect;Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lch/tutteli/atrium/creating/Expect;
 }

--- a/apis/fluent/atrium-api-fluent/src/jvmMain/java/module-info.java
+++ b/apis/fluent/atrium-api-fluent/src/jvmMain/java/module-info.java
@@ -3,6 +3,7 @@ module ch.tutteli.atrium.api.fluent.en_GB {
     requires            ch.tutteli.atrium.logic;
     requires            kotlin.stdlib;
     requires            ch.tutteli.kbox;
+    requires java.sql;
 
     exports ch.tutteli.atrium.api.fluent.en_GB;
 }

--- a/apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sqlExceptionFeatureExtractors.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sqlExceptionFeatureExtractors.kt
@@ -1,0 +1,41 @@
+package ch.tutteli.atrium.api.fluent.en_GB
+
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.creating.FeatureExpect
+import java.sql.SQLException
+
+/**
+ * Extracts the [errorCode][SQLException.getErrorCode] property from the subject of the assertion.
+ *
+ * @since 1.3.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.errorCodeFeature
+ */
+val <T : SQLException> Expect<T>.errorCode: FeatureExpect<T, Int>
+    get() = feature("errorCode", SQLException::getErrorCode)
+
+/**
+ * Extracts the [errorCode][SQLException.getErrorCode] property from the subject of the assertion and makes it the new subject.
+ *
+ * @since 1.3.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.sqlStateFeature
+ */
+fun <T : SQLException> Expect<T>.errorCode(assertionCreator: Expect<Int>.() -> Unit) =
+    feature("errorCode", SQLException::getErrorCode, assertionCreator)
+
+/**
+ * Extracts the [sqlState][SQLException.getSQLState] property from the subject of the assertion.
+ *
+ * @since 1.3.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.errorCode
+ */
+val <T : SQLException> Expect<T>.sqlState: FeatureExpect<T, String>
+    get() = feature("sqlState", SQLException::getSQLState)
+
+/**
+ * Extracts the [sqlState][SQLException.getSQLState] property from the subject of the assertion and makes it the new subject.
+ *
+ * @since 1.3.0
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.sqlState
+ */
+fun <T : SQLException> Expect<T>.sqlState(assertionCreator: Expect<String>.() -> Unit) =
+    feature("sqlState", SQLException::getSQLState, assertionCreator)

--- a/apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sqlExceptionFeatureExtractors.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/sqlExceptionFeatureExtractors.kt
@@ -5,37 +5,55 @@ import ch.tutteli.atrium.creating.FeatureExpect
 import java.sql.SQLException
 
 /**
- * Extracts the [errorCode][SQLException.getErrorCode] property from the subject of the assertion.
+ * Creates an [Expect] for the result of calling `getErrorCode()` on the subject of `this` expectation,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.errorCodeFeature
  *
  * @since 1.3.0
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.errorCodeFeature
  */
 val <T : SQLException> Expect<T>.errorCode: FeatureExpect<T, Int>
     get() = feature("errorCode", SQLException::getErrorCode)
 
 /**
- * Extracts the [errorCode][SQLException.getErrorCode] property from the subject of the assertion and makes it the new subject.
+ * Expects that the result of calling `getErrorCode()` on the subject of `this` expectation
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of `this` expectation.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.sqlStateFeature
  *
  * @since 1.3.0
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.sqlStateFeature
  */
 fun <T : SQLException> Expect<T>.errorCode(assertionCreator: Expect<Int>.() -> Unit) =
     feature("errorCode", SQLException::getErrorCode, assertionCreator)
 
 /**
- * Extracts the [sqlState][SQLException.getSQLState] property from the subject of the assertion.
+ * Creates an [Expect] for the result of calling `getSQLState()` on the subject of `this` expectation,
+ * so that further fluent calls are assertions about it.
+ *
+ * @return The newly created [Expect] for the extracted feature.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.errorCode
  *
  * @since 1.3.0
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.errorCode
  */
 val <T : SQLException> Expect<T>.sqlState: FeatureExpect<T, String>
     get() = feature("sqlState", SQLException::getSQLState)
 
 /**
- * Extracts the [sqlState][SQLException.getSQLState] property from the subject of the assertion and makes it the new subject.
+ * Expects that the result of calling `getSQLState()` on the subject of `this` expectation
+ * holds all assertions the given [assertionCreator] creates for it and
+ * returns an [Expect] for the current subject of `this` expectation.
+ *
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.sqlState
  *
  * @since 1.3.0
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.SQLExceptionFeaturesSamples.sqlState
  */
 fun <T : SQLException> Expect<T>.sqlState(assertionCreator: Expect<String>.() -> Unit) =
     feature("sqlState", SQLException::getSQLState, assertionCreator)

--- a/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/SQLExceptionFeatureExtractorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/SQLExceptionFeatureExtractorSamples.kt
@@ -12,15 +12,15 @@ class SQLExceptionFeaturesSamples {
         val exception = SQLException("Test exception", "42000", 1001)
 
         expect(exception)
-            .errorCode                                            // subject is now of type Int
+            .errorCode                     // subject is now of type Int
             .toEqual(1001)
 
         fails {
             expect(exception)
-                .errorCode                                        // subject is now of type Int
-                .toEqual(9999)                           // fails
-                .toBeGreaterThan(1000)                   // not evaluated/reported because `toEqual` already fails
-        //                                                        use `.errorCode { ... }` if you want all assertions evaluated
+                .errorCode                 // subject is now of type Int
+                .toEqual(9999)             // fails
+                .toBeGreaterThan(1000)     // not evaluated/reported because `toEqual` already fails
+            //                                `.errorCode { ... }` if you want all assertions evaluated
         }
     }
 
@@ -28,15 +28,15 @@ class SQLExceptionFeaturesSamples {
     fun errorCode() {
         val exception = SQLException("Test exception", "42000", 1001)
 
-        expect(exception).errorCode {               // subject within this expectation-group is of type Int
+        expect(exception).errorCode {      // subject within this expectation-group is of type Int
             toBeGreaterThan(1000)
             toEqual(1001)
-        }                                                         // subject here is back to type SQLException
+        }                                  // subject here is back to type SQLException
 
         fails {
             expect(exception).errorCode {
-                toEqual(9999)                            // fails
-                toBeGreaterThan(1000)                    // still evaluated even though `toEqual` already fails
+                toEqual(9999)              // fails
+                toBeGreaterThan(1000)      // still evaluated even though `toEqual` already fails
             }
         }
     }
@@ -46,15 +46,15 @@ class SQLExceptionFeaturesSamples {
         val exception = SQLException("Test exception", "42000", 1001)
 
         expect(exception)
-            .sqlState                                           // subject is now of type String
+            .sqlState                      // subject is now of type String
             .toEqual("42000")
 
         fails {
             expect(exception)
-                .sqlState                                       // subject is now of type String
-                .toEqual("00000")                      // fails
-                .toContain("42")                       // not evaluated/reported because `toEqual` already fails
-            //                                                  use `.sqlState { ... }` if you want all assertions evaluated
+                .sqlState                  // subject is now of type String
+                .toEqual("00000")          // fails
+                .toContain("42")           // not evaluated/reported because `toEqual` already fails
+            //                                use `.sqlState { ... }` if you want all assertions evaluated
         }
     }
 
@@ -64,15 +64,15 @@ class SQLExceptionFeaturesSamples {
     fun sqlState() {
         val exception = SQLException("Test exception", "42000", 1001)
 
-        expect(exception).sqlState {           // subject within this expectation-group is of type String
+        expect(exception).sqlState {       // subject within this expectation-group is of type String
             toEqual("42000")
             toContain("42")
-        }                                                      // subject here is back to type SQLException
+        }                                  // subject here is back to type SQLException
 
         fails {
             expect(exception).sqlState {
-                toEqual("00000")                      // fails
-                toContain("42")                       // still evaluated even though `toEqual` already fails
+                toEqual("00000")           // fails
+                toContain("42")            // still evaluated even though `toEqual` already fails
             }
         }
     }

--- a/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/SQLExceptionFeatureExtractorSamples.kt
+++ b/apis/fluent/atrium-api-fluent/src/jvmTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/samples/SQLExceptionFeatureExtractorSamples.kt
@@ -1,0 +1,79 @@
+package ch.tutteli.atrium.api.fluent.en_GB.samples
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import java.sql.SQLException
+import kotlin.test.Test
+
+class SQLExceptionFeaturesSamples {
+
+    @Test
+    fun errorCodeFeature() {
+        val exception = SQLException("Test exception", "42000", 1001)
+
+        expect(exception)
+            .errorCode                                            // subject is now of type Int
+            .toEqual(1001)
+
+        fails {
+            expect(exception)
+                .errorCode                                        // subject is now of type Int
+                .toEqual(9999)                           // fails
+                .toBeGreaterThan(1000)                   // not evaluated/reported because `toEqual` already fails
+        //                                                        use `.errorCode { ... }` if you want all assertions evaluated
+        }
+    }
+
+    @Test
+    fun errorCode() {
+        val exception = SQLException("Test exception", "42000", 1001)
+
+        expect(exception).errorCode {               // subject within this expectation-group is of type Int
+            toBeGreaterThan(1000)
+            toEqual(1001)
+        }                                                         // subject here is back to type SQLException
+
+        fails {
+            expect(exception).errorCode {
+                toEqual(9999)                            // fails
+                toBeGreaterThan(1000)                    // still evaluated even though `toEqual` already fails
+            }
+        }
+    }
+
+    @Test
+    fun sqlStateFeature() {
+        val exception = SQLException("Test exception", "42000", 1001)
+
+        expect(exception)
+            .sqlState                                           // subject is now of type String
+            .toEqual("42000")
+
+        fails {
+            expect(exception)
+                .sqlState                                       // subject is now of type String
+                .toEqual("00000")                      // fails
+                .toContain("42")                       // not evaluated/reported because `toEqual` already fails
+            //                                                  use `.sqlState { ... }` if you want all assertions evaluated
+        }
+    }
+
+
+
+    @Test
+    fun sqlState() {
+        val exception = SQLException("Test exception", "42000", 1001)
+
+        expect(exception).sqlState {           // subject within this expectation-group is of type String
+            toEqual("42000")
+            toContain("42")
+        }                                                      // subject here is back to type SQLException
+
+        fails {
+            expect(exception).sqlState {
+                toEqual("00000")                      // fails
+                toContain("42")                       // still evaluated even though `toEqual` already fails
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #1421 
this PR is derived from https://github.com/robstoll/atrium/pull/1779

What I did:
- [x] rebased onto latest branch
- [x] align the comments in sqlExceptionFeatureExtractors.kt
- [x] adjust the KDoc in SQLExceptionFeatureExtractorSamples.kt
- [x] generate the api for Kotlin 1.9 and newer
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
