### PR TITLE
#1884 take surrogate code points into account in RegexSearcher

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainRegexExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainRegexExpectationsSpec.kt
@@ -9,13 +9,21 @@ class CharSequenceToContainRegexExpectationsSpec : Spek({
     include(StringSpec)
     include(RegexSpec)
 
-
     describe("context 'aaaa'") {
         it("search for 'aa' finds 3 hits since we want non-disjoint matches") {
             expect("aaaa") toContain o exactly 3 regex "aa"
         }
         it("search for 'aa?' finds 4 hits since we want non-disjoint matches") {
             expect("aaaa") toContain o exactly 4 regex "aa?"
+        }
+    }
+    describe("context ''") {
+        val g = "🚩\uFE0F"
+        it("search for '$g$g' finds 3 hits since we want non-disjoint matches") {
+            expect("$g$g$g$g") toContain o exactly 3 regex "$g$g"
+        }
+        it("search for '$g($g)?' finds 4 hits since we want non-disjoint matches") {
+            expect("$g$g$g$g") toContain o exactly 4 regex "$g($g)?"
         }
     }
 }) {
@@ -60,7 +68,12 @@ class CharSequenceToContainRegexExpectationsSpec : Spek({
             if (aX.isEmpty()) expect toContain o atLeast atLeast regex a
             else expect toContain o atLeast atLeast the regexPatterns(a, *aX)
 
-        private fun toContainAtLeastRegex(expect: Expect<CharSequence>, atLeast: Int, a: String, aX: Array<out String>) =
+        private fun toContainAtLeastRegex(
+            expect: Expect<CharSequence>,
+            atLeast: Int,
+            a: String,
+            aX: Array<out String>
+        ) =
             if (aX.isEmpty()) expect toContain o atLeast atLeast matchFor Regex(a)
             else expect toContain o atLeast atLeast matchFor all(Regex(a), *aX.map { it.toRegex() }.toTypedArray())
 

--- a/atrium-core/api/main/atrium-core.api
+++ b/atrium-core/api/main/atrium-core.api
@@ -647,6 +647,10 @@ public final class ch/tutteli/atrium/core/Some : ch/tutteli/atrium/core/Option {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class ch/tutteli/atrium/core/polyfills/CharExtensionsKt {
+	public static final fun isHighSurrogate (C)Z
+}
+
 public final class ch/tutteli/atrium/core/polyfills/FormatFloatingPointNumberKt {
 	public static final fun formatFloatingPointNumber (Ljava/lang/Number;)Ljava/lang/String;
 }

--- a/atrium-core/api/using-kotlin-1.9-or-newer/atrium-core.api
+++ b/atrium-core/api/using-kotlin-1.9-or-newer/atrium-core.api
@@ -647,6 +647,10 @@ public final class ch/tutteli/atrium/core/Some : ch/tutteli/atrium/core/Option {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class ch/tutteli/atrium/core/polyfills/CharExtensionsKt {
+	public static final fun isHighSurrogate (C)Z
+}
+
 public final class ch/tutteli/atrium/core/polyfills/FormatFloatingPointNumberKt {
 	public static final fun formatFloatingPointNumber (Ljava/lang/Number;)Ljava/lang/String;
 }

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/core/polyfills/charExtensions.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/core/polyfills/charExtensions.kt
@@ -1,0 +1,9 @@
+package ch.tutteli.atrium.core.polyfills
+
+/**
+ * Indicates if the char is a [High-Surrogate Code Unit](http://www.unicode.org/glossary/#high_surrogate_code_unit).
+ * @return true if it is a high-surrogate code unit, false otherwise.
+ *
+ * @since 1.3.0
+ */
+expect fun Char.isHighSurrogate(): Boolean

--- a/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/core/polyfills/isHighSurrogate.kt
+++ b/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/core/polyfills/isHighSurrogate.kt
@@ -1,0 +1,8 @@
+package ch.tutteli.atrium.core.polyfills
+
+const val SURROGATE_RANGE_START = '\uD800'
+const val SURROGATE_RANGE_END_INCLUSIVE = '\uDBFF'
+
+actual fun Char.isHighSurrogate(): Boolean =
+    this >= SURROGATE_RANGE_START && this <= SURROGATE_RANGE_END_INCLUSIVE;
+

--- a/atrium-core/src/jvmMain/kotlin/ch/tutteli/atrium/core/polyfills/charExtensions.kt
+++ b/atrium-core/src/jvmMain/kotlin/ch/tutteli/atrium/core/polyfills/charExtensions.kt
@@ -1,0 +1,4 @@
+package ch.tutteli.atrium.core.polyfills
+
+actual fun Char.isHighSurrogate(): Boolean = Character.isHighSurrogate(this)
+

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/RegexSearcher.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/RegexSearcher.kt
@@ -11,10 +11,14 @@ import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.N
 class RegexSearcher : Searcher<NoOpSearchBehaviour, Regex> {
     override fun search(searchIn: CharSequence, searchFor: Regex): Int {
         var counter = 0
-        var matchResult = searchFor.find(searchIn)
+        val searchInString = searchIn.toString()
+        var matchResult = searchFor.find(searchInString)
         while (matchResult != null) {
-            matchResult = searchFor.find(searchIn, matchResult.range.first + 1)
             ++counter
+            val startIndex = matchResult.range.first.let { startIndex ->
+                startIndex + if (searchInString[startIndex].isHighSurrogate()) 2 else 1
+            }
+            matchResult = searchFor.find(searchIn, startIndex)
         }
         return counter
     }


### PR DESCRIPTION
because if a Pattern (in java) uses BnMS then chars with two code points (high and low surrogate) match even if the start index points to the lower surrogate.

fixes #1884 


______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
