### PR TITLE
Add iterable like to contain in any order only creator samples to api infix

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInAnyOrderOnlyCreators.kt
@@ -27,6 +27,8 @@ import kotlin.jvm.JvmName
  *
  * @param expected The value which is expected to be contained within the [IterableLike].
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.value
+ *
  * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
@@ -40,6 +42,8 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehavio
  * @param values The values which are expected to be contained within the [IterableLike]
  *   -- use the function `values(t, ...)` to create a [Values].
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.values
+ *
  * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.the(values: Values<E>): Expect<T> =
@@ -52,6 +56,8 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehavio
  * @param values The values which are expected to be contained within the [IterableLike] plus a lambda configuring
  *   the [InAnyOrderOnlyReportingOptions] -- use the function `values(t, ..., reportOptionsInAnyOrderOnly = { ... })`
  *   to create a [WithInAnyOrderOnlyReportingOptions] with a wrapped [Values].
+ *
+ *  @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.values
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -71,6 +77,8 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehavio
  * @param assertionCreatorOrNull The identification lambda which creates the assertions which the entry we are looking
  *   for has to hold; or in other words, the function which defines whether an entry is the one we are looking for
  *   or not. In case it is defined as `null`, then an entry is identified if it is `null` as well.
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.entry
  *
  * @return an [Expect] for the subject of `this` expectation.
  */
@@ -95,6 +103,8 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  * @param entries The entries which are expected to be contained within the [IterableLike]
  *   -- use the function `entries(t, ...)` to create an [Entries].
  *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.entries
