### PR TITLE
provide a testFactory method which takes arbitrary spec definitions

### DIFF
--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ExpectationFunctionBaseTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ExpectationFunctionBaseTest.kt
@@ -2,8 +2,12 @@ package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.verbs.internal.testfactories.ExpectTestExecutableForTests
 import ch.tutteli.atrium.creating.Expect
-import ch.tutteli.atrium.specs.*
+import ch.tutteli.atrium.specs.SpecPair
 import ch.tutteli.atrium.specs.integration.utils.*
+import ch.tutteli.atrium.specs.lambda
+import ch.tutteli.atrium.specs.name
+import ch.tutteli.atrium.testfactories.DynamicNodeContainer
+import ch.tutteli.atrium.testfactories.DynamicNodeLike
 import ch.tutteli.atrium.testfactories.TestFactoryBuilder
 import ch.tutteli.kbox.forElementAndForEachIn
 
@@ -12,36 +16,42 @@ expect abstract class ExpectationFunctionBaseTest() {
     protected fun <T> testFactory(
         specPair: SpecPair<T>,
         setup: TestFactoryBuilder<ExpectTestExecutableForTests>.(T) -> Unit,
-    ): Any
+    ): DynamicNodeContainer<DynamicNodeLike>
+
+    protected fun testFactory(
+        specPair: SpecPair<*>,
+        vararg otherSpecPairs: SpecPair<*>,
+        setup: TestFactoryBuilder<ExpectTestExecutableForTests>.() -> Unit,
+    ): DynamicNodeContainer<DynamicNodeLike>
 
     protected fun <SubjectT> subjectLessTestFactory(
         expectationCreator: SpecPair<Expect<SubjectT>.() -> Unit>,
         vararg otherExpectationCreators: SpecPair<Expect<SubjectT>.() -> Unit>,
         groupPrefix: String? = null
-    ): Any
+    ): DynamicNodeContainer<DynamicNodeLike>
 
     protected fun subjectLessTestFactory(
         testData: SubjectLessTestData<*>,
         vararg otherTestData: SubjectLessTestData<*>,
-    ): Any
+    ): DynamicNodeContainer<DynamicNodeLike>
 
     protected fun <SubjectT> expectationCreatorTestFactory(
         subject: SubjectT,
         assertionCreator: ExpectationCreatorTriple<SubjectT>,
         vararg otherAssertionCreators: ExpectationCreatorTriple<SubjectT>,
         groupPrefix: String? = null
-    ): Any
+    ): DynamicNodeContainer<DynamicNodeLike>
 
     protected fun expectationCreatorTestFactory(
         testData: ExpectationCreatorTestData<*>,
         vararg otherTestData: ExpectationCreatorTestData<*>,
-    ): Any
+    ): DynamicNodeContainer<DynamicNodeLike>
 
     protected fun <T : Any> nonNullableCases(
         nonNullableSpecPair: SpecPair<T>,
         nullableSpecPair: Any,
         testExecutable: ExpectTestExecutableForTests.(T) -> Unit,
-    ): Any
+    ): DynamicNodeContainer<DynamicNodeLike>
 }
 
 fun TestFactoryBuilder<ExpectTestExecutableForTests>.applySubjectLessTestSetup(
@@ -92,8 +102,9 @@ fun <T> TestFactoryBuilder<ExpectTestExecutableForTests>.describeFun(
 
 fun <T> TestFactoryBuilder<ExpectTestExecutableForTests>.itFun(
     specPair: SpecPair<T>,
+    additionalDescription: String = "",
     setup: ExpectTestExecutableForTests.(T) -> Unit
-) = it("fun `${specPair.name}") {
+) = it("fun `${specPair.name}`${if (additionalDescription.isEmpty()) "" else " -- $additionalDescription"}") {
     setup(specPair.lambda)
 }
 

--- a/misc/atrium-test-factory/api/main/atrium-test-factory.api
+++ b/misc/atrium-test-factory/api/main/atrium-test-factory.api
@@ -4,6 +4,14 @@ public final class ch/tutteli/atrium/testfactories/BranchTestNode : ch/tutteli/a
 	public final fun getNodes ()Ljava/util/List;
 }
 
+public final class ch/tutteli/atrium/testfactories/DefaultIterableDynamicNodeWrapper : ch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper, java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> (Ljava/util/List;)V
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public abstract interface class ch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+}
+
 public final class ch/tutteli/atrium/testfactories/LeafTestNode : ch/tutteli/atrium/testfactories/TestNode {
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun getDisplayName ()Ljava/lang/String;
@@ -29,12 +37,12 @@ public final class ch/tutteli/atrium/testfactories/TestFactoryBuilderKt {
 }
 
 public final class ch/tutteli/atrium/testfactories/TestFactoryTemplatesKt {
-	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
+	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
 }
 
 public final class ch/tutteli/atrium/testfactories/TestFactory_jvmKt {
-	public static final fun turnTestNodesIntoPlatformSpecificTestFactory (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun turnTestNodesIntoPlatformSpecificTestFactory (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
 }
 
 public abstract class ch/tutteli/atrium/testfactories/TestNode {
@@ -101,6 +109,6 @@ public final class ch/tutteli/atrium/testfactories/expect/root/impl/RootExpectTe
 }
 
 public final class ch/tutteli/atrium/testfactories/junit/TurnIntoJunitDynamicNodesKt {
-	public static final fun turnIntoJunitDynamicNodes (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/util/List;
+	public static final fun turnIntoJunitDynamicNodes (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
 }
 

--- a/misc/atrium-test-factory/api/using-kotlin-1.9-or-newer/atrium-test-factory.api
+++ b/misc/atrium-test-factory/api/using-kotlin-1.9-or-newer/atrium-test-factory.api
@@ -4,6 +4,14 @@ public final class ch/tutteli/atrium/testfactories/BranchTestNode : ch/tutteli/a
 	public final fun getNodes ()Ljava/util/List;
 }
 
+public final class ch/tutteli/atrium/testfactories/DefaultIterableDynamicNodeWrapper : ch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper, java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> (Ljava/util/List;)V
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public abstract interface class ch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+}
+
 public final class ch/tutteli/atrium/testfactories/LeafTestNode : ch/tutteli/atrium/testfactories/TestNode {
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun getDisplayName ()Ljava/lang/String;
@@ -29,12 +37,12 @@ public final class ch/tutteli/atrium/testfactories/TestFactoryBuilderKt {
 }
 
 public final class ch/tutteli/atrium/testfactories/TestFactoryTemplatesKt {
-	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
+	public static final fun testFactoryTemplate (Lkotlin/jvm/functions/Function1;[Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
 }
 
 public final class ch/tutteli/atrium/testfactories/TestFactory_jvmKt {
-	public static final fun turnTestNodesIntoPlatformSpecificTestFactory (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun turnTestNodesIntoPlatformSpecificTestFactory (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
 }
 
 public abstract class ch/tutteli/atrium/testfactories/TestNode {
@@ -101,6 +109,6 @@ public final class ch/tutteli/atrium/testfactories/expect/root/impl/RootExpectTe
 }
 
 public final class ch/tutteli/atrium/testfactories/junit/TurnIntoJunitDynamicNodesKt {
-	public static final fun turnIntoJunitDynamicNodes (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/util/List;
+	public static final fun turnIntoJunitDynamicNodes (Ljava/util/List;Lkotlin/jvm/functions/Function0;)Lch/tutteli/atrium/testfactories/IterableDynamicNodeWrapper;
 }
 

--- a/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/TestFactory.kt
+++ b/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/TestFactory.kt
@@ -12,13 +12,35 @@ package ch.tutteli.atrium.testfactories
 expect annotation class TestFactory()
 
 /**
+ * Note, we only have a type parameter because Kotlin does not allow yet to have a generic type with a fixed type parameter
+ * on the RHS of an actual typealias such as `actual typealias DynamicNodeContainer = Iterable<DynamicNode>` and
+ * because JUnits compatibility check at runtime requires a ParameterizedType.
+ * This is also the reason why we need [DynamicNodeLike]
+ *
+ * @since 1.3.0
+ */
+expect interface DynamicNodeContainer<T : DynamicNodeLike>
+
+/**
+ * Note, this type only exists  because Kotlin does not allow yet to have a generic type with a fixed type parameter
+ * on the RHS of an actual typealias such as `actual typealias DynamicNodeContainer = Iterable<DynamicNode>` and
+ * because JUnits compatibility check at runtime requires a ParameterizedType. If JUnit would not require it
+ * but instead check if a supertype is compliant, then we could just use DynamicNodeContainer and type alias it to
+ * IterableDynamicNodeWrapper in jvm.
+ *
+ * @since 1.3.0
+ */
+expect abstract class DynamicNodeLike
+
+/**
  * Turns the given [testNodes] into a platform specific representation such as JUnit's DynamicNode.
  *
  * @return The platform specific test factories.
  *
  * @since 1.3.0
  */
-expect fun <TestExecutableT: TestExecutable> turnTestNodesIntoPlatformSpecificTestFactory(
+expect fun <TestExecutableT : TestExecutable> turnTestNodesIntoPlatformSpecificTestFactory(
     testNodes: List<TestNode>,
     testExecutableFactory: () -> TestExecutableT
-): Any
+): DynamicNodeContainer<DynamicNodeLike>
+

--- a/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/expect/ExpectTestExecutable.kt
+++ b/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/expect/ExpectTestExecutable.kt
@@ -44,7 +44,7 @@ interface ExpectTestExecutable : TestExecutable, TestExecutableImplContract {
      *
      * @param description Description of the root group.
      * @param groupingActions Some action which defines what happens within the group (typically, creating some
-     *   expectations via [ch.tutteli.atrium.api.verbs.expect] or nesting the grouping further).
+     *   expectations via `ch.tutteli.atrium.api.verbs.expect` or nesting the grouping further).
      *
      * @since 1.3.0
      */

--- a/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/testFactoryTemplates.kt
+++ b/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/testFactoryTemplates.kt
@@ -15,7 +15,8 @@ import ch.tutteli.kbox.glue
 fun <TestExecutableT : TestExecutable> testFactoryTemplate(
     setup: TestFactoryBuilder<TestExecutableT>.() -> Unit,
     testExecutableFactory: () -> TestExecutableT
-): Any = turnTestNodesIntoPlatformSpecificTestFactory(buildTestNodes(setup), testExecutableFactory)
+): DynamicNodeContainer<DynamicNodeLike> =
+    turnTestNodesIntoPlatformSpecificTestFactory(buildTestNodes(setup), testExecutableFactory)
 
 /**
  * Template method intended for providers of expectation verbs.
@@ -31,6 +32,6 @@ fun <TestExecutableT : TestExecutable> testFactoryTemplate(
     setup: TestFactoryBuilder<TestExecutableT>.() -> Unit,
     otherSetups: Array<out TestFactoryBuilder<TestExecutableT>.() -> Unit>,
     testExecutableFactory: () -> TestExecutableT
-): Any = turnTestNodesIntoPlatformSpecificTestFactory(
+): DynamicNodeContainer<DynamicNodeLike> = turnTestNodesIntoPlatformSpecificTestFactory(
     (setup glue otherSetups).flatMap(::buildTestNodes), testExecutableFactory
 )

--- a/misc/atrium-test-factory/src/jsMain/kotlin/ch/tutteli/atrium/testfactories/TestFactory.js.kt
+++ b/misc/atrium-test-factory/src/jsMain/kotlin/ch/tutteli/atrium/testfactories/TestFactory.js.kt
@@ -4,7 +4,11 @@ import ch.tutteli.atrium.testfactories.mocha.turnIntoDescribeIt
 
 actual typealias TestFactory = kotlin.test.Test
 
+actual interface DynamicNodeContainer<T : DynamicNodeLike>
+actual abstract class DynamicNodeLike
+object UnitDynamicNodeContainer : DynamicNodeContainer<DynamicNodeLike>
+
 actual fun <TestExecutableT : TestExecutable> turnTestNodesIntoPlatformSpecificTestFactory(
     testNodes: List<TestNode>,
     testExecutableFactory: () -> TestExecutableT
-): Any = turnIntoDescribeIt(testNodes, testExecutableFactory, isFirstDescribe = true)
+): DynamicNodeContainer<DynamicNodeLike> = turnIntoDescribeIt(testNodes, testExecutableFactory, isFirstDescribe = true)

--- a/misc/atrium-test-factory/src/jvmMain/kotlin/ch/tutteli/atrium/testfactories/TestFactory.jvm.kt
+++ b/misc/atrium-test-factory/src/jvmMain/kotlin/ch/tutteli/atrium/testfactories/TestFactory.jvm.kt
@@ -1,10 +1,18 @@
 package ch.tutteli.atrium.testfactories
 
 import ch.tutteli.atrium.testfactories.junit.turnIntoJunitDynamicNodes
+import org.junit.jupiter.api.DynamicNode
 
 actual typealias TestFactory = org.junit.jupiter.api.TestFactory
+actual typealias DynamicNodeContainer<T> = IterableDynamicNodeWrapper<T>
+actual typealias DynamicNodeLike = DynamicNode
+
+interface IterableDynamicNodeWrapper<T : DynamicNode> : Iterable<DynamicNode>
+
+class DefaultIterableDynamicNodeWrapper<T : DynamicNode>(list: List<DynamicNode>) : IterableDynamicNodeWrapper<T>,
+    Iterable<DynamicNode> by list
 
 actual fun <TestExecutableT : TestExecutable> turnTestNodesIntoPlatformSpecificTestFactory(
     testNodes: List<TestNode>,
     testExecutableFactory: () -> TestExecutableT
-): Any = turnIntoJunitDynamicNodes(testNodes, testExecutableFactory)
+): DynamicNodeContainer<DynamicNodeLike> = turnIntoJunitDynamicNodes(testNodes, testExecutableFactory)

--- a/misc/atrium-test-factory/src/jvmMain/kotlin/ch/tutteli/atrium/testfactories/junit/turnIntoJunitDynamicNodes.kt
+++ b/misc/atrium-test-factory/src/jvmMain/kotlin/ch/tutteli/atrium/testfactories/junit/turnIntoJunitDynamicNodes.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DynamicTest.dynamicTest
 fun <TestExecutableT : TestExecutable> turnIntoJunitDynamicNodes(
     testNodes: List<TestNode>,
     testExecutableFactory: () -> TestExecutableT
-): List<org.junit.jupiter.api.DynamicNode> =
+): DynamicNodeContainer<DynamicNodeLike> = DefaultIterableDynamicNodeWrapper(
     testNodes.map { node ->
         when (node) {
             is BranchTestNode -> dynamicContainer(
@@ -23,3 +23,4 @@ fun <TestExecutableT : TestExecutable> turnIntoJunitDynamicNodes(
             }
         }
     }
+)

--- a/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -15,7 +15,8 @@ import ch.tutteli.atrium.reporting.Text
 import ch.tutteli.atrium.reporting.erroradjusters.MultiAtriumErrorAdjuster
 import ch.tutteli.atrium.reporting.erroradjusters.RemoveAtriumFromAtriumError
 import ch.tutteli.atrium.reporting.erroradjusters.RemoveRunnerFromAtriumError
-import ch.tutteli.atrium.testfactories.*
+import ch.tutteli.atrium.testfactories.TestFactoryBuilder
+import ch.tutteli.atrium.testfactories.testFactoryTemplate
 
 @OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
 fun <T> expect(subject: T): RootExpect<T> =


### PR DESCRIPTION
moreover:
- work around the kotlin does not support fixed type parameter on RHS of actual typealias by defining an expected interface with type alias and a dummy element
- this way we also work around the JUnit warning regarding wrong return type (a bit a pity that it has to be parameterized type for JUnit check to work).
- improve function naming in intellij for JS, track currentTest.title



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
