### PR TITLE
workaround spek bug that all specs are executed

### DIFF
--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-multiplatform.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-multiplatform.gradle.kts
@@ -27,11 +27,6 @@ kotlin {
     jvm {
         // for module-info.java and Java sources in test
         withJava()
-        testRuns["test"].executionTask.configure {
-            useJUnitPlatform {
-                includeEngines("spek2", "junit-jupiter")
-            }
-        }
     }
 
     js(IR) {
@@ -76,5 +71,20 @@ kotlin {
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
     rootProject.configure<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension> {
         lockFileDirectory = rootProject.projectDir.resolve("gradle")
+    }
+}
+
+// need to do it afterEvaluate as the spek plugin adds spek and we don't want it
+// also the reason why we don't addIncludeEngines but set it
+project.afterEvaluate {
+    kotlin {
+        jvm {
+            // for module-info.java and Java sources in test
+            testRuns["test"].executionTask.configure {
+                useJUnitPlatform {
+                    includeEngines = setOf("spek2-atrium", "junit-jupiter")
+                }
+            }
+        }
     }
 }

--- a/logic/atrium-logic/src/commonTest/kotlin/ch/tutteli/atrium/logic/utils/CollectAndAppendLogicTest.kt
+++ b/logic/atrium-logic/src/commonTest/kotlin/ch/tutteli/atrium/logic/utils/CollectAndAppendLogicTest.kt
@@ -1,0 +1,22 @@
+package ch.tutteli.atrium.logic.utils
+
+import ch.tutteli.atrium.api.fluent.en_GB.feature
+import ch.tutteli.atrium.api.fluent.en_GB.toBeAnInstanceOf
+import ch.tutteli.atrium.api.fluent.en_GB.toContainExactly
+import ch.tutteli.atrium.api.verbs.internal.expect
+import kotlin.test.Test
+
+class CollectAndAppendLogicTest {
+
+    @Test
+    fun workAsExpected() {
+        data class Dummy(val l: List<Any>)
+
+        expect(Dummy(listOf(1, "hello"))).toBeAnInstanceOf<Dummy> {
+            feature { f(it::l) }.toContainExactly(
+                { toBeAnInstanceOf<Int>() },
+                { toBeAnInstanceOf<String>() }
+            )
+        }
+    }
+}

--- a/misc/atrium-specs/build.gradle.kts
+++ b/misc/atrium-specs/build.gradle.kts
@@ -28,12 +28,18 @@ kotlin {
         jvmMain {
             dependencies {
                 api(libs.mockk.jvm)
-                api(libs.spek.jvm)
                 api(libs.niok)
                 api(libs.tutteli.spek)
                 api(libs.mockitoKotlin)
                 api(kotlin("test-junit5"))
                 api(libs.junit.platform.commons)
+
+                //TODO 1.5.0 remove once we moved away from spek
+                api(libs.spek.jvm)
+                implementation(libs.spek.runner)
+                implementation(libs.spek.runtime)
+                implementation(libs.junit.platform.console)
+
             }
         }
 

--- a/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/AtriumSpekBasedTestEngine.kt
+++ b/misc/atrium-specs/src/jvmMain/kotlin/ch/tutteli/atrium/specs/AtriumSpekBasedTestEngine.kt
@@ -1,0 +1,116 @@
+package ch.tutteli.atrium.specs
+
+import org.junit.platform.engine.*
+import org.junit.platform.engine.discovery.ClassSelector
+import org.junit.platform.engine.discovery.ClasspathRootSelector
+import org.junit.platform.engine.discovery.PackageSelector
+import org.spekframework.spek2.junit.JUnitEngineExecutionListenerAdapter
+import org.spekframework.spek2.junit.SpekEngineDescriptor
+import org.spekframework.spek2.junit.SpekTestDescriptor
+import org.spekframework.spek2.junit.SpekTestDescriptorFactory
+import org.spekframework.spek2.runtime.JvmDiscoveryContextFactory
+import org.spekframework.spek2.runtime.SpekRuntime
+import org.spekframework.spek2.runtime.execution.DiscoveryRequest
+import org.spekframework.spek2.runtime.execution.ExecutionRequest
+import org.spekframework.spek2.runtime.scope.Path
+import org.spekframework.spek2.runtime.scope.PathBuilder
+import java.lang.reflect.Modifier
+import java.nio.file.Paths
+import org.junit.platform.engine.ExecutionRequest as JUnitExecutionRequest
+
+class AtriumSpekBasedTestEngine : TestEngine {
+    private val spekRuntime by lazy { SpekRuntime() }
+    private val descriptorFactory = SpekTestDescriptorFactory()
+
+    override fun getId(): String = "spek2-atrium"
+
+    override fun discover(discoveryRequest: EngineDiscoveryRequest, uniqueId: UniqueId): TestDescriptor {
+        val engineDescriptor = SpekEngineDescriptor(uniqueId, id)
+
+        val sourceDirs = discoveryRequest.getSelectorsByType(ClasspathRootSelector::class.java)
+            .map { it.classpathRoot }
+            .map { Paths.get(it) }
+            .map { it.toString() }
+
+        val classSelectors = discoveryRequest.getSelectorsByType(ClassSelector::class.java)
+            .filter {
+                // get all super classes
+                val superClasses = mutableListOf<String>()
+                var current = it.javaClass.superclass
+                while (current != null) {
+                    superClasses.add(current.name)
+                    current = current.superclass
+                }
+
+                superClasses.contains("org.spekframework.spek2.Spek")
+            }
+            .filter {
+                !(it.javaClass.isAnonymousClass
+                    || it.javaClass.isLocalClass
+                    || it.javaClass.isSynthetic
+                    || Modifier.isAbstract(it.javaClass.modifiers))
+            }.map {
+                PathBuilder
+                    .from(it.javaClass.kotlin)
+                    .build()
+            }
+
+        val packageSelectors = discoveryRequest.getSelectorsByType(PackageSelector::class.java)
+            .map {
+                PathBuilder()
+                    .appendPackage(it.packageName)
+                    .build()
+            }
+
+        val filters = linkedSetOf<Path>()
+
+        filters.addAll(classSelectors)
+        filters.addAll(packageSelectors)
+
+//        // todo: empty filter should imply root
+//        if (filters.isEmpty()) {
+//            filters.add(PathBuilder.ROOT)
+//        }
+
+        // won't find anything without filter hence can return empty engine descriptor
+        if (filters.isEmpty()) {
+            return engineDescriptor
+        }
+
+        val context = JvmDiscoveryContextFactory.create(sourceDirs)
+
+        val discoveryResult = spekRuntime.discover(DiscoveryRequest(context, filters.toList()))
+
+        discoveryResult.roots
+            .map { descriptorFactory.create(it) }
+            .forEach(engineDescriptor::addChild)
+
+        return engineDescriptor
+
+    }
+
+    override fun execute(request: JUnitExecutionRequest) {
+        try {
+            val roots = request.rootTestDescriptor.children
+                .filterIsInstance<SpekTestDescriptor>()
+                .map(SpekTestDescriptor::scope)
+
+            val executionRequest = ExecutionRequest(
+                roots, JUnitEngineExecutionListenerAdapter(request.engineExecutionListener, descriptorFactory)
+            )
+
+            spekRuntime.execute(executionRequest)
+        } catch (t: Throwable) {
+            t.printStackTrace()
+            request.fail(t)
+        }
+    }
+
+    private fun JUnitExecutionRequest.fail(throwable: Throwable) {
+        engineExecutionListener.executionFinished(
+            rootTestDescriptor,
+            TestExecutionResult.failed(throwable)
+        )
+    }
+}
+

--- a/misc/atrium-specs/src/jvmMain/resources/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/misc/atrium-specs/src/jvmMain/resources/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,1 @@
+ch.tutteli.atrium.specs.AtriumSpekBasedTestEngine


### PR DESCRIPTION
introduce own engine based on SpekTestEngine but which fixes the discovery so that we can run single samples again



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