+ *
  * @return an [Expect] for the subject of `this` expectation.
  */
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySearchBehaviour>.the(
@@ -118,6 +128,8 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  * @param entries The entries which are expected to be contained within the [IterableLike] plus a lambda configuring
  *   the [InAnyOrderOnlyReportingOptions] -- use the function `entries(t, ..., reportOptionsInAnyOrderOnly = { ... })`
  *   to create a [WithInAnyOrderOnlyReportingOptions] with a wrapped [Entries].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.entries
  *
  * @return an [Expect] for the subject of `this` expectation.
  *
@@ -145,9 +157,11 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InAnyOrderOnlySe
  *   [Iterable], [Sequence] or one of the [Array] types
  *   or the given [expectedIterableLike] does not have elements (is empty).
  *
- * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.elementsOf
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInAnyOrderOnlyCreatorSamples.elementsOf
+ * @return an [Expect] for the subject of `this` expectation.
+ *
+ * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
  */
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike
@@ -172,6 +186,10 @@ inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InAnyOrderOn
  * @throws IllegalArgumentException in case the wrapped [IterableLike] is not
  *   an [Iterable], [Sequence] or one of the [Array] types
  *   or the wrapped [IterableLike] does not have elements (is empty).
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.elementsOf
+ *
+ * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.18.0
  */

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -1,0 +1,138 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+import ch.tutteli.atrium.api.infix.en_GB.inAny
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.api.infix.en_GB.*
+
+class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
+    @Test
+    fun value() {
+        expect(listOf("A")) toContain o inAny order but only value("A")
+
+        fails { // because the List does not contain expected value
+            expect(listOf("B")) toContain o inAny order but only value("A")
+        }
+
+        fails { // because the List contains multiple elements
+            expect(listOf("A", "A")) toContain o inAny order but only value("A")
+        }
+    }
+
+    @Test
+    fun values() {
+        expect(listOf("A", "B", "C")) toContain o inAny order but only the values(
+            "C", "B", "A"
+        )
+
+        fails { // because not all elements found
+            expect(listOf("A", "B", "C")) toContain o inAny order but only the values(
+                "B", "A"
+            )
+        }
+
+        fails { // because more elements expected than found
+            expect(listOf("A", "B", "C")) toContain o inAny order but only the values(
+                "D", "C", "B", "A"
+            )
+        }
+    }
+
+    @Test
+    fun entry() {
+        expect(listOf("A")) toContain o inAny order but only entry {
+            toEqual("A")
+        }
+
+        expect(listOf(null)) toContain o inAny order but only entry(null)
+
+        fails { // because the List does not contain "A"
+            expect(listOf("B")) toContain o inAny order but only entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because the List does not contain null
+            expect(listOf("A")) toContain o inAny order but only entry(null)
+        }
+
+        fails { // because the List contains multiple elements
+            expect(listOf("A", "A")) toContain o inAny order but only entry {
+                toEqual("A")
+            }
+        }
+
+        fails { // because assertionCreatorOrNull is non-null and has no expectation
+            expect(listOf("A", "B", "C")) toContain o inAny order but only entry {
+                /* do nothing */
+            }
+        }
+    }
+
+    @Test
+    fun entries() {
+        expect(listOf("A", "B", "C")) toContain o inAny order but only the entries(
+            { toEqual("C") },
+            { toEqual("B") },
+            { toEqual("A") }
+        )
+
+        expect(listOf("A", null, "A", null)) toContain o inAny order but only the entries(
+            null,
+            null,
+            { toEqual("A") },
+            { toEqual("A") }
+        )
+
+        fails { // because the List contains additionally an "A" (not covered in entries)
+            expect(listOf("A", "B", "C")) toContain o inAny order but only the entries(
+                { toEqual("C") },
+                { toEqual("B") }
+            )
+        }
+
+        fails { // because the List does not contain a "D"
+            expect(listOf("A", "B", "C")) toContain o inAny order but only the entries(
+                { toEqual("D") },
+                { toEqual("C") },
+                { toEqual("B") },
+                { toEqual("A") }
+            )
+        }
+
+        fails { // because the List does not contain a null
+            expect(listOf("A", "B", "C")) toContain o inAny order but only the entries(
+                { toEqual("C") },
+                { toEqual("B") },
+                null
+            )
+        }
+
+        fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
+            expect(listOf("A", "B")) toContain o inAny order but only the entries(
+                { toEqual("A") },
+                { /* do nothing */ }
+            )
+        }
+    }
+
+    @Test
+    fun elementsOf() {
+        expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf(
+            listOf("A", "B", "C")
+        )
+
+        fails { // because not all elements found
+            expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf(
+                listOf("B", "A")
+            )
+        }
+
+        fails { // because more elements expected than found
+            expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf(
+                listOf("B", "A", "C", "D")
+            )
+        }
+    }
+}

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -7,14 +7,14 @@ import ch.tutteli.atrium.api.infix.en_GB.*
 class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
     @Test
     fun value() {
-        expect(listOf("A")) toContain o inAny order but only value("A")
+        expect(listOf("A")) toContain o inAny order but only value "A"
 
         fails { // because the List does not contain expected value
-            expect(listOf("B")) toContain o inAny order but only value("A")
+            expect(listOf("B")) toContain o inAny order but only value "A"
         }
 
         fails { // because the List contains multiple elements
-            expect(listOf("A", "A")) toContain o inAny order but only value("A")
+            expect(listOf("A", "A")) toContain o inAny order but only value "A"
         }
     }
 
@@ -117,20 +117,14 @@ class IterableLikeToContainInAnyOrderOnlyCreatorSamples {
 
     @Test
     fun elementsOf() {
-        expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf(
-            listOf("A", "B", "C")
-        )
+        expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf listOf("A", "B", "C")
 
         fails { // because not all elements found
-            expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf(
-                listOf("B", "A")
-            )
+            expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf listOf("B", "A")
         }
 
         fails { // because more elements expected than found
-            expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf(
-                listOf("B", "A", "C", "D")
-            )
+            expect(listOf("A", "B", "C")) toContain o inAny order but only elementsOf listOf("B", "A", "C", "D")
         }
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInAnyOrderOnlyCreatorSamples.kt
@@ -2,8 +2,6 @@ package ch.tutteli.atrium.api.infix.en_GB.samples
 
 import ch.tutteli.atrium.api.verbs.expect
 import kotlin.test.Test
-import ch.tutteli.atrium.api.infix.en_GB.inAny
-import ch.tutteli.atrium.api.infix.en_GB.o
 import ch.tutteli.atrium.api.infix.en_GB.*
 
 class IterableLikeToContainInAnyOrderOnlyCreatorSamples {


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
