### PR TITLE
migrate CharSequenceNotToContainExpectationsSpec to kotlin-test #1955

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainExpectationsTest.kt
@@ -1,12 +1,12 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest
 
-class CharSequenceNotToContainExpectationsTest : ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest(
+class CharSequenceNotToContainExpectationsTest : AbstractCharSequenceNotToContainExpectationsTest(
     getNotToContainTriple(),
     getNotToContainIgnoringCaseTriple()
 ) {
-
     companion object : CharSequenceToContainSpecBase() {
 
         private fun getNotToContainTriple() =

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainExpectationsTest.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 
-class CharSequenceNotToContainExpectationsSpec : ch.tutteli.atrium.specs.integration.CharSequenceNotToContainExpectationsSpec(
+class CharSequenceNotToContainExpectationsTest : ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest(
     getNotToContainTriple(),
     getNotToContainIgnoringCaseTriple()
 ) {

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainSpecBase.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainSpecBase.kt
@@ -1,5 +1,6 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
+import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
@@ -7,9 +8,9 @@ import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.N
 import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.AtLeastCheckerStep
 import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.name
-import ch.tutteli.atrium.specs.notImplemented
 import kotlin.reflect.KFunction3
 import kotlin.reflect.KProperty
+import kotlin.test.Test
 
 abstract class CharSequenceToContainSpecBase {
     private val toContainProp: KProperty<*> = Expect<String>::toContain
@@ -34,54 +35,54 @@ abstract class CharSequenceToContainSpecBase {
     protected val values = CharSequenceContains.CheckerStep<CharSequence, NoOpSearchBehaviour>::values.name
     protected val elementsOf = CharSequenceContains.EntryPointStep<String, IgnoringCaseSearchBehaviour>::elementsOf.name
 
-    @Suppress("unused", "UNUSED_VALUE")
-    private fun ambiguityTest() {
-        val a1: Expect<String> = notImplemented()
+    @Test
+    fun ambiguityTest() {
+        val a1: Expect<CharSequence> = expect("Hello my name is Robert")
 
-        a1.toContain.atLeast(1).value(1)
-        a1.toContain.atMost(2).values("a", 1)
-        a1.toContain.notOrAtMost(2).regex("h|b")
-        a1.toContain.exactly(2).regex("h|b", "b")
-        a1.toContain.atLeast(2).matchFor(Regex("bla"))
-        a1.toContain.atLeast(2).matchFor(Regex("bla"), Regex("b"))
-        a1.toContain.atLeast(2).elementsOf(listOf("a", 2))
+        a1.toContain.atLeast(1).value('R')
+        a1.toContain.atMost(2).values('l', 'm')
+        a1.toContain.notOrAtMost(2).regex("H|R")
+        a1.toContain.exactly(2).regex("H|R", "l.")
+        a1.toContain.atLeast(2).matchFor(Regex("\\w"))
+        a1.toContain.atLeast(2).matchFor(Regex("\\w"), Regex("\\s"))
+        a1.toContain.atLeast(2).elementsOf(listOf('l', 'm'))
 
-        a1.notToContain.value(1)
-        a1.notToContain.values("a", 1)
-        a1.notToContain.regex("h|b", "b")
-        a1.notToContain.matchFor(Regex("bla"))
-        a1.notToContain.matchFor(Regex("bla"), Regex("b"))
-        a1.notToContain.elementsOf(listOf("a", 2))
+        a1.notToContain.value('E')
+        a1.notToContain.values('L', 'M')
+        a1.notToContain.regex("h|E", "L.")
+        a1.notToContain.matchFor(Regex("\\d"))
+        a1.notToContain.matchFor(Regex("\\d"), Regex("\\s{2}"))
+        a1.notToContain.elementsOf(listOf('L', 'M'))
 
-        a1.toContain.ignoringCase.atLeast(1).value("a")
-        a1.toContain.ignoringCase.atLeast(1).values("a", 'b')
-        a1.toContain.ignoringCase.atLeast(1).regex("a")
-        a1.toContain.ignoringCase.atLeast(1).regex("a", "bl")
+        a1.toContain.ignoringCase.atLeast(1).value('E')
+        a1.toContain.ignoringCase.atLeast(1).values('L', 'M')
+        a1.toContain.ignoringCase.atLeast(1).regex("h|M")
+        a1.toContain.ignoringCase.atLeast(1).regex("h|M", "\\s")
         // not supported on purpose as one can specify an ignore case flag for Regex
         // and hence these would be a second way to do the same thing
         //a1.toContain.ignoringCase.atLeast(1).regex(Regex("a"))
         //a1.toContain.ignoringCase.atLeast(1).regex(Regex("a"), Regex("bl"))
-        a1.toContain.ignoringCase.atLeast(1).elementsOf(listOf(1, 2))
+        a1.toContain.ignoringCase.atLeast(1).elementsOf(listOf('L', 'M'))
 
-        a1.notToContain.ignoringCase.value("a")
-        a1.notToContain.ignoringCase.values("a", 'b')
-        a1.notToContain.ignoringCase.regex("a")
-        a1.notToContain.ignoringCase.regex("a", "bl")
+        a1.notToContain.ignoringCase.value('c')
+        a1.notToContain.ignoringCase.values('c', 'D')
+        a1.notToContain.ignoringCase.regex("l\\s")
+        a1.notToContain.ignoringCase.regex("l\\s", "l{3}")
         // not supported on purpose as one can specify an ignore case flag for Regex
         // and hence these would be a second way to do the same thing
         //a1.notToContain.ignoringCase.regex(Regex("a"))
         //a1.notToContain.ignoringCase.regex(Regex("a"), Regex("bl"))
-        a1.notToContain.ignoringCase.elementsOf(listOf(1, 2))
+        a1.notToContain.ignoringCase.elementsOf(listOf('c', 'D'))
 
         // skip atLeast
-        a1.toContain.ignoringCase.value("a")
-        a1.toContain.ignoringCase.values("a", 'b')
-        a1.toContain.ignoringCase.regex("a")
-        a1.toContain.ignoringCase.regex("a", "bl")
+        a1.toContain.ignoringCase.value('E')
+        a1.toContain.ignoringCase.values('L', 'M')
+        a1.toContain.ignoringCase.regex("h|M")
+        a1.toContain.ignoringCase.regex("h|M", "\\s")
         // not supported on purpose as one can specify an ignore case flag for Regex
         // and hence these would be a second way to do the same thing
         //a1.toContain.ignoringCase.regex(Regex("a"))
         //a1.toContain.ignoringCase.regex(Regex("a"), Regex("bl"))
-        a1.toContain.ignoringCase.elementsOf(listOf("a", 2))
+        a1.toContain.ignoringCase.elementsOf(listOf('L', 'M'))
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainExpectationsTest.kt
@@ -1,12 +1,12 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest
 
-class CharSequenceNotToContainExpectationsTest : ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest(
+class CharSequenceNotToContainExpectationsTest : AbstractCharSequenceNotToContainExpectationsTest(
     getNotToContainTriple(),
     getNotToContainIgnoringCaseTriple()
 ) {
-
     companion object : CharSequenceToContainSpecBase() {
 
         private fun getNotToContainTriple() =

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainExpectationsTest.kt
@@ -2,7 +2,7 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 
-class CharSequenceNotToContainExpectationsSpec : ch.tutteli.atrium.specs.integration.CharSequenceNotToContainExpectationsSpec(
+class CharSequenceNotToContainExpectationsTest : ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest(
     getNotToContainTriple(),
     getNotToContainIgnoringCaseTriple()
 ) {

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainSpecBase.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainSpecBase.kt
@@ -1,5 +1,6 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
+import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
@@ -9,8 +10,8 @@ import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.AtLeastCheck
 import ch.tutteli.atrium.logic.creating.charsequence.contains.steps.NotCheckerStep
 import ch.tutteli.atrium.specs.fun1
 import ch.tutteli.atrium.specs.name
-import ch.tutteli.atrium.specs.notImplemented
 import kotlin.reflect.KFunction2
+import kotlin.test.Test
 
 abstract class CharSequenceToContainSpecBase {
     private val toContainProp: KFunction2<Expect<String>, o, CharSequenceContains.EntryPointStep<String, NoOpSearchBehaviour>> =
@@ -40,63 +41,63 @@ abstract class CharSequenceToContainSpecBase {
     protected val values = "the values"
     protected val elementsOf = CharSequenceContains.EntryPointStep<String, IgnoringCaseSearchBehaviour>::elementsOf.name
 
-    @Suppress("unused", "UNUSED_VALUE")
-    private fun ambiguityTest() {
-        val a1: Expect<String> = notImplemented()
+    @Test
+    fun ambiguityTest() {
+        val a1: Expect<CharSequence> = expect("Hello my name is Robert")
 
-        a1 toContain o atLeast 1 value 1
-        a1 toContain o atMost 2 the values("a", 1)
-        a1 toContain o notOrAtMost 2 regex "h|b"
-        a1 toContain o exactly 2 the regexPatterns("h|b", "b")
-        a1 toContain o atLeast 2 matchFor Regex("bla")
-        a1 toContain o atLeast 2 matchFor all(Regex("bla"), Regex("b"))
-        a1 toContain o atLeast 2 elementsOf listOf(1, 2)
+        a1 toContain o atLeast 1 value 'R'
+        a1 toContain o atMost 2 the values('l', 'm')
+        a1 toContain o notOrAtMost 2 regex "H|R"
+        a1 toContain o exactly 2 the regexPatterns("H|R", "l.")
+        a1 toContain o atLeast 2 matchFor Regex("\\w")
+        a1 toContain o atLeast 2 matchFor all(Regex("\\w"), Regex("\\s"))
+        a1 toContain o atLeast 2 elementsOf listOf('l', 'm')
 
-        a1 notToContain o value "a"
-        a1 notToContain o the values("a", 'b')
-        a1 notToContain o regex "a"
-        a1 notToContain o the regexPatterns("a", "bl")
-        a1 notToContain o matchFor Regex("a")
-        a1 notToContain o matchFor all(Regex("a"), Regex("bl"))
-        a1 notToContain o elementsOf listOf(1, 2)
+        a1 notToContain o value 'E'
+        a1 notToContain o the values('L', 'M')
+        a1 notToContain o regex "h|E"
+        a1 notToContain o the regexPatterns("h|E", "O{2}")
+        a1 notToContain o matchFor Regex("\\d")
+        a1 notToContain o matchFor all(Regex("\\d"), Regex("\\s{2}"))
+        a1 notToContain o elementsOf listOf('L', 'M')
 
-        a1 toContain o ignoring case atLeast 1 value "a"
-        a1 toContain o ignoring case atLeast 1 the values("a", 'b')
-        a1 toContain o ignoring case atLeast 1 regex "a"
-        a1 toContain o ignoring case atLeast 1 the regexPatterns("a", "bl")
+        a1 toContain o ignoring case atLeast 1 value 'E'
+        a1 toContain o ignoring case atLeast 1 the values('L', 'M')
+        a1 toContain o ignoring case atLeast 1 regex "h|M"
+        a1 toContain o ignoring case atLeast 1 the regexPatterns("h|M", "\\s")
         // not supported on purpose as one can specify an ignore case flag for Regex
         // and hence these would be a second way to do the same thing
         //a1 toContain o ignoring case atLeast 1 matchFor Regex("a")
         //a1 toContain o ignoring case atLeast 1 matchFor all(Regex("a"), Regex("bl"))
-        a1 toContain o ignoring case atLeast 1 elementsOf listOf(1, 2)
+        a1 toContain o ignoring case atLeast 1 elementsOf listOf('L', 'M')
 
-        a1 notToContain o ignoring case value "a"
-        a1 notToContain o ignoring case the values("a", 'b')
-        a1 notToContain o ignoring case regex "a"
-        a1 notToContain o ignoring case the regexPatterns("a", "bl")
+        a1 notToContain o ignoring case value 'c'
+        a1 notToContain o ignoring case the values('c', 'D')
+        a1 notToContain o ignoring case regex "l\\s"
+        a1 notToContain o ignoring case the regexPatterns("l\\s", "l{3}")
         // not supported on purpose as one can specify an ignore case flag for Regex
         // and hence these would be a second way to do the same thing
         //a1 notToContain o ignoring case matchFor Regex("a")
         //a1 notToContain o ignoring case matchFor all(Regex("a"), Regex("bl"))
-        a1 notToContain o ignoring case elementsOf listOf(1, 2)
+        a1 notToContain o ignoring case elementsOf listOf('c', 'D')
 
         // skip atLeast
-        a1 toContain o ignoring case value "a"
-        a1 toContain o ignoring case the values("a", 'b')
-        a1 toContain o ignoring case regex "a"
-        a1 toContain o ignoring case the regexPatterns("a", "bl")
+        a1 toContain o ignoring case value 'E'
+        a1 toContain o ignoring case the values('L', 'M')
+        a1 toContain o ignoring case regex "h|M"
+        a1 toContain o ignoring case the regexPatterns("h|M", "\\s")
         // not supported on purpose as one can specify an ignore case flag for Regex
         // and hence these would be a second way to do the same thing
         //a1 toContain o ignoring case matchFor Regex("a")
         //a1 toContain o ignoring case matchFor all(Regex("a"), Regex("bl"))
-        a1 toContain o ignoring case elementsOf listOf("a", 2)
+        a1 toContain o ignoring case elementsOf listOf('L', 'M')
 
-        a1 and { it toContain o atLeast 1 value 1 }
-        a1 and { it toContain o atMost 2 the values("a", 1) }
-        a1 and { it toContain o notOrAtMost 2 regex "h|b" }
-        a1 and { it toContain o exactly 2 the regexPatterns("h|b", "b") }
-        a1 and { it toContain o atLeast 2 matchFor Regex("bla") }
-        a1 and { it toContain o atLeast 2 matchFor all(Regex("bla"), Regex("b")) }
-        a1 and { it toContain o atLeast 2 elementsOf listOf(1, 2) }
+        a1 and { it toContain o atLeast 1 value 'R' }
+        a1 and { it toContain o atMost 2 the values('l', 'm') }
+        a1 and { it toContain o notOrAtMost 2 regex "H|R" }
+        a1 and { it toContain o exactly 2 the regexPatterns("H|R", "l.") }
+        a1 and { it toContain o atLeast 2 matchFor Regex("\\w") }
+        a1 and { it toContain o atLeast 2 matchFor all(Regex("\\w"), Regex("\\s")) }
+        a1 and { it toContain o atLeast 2 elementsOf listOf('l', 'm') }
     }
 }

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceNotToContainExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceNotToContainExpectationsTest.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCharSequenceExpectation
 import org.spekframework.spek2.style.specification.Suite
 
-abstract class CharSequenceNotToContainExpectationsSpec(
+abstract class AbstractCharSequenceNotToContainExpectationsTest(
     notToContainPair: Pair<(String) -> String, Fun2<CharSequence, Any, Array<out Any>>>,
     notToContainIgnoringCasePair: Pair<(String) -> String, Fun2<CharSequence, Any, Array<out Any>>>,
     describePrefix: String = "[Atrium] "

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceNotToContainExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceNotToContainExpectationsTest.kt
@@ -2,34 +2,30 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.messageToContain
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
-import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.core.polyfills.format
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.testfactories.TestFactory
 import ch.tutteli.atrium.translations.DescriptionCharSequenceExpectation
-import org.spekframework.spek2.style.specification.Suite
 
+@Suppress("FunctionName")
 abstract class AbstractCharSequenceNotToContainExpectationsTest(
-    notToContainPair: Pair<(String) -> String, Fun2<CharSequence, Any, Array<out Any>>>,
-    notToContainIgnoringCasePair: Pair<(String) -> String, Fun2<CharSequence, Any, Array<out Any>>>,
-    describePrefix: String = "[Atrium] "
-) : CharSequenceToContainSpecBase({
+    private val notToContainPair: Pair<(String) -> String, Fun2<CharSequence, Any, Array<out Any>>>,
+    private val notToContainIgnoringCasePair: Pair<(String) -> String, Fun2<CharSequence, Any, Array<out Any>>>,
+) : ExpectationFunctionBaseTest() {
 
-    val notToContain = notToContainPair.second
-    val notToContainIgnoringCase = notToContainIgnoringCasePair.second
+    private val notToContainSpec = notToContainPair.second
+    private val notToContainIgnoringCaseSpec = notToContainIgnoringCasePair.second
 
-    include(object : SubjectLessSpec<CharSequence>(
-        describePrefix,
-        notToContain.forSubjectLessTest(2.3, arrayOf()),
-        notToContainIgnoringCase.forSubjectLessTest(2.3, arrayOf())
-    ) {})
+    @TestFactory
+    fun subjectLessTest() = subjectLessTestFactory(
+        notToContainSpec.forSubjectLessTest(2.3, arrayOf()),
+        notToContainIgnoringCaseSpec.forSubjectLessTest(2.3, arrayOf()),
+    )
 
-    fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
-        describeFunTemplate(describePrefix, funName, body = body)
+    fun Expect<CharSequence>.notToContainFun(a: Any, vararg aX: Any) = notToContainSpec(this, a, aX)
 
-    fun Expect<CharSequence>.notToContainFun(a: Any, vararg aX: Any) = notToContain(this, a, aX)
-
-    fun Expect<CharSequence>.notToContainIgnoringCaseFun(a: Any, vararg aX: Any) = notToContainIgnoringCase(this, a, aX)
+    fun Expect<CharSequence>.notToContainIgnoringCaseFun(a: Any, vararg aX: Any) = notToContainIgnoringCaseSpec(this, a, aX)
 
     val notToContainDescr = DescriptionCharSequenceExpectation.NOT_TO_CONTAIN.getDefault()
     val notToContainIgnoringCaseDescr =
@@ -37,10 +33,9 @@ abstract class AbstractCharSequenceNotToContainExpectationsTest(
 
     val valueWithIndent = "$indentRootBulletPoint$listBulletPoint$value"
 
-    describeFun(notToContain.name, notToContainIgnoringCase.name) {
-
-        context("throws an $illegalArgumentException") {
-
+    @TestFactory
+    fun notToContain__subject_throws_an_IllegalArgumentException() =
+        testFactory(notToContainSpec) {
             it("if an object is passed as first expected") {
                 expect {
                     expect(text).notToContainFun(expect(text))
@@ -63,25 +58,28 @@ abstract class AbstractCharSequenceNotToContainExpectationsTest(
             }
         }
 
-        context("text '$helloWorld'") {
-            context("happy case with $notToContain once") {
-                it("${notToContainPair.first("'h'")} does not throw") {
-                    expect(helloWorld).notToContainFun('h')
-                }
-                it("${notToContainPair.first("'h' and 'E' and 'w'")} does not throw") {
-                    expect(helloWorld).notToContainFun('h', 'E', 'w')
-                }
-                it("${notToContainPair.first("'w' and 'h' and 'E'")} does not throw") {
-                    expect(helloWorld).notToContainFun('w', 'h', 'E')
-                }
-                it("${notToContainIgnoringCasePair.first("'x' and 'y' and 'z'")} does not throw") {
-                    expect(helloWorld).notToContainIgnoringCaseFun('x', 'y', 'z')
-                }
+    @TestFactory
+    fun notToContain__subject_happy_case_with_notToContain_once() =
+        testFactory(notToContainSpec) {
+            it("${notToContainPair.first("'h'")} does not throw") {
+                expect(helloWorld).notToContainFun('h')
             }
+            it("${notToContainPair.first("'h' and 'E' and 'w'")} does not throw") {
+                expect(helloWorld).notToContainFun('h', 'E', 'w')
+            }
+            it("${notToContainPair.first("'w' and 'h' and 'E'")} does not throw") {
+                expect(helloWorld).notToContainFun('w', 'h', 'E')
+            }
+            it("${notToContainIgnoringCasePair.first("'x' and 'y' and 'z'")} does not throw") {
+                expect(helloWorld).notToContainIgnoringCaseFun('x', 'y', 'z')
+            }
+        }
 
-            context("failing cases; search string at different positions") {
-                it("${notToContainPair.first("'l'")} throws AssertionError") {
-                    expect {
+    @TestFactory
+    fun notToContain__subject_failing_cases__search_string_at_different_positions() =
+        testFactory(notToContainSpec) {
+            it("${notToContainPair.first("'l'")} throws AssertionError") {
+                expect {
                         expect(helloWorld).notToContainFun('l')
                     }.toThrow<AssertionError> {
                         messageToContain(
@@ -92,43 +90,51 @@ abstract class AbstractCharSequenceNotToContainExpectationsTest(
                         )
                     }
                 }
-                it("${notToContainPair.first("'H', 'l'")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).notToContainFun('H', 'l')
-                    }.toThrow<AssertionError> { messageToContain("$valueWithIndent: 'l'") }
-                }
-                it("${notToContainPair.first("'l', 'H'")} once throws AssertionError") {
-                    expect {
-                        expect(helloWorld).notToContainFun('l', 'H')
-                    }.toThrow<AssertionError> { messageToContain("$valueWithIndent: 'l'") }
-                }
-                it("${notToContainIgnoringCasePair.first("'H', 'l'")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).notToContainIgnoringCaseFun('H', 'l')
-                    }.toThrow<AssertionError> {
-                        messageToContain(
-                            "$rootBulletPoint$notToContainIgnoringCaseDescr: $separator" +
-                                "$valueWithIndent: 'H'",
-                            "$valueWithIndent: 'l'"
-                        )
-                    }
-                }
-                it("${notToContainIgnoringCasePair.first("'L', 'H'")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).notToContainIgnoringCaseFun('L', 'H')
-                    }.toThrow<AssertionError> { messageToContain('H', 'L') }
-                }
-                it("${notToContainPair.first("'o', 'E', 'w', 'l'")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).notToContainFun('o', 'E', 'w', 'l')
-                    }.toThrow<AssertionError> { messageToContain('o', 'l') }
-                }
-                it("${notToContainIgnoringCasePair.first("'o', 'E', 'w', 'l'")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).notToContainIgnoringCaseFun('o', 'E', 'w', 'l')
-                    }.toThrow<AssertionError> { messageToContain('o', 'E', "w", 'l') }
+            it("${notToContainPair.first("'H', 'l'")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).notToContainFun('H', 'l')
+                }.toThrow<AssertionError> { messageToContain("$valueWithIndent: 'l'") }
+            }
+            it("${notToContainPair.first("'l', 'H'")} once throws AssertionError") {
+                expect {
+                    expect(helloWorld).notToContainFun('l', 'H')
+                }.toThrow<AssertionError> { messageToContain("$valueWithIndent: 'l'") }
+            }
+            it("${notToContainIgnoringCasePair.first("'H', 'l'")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).notToContainIgnoringCaseFun('H', 'l')
+                }.toThrow<AssertionError> {
+                    messageToContain(
+                        "$rootBulletPoint$notToContainIgnoringCaseDescr: $separator" +
+                            "$valueWithIndent: 'H'",
+                        "$valueWithIndent: 'l'"
+                    )
                 }
             }
+            it("${notToContainIgnoringCasePair.first("'L', 'H'")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).notToContainIgnoringCaseFun('L', 'H')
+                }.toThrow<AssertionError> { messageToContain('H', 'L') }
+            }
+            it("${notToContainPair.first("'o', 'E', 'w', 'l'")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).notToContainFun('o', 'E', 'w', 'l')
+                }.toThrow<AssertionError> { messageToContain('o', 'l') }
+            }
+            it("${notToContainIgnoringCasePair.first("'o', 'E', 'w', 'l'")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).notToContainIgnoringCaseFun('o', 'E', 'w', 'l')
+                }.toThrow<AssertionError> { messageToContain('o', 'E', "w", 'l') }
+            }
         }
+
+    companion object {
+        val text: CharSequence = "Hello my name is Robert"
+        val helloWorld: CharSequence = "Hello World, I am Oskar"
+
+        val numberOfOccurrences = DescriptionCharSequenceExpectation.NUMBER_OF_MATCHES.getDefault()
+        val value = DescriptionCharSequenceExpectation.VALUE.getDefault()
+
+        val separator = lineSeparator
     }
-})
+}


### PR DESCRIPTION
migrate CharSequenceNotToContainExpectationsSpec to kotlin-test #1955
 - [x] rename CharSequenceNotToContainExpectationsSpec to AbstractCharSequenceNotToContainExpectationsTest  
 - [x] rename CharSequenceNotToContainExpectationsSpec to CharSequenceNotToContainExpectationsTest
 - [x] rename CharSequenceNotToContainExpectationsSpec to CharSequenceNotToContainExpectationsTest
 - [x] let AbstractCharSequenceNotToContainExpectationsTest extend ExpectationFunctionBaseTest
 - [x] transform the tests with the ..Spec variant
 - [x] let CharSequenceNotToContainExpectationsTest extend AbstractCharSequenceNotToContainExpectationsTest
 - [x] let CharSequenceNotToContainExpectationsTest extend AbstractCharSequenceNotToContainExpectationsTest
 - [x] rewrite ambiguityTest on CharSequenceToContainSpecBase
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
