### PR TITLE
add TODO for 2.0.0 to challenge the use of data classes

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/parameterObjects.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonMain/kotlin/ch/tutteli/atrium/api/fluent/en_GB/parameterObjects.kt
@@ -48,6 +48,7 @@ class Entries<T : Any>(
  * Parameter object to express a key/value [Pair] whose value type is a nullable lambda with an
  * [Expect] receiver, which means one can either pass a lambda or `null`.
  */
+//TODO 2.0.0 remove data?
 data class KeyValue<out K, V : Any>(val key: K, val valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?) {
     fun toPair(): Pair<K, (Expect<V>.() -> Unit)?> = key to valueAssertionCreatorOrNull
 
@@ -58,6 +59,7 @@ data class KeyValue<out K, V : Any>(val key: K, val valueAssertionCreatorOrNull:
 /**
  * Represents a [Group] with a single value.
  */
+//TODO 2.0.0 remove data?
 data class Value<out T>(val expected: T) : Group<T> {
     override fun toList(): List<T> = listOf(expected)
 }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entry.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Entry.kt
@@ -16,6 +16,7 @@ import ch.tutteli.atrium.logic.utils.Group
  *   to be identified if it holds all [Assertion]s the lambda creates.
  *   In case it is defined as `null`, then an entry is identified if it is `null` as well.
  */
+//TODO 2.0.0 remove data?
 data class Entry<T : Any> internal constructor(
     val assertionCreatorOrNull: (Expect<T>.() -> Unit)?
 ) : Group<(Expect<T>.() -> Unit)?> {

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/IndexWithCreator.kt
@@ -11,4 +11,5 @@ import ch.tutteli.atrium.creating.Expect
  *
  *  @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 data class IndexWithCreator<E> internal constructor(val index: Int, val assertionCreator: Expect<E>.() -> Unit)

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/KeyWithCreator.kt
@@ -11,4 +11,5 @@ import ch.tutteli.atrium.creating.Expect
  *
  *  @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 data class KeyWithCreator<out K, V> internal constructor(val key: K, val assertionCreator: Expect<V>.() -> Unit)

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/PresentWithCreator.kt
@@ -10,4 +10,5 @@ import ch.tutteli.atrium.creating.Expect
  *
  *  @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 data class PresentWithCreator<E> internal constructor(val assertionCreator: Expect<E>.() -> Unit)

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/SuccessWithCreator.kt
@@ -9,4 +9,5 @@ import ch.tutteli.atrium.creating.Expect
  *
  * @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 data class SuccessWithCreator<E> internal constructor(val assertionCreator: Expect<E>.() -> Unit);

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/Value.kt
@@ -7,6 +7,7 @@ import ch.tutteli.atrium.logic.utils.Group
  *
  * Use the function `value(t)` to create this representation.
  */
+//TODO 2.0.0 remove data?
 data class Value<out T> internal constructor(val expected: T) : Group<T> {
     override fun toList() = listOf(expected)
 }

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/ExtractorWithCreator.kt
@@ -15,6 +15,7 @@ import kotlin.reflect.KProperty1
  *
  * @since 0.16.0
  */
+//TODO 2.0.0 remove data?
 data class ExtractorWithCreator<T, R> internal constructor(
     val extractor: (T) -> R,
     val assertionCreator: Expect<R>.() -> Unit

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FailureDescriptionWithCreator.kt
@@ -14,6 +14,7 @@ import ch.tutteli.atrium.creating.Expect
  *
  * @since 1.2.0
  */
+//TODO 2.0.0 remove data?
 data class FailureDescriptionWithCreator<T> internal constructor(
     val failureDescription: String,
     val assertionCreator: Expect<T>.(T) -> Unit

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/Feature.kt
@@ -17,6 +17,7 @@ import kotlin.reflect.KProperty1
  *
  * @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 @OptIn(ExperimentalComponentFactoryContainer::class)
 data class Feature<T, R> internal constructor(
     val descriptionProvider: (ComponentFactoryContainer) -> String,

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/FeatureWithCreator.kt
@@ -20,6 +20,7 @@ import kotlin.reflect.KProperty1
  *
  * @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 @OptIn(ExperimentalComponentFactoryContainer::class)
 data class FeatureWithCreator<T, R> internal constructor(
     val descriptionProvider: (ComponentFactoryContainer) -> String,

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/feature/MetaFeatureOptionWithCreator.kt
@@ -15,6 +15,7 @@ import ch.tutteli.atrium.logic.creating.feature.MetaFeature
  *
  * @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 data class MetaFeatureOptionWithCreator<T, R> internal constructor(
     val provider: MetaFeatureOption<T>.(T) -> MetaFeature<R>,
     val assertionCreator: Expect<R>.() -> Unit

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInAnyOrderOnlyReportingOptions.kt
@@ -7,4 +7,5 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrd
  *
  * @since 0.18.0
  */
+//TODO 2.0.0 remove data?
 data class WithInAnyOrderOnlyReportingOptions<out T>(val options: InAnyOrderOnlyReportingOptions.() -> Unit, val t: T)

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/iterable/WithInOrderOnlyReportingOptions.kt
@@ -7,4 +7,5 @@ import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderO
  *
  * @since 0.18.0
  */
+//TODO 2.0.0 remove data?
 data class WithInOrderOnlyReportingOptions<out T>(val options: InOrderOnlyReportingOptions.() -> Unit, val t: T)

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/map/KeyWithValueCreator.kt
@@ -8,6 +8,7 @@ import ch.tutteli.atrium.creating.Expect
  *
  * Use the function `keyValue(x) { ... }` to create this representation.
  */
+//TODO 2.0.0 remove data?
 data class KeyWithValueCreator<out K, V : Any> internal constructor(
     val key: K,
     val valueAssertionCreatorOrNull: (Expect<V>.() -> Unit)?

--- a/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor.kt
+++ b/apis/infix/atrium-api-infix/src/commonMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/thirdparty/DescriptionRepresentationWithExecutor.kt
@@ -13,6 +13,7 @@ package ch.tutteli.atrium.api.infix.en_GB.creating.thirdparty
  *
  * @since 1.2.0
  */
+//TODO 2.0.0 remove data?
 data class DescriptionRepresentationWithExecutor<T> internal constructor(
     val description: String,
     val representation: Any?,

--- a/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator.kt
+++ b/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithCreator.kt
@@ -10,4 +10,5 @@ import ch.tutteli.atrium.creating.Expect
  *
  *  @since 0.12.0
  */
+//TODO 2.0.0 remove data?
 data class PathWithCreator<E> internal constructor(val path: String, val assertionCreator: Expect<E>.() -> Unit)

--- a/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding.kt
+++ b/apis/infix/atrium-api-infix/src/jvmMain/kotlin/ch/tutteli/atrium/api/infix/en_GB/creating/path/PathWithEncoding.kt
@@ -10,6 +10,7 @@ import java.nio.file.Path
  *
  *  @since 0.13.0
  */
+//TODO 2.0.0 remove data?
 data class PathWithEncoding internal constructor(
     val path: Path,
     val sourceCharset: Charset,

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/ComponentFactoryContainer.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/ComponentFactoryContainer.kt
@@ -76,6 +76,7 @@ interface ComponentFactoryContainer {
  * component should be treated as singleton or not.
  */
 @ExperimentalComponentFactoryContainer
+//TODO 2.0.0 remove data
 data class ComponentFactory(val build: (ComponentFactoryContainer) -> Any, val producesSingleton: Boolean)
 
 /**

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/FeatureExpectOptions.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/FeatureExpectOptions.kt
@@ -10,6 +10,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  * @property representationInsteadOfFeature Defines a custom representation based on a present subject if not null.
  */
 @ExperimentalNewExpectTypes
+//TODO 2.0.0 remove data
 data class FeatureExpectOptions<R>(
     val description: Translatable? = null,
     val representationInsteadOfFeature: ((R) -> Any)? = null

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/RootExpectOptions.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/RootExpectOptions.kt
@@ -13,6 +13,7 @@ import ch.tutteli.atrium.reporting.translating.Translatable
  * @property representationInsteadOfSubject Defines a custom representation based on a present subject if not null.
  * @property componentFactoryContainer Defines a custom components.
  */
+//TODO 2.0.0 remove data
 @ExperimentalNewExpectTypes
 @OptIn(ExperimentalComponentFactoryContainer::class)
 data class RootExpectOptions<T>(

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt
@@ -7,6 +7,7 @@ package ch.tutteli.atrium.reporting
  * @property string The string which should be treated as raw [String].
  * @param string The string which should be treated as raw [String].
  */
+//TODO 2.0.0 remove data?
 //TODO add when using Kotlin apiLevel 2.0.0
 //@ConsistentCopyVisibility
 data class Text private constructor(val string: String) {

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/translating/Locale.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/translating/Locale.kt
@@ -9,6 +9,7 @@ package ch.tutteli.atrium.reporting.translating
  * @property country can be null or needs to consist of at least one letter and only letters
  * @property variant can be null or needs at least one character, cannot be blank though (use null instead)
  */
+//TODO 2.0.0 remove data?
 data class Locale(val language: String, val script: String?, val country: String?, val variant: String?) {
     constructor(language: String, country: String) : this(language, null, country, null)
     constructor(language: String) : this(language, null, null, null)

--- a/gradle/build-logic/dev/src/main/kotlin/generation.kt
+++ b/gradle/build-logic/dev/src/main/kotlin/generation.kt
@@ -13,7 +13,6 @@ import java.nio.file.Paths
 import java.util.*
 import kotlin.streams.asSequence
 
-//TODO 1.4.0 consider to switch to Kotlin Symbol Processing (KSP)
 /**
  * Use the function `forTarget` to create this data class.
  */

--- a/gradle/build-logic/root-build/src/main/kotlin/build-logic.root-build.gradle.kts
+++ b/gradle/build-logic/root-build/src/main/kotlin/build-logic.root-build.gradle.kts
@@ -13,8 +13,6 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
-val rootProject = this
-
 ifIsPublishing {
     println(
         """

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/feature/MetaFeature.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/feature/MetaFeature.kt
@@ -16,6 +16,7 @@ import ch.tutteli.atrium.reporting.translating.Untranslatable
  * @property maybeSubject The feature as such where it is [Some] in case the extraction was successful or [None] if it
  *   was not.
  */
+//TODO 2.0.0 remove data?
 data class MetaFeature<T>(val description: Translatable, val representation: Any?, val maybeSubject: Option<T>) {
     constructor(description: String, representation: Any?, maybeSubject: Option<T>) :
         this(Untranslatable(description), representation, maybeSubject)


### PR DESCRIPTION
data classes are not best friends of backward compatibility, whenever you add a property, we break bc. So check if we have cases which we want to extend.

moreover:
- remove TODO about KSP, not worth the effort



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
