### PR TITLE
migrate IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec to kotlin test

### DIFF
--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec.kt
@@ -1,20 +1,24 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
+import kotlin.test.*
+import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InAnyOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.creating.iterablelike.contains.reporting.InOrderOnlyReportingOptions
 import ch.tutteli.atrium.logic.utils.Group
-import ch.tutteli.atrium.specs.notImplemented
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInAnyOrderOnlyReportOptions
+import ch.tutteli.atrium.specs.integration.IterableToContainSpecBase.Companion.emptyInOrderOnlyReportOptions
 
-class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
-    ch.tutteli.atrium.specs.integration.IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec(
-        getContainsPair(),
-        Companion::groupFactory,
-        "[Atrium][Builder] "
-    ) {
+/**
+ * Migrated from Atrium's custom test framework to kotlin-test.
+ * This test class verifies the behavior of toContain with inGiven order, only, grouped entries, and inAny order.
+ */
+class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec {
+
     companion object : IterableToContainSpecBase() {
         fun getContainsPair() =
-            "$toContain $filler $inOrder $andOnly $grouped $within $withinInAnyOrder" to Companion::toContainInOrderOnlyGroupedInAnyOrderEntries
+            "$toContain $filler $inOrder $andOnly $grouped $within $withinInAnyOrder" to
+                Companion::toContainInOrderOnlyGroupedInAnyOrderEntries
 
         private fun toContainInOrderOnlyGroupedInAnyOrderEntries(
             expect: Expect<Iterable<Double?>>,
@@ -42,160 +46,292 @@ class IterableToContainInOrderOnlyGroupedEntriesExpectationsSpec :
                 )
             }
 
-
         private fun groupFactory(groups: Array<out (Expect<Double>.() -> Unit)?>) =
             when (groups.size) {
                 0 -> object : Group<(Expect<Double>.() -> Unit)?> {
                     override fun toList() = emptyList<Expect<Double>.() -> Unit>()
                 }
-
                 1 -> entry(groups[0])
                 else -> entries(groups[0], *groups.drop(1).toTypedArray())
             }
+
+        private fun context(vararg assertionCreators: (Expect<Double>.() -> Unit)?) =
+            groupFactory(assertionCreators)
     }
 
+    // ===== Empty Group Validation Tests =====
 
-    @Suppress("unused", "UNUSED_VALUE")
-    private fun ambiguityTest() {
-        var list: Expect<List<Number>> = notImplemented()
-        var nList: Expect<Set<Number?>> = notImplemented()
-        var subList: Expect<ArrayList<Number>> = notImplemented()
-        var star: Expect<Collection<*>> = notImplemented()
+    @Test
+    fun `throws IllegalArgumentException if first group is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            val (_, containsFun) = getContainsPair()
+            containsFun(
+                expect(listOf(1.0, 2.0, 3.0, 4.0)),
+                context(),
+                context({ toEqual(-1.2) }),
+                emptyArray(),
+                emptyInOrderOnlyReportOptions,
+                emptyInAnyOrderOnlyReportOptions
+            )
+        }.also { exception ->
+            assertTrue(exception.message?.contains("a group of values cannot be empty") == true)
+        }
+    }
 
-        list = list toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {})
-        )
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {})
-        )
-        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {})
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry {},
-            entries({}, {})
-        ))
+    @Test
+    fun `throws IllegalArgumentException if second group is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            val (_, containsFun) = getContainsPair()
+            containsFun(
+                expect(listOf(1.0, 2.0, 3.0, 4.0)),
+                context({ toEqual(1.2) }),
+                context(),
+                emptyArray(),
+                emptyInOrderOnlyReportOptions,
+                emptyInAnyOrderOnlyReportOptions
+            )
+        }.also { exception ->
+            assertTrue(exception.message?.contains("a group of values cannot be empty") == true)
+        }
+    }
 
