### PR TITLE
[Infix] Add samples for iterableLikeToContainInAnyOrderCreators

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderCreators.kt
@@ -24,6 +24,8 @@ import ch.tutteli.atrium.logic.utils.toVarArg
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.value
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 infix fun <E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.value(expected: E): Expect<T> =
@@ -49,6 +51,8 @@ infix fun <E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.val
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.values
+ *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
 infix fun <E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.the(values: Values<E>): Expect<T> =
@@ -66,6 +70,8 @@ infix fun <E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.the
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.entry
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -85,6 +91,8 @@ infix fun <E : Any, T : IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBeh
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
  * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.entries
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
  */
@@ -112,7 +120,7 @@ infix fun <E : Any, T : IterableLike> CheckerStep<out E?, T, InAnyOrderSearchBeh
  *
  * @since 0.13.0
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.elementsOf
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderCreatorSamples.elementsOf
  */
 inline infix fun <reified E, T : IterableLike> CheckerStep<E, T, InAnyOrderSearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderCreatorSamples.kt
@@ -1,0 +1,167 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.atLeast
+import ch.tutteli.atrium.api.infix.en_GB.atMost
+import ch.tutteli.atrium.api.infix.en_GB.elementsOf
+import ch.tutteli.atrium.api.infix.en_GB.entries
+import ch.tutteli.atrium.api.infix.en_GB.entry
+import ch.tutteli.atrium.api.infix.en_GB.exactly
+import ch.tutteli.atrium.api.infix.en_GB.inAny
+import ch.tutteli.atrium.api.infix.en_GB.it
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.api.infix.en_GB.order
+import ch.tutteli.atrium.api.infix.en_GB.the
+import ch.tutteli.atrium.api.infix.en_GB.toContain
+import ch.tutteli.atrium.api.infix.en_GB.toEqual
+import ch.tutteli.atrium.api.infix.en_GB.value
+import ch.tutteli.atrium.api.infix.en_GB.values
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+class IterableLikeToContainInAnyOrderCreatorSamples {
+    @Test
+    fun value() {
+        expect(listOf("A", "B")) toContain o inAny order exactly 1 value "A"
+        expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 2 value ("A")
+        expect(listOf("A", "B", "B")) toContain o inAny order atMost 2 value "B"
+
+        fails {
+            expect(listOf("A", "B")) toContain o inAny order exactly 2 value "A"
+            expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 3 value "A"
+            expect(listOf("A", "B", "B", "B")) toContain o inAny order atMost 2 value "B"
+        }
+    }
+
+    @Test
+    fun values() {
+        expect(listOf("A", "B")) toContain o inAny order exactly 1 the values("B", "A")
+        expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 2 the values("B", "A")
+        expect(listOf("A", "B", "B")) toContain o inAny order atMost 2 the values("B", "A")
+
+        fails {
+            expect(listOf("A", "B")) toContain o inAny order exactly 2 the values("B", "A")
+            expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 3 the values("B", "A")
+            expect(listOf("A", "B", "B", "B")) toContain o inAny order atMost 2 the values("B", "A")
+        }
+    }
+
+    @Test
+    fun entry() {
+        expect(listOf("A", "B")) toContain o inAny order exactly 1 entry {
+            it toEqual "A"
+        }
+
+        expect(listOf("A", null, null)) toContain o inAny order exactly 2 entry null // null is identified
+
+        expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 2 entry {
+            it toEqual "A"
+        }
+
+        expect(listOf("A", "B", "B")) toContain o inAny order atMost 2 entry {
+            it toEqual "A"
+        }
+
+        fails { // because the count of "A" is not 2
+            expect(listOf("A", "B")) toContain o inAny order exactly 2 entry {
+                it toEqual "A"
+            }
+        }
+
+        fails { // because all elements are not null
+            expect(listOf("A", "B", "C")) toContain o inAny order exactly 1 entry null
+        }
+
+        fails { // because assertionCreatorOrNull is non-null and has no expectation
+            expect(listOf("A", "B", "A", "B")) toContain o inAny order exactly 1 entry {
+                /* do nothing */
+            }
+        }
+
+        fails { // because the count of "A" is less than 3
+            expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 3 entry {
+                it toEqual "A"
+            }
+        }
+
+        fails { // because the count of "B" is more than 2
+            expect(listOf("A", "B", "B", "B")) toContain o inAny order atMost 2 entry {
+                it toEqual "B"
+            }
+        }
+    }
+
+    @Test
+    fun entries() {
+        expect(listOf("A", "B")) toContain o inAny order exactly 1 the entries(
+            { it toEqual "B" },
+            { it toEqual "A" }
+        )
+
+        expect(listOf("A", null, "A", null)) toContain o inAny order exactly 2 the entries(
+            null,
+            { it toEqual "A" }
+        )
+
+        expect(listOf(null, null)) toContain o inAny order exactly 2 the entries(
+            null
+        )
+
+        expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 2 the entries(
+            { it toEqual "B" },
+            { it toEqual "A" }
+        )
+
+        expect(listOf("A", "B", "B")) toContain o inAny order atMost 2 the entries(
+            { it toEqual "B" },
+            { it toEqual "A" }
+        )
+
+        fails { // because the count of "A" is not 2
+            expect(listOf("A", "B", "B")) toContain o inAny order exactly 2 the entries(
+                { it toEqual "A" },
+                { it toEqual "B" }
+            )
+        }
+
+        fails { // because all elements are not null
+            expect(listOf("A", "B", "C")) toContain o inAny order exactly 1 the entries(
+                { it toEqual "A" },
+                null
+            )
+        }
+
+        fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
+            expect(listOf("A", "B")) toContain o inAny order exactly 1 the entries(
+                { it toEqual "A" },
+                { /* do nothing */ }
+            )
+        }
+
+        fails { // because the count of "A" is less than 2
+            expect(listOf("A", "B", "B")) toContain o inAny order atLeast 2 the entries(
+                { it toEqual "B" },
+                { it toEqual "A" }
+            )
+        }
+
+        fails { // because the count of "B" is more than 2
+            expect(listOf("A", "B", "B", "B")) toContain o inAny order atMost 2 the entries(
+                { it toEqual "B" },
+                { it toEqual "A" }
+            )
+        }
+    }
+
+    @Test
+    fun elementsOf() {
+        expect(listOf("A", "B")) toContain o inAny order exactly 1 elementsOf listOf("A", "B")
+        expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 2 elementsOf listOf("A", "B")
+        expect(listOf("A", "B", "B")) toContain o inAny order atMost 2 elementsOf listOf("A", "B")
+
+        fails {
+            expect(listOf("A", "B")) toContain o inAny order exactly 2 elementsOf listOf("A", "B")
+            expect(listOf("A", "B", "A", "B")) toContain o inAny order atLeast 3 elementsOf listOf("A", "B")
+            expect(listOf("A", "B", "B", "B")) toContain o inAny order atMost 2 elementsOf listOf("A", "B")
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1910 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
