### PR TITLE
#1959 migrate char sequence to contain exactly expectations spec to kotlin test

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
@@ -2,8 +2,8 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 
-class CharSequenceToContainExactlyExpectationsSpec :
-    ch.tutteli.atrium.specs.integration.CharSequenceToContainExactlyExpectationsSpec(
+class CharSequenceToContainExactlyExpectationsTest :
+    ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainExactlyExpectationsTest(
         getExactlyTriple(),
         getExactlyIgnoringCaseTriple(),
         getNotToContainPair()

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
@@ -2,8 +2,8 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 
-class CharSequenceToContainExactlyExpectationsSpec :
-    ch.tutteli.atrium.specs.integration.CharSequenceToContainExactlyExpectationsSpec(
+class CharSequenceToContainExactlyExpectationsTest :
+    ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainExactlyExpectationsTest(
         getExactlyTriple(),
         getExactlyIgnoringCaseTriple(),
         getNotToContainPair()

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainExactlyExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainExactlyExpectationsTest.kt
@@ -7,7 +7,7 @@ import ch.tutteli.atrium.specs.*
 import ch.tutteli.atrium.translations.DescriptionCharSequenceExpectation.EXACTLY
 import org.spekframework.spek2.style.specification.Suite
 
-abstract class CharSequenceToContainExactlyExpectationsSpec(
+abstract class AbstractCharSequenceToContainExactlyExpectationsTest(
     toContainExactlyPair: Pair<(String, String) -> String, Fun3<CharSequence, Int, Any, Array<out Any>>>,
     toContainExactlyIgnoringCasePair: Pair<(String, String) -> String, Fun3<CharSequence, Int, Any, Array<out Any>>>,
     notToContainPair: Pair<String, (Int) -> String>,

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainExactlyExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainExactlyExpectationsTest.kt
@@ -4,218 +4,238 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.helloWorld
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.numberOfOccurrences
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.separator
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.text
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.toContainDescr
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.toContainIgnoringCase
+import ch.tutteli.atrium.specs.integration.CharSequenceToContainSpecBase.Companion.value
+import ch.tutteli.atrium.testfactories.TestFactory
 import ch.tutteli.atrium.translations.DescriptionCharSequenceExpectation.EXACTLY
 import org.spekframework.spek2.style.specification.Suite
 
 abstract class AbstractCharSequenceToContainExactlyExpectationsTest(
-    toContainExactlyPair: Pair<(String, String) -> String, Fun3<CharSequence, Int, Any, Array<out Any>>>,
-    toContainExactlyIgnoringCasePair: Pair<(String, String) -> String, Fun3<CharSequence, Int, Any, Array<out Any>>>,
-    notToContainPair: Pair<String, (Int) -> String>,
-    describePrefix: String = "[Atrium] "
-) : CharSequenceToContainSpecBase({
+    private val toContainExactlyPairSpec: Pair<(String, String) -> String, Fun3<CharSequence, Int, Any, Array<out Any>>>,
+    private val toContainExactlyIgnoringCasePairSpec: Pair<(String, String) -> String, Fun3<CharSequence, Int, Any, Array<out Any>>>,
+    private val notToContainPairSpec: Pair<String, (Int) -> String>,
 
-    val toContainExactly = toContainExactlyPair.second
-    val toContainExactlyIgnoringCase = toContainExactlyIgnoringCasePair.second
+) : ExpectationFunctionBaseTest() {
 
-    include(object : SubjectLessSpec<CharSequence>(
-        describePrefix,
-        toContainExactly.forSubjectLessTest(2, 2.3, arrayOf()),
-        toContainExactlyIgnoringCase.forSubjectLessTest(2, 2.3, arrayOf())
-    ) {})
+    val toContainExactlySpec = toContainExactlyPairSpec.second
+    val toContainExactlyIgnoringCaseSpec = toContainExactlyIgnoringCasePairSpec.second
 
-    fun describeFun(vararg funName: String, body: Suite.() -> Unit) =
-        describeFunTemplate(describePrefix, funName, body = body)
+    @TestFactory
+    fun subjectLessTest() = subjectLessTestFactory(
+        toContainExactlySpec.forSubjectLessTest(1, 2.3, arrayOf()),
+        toContainExactlyIgnoringCaseSpec.forSubjectLessTest(2,2.3, arrayOf())
+    )
 
     fun Expect<CharSequence>.toContainExactlyFun(exactly: Int, a: Any, vararg aX: Any) =
-        toContainExactly(this, exactly, a, aX)
+        toContainExactlySpec(this, exactly, a, aX)
 
     fun Expect<CharSequence>.toContainExactlyIgnoringCaseFun(exactly: Int, a: Any, vararg aX: Any) =
-        toContainExactlyIgnoringCase(this, exactly, a, aX)
+        toContainExactlyIgnoringCaseSpec(this, exactly, a, aX)
 
     val exactlyDescr = EXACTLY.getDefault()
     val valueWithIndent = "$indentRootBulletPoint$listBulletPoint$value"
 
-    describeFun(toContainExactly.name, toContainExactlyIgnoringCase.name) {
+    @TestFactory
+    fun toContainExactly_throws_IllegalArgumentException_for_invalid_parameters() = testFactory(toContainExactlySpec) {
+        val (notToContain, errorMsgContainsNot) = notToContainPairSpec
 
-        context("throws an $illegalArgumentException") {
-            val (notToContain, errorMsgContainsNot) = notToContainPair
-
-            it("for exactly -1 -- only positive numbers") {
-                expect {
-                    expect(text).toContainExactlyFun(-1, "")
-                }.toThrow<IllegalArgumentException> { messageToContain("positive number", -1) }
-            }
-            it("for exactly 0 -- points to $notToContain") {
-                expect {
-                    expect(text).toContainExactlyFun(0, "")
-                }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgContainsNot(0)) } }
-            }
-            it("if an object is passed as first expected") {
-                expect {
-                    expect(text).toContainExactlyFun(1, expect(text))
-                }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
-            }
-            it("if an object is passed as second expected") {
-                expect {
-                    expect(text).toContainExactlyFun(1, "that's fine", expect(text))
-                }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
-            }
+        it("for exactly -1 -- only positive numbers") {
+            expect {
+                expect(text).toContainExactlyFun(-1, "")
+            }.toThrow<IllegalArgumentException> { messageToContain("positive number", "-1") }
         }
-
-        context("text 'aaaa'") {
-            it("search for 'aa' finds 3 hits since we want non-disjoint matches") {
-                expect("aaaa" as CharSequence).toContainExactlyFun(3, "aa")
-            }        }
-
-        context("text '$helloWorld'") {
-
-            context("happy case with $toContainExactly once") {
-                it("${toContainExactlyPair.first("'H'", "once")} does not throw") {
-                    expect(helloWorld).toContainExactlyFun(1, 'H')
-                }
-                it("${toContainExactlyPair.first("'H' and 'e' and 'W'", "once")} does not throw") {
-                    expect(helloWorld).toContainExactlyFun(1, 'H', 'e', 'W')
-                }
-                it("${toContainExactlyPair.first("'W' and 'H' and 'e'", "once")} does not throw") {
-                    expect(helloWorld).toContainExactlyFun(1, 'W', 'H', 'e')
-                }
-            }
-
-            context("failing cases; search string at different positions with $toContainExactly once") {
-                it("${toContainExactlyPair.first("'h'", "once")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(1, 'h')
-                    }.toThrow<AssertionError> { messageToContain("$exactlyDescr: 1", "$valueWithIndent: 'h'") }
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'h'", "once")} throws AssertionError") {
-                    expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'h')
-                }
-
-                it("${toContainExactlyPair.first("'H', 'E'", "once")} throws AssertionError mentioning only 'E'") {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(1, 'H', 'E')
-                    }.toThrow<AssertionError> {
-                        message {
-                            toContain("$exactlyDescr: 1", "$valueWithIndent: 'E'")
-                            notToContain("$valueWithIndent: 'H'")
-                        }
-                    }
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'H', 'E'", "once")} throws AssertionError") {
-                    expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'H', 'E')
-                }
-
-                it("${toContainExactlyPair.first("'E', 'H'", "once")} throws AssertionError mentioning only 'E'") {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(1, 'E', 'H')
-                    }.toThrow<AssertionError> {
-                        message {
-                            toContain("$exactlyDescr: 1", "$valueWithIndent: 'E'")
-                            notToContain("$valueWithIndent: 'H'")
-                        }
-                    }
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'E', 'H'", "once")} throws AssertionError") {
-                    expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'E', 'H')
-                }
-
-                it("${toContainExactlyPair.first("'H' and 'E' and 'w'", "once")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(1, 'H', 'E', 'w')
-                    }.toThrow<AssertionError> { messageToContain(exactlyDescr, 'E', 'w') }
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'H' and 'E' and 'w'", "once")} throws AssertionError") {
-                    expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'H', 'E', 'w')
-                }
-            }
-
-            context("multiple occurrences of the search string") {
-                it("${toContainExactlyPair.first("'o'", "once")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(1, 'o')
-                    }.toThrow<AssertionError> { messageToContain("$exactlyDescr: 1", "$valueWithIndent: 'o'") }
-                }
-                it("${toContainExactlyPair.first("'o'", "twice")} does not throw") {
-                    expect(helloWorld).toContainExactlyFun(2, 'o')
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'o'", "twice")} throws") {
-                    expect {
-                        expect(helloWorld).toContainExactlyIgnoringCaseFun(2, 'o')
-                    }.toThrow<AssertionError> {
-                        message {
-                            toContain(
-                                "$rootBulletPoint$toContainIgnoringCase: $separator" +
-                                    "$valueWithIndent: 'o'",
-                                "$numberOfOccurrences: 3$separator"
-                            )
-                            toEndWith("$exactlyDescr: 2")
-                        }
-                    }
-                }
-
-                it(
-                    "${toContainExactlyPair.first("'o'", "3 times")} throws AssertionError and message contains both, " +
-                        "how many times we expected (3) and how many times it actually contained 'o' (2)"
-                ) {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(3, 'o')
-                    }.toThrow<AssertionError> {
-                        message {
-                            toContain(
-                                "$rootBulletPoint$toContainDescr: $separator" +
-                                    "$valueWithIndent: 'o'",
-                                "$numberOfOccurrences: 2$separator"
-                            )
-                            toEndWith("$exactlyDescr: 3")
-                        }
-                    }
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'o'", "3 times")} does not throw") {
-                    expect(helloWorld).toContainExactlyIgnoringCaseFun(3, 'o')
-                }
-                it("${toContainExactlyIgnoringCasePair.first("'o' and 'o'", "3 times")} does not throw") {
-                    expect(helloWorld).toContainExactlyIgnoringCaseFun(3, 'o', 'o')
-                }
-
-                it("${toContainExactlyPair.first("'o' and 'l'", "twice")} throws AssertionError") {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(2, 'o', 'l')
-                    }.toThrow<AssertionError> {
-                        message {
-                            toContain(
-                                "$rootBulletPoint$toContainDescr: $separator" +
-                                    "$valueWithIndent: 'l'",
-                                "$numberOfOccurrences: 3$separator"
-                            )
-                            toEndWith("$exactlyDescr: 2")
-                            notToContain("$valueWithIndent: 'o'")
-                        }
-                    }
-                }
-                it("${toContainExactlyPair.first("'l'", "3 times")} does not throw") {
-                    expect(helloWorld).toContainExactlyFun(3, 'l')
-                }
-                it(
-                    "${toContainExactlyPair.first(
-                        "'o' and 'l'",
-                        "3 times"
-                    )} throws AssertionError and message contains both, how many times we expected (3) and how many times it actually contained 'o' (2)"
-                ) {
-                    expect {
-                        expect(helloWorld).toContainExactlyFun(3, 'o', 'l')
-                    }.toThrow<AssertionError> {
-                        message {
-                            toContain(
-                                "$rootBulletPoint$toContainDescr: $separator" +
-                                    "$valueWithIndent: 'o'",
-                                "$numberOfOccurrences: 2$separator"
-                            )
-                            toEndWith("$exactlyDescr: 3")
-                            notToContain("$valueWithIndent: 'l'")
-                        }
-                    }
-                }
-            }
+        it("for exactly 0 -- points to $notToContain") {
+            expect {
+                expect(text).toContainExactlyFun(0, "")
+            }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgContainsNot(0)) } }
+        }
+        it("if an object is passed as first expected") {
+            expect {
+                expect(text).toContainExactlyFun(1, expect(text))
+            }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
+        }
+        it("if an object is passed as second expected") {
+            expect {
+                expect(text).toContainExactlyFun(1, "that's fine", expect(text))
+            }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
         }
     }