-        list = list toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            report = {}
-        )
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            report = {}
-        )
-        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            report = {}
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry {},
-            entries({}, {}),
-            report = {}
-        ))
+    @Test
+    fun `throws IllegalArgumentException if third group is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            val (_, containsFun) = getContainsPair()
+            containsFun(
+                expect(listOf(1.0, 2.0, 3.0, 4.0)),
+                context({ toEqual(1.2) }),
+                context({ toEqual(4.3) }),
+                arrayOf(context()),
+                emptyInOrderOnlyReportOptions,
+                emptyInAnyOrderOnlyReportOptions
+            )
+        }.also { exception ->
+            assertTrue(exception.message?.contains("a group of values cannot be empty") == true)
+        }
+    }
 
-        list = list toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            reportInGroup = {}
-        )
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            reportInGroup = {}
-        )
-        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            reportInGroup = {}
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry {},
-            entries({}, {}),
-            reportInGroup = {}
-        ))
+    @Test
+    fun `throws IllegalArgumentException if fourth group is empty`() {
+        assertFailsWith<IllegalArgumentException> {
+            val (_, containsFun) = getContainsPair()
+            containsFun(
+                expect(listOf(1.0, 2.0, 3.0, 4.0)),
+                context({ toEqual(1.2) }),
+                context({ toEqual(4.3) }),
+                arrayOf(context({ toEqual(5.7) }), context()),
+                emptyInOrderOnlyReportOptions,
+                emptyInAnyOrderOnlyReportOptions
+            )
+        }.also { exception ->
+            assertTrue(exception.message?.contains("a group of values cannot be empty") == true)
+        }
+    }
 
-        list = list toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            report = {},
-            reportInGroup = {}
-        )
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            report = {},
-            reportInGroup = {}
-        )
-        subList = subList toContain o inGiven order and only grouped entries within group inAny order(
-            entry {},
-            entries({}, {}),
-            report = {},
-            reportInGroup = {}
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry {},
-            entries({}, {}),
-            report = {},
-            reportInGroup = {}
-        ))
+    // ===== Empty Iterable Tests =====
 
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
+    @Test
+    fun `empty iterable with expectations throws AssertionError`() {
+        assertFailsWith<AssertionError> {
+            expect(emptyList<Double?>()) toContain o inGiven order and only grouped entries within group inAny order(
+                entry { toEqual(1.0) },
+                entry { toEqual(1.2) }
+            )
+        }
+    }
+
+    // ===== Happy Path Tests =====
+
+    @Test
+    fun `(1_0), (2_0, 3_0), (4_0, 4_0) succeeds`() {
+        expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+            entry { toEqual(1.0) },
+            entries({ toEqual(2.0) }, { toEqual(3.0) }),
+            entries({ toEqual(4.0) }, { toEqual(4.0) })
+        )
+    }
+
+    @Test
+    fun `(2_0, 1_0), (4_0, 3_0), (4_0) succeeds`() {
+        expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+            entries({ toEqual(2.0) }, { toEqual(1.0) }),
+            entries({ toEqual(4.0) }, { toEqual(3.0) }),
+            entry { toEqual(4.0) }
+        )
+    }
+
+    @Test
+    fun `(2_0, 3_0, 1_0), (4_0), (4_0) succeeds`() {
+        expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+            entries({ toEqual(2.0) }, { toEqual(3.0) }, { toEqual(1.0) }),
+            entry { toEqual(4.0) },
+            entry { toEqual(4.0) }
+        )
+    }
+
+    @Test
+    fun `(1_0, 2_0), (4_0, 3_0, 4_0) succeeds`() {
+        expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+            entries({ toEqual(1.0) }, { toEqual(2.0) }),
+            entries({ toEqual(4.0) }, { toEqual(3.0) }, { toEqual(4.0) })
+        )
+    }
+
+    @Test
+    fun `range matchers with toBeLessThan and toBeGreaterThan succeed`() {
+        expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+            entries(
+                { toBeGreaterThan(1.0) and o toBeLessThan(2.1) },
+                { toBeLessThan(2.0) }
+            ),
+            entries(
+                { toBeGreaterThan(3.0) },
+                { toBeGreaterThan(2.0) },
+                { toBeGreaterThan(1.0) and o toBeLessThan(5.0) }
+            )
+        )
+    }
+
+    // ===== Error Cases =====
+
+    @Test
+    fun `(4_0, 1_0), (2_0, 3_0, 4_0) wrong order fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries({ toEqual(4.0) }, { toEqual(1.0) }),
+                entries({ toEqual(2.0) }, { toEqual(3.0) }, { toEqual(4.0) })
+            )
+        }
+    }
+
+    @Test
+    fun `first win applies - toBeLessThan(2_1) matches 1_0 not 2_0`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries({ toBeLessThan(2.1) }, { toBeLessThan(2.0) }),
+                entries({ toEqual(4.0) }, { toEqual(3.0) }, { toEqual(4.0) })
+            )
+        }
+    }
+
+    @Test
+    fun `(1_0), (4_0, 2_0, 3_0) - additional element 4_0 fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entry { toEqual(1.0) },
+                entries({ toEqual(4.0) }, { toEqual(2.0) }, { toEqual(3.0) })
+            )
+        }
+    }
+
+    @Test
+    fun `(1_0), (4_0) - missing 2_0, 3_0, 4_0 fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entry { toEqual(1.0) },
+                entry { toEqual(4.0) }
+            )
+        }
+    }
+
+    @Test
+    fun `(1_0, 3_0), (5_0) - wrong value and missing elements fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries({ toEqual(1.0) }, { toEqual(3.0) }),
+                entry { toEqual(5.0) }
+            )
+        }
+    }
+
+    @Test
+    fun `(4_0, 1_0, 3_0, 2_0), (5_0, 4_0) - too many expected elements fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries({ toEqual(4.0) }, { toEqual(1.0) }, { toEqual(3.0) }, { toEqual(2.0) }),
+                entries({ toEqual(5.0) }, { toEqual(4.0) })
+            )
+        }
+    }
+
+    // ===== Report Options Tests =====
+
+    @Test
+    fun `showOnlyFailing report option shows only failing indices`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entry { toEqual(1.0) },
+                entries({ toEqual(2.0) }, { toEqual(4.0) }),
+                entries(
+                    { toEqual(1.0) }, { toEqual(2.0) }, { toEqual(3.0) },
+                    { toEqual(4.0) }, { toEqual(5.0) }, { toEqual(6.0) },
+                    { toEqual(7.0) }, { toEqual(8.0) }, { toEqual(9.0) },
+                    { toEqual(10.0) }, { toEqual(11.0) }
+                ),
+                report = { showOnlyFailing() }
+            )
+        }
+    }
+
+    @Test
+    fun `showOnlyFailing for both report and reportInGroup`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries({ toEqual(1.0) }, { toEqual(2.0) }, { toEqual(3.0) }),
+                entries({ toEqual(4.0) }, { toEqual(4.0) }, { toEqual(5.0) }),
+                report = { showOnlyFailing() },
+                reportInGroup = { showOnlyFailing() }
+            )
+        }
+    }
+
+    @Test
+    fun `showOnlyFailingIfMoreExpectedElementsThan(3) shows only failing when threshold exceeded`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(1.0, 2.0, 3.0, 4.0, 4.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries({ toEqual(1.0) }, { toEqual(2.0) }, { toEqual(3.0) }),
+                entries({ toEqual(4.0) }, { toEqual(4.0) }, { toEqual(5.0) }),
+                report = { showOnlyFailingIfMoreExpectedElementsThan(3) }
+            )
+        }
+    }
+
+    // ===== Nullable Cases =====
+
+    @Test
+    fun `nullable - (toEqual(1_0), null), (null, toEqual(3_0)) succeeds`() {
+        expect(listOf(null, 1.0, null, 3.0)) toContain o inGiven order and only grouped entries within group inAny order(
+            entries({ toEqual(1.0) }, null),
+            entries(null, { toEqual(3.0) })
+        )
+    }
+
+    @Test
+    fun `nullable - (null), (null, toBeGreaterThan(2_0), toBeLessThan(5_0)) succeeds`() {
+        expect(listOf(null, 1.0, null, 3.0)) toContain o inGiven order and only grouped entries within group inAny order(
             entry(null),
-            entries({}, null)
+            entries(null, { toBeGreaterThan(2.0) }, { toBeLessThan(5.0) })
         )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry(null),
-            entries(null, {})
-        ))
+    }
 
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry(null),
-            entries({}, null),
-            report = {}
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry(null),
-            entries(null, {}),
-            report = {}
-        ))
+    @Test
+    fun `nullable - (null, null), (toBeLessThan(5_0), toBeGreaterThan(2_0)) wrong order fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(null, 1.0, null, 3.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries(null, null),
+                entries({ toBeLessThan(5.0) }, { toBeGreaterThan(2.0) })
+            )
+        }
+    }
 
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry(null),
-            entries({}, null),
-            reportInGroup = {}
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry(null),
-            entries(null, {}),
-            reportInGroup = {}
-        ))
-
-        nList = nList toContain o inGiven order and only grouped entries within group inAny order(
-            entry(null),
-            entries({}, null),
-            report = {},
-            reportInGroup = {}
-        )
-        // TODO type parameter should not be necessary: https://youtrack.jetbrains.com/issue/KT-60976/overload-ambiguity-mismatch-in-case-of-covariance-and-only-in-conjunction-with-Any
-        star = (star toContain o inGiven order and only grouped entries within group).inAny<Any, Collection<*>>(order(
-            entry(null),
-            entries(null, {}),
-            report = {},
-            reportInGroup = {}
-        ))
+    @Test
+    fun `nullable - (null, toEqual(1_0)), (toEqual(3_0), null, null) too many nulls fails`() {
+        assertFailsWith<AssertionError> {
+            expect(listOf(null, 1.0, null, 3.0)) toContain o inGiven order and only grouped entries within group inAny order(
+                entries(null, { toEqual(1.0) }),
+                entries({ toEqual(3.0) }, null, null)
+            )
+        }
     }
 }

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Thu Oct 02 11:33:40 IST 2025
+sdk.dir=/home/ayush/Android/Sdk


### PR DESCRIPTION
… kotlin-test #2027



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
