### PR TITLE
Add IterableLikeToContainInOrderOnlyCreatorSamples to api-infix

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -147,7 +147,7 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  *
  * @since 0.14.0 -- API existed for [Iterable] since 0.13.0 but not for [IterableLike].
  *
- * @sample ch.tutteli.atrium.api.fluent.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.elementsOf
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.elementsOf
  */
 inline infix fun <reified E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.elementsOf(
     expectedIterableLike: IterableLike

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/iterableLikeToContainInOrderOnlyCreators.kt
@@ -27,6 +27,8 @@ import kotlin.jvm.JvmName
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.value
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.value(expected: E): Expect<T> =
     this the values(expected)
@@ -41,6 +43,8 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.values
  */
 infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>.the(values: Values<E>): Expect<T> =
     the(WithInOrderOnlyReportingOptions({}, values))
@@ -78,6 +82,8 @@ infix fun <E, T : IterableLike> EntryPointStep<E, T, InOrderOnlySearchBehaviour>
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.entry
  */
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.entry(
     assertionCreatorOrNull: (Expect<E>.() -> Unit)?
@@ -96,6 +102,8 @@ infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearc
  * @return an [Expect] for the subject of `this` expectation.
  *
  * @since 0.14.0 -- API existed for [Iterable] but not for [IterableLike].
+ *
+ * @sample ch.tutteli.atrium.api.infix.en_GB.samples.IterableLikeToContainInOrderOnlyCreatorSamples.entries
  */
 
 infix fun <E : Any, T : IterableLike> EntryPointStep<out E?, T, InOrderOnlySearchBehaviour>.the(

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/samples/IterableLikeToContainInOrderOnlyCreatorSamples.kt
@@ -1,0 +1,161 @@
+package ch.tutteli.atrium.api.infix.en_GB.samples
+
+import ch.tutteli.atrium.api.infix.en_GB.and
+import ch.tutteli.atrium.api.infix.en_GB.elementsOf
+import ch.tutteli.atrium.api.infix.en_GB.entries
+import ch.tutteli.atrium.api.infix.en_GB.entry
+import ch.tutteli.atrium.api.infix.en_GB.inGiven
+import ch.tutteli.atrium.api.infix.en_GB.it
+import ch.tutteli.atrium.api.infix.en_GB.o
+import ch.tutteli.atrium.api.infix.en_GB.only
+import ch.tutteli.atrium.api.infix.en_GB.order
+import ch.tutteli.atrium.api.infix.en_GB.the
+import ch.tutteli.atrium.api.infix.en_GB.toContain
+import ch.tutteli.atrium.api.infix.en_GB.toEqual
+import ch.tutteli.atrium.api.infix.en_GB.value
+import ch.tutteli.atrium.api.infix.en_GB.values
+import ch.tutteli.atrium.api.verbs.expect
+import kotlin.test.Test
+
+class IterableLikeToContainInOrderOnlyCreatorSamples {
+    @Test
+    fun value() {
+        expect(listOf("A")) toContain o inGiven order and only value "A"
+
+        fails { // because the List does not contain expected value
+            expect(listOf("B")) toContain o inGiven order and only value "A"
+        }
+
+        fails { // because the List contains multiple elements
+            expect(listOf("A", "A")) toContain o inGiven order and only value "A"
+        }
+    }
+
+    @Test
+    fun values() {
+        expect(listOf("A", "B", "C")) toContain o inGiven order and only the values("A", "B", "C")
+
+        fails { // although same elements but not in same order
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the values("A", "C", "B")
+        }
+
+        fails { // because not all elements found
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the values("A", "B")
+        }
+
+        fails { // because more elements expected than found
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the values("A", "B", "C", "D")
+        }
+
+        fails { // because order is wrong
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the values("B", "A")
+        }
+    }
+
+
+    @Test
+    fun entry() {
+        expect(listOf("A")) toContain o inGiven order and only entry {
+            it toEqual "A"
+        }
+
+        expect(listOf(null)) toContain o inGiven order and only entry null
+
+        fails { // because the List does not contain "A"
+            expect(listOf("B")) toContain o inGiven order and only entry {
+                it toEqual "A"
+            }
+        }
+
+        fails { // because the List does not contain null
+            expect(listOf("A")) toContain o inGiven order and only entry null
+        }
+
+        fails { // because the List contains multiple elements
+            expect(listOf("A", "A")) toContain o inGiven order and only entry {
+                it toEqual "A"
+            }
+        }
+
+        fails { // because assertionCreatorOrNull is non-null and has no expectation
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only entry {
+                /* do nothing */
+            }
+        }
+    }
+
+    @Test
+    fun entries() {
+        expect(listOf("A", "B", "C")) toContain o inGiven order and only the entries(
+            { it toEqual "A" },
+            { it toEqual "B" },
+            { it toEqual "C" })
+
+        expect(listOf(null, "A", null, "A")) toContain o inGiven order and only the entries(
+            null,
+            { it toEqual "A" },
+            null,
+            { it toEqual "A" })
+
+        fails { // because the List contains an additional "A" at the beginning
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the entries(
+                { it toEqual "B" },
+                { it toEqual "C" })
+        }
+
+        fails { // because the List does not contain a "D" at the end
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the entries(
+                { it toEqual "A" },
+                { it toEqual "B" },
+                { it toEqual "C" },
+                { it toEqual "D" })
+        }
+
+        fails { // because the List contains a "C" and not null at the end
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the entries(
+                { it toEqual "A" },
+                { it toEqual "B" },
+                null
+            )
+        }
+
+        fails { // because order is wrong
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only the entries(
+                { it toEqual "C" },
+                { it toEqual "B" },
+                { it toEqual "A" })
+        }
+
+        fails { // because order is wrong
+            expect(listOf(null, "A", null)) toContain o inGiven order and only the entries(
+                null,
+                null,
+                { it toEqual "A" },
+            )
+        }
+
+        fails { // because otherAssertionCreatorsOrNulls contains a lambda which is non-null and has no expectation
+            expect(listOf("A", "B")) toContain o inGiven order and only the entries(
+                { it toEqual "A" },
+                { /* do nothing */ })
+        }
+    }
+
+    @Test
+    fun elementsOf() {
+        expect(listOf("A", "B", "C")) toContain o inGiven order and only elementsOf (listOf("A", "B", "C"))
+
+
+        fails { // although same elements but not in same order
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only elementsOf (listOf("A", "C", "B"))
+        }
+
+        fails { // because not all elements found
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only elementsOf (listOf("A", "B"))
+        }
+
+        fails { // because more elements expected than found
+            expect(listOf("A", "B", "C")) toContain o inGiven order and only elementsOf (listOf("A", "B", "C", "D"))
+        }
+    }
+}


### PR DESCRIPTION
resolves #1912 
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