-})
+
+    @TestFactory
+    fun text_aaaa__search_for_aa_finds_3_non_disjoint_matches() = testFactory(toContainExactlySpec) {
+        it("search for 'aa' finds 3 hits since we want non-disjoint matches") {
+            expect("aaaa" as CharSequence).toContainExactlyFun(3, "aa")
+        }
+    }
+
+    @TestFactory
+    fun helloWorld__happy_case_with_toContainExactly_once() = testFactory(toContainExactlySpec) {
+        it("${toContainExactlyPairSpec.first("'H'", "once")} does not throw") {
+            expect(helloWorld).toContainExactlyFun(1, 'H')
+        }
+        it("${toContainExactlyPairSpec.first("'H' and 'e' and 'W'", "once")} does not throw") {
+            expect(helloWorld).toContainExactlyFun(1, 'H', 'e', 'W')
+        }
+        it("${toContainExactlyPairSpec.first("'W' and 'H' and 'e'", "once")} does not throw") {
+            expect(helloWorld).toContainExactlyFun(1, 'W', 'H', 'e')
+        }
+    }
+
+    @TestFactory
+    fun helloWorld__failing_cases_search_string_at_different_positions_toContainExactly() =
+        testFactory(toContainExactlySpec) {
+            it("${toContainExactlyPairSpec.first("'h'", "once")} throws AssertionError") {
+                expect {
+                    expect(text).toContainExactlyFun(1, 'h')
+                }.toThrow<AssertionError> { messageToContain("$exactlyDescr: 1", "$valueWithIndent: 'h'") }
+            }
+            it("${toContainExactlyPairSpec.first("'H', 'E'", "once")} throws AssertionError mentioning only 'E'") {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(1, 'H', 'E')
+                }.toThrow<AssertionError> {
+                    message {
+                        toContain("$exactlyDescr: 1", "$valueWithIndent: 'E'")
+                        notToContain("$valueWithIndent: 'H'")
+                    }
+                }
+            }
+            it("${toContainExactlyPairSpec.first("'E', 'H'", "once")} throws AssertionError mentioning only 'E'") {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(1, 'E', 'H')
+                }.toThrow<AssertionError> {
+                    message {
+                        toContain("$exactlyDescr: 1", "$valueWithIndent: 'E'")
+                        notToContain("$valueWithIndent: 'H'")
+                    }
+                }
+            }
+
+            it("${toContainExactlyPairSpec.first("'H' and 'E' and 'w'", "once")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(1, 'H', 'E', 'w')
+                }.toThrow<AssertionError> { messageToContain(exactlyDescr, 'E', 'w') }
+            }
+        }
+
+    @TestFactory
+    fun helloWorld__failing_cases_search_string_at_different_positions_toContainExactlyIgnoringCase() =
+        testFactory(toContainExactlyIgnoringCaseSpec) {
+            it("${toContainExactlyIgnoringCasePairSpec.first("'h'", "once")} does not throw (case ignored)") {
+                expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'h')
+            }
+
+            it("${toContainExactlyIgnoringCasePairSpec.first("'H', 'E'", "once")} does not throw (case ignored)") {
+                expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'H', 'E')
+            }
+
+            it("${toContainExactlyIgnoringCasePairSpec.first("'E', 'H'", "once")} does not throw (case ignored)") {
+                expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'E', 'H')
+            }
+
+            it("${toContainExactlyIgnoringCasePairSpec.first("'H' and 'E' and 'w'", "once")} does not throw (case ignored)") {
+                expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'H', 'E', 'w')
+            }
+        }
+
+    @TestFactory
+    fun helloWorld__multiple_occurrences_of_search_string_toContainExactly() =
+        testFactory(toContainExactlySpec) {
+            it("${toContainExactlyPairSpec.first("'o'", "once")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(1, 'o')
+                }.toThrow<AssertionError> { messageToContain("$exactlyDescr: 1", "$valueWithIndent: 'o'") }
+            }
+            it("${toContainExactlyPairSpec.first("'o'", "twice")} does not throw") {
+                expect(helloWorld).toContainExactlyFun(2, 'o')
+            }
+            it(
+                "${toContainExactlyPairSpec.first("'o'", "3 times")} throws AssertionError and message contains both, " +
+                    "how many times we expected (3) and how many times it actually contained 'o' (2)"
+            ) {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(3, 'o')
+                }.toThrow<AssertionError> {
+                    message {
+                        toContain(
+                            "$rootBulletPoint$toContainDescr: $separator" +
+                                "$valueWithIndent: 'o'",
+                            "$numberOfOccurrences: 2$separator"
+                        )
+                        toEndWith("$exactlyDescr: 3")
+                    }
+                }
+            }
+            it("${toContainExactlyPairSpec.first("'o' and 'l'", "twice")} throws AssertionError") {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(2, 'o', 'l')
+                }.toThrow<AssertionError> {
+                    message {
+                        toContain(
+                            "$rootBulletPoint$toContainDescr: $separator" +
+                                "$valueWithIndent: 'l'",
+                            "$numberOfOccurrences: 3$separator"
+                        )
+                        toEndWith("$exactlyDescr: 2")
+                        notToContain("$valueWithIndent: 'o'")
+                    }
+                }
+            }
+            it("${toContainExactlyPairSpec.first("'l'", "3 times")} does not throw") {
+                expect(helloWorld).toContainExactlyFun(3, 'l')
+            }
+            it(
+                "${toContainExactlyPairSpec.first(
+                    "'o' and 'l'",
+                    "3 times"
+                )} throws AssertionError and message contains both, how many times we expected (3) and how many times it actually contained 'o' (2)"
+            ) {
+                expect {
+                    expect(helloWorld).toContainExactlyFun(3, 'o', 'l')
+                }.toThrow<AssertionError> {
+                    message {
+                        toContain(
+                            "$rootBulletPoint$toContainDescr: $separator" +
+                                "$valueWithIndent: 'o'",
+                            "$numberOfOccurrences: 2$separator"
+                        )
+                        toEndWith("$exactlyDescr: 3")
+                        notToContain("$valueWithIndent: 'l'")
+                    }
+                }
+            }
+        }
+
+    @TestFactory
+    fun helloWorld__multiple_occurrences_of_search_string_toContainExactlyIgnoringCase() =
+        testFactory(toContainExactlyIgnoringCaseSpec) {
+            it("${toContainExactlyIgnoringCasePairSpec.first("'o'", "twice")} throws (3 matches found, expected 2)") {
+                expect {
+                    expect(helloWorld).toContainExactlyIgnoringCaseFun(2, 'o')
+                }.toThrow<AssertionError> {
+                    message {
+                        toContain(
+                            "$rootBulletPoint$toContainIgnoringCase: $separator" +
+                                "$valueWithIndent: 'o'",
+                            "$numberOfOccurrences: 3$separator"
+                        )
+                        toEndWith("$exactlyDescr: 2")
+                    }
+                }
+            }
+            it("${toContainExactlyIgnoringCasePairSpec.first("'o'", "3 times")} does not throw") {
+                expect(helloWorld).toContainExactlyIgnoringCaseFun(3, 'o')
+            }
+            it("${toContainExactlyIgnoringCasePairSpec.first("'o' and 'o'", "3 times")} does not throw") {
+                expect(helloWorld).toContainExactlyIgnoringCaseFun(3, 'o', 'o')
+            }
+        }
+
+
+
+
+}


### PR DESCRIPTION
Migrate CharSequenceToContainExactlyExpectationsSpec to kotlin-test
______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
