### PR TITLE
fix compileOnly issues in JS use api for translation

### DIFF
--- a/apis/fluent/atrium-api-fluent/build.gradle.kts
+++ b/apis/fluent/atrium-api-fluent/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
         commonMain {
             dependencies {
                 api(prefixedProject("logic"))
-                compileOnly(prefixedProject("translations-en_GB"))
             }
         }
 

--- a/apis/infix/atrium-api-infix/build.gradle.kts
+++ b/apis/infix/atrium-api-infix/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
         commonMain {
             dependencies {
                 api(prefixedProject("logic"))
-                compileOnly(prefixedProject("translations-en_GB"))
             }
         }
 

--- a/logic/atrium-logic/build.gradle.kts
+++ b/logic/atrium-logic/build.gradle.kts
@@ -12,8 +12,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(prefixedProject("core"))
-                // it is up to the consumer which atrium-translations module is used at runtime
-                compileOnly(prefixedProject("translations-en_GB"))
+                api(prefixedProject("translations-en_GB"))
             }
         }
         jvmMain {

--- a/misc/atrium-verbs-internal/build.gradle.kts
+++ b/misc/atrium-verbs-internal/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
             dependencies {
                 api(prefixedProject("logic"))
                 api(prefixedProject("test-factory"))
-                compileOnly(prefixedProject("translations-en_GB"))
+                api(prefixedProject("translations-en_GB"))
             }
         }
 

--- a/misc/atrium-verbs/build.gradle.kts
+++ b/misc/atrium-verbs/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
             dependencies {
                 api(prefixedProject("logic"))
                 api(prefixedProject("test-factory"))
-                compileOnly(prefixedProject("translations-en_GB"))
+                api(prefixedProject("translations-en_GB"))
             }
         }
 


### PR DESCRIPTION
because we no longer support de_CH anyway and will most likely not depend on translation-en_GB at the end of 1.3.0 we can also just use api



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
