### PR TITLE
improve workaround for js double ex msg printing, allow to query message

### DIFF
--- a/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
+++ b/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/reporting/AtriumError.kt
@@ -22,25 +22,32 @@ actual class AtriumError private constructor(
 
     internal actual constructor(message: String, rootAssertion: Assertion) : this(message, rootAssertion, Unit)
 
+
+
     override val message: String?
         get() {
+            // workaround for intellij's double print exception message problem. Intellij is outputting the message once
+            // as message and once as part of the stack-trace (no idea why they do it) -- see also
             val process = js("process.env._") as? String
-            return if (process?.contains("idea") == true) {
-                "".also {
-                    // if the process contains idea, then we assume we deal with intellij-idea and that it suffers
-                    // from the double print exception message problem by outputting the message once as message and
-                    // once as part of the stack-trace (no idea why they do it).
-                    // Currently, kotlin calls `message` twice, once when populating the stacktrace and once when
-                    // reporting the failure. To work around the bug we return an empty string for the `message`
-                    // and instead print it when intellij most likely wants to report the failure
-                    //
-                    // we tried to sneak it into the stack (as it is a String) but it looks like intellij-idea does a
-                    // post-processing of the stack and double prints it again *sight*
-                    if (Error().stackBacktrace.first().contains("AtriumError")) {
-                        println("\n" + internalMessage)
-                    }
-                }
-            } else {
+            return process?.takeIf {
+                // if there is a process.env and it contains idea, then we assume we deal with intellij-idea
+                it.contains("idea")
+            }?.takeIf {
+                // Currently, kotlin calls `message` twice, once when populating the stacktrace (in this case the
+                // first stacktrace does not contain AtriumError) and once when reporting the failure (here AtriumError
+                // is in the first stacktrace). To work around the bug we return an empty string for the `message`
+                // and instead print it when intellij most likely wants to report the failure
+                // (with the benefit that we get coloured code).
+                //
+                // we tried to sneak the message into the stack (as it is a String) instead of printing it but it looks
+                // like intellij-idea does a post-processing of the stack and double prints it again *sight*
+                // in any case, the added benefit of a coloured output seems worth this hack.
+                val stack = Error().stackBacktrace
+                stack.first().startsWith("AtriumError") && stack.any { it.startsWith("Runner.fail") }
+            }?.let {
+                println("\n" + internalMessage)
+                ""
+            } ?: run {
                 internalMessage
             }
         }


### PR DESCRIPTION
With the current workaround, one gets an empty `message` when working in Intellij (e.g. running tests in Intellij). Make sure we only return empty message (and print the message instead) in case of reporting the failure via mocha



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
