### PR TITLE
reassign in ambiguityTest, move displayName up to TestNode

### DIFF
--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ArrayAsListExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ArrayAsListExpectationsTest.kt
@@ -3,7 +3,6 @@ package ch.tutteli.atrium.api.fluent.en_GB
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractArrayAsListExpectationsTest
-import ch.tutteli.atrium.specs.notImplemented
 import kotlin.test.Test
 
 class ArrayAsListExpectationsTest : AbstractArrayAsListExpectationsTest(
@@ -29,7 +28,7 @@ class ArrayAsListExpectationsTest : AbstractArrayAsListExpectationsTest(
     Expect<BooleanArray>::asList
 ) {
 
-    @Suppress("UNUSED_VALUE", "AssignedValueIsNeverRead")
+    @Suppress("UNUSED_VALUE", "UNUSED_VARIABLE", "unused", "AssignedValueIsNeverRead")
     @Test
     fun ambiguityTest() {
         var a1: Expect<Array<Int>> = expect(arrayOf(1))
@@ -39,19 +38,19 @@ class ArrayAsListExpectationsTest : AbstractArrayAsListExpectationsTest(
 
         var star: Expect<Array<*>> = expect(arrayOf(1))
 
-        a1.asList()
-        a2.asList()
+        val l1: Expect<List<Int>> = a1.asList()
+        val l2: Expect<List<Int>> = a2.asList()
 
         a1 = a1.asList { toContain(1) }
         a2 = a2.asList { toContain(1) }
 
-        a1b.asList()
-        a2b.asList()
+        val l1b: Expect<List<Int?>> = a1b.asList()
+        val l2b: Expect<List<Int?>> = a2b.asList()
 
         a1b = a1b.asList { toContain(1) }
         a2b = a2b.asList { toContain(1) }
 
-        star.asList()
+        val lStar: Expect<List<*>> = star.asList()
         star = star.asList { toContain(1) }
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceExpectationsTest.kt
@@ -19,22 +19,23 @@ class CharSequenceExpectationsTest : AbstractCharSequenceExpectationsTest(
     fun1(Expect<CharSequence>::notToMatch)
 ) {
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<String> = expect("Hello my name is Robert")
-        val a2: Expect<String> = expect("")
+        var a1: Expect<String> = expect("Hello my name is Robert")
+        var a2: Expect<String> = expect("")
 
-        a2.toBeEmpty()
+        a2 = a2.toBeEmpty()
 
-        a1.notToBeEmpty()
-        a1.notToBeBlank()
+        a1 = a1.notToBeEmpty()
+        a1 = a1.notToBeBlank()
 
-        a1.toStartWith("Hello")
-        a1.notToStartWith("Robert")
-        a1.toEndWith("Robert")
-        a1.notToEndWith("Hello")
+        a1 = a1.toStartWith("Hello")
+        a1 = a1.notToStartWith("Robert")
+        a1 = a1.toEndWith("Robert")
+        a1 = a1.notToEndWith("Hello")
 
-        a1.toMatch(Regex(".+Robert"))
-        a1.notToMatch(Regex("a"))
+        a1 = a1.toMatch(Regex(".+Robert"))
+        a1 = a1.notToMatch(Regex("a"))
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainExpectationsTest.kt
@@ -9,7 +9,7 @@ class CharSequenceNotToContainExpectationsTest : AbstractCharSequenceNotToContai
     getNotToContainIgnoringCaseTriple()
 ) {
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainOrAtMostExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceNotToContainOrAtMostExpectationsTest.kt
@@ -10,7 +10,7 @@ class CharSequenceNotToContainOrAtMostExpectationsTest : AbstractCharSequenceNot
     getNotToContainPair()
 ) {
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 
@@ -36,6 +36,5 @@ class CharSequenceNotToContainOrAtMostExpectationsTest : AbstractCharSequenceNot
         private fun getNotToContainPair() = toContainNot to Companion::getErrorMsgNotToContain
 
         private fun getErrorMsgNotToContain(times: Int) = "use $toContainNot instead of $notOrAtMost($times)"
-
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainAtLeastElementsOfExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainAtLeastElementsOfExpectationsTest.kt
@@ -7,7 +7,7 @@ import ch.tutteli.atrium.testfactories.TestFactory
 import kotlin.test.Test
 
 class CharSequenceToContainAtLeastElementsOfExpectationsTest : AbstractCharSequenceToContainAtLeastExpectationsTest(
-    getAtLeastElementsOfTriple(),
+    getAtLeastElementsOfPair(),
     getAtLeastIgnoringCaseElementsOfTriple(),
     getAtLeastButAtMostElementsOfTriple(),
     getAtLeastButAtMostIgnoringCaseElementsOfTriple(),
@@ -17,31 +17,27 @@ class CharSequenceToContainAtLeastElementsOfExpectationsTest : AbstractCharSeque
 ) {
 
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     @TestFactory
-    fun toContainAtLeastOneElementsOf() =
-        iterableLikeToIterableTestFactory("$toContain.$atLeast(1).$elementsOf", "hello", { input ->
+    fun iterableLikeToIterableTest() = iterableLikeToIterableTestFactory(
+        subject = "hello",
+        "$toContain.$atLeast(1).$elementsOf" to { input ->
             toContain.atLeast(1).elementsOf(input)
-        })
-
-    @TestFactory
-    fun toContainIgnoringCaseAtLeastOneElementsOf() =
-        iterableLikeToIterableTestFactory("$toContain.$ignoringCase.$atLeast(1).$elementsOf", "hello", { input ->
+        },
+        "$toContain.$ignoringCase.$atLeast(1).$elementsOf" to { input ->
             toContain.ignoringCase.atLeast(1).elementsOf(input)
-        })
-
-    @TestFactory
-    fun toContainIgnoringCaseElementsOf() =
-        iterableLikeToIterableTestFactory("$toContain.$ignoringCase.$elementsOf", "hello", { input ->
+        },
+        "$toContain.$ignoringCase.$elementsOf" to { input ->
             toContain.ignoringCase.elementsOf(input)
-        })
+        }
+    )
 
     companion object : CharSequenceToContainSpecBase() {
 
         private val atLeastDescr = { what: String, times: String -> "$toContain $what $atLeast $times" }
 
-        internal fun getAtLeastElementsOfTriple() =
+        internal fun getAtLeastElementsOfPair() =
             atLeastDescr to ("$toContain.$atLeast.$elementsOf" to Companion::toContainAtLeastElementsOf)
 
         private fun toContainAtLeastElementsOf(

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainAtLeastValuesExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainAtLeastValuesExpectationsTest.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.api.fluent.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainAtLeastExpectationsTest
+import kotlin.test.Test
 
 class CharSequenceToContainAtLeastValuesExpectationsTest : AbstractCharSequenceToContainAtLeastExpectationsTest(
     getAtLeastValuesTriple(),
@@ -12,6 +13,8 @@ class CharSequenceToContainAtLeastValuesExpectationsTest : AbstractCharSequenceT
     getExactlyPair(),
     Companion::getErrorMsgAtLeastButAtMost
 ) {
+    @Test
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainAtMostExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainAtMostExpectationsTest.kt
@@ -11,7 +11,7 @@ class CharSequenceToContainAtMostExpectationsTest : AbstractCharSequenceToContai
     getExactlyPair()
 ) {
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
@@ -10,7 +10,7 @@ class CharSequenceToContainExactlyExpectationsTest : AbstractCharSequenceToConta
     getNotToContainPair()
 ) {
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 
@@ -24,7 +24,6 @@ class CharSequenceToContainExactlyExpectationsTest : AbstractCharSequenceToConta
         private fun getExactlyIgnoringCaseTriple() =
             { what: String, times: String -> "$toContain $ignoringCase $what $exactly $times" } to
                 ("$toContain.$ignoringCase.$exactly.$value/$values" to Companion::toContainExactlyIgnoringCase)
-
 
         private fun toContainExactlyIgnoringCase(
             expect: Expect<CharSequence>,

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainNotToContainExpectationsBuilderTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainNotToContainExpectationsBuilderTest.kt
@@ -1,8 +1,8 @@
 package ch.tutteli.atrium.api.fluent.en_GB
 
+import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainNotToContainExpectationsTest
-import ch.tutteli.atrium.api.verbs.internal.expect
 import kotlin.test.Test
 
 class CharSequenceToContainNotToContainExpectationsBuilderTest :
@@ -25,11 +25,14 @@ class CharSequenceToContainNotToContainExpectationsBuilderTest :
             else expect.notToContain.values(a, *aX)
     }
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<String> = expect("1ac")
+        var a1: Expect<String> = expect("1ac")
 
-        a1.toContain(1, "a", 'c')
-        a1.notToContain(2, "b", 'd')
+        a1 = a1.toContain.atLeast(1).value(1)
+        a1 = a1.toContain.atLeast(1).values(1, "a", 'c')
+        a1 = a1.notToContain.value(2)
+        a1 = a1.notToContain.values(2, "b", 'd')
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainNotToContainExpectationsShortcutTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/CharSequenceToContainNotToContainExpectationsShortcutTest.kt
@@ -4,7 +4,6 @@ import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainNotToContainExpectationsTest
-import ch.tutteli.atrium.specs.notImplemented
 import kotlin.test.Test
 
 class CharSequenceToContainNotToContainExpectationsShortcutTest :
@@ -21,11 +20,12 @@ class CharSequenceToContainNotToContainExpectationsShortcutTest :
             fun2(Expect<CharSequence>::notToContain)
     }
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<String> = expect("1ac")
+        var a1: Expect<String> = expect("1ac")
 
-        a1.toContain(1, "a", 'c')
-        a1.notToContain(2, "b", 'd')
+        a1 = a1.toContain(1, "a", 'c')
+        a1 = a1.notToContain(2, "b", 'd')
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableExpectationsTest.kt
@@ -23,13 +23,15 @@ class ComparableExpectationsTest : AbstractComparableExpectationsTest(
     TO_BE_LESS_THAN_OR_EQUAL_TO.getDefault(),
     TO_BE_GREATER_THAN_OR_EQUAL_TO.getDefault(),
 ) {
+
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
         var a1: Expect<Int> = expect(1)
         a1 = a1.toBeLessThan(2)
-        a1.toBeLessThanOrEqualTo(1)
-        a1.toBeGreaterThan(0)
-        a1.toBeGreaterThanOrEqualTo(1)
-        a1.toBeEqualComparingTo(1)
+        a1 = a1.toBeLessThanOrEqualTo(1)
+        a1 = a1.toBeGreaterThan(0)
+        a1 = a1.toBeGreaterThanOrEqualTo(1)
+        a1 = a1.toBeEqualComparingTo(1)
     }
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableNotToExpectationsTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ComparableNotToExpectationsTest.kt
@@ -22,5 +22,5 @@ class ComparableNotToExpectationsTest : AbstractComparableExpectationsTest(
     NOT_TO_BE_LESS_THAN.getDefault(),
 ) {
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 }

--- a/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ExtractSubjectTest.kt
+++ b/apis/fluent/atrium-api-fluent/src/commonTest/kotlin/ch/tutteli/atrium/api/fluent/en_GB/ExtractSubjectTest.kt
@@ -13,19 +13,20 @@ class ExtractSubjectTest : AbstractExtractSubjectTest(
     extractSubjectDefaultFailureDescription = "❗❗ subject extraction not possible, previous expectation failed, cannot show sub-expectations"
 ) {
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val int: Expect<Int> = expect(1)
-        val nullableInt: Expect<Int?> = expect(1)
-        val star: Expect<*> = expect(1)
+        var int: Expect<Int> = expect(1)
+        var nullableInt: Expect<Int?> = expect(1)
+        var star: Expect<*> = expect(1)
 
-        int.extractSubject { _ -> toEqual(1) }
-        int.extractSubject(failureDescription = "custom descr") { _ -> toEqual(1) }
+        int = int.extractSubject { _ -> toEqual(1) }
+        int = int.extractSubject(failureDescription = "custom descr") { _ -> toEqual(1) }
 
-        nullableInt.extractSubject { _ -> toEqual(1) }
-        nullableInt.extractSubject(failureDescription = "custom descr") { _ -> toEqual(1) }
+        nullableInt = nullableInt.extractSubject { _ -> toEqual(1) }
+        nullableInt = nullableInt.extractSubject(failureDescription = "custom descr") { _ -> toEqual(1) }
 
-        star.extractSubject { _ -> toBeAnInstanceOf<Int>() }
-        star.extractSubject(failureDescription = "custom descr") { _ -> toBeAnInstanceOf<Int>() }
+        star = star.extractSubject { _ -> toBeAnInstanceOf<Int>() }
+        star = star.extractSubject(failureDescription = "custom descr") { _ -> toBeAnInstanceOf<Int>() }
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ArrayAsListExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ArrayAsListExpectationsTest.kt
@@ -64,11 +64,14 @@ class ArrayAsListExpectationsTest : AbstractArrayAsListExpectationsTest(
         fun doubleArrayWithCreator(expect: Expect<DoubleArray>, expectationCreator: Expect<List<Double>>.() -> Unit) =
             expect asList { expectationCreator() }
 
-        fun booleanArrayWithCreator(expect: Expect<BooleanArray>, expectationCreator: Expect<List<Boolean>>.() -> Unit) =
+        fun booleanArrayWithCreator(
+            expect: Expect<BooleanArray>,
+            expectationCreator: Expect<List<Boolean>>.() -> Unit
+        ) =
             expect asList { expectationCreator() }
     }
 
-    @Suppress("UNUSED_VALUE")
+    @Suppress("UNUSED_VALUE", "UNUSED_VARIABLE", "unused", "AssignedValueIsNeverRead")
     @Test
     fun ambiguityTest() {
         var a1: Expect<Array<Int>> = expect(arrayOf(1))
@@ -78,19 +81,19 @@ class ArrayAsListExpectationsTest : AbstractArrayAsListExpectationsTest(
 
         var star: Expect<Array<*>> = expect(arrayOf(1))
 
-        a1 asList o
-        a2 asList o
+        val l1: Expect<List<Int>> = a1 asList o
+        val l2: Expect<List<Int>> = a2 asList o
 
         a1 = a1 asList { it toContain 1 }
         a2 = a2 asList { it toContain 1 }
 
-        a1b asList o
-        a2b asList o
+        val l1b: Expect<List<Int?>> = a1b asList o
+        val l2b: Expect<List<Int?>> = a2b asList o
 
         a1b = a1b asList { it toContain 1 }
         a2b = a2b asList { it toContain 1 }
 
-        star asList o
+        val lStar: Expect<List<*>> = star asList o
         star = star asList { it toContain 1 }
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceExpectationsTest.kt
@@ -23,22 +23,23 @@ class CharSequenceExpectationsTest : AbstractCharSequenceExpectationsTest(
         private fun notToBeBlank(expect: Expect<CharSequence>) = expect notToBe blank
     }
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<String> = expect("Hello my name is Robert")
-        val a2: Expect<String> = expect("")
+        var a1: Expect<String> = expect("Hello my name is Robert")
+        var a2: Expect<String> = expect("")
 
-        a2 toBe empty
+        a2 = a2 toBe empty
 
-        a1 notToBe empty
-        a1 notToBe blank
+        a1 = a1 notToBe empty
+        a1 = a1 notToBe blank
 
-        a1 toStartWith "Hello"
-        a1 notToStartWith "Robert"
-        a1 toEndWith "Robert"
-        a1 notToEndWith "Hello"
+        a1 = a1 toStartWith "Hello"
+        a1 = a1 notToStartWith "Robert"
+        a1 = a1 toEndWith "Robert"
+        a1 = a1 notToEndWith "Hello"
 
-        a1 toMatch Regex(".+Robert")
-        a1 notToMatch Regex("a")
+        a1 = a1 toMatch Regex(".+Robert")
+        a1 = a1 notToMatch Regex("a")
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainExpectationsTest.kt
@@ -2,11 +2,15 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainExpectationsTest
+import kotlin.test.Test
 
 class CharSequenceNotToContainExpectationsTest : AbstractCharSequenceNotToContainExpectationsTest(
     getNotToContainTriple(),
     getNotToContainIgnoringCaseTriple()
 ) {
+    @Test
+    fun trigger_run_gutter() = Unit
+
     companion object : CharSequenceToContainSpecBase() {
 
         private fun getNotToContainTriple() =

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainOrAtMostExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceNotToContainOrAtMostExpectationsTest.kt
@@ -2,13 +2,15 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceNotToContainOrAtMostExpectationsTest
+import kotlin.test.Test
 
-class CharSequenceNotToContainOrAtMostExpectationsTest :
-    AbstractCharSequenceNotToContainOrAtMostExpectationsTest(
-        getNotOrAtMostTriple(),
-        getNotOrAtMostIgnoringCaseTriple(),
-        getNotToContainPair()
-    ) {
+class CharSequenceNotToContainOrAtMostExpectationsTest : AbstractCharSequenceNotToContainOrAtMostExpectationsTest(
+    getNotOrAtMostTriple(),
+    getNotOrAtMostIgnoringCaseTriple(),
+    getNotToContainPair()
+) {
+    @Test
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainAtLeastElementsOfExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainAtLeastElementsOfExpectationsTest.kt
@@ -15,27 +15,22 @@ class CharSequenceToContainAtLeastElementsOfExpectationsTest : AbstractCharSeque
     getExactlyPair(),
     Companion::getErrorMsgAtLeastButAtMost
 ) {
-
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     @TestFactory
-    fun toContainAtLeastOneElementsOf() =
-        iterableLikeToIterableTestFactory("$toContain.$atLeast(1).$elementsOf", "hello", { input ->
-        it toContain o atLeast 1 elementsOf input
-    })
-
-    @TestFactory
-    fun toContainIgnoringCaseAtLeastOneElementsOf() =
-        iterableLikeToIterableTestFactory("$toContain.$ignoringCase.$atLeast(1).$elementsOf", "hello", { input ->
-        it toContain o ignoring case atLeast 1 elementsOf input
-    })
-
-    @TestFactory
-    fun toContainIgnoringCaseElementsOf() =
-        iterableLikeToIterableTestFactory("$toContain.$ignoringCase.$elementsOf", "hello", { input ->
-        it toContain o ignoring case elementsOf input
-    })
+    fun iterableLikeToIterableTest() = iterableLikeToIterableTestFactory(
+        subject = "hello",
+        "$toContain.$atLeast(1).$elementsOf" to { input ->
+            it toContain o atLeast 1 elementsOf input
+        },
+        "$toContain.$ignoringCase.$atLeast(1).$elementsOf" to { input ->
+            it toContain o ignoring case atLeast 1 elementsOf input
+        },
+        "$toContain.$ignoringCase.$elementsOf" to { input ->
+            it toContain o ignoring case elementsOf input
+        },
+    )
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainAtLeastValuesExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainAtLeastValuesExpectationsTest.kt
@@ -2,6 +2,7 @@ package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainAtLeastExpectationsTest
+import kotlin.test.Test
 
 class CharSequenceToContainAtLeastValuesExpectationsTest : AbstractCharSequenceToContainAtLeastExpectationsTest(
     getAtLeastValuesTriple(),
@@ -12,6 +13,8 @@ class CharSequenceToContainAtLeastValuesExpectationsTest : AbstractCharSequenceT
     getExactlyPair(),
     Companion::getErrorMsgAtLeastButAtMost
 ) {
+    @Test
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainAtMostExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainAtMostExpectationsTest.kt
@@ -12,7 +12,7 @@ class CharSequenceToContainAtMostExpectationsTest : AbstractCharSequenceToContai
     getExactlyPair()
 ) {
     @Test
-    fun trigger_run_gutter() = 1
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainExactlyExpectationsTest.kt
@@ -1,13 +1,16 @@
 package ch.tutteli.atrium.api.infix.en_GB
 
 import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainExactlyExpectationsTest
+import kotlin.test.Test
 
-class CharSequenceToContainExactlyExpectationsTest :
-    ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainExactlyExpectationsTest(
-        getExactlyTriple(),
-        getExactlyIgnoringCaseTriple(),
-        getNotToContainPair()
-    ) {
+class CharSequenceToContainExactlyExpectationsTest : AbstractCharSequenceToContainExactlyExpectationsTest(
+    getExactlyTriple(),
+    getExactlyIgnoringCaseTriple(),
+    getNotToContainPair()
+) {
+    @Test
+    fun trigger_run_gutter() = Unit
 
     companion object : CharSequenceToContainSpecBase() {
 

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainNotToContainBuilderExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainNotToContainBuilderExpectationsTest.kt
@@ -3,7 +3,6 @@ package ch.tutteli.atrium.api.infix.en_GB
 import ch.tutteli.atrium.api.verbs.internal.expect
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.integration.AbstractCharSequenceToContainNotToContainExpectationsTest
-import ch.tutteli.atrium.specs.notImplemented
 import kotlin.test.Test
 
 class CharSequenceToContainNotToContainBuilderExpectationsTest :
@@ -11,6 +10,7 @@ class CharSequenceToContainNotToContainBuilderExpectationsTest :
         getToContainPair(),
         getNotToContainPair()
     ) {
+
     companion object : CharSequenceToContainSpecBase() {
 
         private fun getToContainPair() = "$toContain o $value/$values" to Companion::toContainBuilder
@@ -25,11 +25,14 @@ class CharSequenceToContainNotToContainBuilderExpectationsTest :
             else expect notToContain o the values(a, *aX)
     }
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<String> = expect("1ac")
+        var a1: Expect<String> = expect("1ac")
 
-        a1 toContain values(1, "a", 'c')
-        a1 notToContain values(2, "b", 'd')
+        a1 = a1 toContain o atLeast 1 value 1
+        a1 = a1 toContain o atLeast 1 the values(1, "a", 'c')
+        a1 = a1 notToContain o value 2
+        a1 = a1 notToContain o the values(2, "b", 'd')
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainNotToContainShortcutExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/CharSequenceToContainNotToContainShortcutExpectationsTest.kt
@@ -26,11 +26,12 @@ class CharSequenceToContainNotToContainShortcutExpectationsTest :
             else expect notToContain values(a, *aX)
     }
 
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<String> = expect("1ac")
+        var a1: Expect<String> = expect("1ac")
 
-        a1 toContain values(1, "a", 'c')
-        a1 notToContain values(2, "b", 'd')
+        a1 = a1 toContain values(1, "a", 'c')
+        a1 = a1 notToContain values(2, "b", 'd')
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ComparableExpectationsTest.kt
@@ -23,13 +23,14 @@ class ComparableExpectationsTest : AbstractComparableExpectationsTest(
     TO_BE_LESS_THAN_OR_EQUAL_TO.getDefault(),
     TO_BE_GREATER_THAN_OR_EQUAL_TO.getDefault(),
 ) {
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
     @Test
     fun ambiguityTest() {
-        val a1: Expect<Int> = expect(1)
-        a1 toBeLessThan 2
-        a1 toBeLessThanOrEqualTo 1
-        a1 toBeGreaterThan 0
-        a1 toBeGreaterThanOrEqualTo 1
-        a1 toBeEqualComparingTo 1
+        var a1: Expect<Int> = expect(1)
+        a1 = a1 toBeLessThan 2
+        a1 = a1 toBeLessThanOrEqualTo 1
+        a1 = a1 toBeGreaterThan 0
+        a1 = a1 toBeGreaterThanOrEqualTo 1
+        a1 = a1 toBeEqualComparingTo 1
     }
 }

--- a/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ExtractSubjectTest.kt
+++ b/apis/infix/atrium-api-infix/src/commonTest/kotlin/ch/tutteli/atrium/api/infix/en_GB/ExtractSubjectTest.kt
@@ -5,6 +5,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.fun2
 import ch.tutteli.atrium.specs.integration.AbstractExtractSubjectTest
 import ch.tutteli.atrium.specs.withNullableSuffix
+import kotlin.test.Test
 
 class ExtractSubjectTest : AbstractExtractSubjectTest(
     fun2(Companion::extractSubject),
@@ -33,19 +34,22 @@ class ExtractSubjectTest : AbstractExtractSubjectTest(
             }
     }
 
-    @Suppress("unused")
-    private fun ambiguityTest() {
-        val int: Expect<Int> = expect(1)
-        val nullableInt: Expect<Int?> = expect(1)
-        val star: Expect<*> = expect(1)
+    @Suppress("AssignedValueIsNeverRead", "UNUSED_VALUE")
+    @Test
+    fun ambiguityTest() {
+        var int: Expect<Int> = expect(1)
+        var nullableInt: Expect<Int?> = expect(1)
+        var star: Expect<*> = expect(1)
 
-        int extractSubject { _ -> toEqual(1) }
-        int extractSubject withFailureDescription(failureDescription = "custom descr") { _ -> toEqual(1) }
+        int = int extractSubject { _ -> toEqual(1) }
+        int = int extractSubject withFailureDescription(failureDescription = "custom descr") { _ -> toEqual(1) }
 
-        nullableInt extractSubject { _ -> toEqual(1) }
-        nullableInt extractSubject withFailureDescription(failureDescription = "custom descr") { _ -> toEqual(1) }
+        nullableInt = nullableInt extractSubject { _ -> toEqual(1) }
+        nullableInt =
+            nullableInt extractSubject withFailureDescription(failureDescription = "custom descr") { _ -> toEqual(1) }
 
-        star extractSubject { _ -> toBeAnInstanceOf<Int>() }
-        star extractSubject withFailureDescription(failureDescription = "custom descr") { _ -> toBeAnInstanceOf<Int>() }
+        star = star extractSubject { _ -> toBeAnInstanceOf<Int>() }
+        star =
+            star extractSubject withFailureDescription(failureDescription = "custom descr") { _ -> toBeAnInstanceOf<Int>() }
     }
 }

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractArrayAsListExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractArrayAsListExpectationsTest.kt
@@ -35,10 +35,11 @@ abstract class AbstractArrayAsListExpectationsTest(
     private val booleanArrWithCreator: Expect<BooleanArray>.(Expect<List<Boolean>>.() -> Unit) -> Expect<BooleanArray>,
 ) : ExpectationFunctionBaseTest() {
 
+    @Suppress("RemoveExplicitTypeArguments")
     @TestFactory
-    fun subjectLessTest(): Any {
+    fun subjectLessTest() = run {
         val asListWithCreator = "$asListFunName with Creator"
-        return subjectLessTestFactory(
+        subjectLessTestFactory(
             SubjectLessTestData<Array<Int>>(
                 asListFunName to expectLambda { arr(this) },
                 asListWithCreator to expectLambda { arrWithCreator(this) { toContain(1) } },
@@ -88,9 +89,9 @@ abstract class AbstractArrayAsListExpectationsTest(
     }
 
     @TestFactory
-    fun expectationCreatorTest(): Any {
+    fun expectationCreatorTest() = run {
         val anElementWhichEquals = DescriptionIterableLikeExpectation.AN_ELEMENT_WHICH_EQUALS.getDefault()
-        return expectationCreatorTestFactory(
+        expectationCreatorTestFactory(
             ExpectationCreatorTestData(
                 arrayOf(1),
                 ExpectationCreatorTriple(

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceNotToContainOrAtMostExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceNotToContainOrAtMostExpectationsTest.kt
@@ -60,21 +60,20 @@ abstract class AbstractCharSequenceNotToContainOrAtMostExpectationsTest(
         }
 
     @TestFactory
-    fun notToContainOrAtMost__helloWorld__happy_cases() =
-        testFactory(notToContainOrAtMostSpec) {
-            it("${notToContainOrAtMostPair.first("'H'", "once")} does not throw") {
-                expect(helloWorld).notToContainOrAtMostFun(1, 'H')
-            }
-            it("${notToContainOrAtMostPair.first("'H' and 'e' and 'W'", "once")} does not throw") {
-                expect(helloWorld).notToContainOrAtMostFun(1, 'H', 'e', 'W')
-            }
-            it("${notToContainOrAtMostPair.first("'W' and 'H' and 'e'", "once")} does not throw") {
-                expect(helloWorld).notToContainOrAtMostFun(1, 'W', 'H', 'e')
-            }
-            it("${notToContainOrAtMostPair.first("'x' and 'y' and 'z'", "twice")} does not throw") {
-                expect(helloWorld).notToContainOrAtMostFun(2, 'x', 'y', 'z')
-            }
+    fun notToContainOrAtMost__helloWorld__happy_cases() = testFactory(notToContainOrAtMostSpec) {
+        it("${notToContainOrAtMostPair.first("'H'", "once")} does not throw") {
+            expect(helloWorld).notToContainOrAtMostFun(1, 'H')
         }
+        it("${notToContainOrAtMostPair.first("'H' and 'e' and 'W'", "once")} does not throw") {
+            expect(helloWorld).notToContainOrAtMostFun(1, 'H', 'e', 'W')
+        }
+        it("${notToContainOrAtMostPair.first("'W' and 'H' and 'e'", "once")} does not throw") {
+            expect(helloWorld).notToContainOrAtMostFun(1, 'W', 'H', 'e')
+        }
+        it("${notToContainOrAtMostPair.first("'x' and 'y' and 'z'", "twice")} does not throw") {
+            expect(helloWorld).notToContainOrAtMostFun(2, 'x', 'y', 'z')
+        }
+    }
 
     @TestFactory
     fun notToContainOrAtMostIgnoringCase__helloWorld__happy_cases() =

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainAtLeastExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainAtLeastExpectationsTest.kt
@@ -49,41 +49,40 @@ abstract class AbstractCharSequenceToContainAtLeastExpectationsTest(
     val valueWithIndent = "$indentRootBulletPoint$listBulletPoint$value"
 
     @TestFactory
-    fun toContainAtLeast__subject_throws_an_IllegalArgumentException() =
-        testFactory(toContainAtLeastSpec) {
-            val (notToContain, errorMsgNotToContain) = notToContainPair
+    fun toContainAtLeast__subject_throws_an_IllegalArgumentException() = testFactory(toContainAtLeastSpec) {
+        val (notToContain, errorMsgNotToContain) = notToContainPair
 
-            it("for at least -1 -- only positive numbers") {
-                expect {
-                    expect(text).toContainAtLeastFun(-1, "")
-                }.toThrow<IllegalArgumentException> { messageToContain("positive number", -1) }
-            }
-            it("for at least 0 -- points to $notToContain") {
-                expect {
-                    expect(text).toContainAtLeastFun(0, "")
-                }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgNotToContain(0)) } }
-            }
-            it("if an object is passed as first expected") {
-                expect {
-                    expect(text).toContainAtLeastFun(1, expect(text))
-                }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
-            }
-            it("if an object is passed as second expected") {
-                expect {
-                    expect(text).toContainAtLeastFun(1, "that's fine", expect(text))
-                }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
-            }
-            it("searching for an empty String - warns the user that the assertion is useless") {
-                expect {
-                    expect(text).toContainAtLeastFun(1, "that's fine", "" /* <- that's not */)
-                }.toThrow<IllegalArgumentException> { messageToContain("empty string", "forgot") }
-            }
-            it("searching for an empty CharSequence - warns the user that the assertion is useless") {
-                expect {
-                    expect(text).toContainAtLeastFun(1, "that's fine", StringBuilder() /* <- that's not */)
-                }.toThrow<IllegalArgumentException> { messageToContain("empty CharSequence", "forgot") }
-            }
+        it("for at least -1 -- only positive numbers") {
+            expect {
+                expect(text).toContainAtLeastFun(-1, "")
+            }.toThrow<IllegalArgumentException> { messageToContain("positive number", -1) }
         }
+        it("for at least 0 -- points to $notToContain") {
+            expect {
+                expect(text).toContainAtLeastFun(0, "")
+            }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgNotToContain(0)) } }
+        }
+        it("if an object is passed as first expected") {
+            expect {
+                expect(text).toContainAtLeastFun(1, expect(text))
+            }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
+        }
+        it("if an object is passed as second expected") {
+            expect {
+                expect(text).toContainAtLeastFun(1, "that's fine", expect(text))
+            }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
+        }
+        it("searching for an empty String - warns the user that the assertion is useless") {
+            expect {
+                expect(text).toContainAtLeastFun(1, "that's fine", "" /* <- that's not */)
+            }.toThrow<IllegalArgumentException> { messageToContain("empty string", "forgot") }
+        }
+        it("searching for an empty CharSequence - warns the user that the assertion is useless") {
+            expect {
+                expect(text).toContainAtLeastFun(1, "that's fine", StringBuilder() /* <- that's not */)
+            }.toThrow<IllegalArgumentException> { messageToContain("empty CharSequence", "forgot") }
+        }
+    }
 
     @TestFactory
     fun toContainAtLeastButAtMost__subject_throws_an_IllegalArgumentException() =
@@ -123,18 +122,17 @@ abstract class AbstractCharSequenceToContainAtLeastExpectationsTest(
         }
 
     @TestFactory
-    fun toContainAtLeast__happy_case_with_toContainAtLeast_once() =
-        testFactory(toContainAtLeastSpec) {
-            it("${toContainAtLeastPair.first("'H'", "once")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(1, 'H')
-            }
-            it("${toContainAtLeastPair.first("'H' and 'e' and 'W'", "once")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(1, 'H', 'e', 'W')
-            }
-            it("${toContainAtLeastPair.first("'W' and 'H' and 'e'", "once")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(1, 'W', 'H', 'e')
-            }
+    fun toContainAtLeast__happy_case_with_toContainAtLeast_once() = testFactory(toContainAtLeastSpec) {
+        it("${toContainAtLeastPair.first("'H'", "once")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(1, 'H')
         }
+        it("${toContainAtLeastPair.first("'H' and 'e' and 'W'", "once")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(1, 'H', 'e', 'W')
+        }
+        it("${toContainAtLeastPair.first("'W' and 'H' and 'e'", "once")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(1, 'W', 'H', 'e')
+        }
+    }
 
     @TestFactory
     fun toContainAtLeast__subject_failing_cases__search_string_at_different_positions() =
@@ -161,10 +159,7 @@ abstract class AbstractCharSequenceToContainAtLeastExpectationsTest(
             }
             it(
                 "${
-                    toContainAtLeastPair.first(
-                        "'H', 'E', 'w' and 'r'",
-                        "once"
-                    )
+                    toContainAtLeastPair.first("'H', 'E', 'w' and 'r'", "once")
                 } throws AssertionError mentioning 'E' and 'w'"
             ) {
                 expect {
@@ -184,75 +179,67 @@ abstract class AbstractCharSequenceToContainAtLeastExpectationsTest(
             it("${toContainAtLeastIgnoringCasePair.first("'h'", "once")} does not throw") {
                 expect(helloWorld).toContainAtLeastIgnoringCaseFun(1, 'h')
             }
-
-
             it("${toContainAtLeastIgnoringCasePair.first("'H', 'E'", "once")} does not throw") {
                 expect(helloWorld).toContainAtLeastIgnoringCaseFun(1, 'H', 'E')
             }
-
-
             it("${toContainAtLeastIgnoringCasePair.first("'E', 'H'", "once")} does not throw") {
                 expect(helloWorld).toContainAtLeastIgnoringCaseFun(1, 'E', 'H')
             }
-
-
             it("${toContainAtLeastIgnoringCasePair.first("'H', 'E', 'w' and 'r'", "once")} does not throw") {
-                expect(helloWorld)
-                    .toContainAtLeastIgnoringCaseFun(1, 'H', 'E', 'w', 'r')
+                expect(helloWorld).toContainAtLeastIgnoringCaseFun(1, 'H', 'E', 'w', 'r')
             }
         }
 
     @TestFactory
-    fun toContainAtLeast__multiple_occurrences_of_the_search_string() =
-        testFactory(toContainAtLeastSpec) {
-            it("${toContainAtLeastPair.first("'o'", "once")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(1, 'o')
-            }
-            it("${toContainAtLeastPair.first("'o'", "twice")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(2, 'o')
-            }
-            it(
-                "${toContainAtLeastPair.first("'o'", "3 times")} throws AssertionError and message contains both, " +
-                    "how many times we expected (3) and how many times it actually contained 'o' (2)"
-            ) {
-                expect {
-                    expect(helloWorld).toContainAtLeastFun(3, 'o')
-                }.toThrow<AssertionError> {
-                    message {
-                        toContain(
-                            "$rootBulletPoint$toContainDescr: $separator" +
-                                "$valueWithIndent: 'o'",
-                            "$numberOfOccurrences: 2$separator"
-                        )
-                        toEndWith("$atLeast: 3")
-                    }
-                }
-            }
-            it("${toContainAtLeastPair.first("'o' and 'l'", "twice")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(2, 'o', 'l')
-            }
-            it("${toContainAtLeastPair.first("'l'", "3 times")} does not throw") {
-                expect(helloWorld).toContainAtLeastFun(3, 'l')
-            }
-            it(
-                "${toContainAtLeastPair.first("'o' and 'l'", "3 times")} throws AssertionError " +
-                    "and message contains both, at least: 3 and how many times it actually contained 'o' (2)"
-            ) {
-                expect {
-                    expect(helloWorld).toContainAtLeastFun(3, 'o', 'l')
-                }.toThrow<AssertionError> {
-                    message {
-                        toContain(
-                            "$rootBulletPoint$toContainDescr: $separator" +
-                                "$valueWithIndent: 'o'",
-                            "$numberOfOccurrences: 2$separator"
-                        )
-                        toEndWith("$atLeast: 3")
-                        notToContain("$valueWithIndent: 'l'")
-                    }
+    fun toContainAtLeast__multiple_occurrences_of_the_search_string() = testFactory(toContainAtLeastSpec) {
+        it("${toContainAtLeastPair.first("'o'", "once")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(1, 'o')
+        }
+        it("${toContainAtLeastPair.first("'o'", "twice")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(2, 'o')
+        }
+        it(
+            "${toContainAtLeastPair.first("'o'", "3 times")} throws AssertionError and message contains both, " +
+                "how many times we expected (3) and how many times it actually contained 'o' (2)"
+        ) {
+            expect {
+                expect(helloWorld).toContainAtLeastFun(3, 'o')
+            }.toThrow<AssertionError> {
+                message {
+                    toContain(
+                        "$rootBulletPoint$toContainDescr: $separator" +
+                            "$valueWithIndent: 'o'",
+                        "$numberOfOccurrences: 2$separator"
+                    )
+                    toEndWith("$atLeast: 3")
                 }
             }
         }
+        it("${toContainAtLeastPair.first("'o' and 'l'", "twice")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(2, 'o', 'l')
+        }
+        it("${toContainAtLeastPair.first("'l'", "3 times")} does not throw") {
+            expect(helloWorld).toContainAtLeastFun(3, 'l')
+        }
+        it(
+            "${toContainAtLeastPair.first("'o' and 'l'", "3 times")} throws AssertionError " +
+                "and message contains both, at least: 3 and how many times it actually contained 'o' (2)"
+        ) {
+            expect {
+                expect(helloWorld).toContainAtLeastFun(3, 'o', 'l')
+            }.toThrow<AssertionError> {
+                message {
+                    toContain(
+                        "$rootBulletPoint$toContainDescr: $separator" +
+                            "$valueWithIndent: 'o'",
+                        "$numberOfOccurrences: 2$separator"
+                    )
+                    toEndWith("$atLeast: 3")
+                    notToContain("$valueWithIndent: 'l'")
+                }
+            }
+        }
+    }
 
     @TestFactory
     fun toContainAtLeastIgnoringCase__multiple_occurrences_of_the_search_string() =
@@ -332,22 +319,18 @@ abstract class AbstractCharSequenceToContainAtLeastExpectationsTest(
     }
 
     @TestFactory
-    fun toContainAtLeastButAtMostIgnoringCase() =
-        testFactory(toContainAtLeastButAtMostIgnoringCaseSpec) {
-            it(
-                "${toContainAtLeastButAtMostIgnoringCasePair.first("'o' and 'l'", "twice", "3 times")} " +
-                    "does not throw"
-            ) {
-                expect(helloWorld)
-                    .toContainAtLeastButAtMostIgnoringCaseFun(2, 3, 'o', 'l')
-            }
-
-
-            it("${toContainAtLeastIgnoringCasePair.first("'o' and 'l'", " 3 times")} does not throw") {
-                expect(helloWorld)
-                    .toContainAtLeastButAtMostIgnoringCaseFun(3, 4, 'o', 'l')
-            }
+    fun toContainAtLeastButAtMostIgnoringCase() = testFactory(toContainAtLeastButAtMostIgnoringCaseSpec) {
+        it(
+            "${toContainAtLeastButAtMostIgnoringCasePair.first("'o' and 'l'", "twice", "3 times")} " +
+                "does not throw"
+        ) {
+            expect(helloWorld).toContainAtLeastButAtMostIgnoringCaseFun(2, 3, 'o', 'l')
         }
+
+        it("${toContainAtLeastIgnoringCasePair.first("'o' and 'l'", " 3 times")} does not throw") {
+            expect(helloWorld).toContainAtLeastButAtMostIgnoringCaseFun(3, 4, 'o', 'l')
+        }
+    }
 
     companion object {
         val exactly = DescriptionCharSequenceExpectation.EXACTLY.getDefault()

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainAtMostExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainAtMostExpectationsTest.kt
@@ -35,51 +35,49 @@ abstract class AbstractCharSequenceToContainAtMostExpectationsTest(
     val valueWithIndent = "$indentRootBulletPoint$listBulletPoint$value"
 
     @TestFactory
-    fun toContainAtMost__subject_throws_an_IllegalArgumentException() =
-        testFactory(toContainAtMostSpec) {
-            val (notToContain, errorMsgContainsNot) = notToContainPair
-            val (exactly, errorMsgExactly) = exactlyPair
+    fun toContainAtMost__subject_throws_an_IllegalArgumentException() = testFactory(toContainAtMostSpec) {
+        val (notToContain, errorMsgContainsNot) = notToContainPair
+        val (exactly, errorMsgExactly) = exactlyPair
 
-            it("for at most -1 -- only positive numbers") {
-                expect {
-                    expect(text).toContainAtMostFun(-1, "")
-                }.toThrow<IllegalArgumentException> { messageToContain("positive number", -1) }
-            }
-            it("for at most 0 -- points to $notToContain") {
-                expect {
-                    expect(text).toContainAtMostFun(0, "")
-                }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgContainsNot(0)) } }
-            }
-            it("for at most 1 -- points to $exactly") {
-                expect {
-                    expect(text).toContainAtMostFun(1, "")
-                }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgExactly(1)) } }
-            }
-            it("if an object is passed as first expected") {
-                expect {
-                    expect(text).toContainAtMostFun(2, expect(text))
-                }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
-            }
-            it("if an object is passed as second expected") {
-                expect {
-                    expect(text).toContainAtMostFun(2, "that's fine", expect(text))
-                }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
-            }
+        it("for at most -1 -- only positive numbers") {
+            expect {
+                expect(text).toContainAtMostFun(-1, "")
+            }.toThrow<IllegalArgumentException> { messageToContain("positive number", -1) }
         }
+        it("for at most 0 -- points to $notToContain") {
+            expect {
+                expect(text).toContainAtMostFun(0, "")
+            }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgContainsNot(0)) } }
+        }
+        it("for at most 1 -- points to $exactly") {
+            expect {
+                expect(text).toContainAtMostFun(1, "")
+            }.toThrow<IllegalArgumentException> { message { toEqual(errorMsgExactly(1)) } }
+        }
+        it("if an object is passed as first expected") {
+            expect {
+                expect(text).toContainAtMostFun(2, expect(text))
+            }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
+        }
+        it("if an object is passed as second expected") {
+            expect {
+                expect(text).toContainAtMostFun(2, "that's fine", expect(text))
+            }.toThrow<IllegalArgumentException> { messageToContain("CharSequence", "Number", "Char") }
+        }
+    }
 
     @TestFactory
-    fun toContainAtMost__subject_happy_case_with_toContainAtMost_twice() =
-        testFactory(toContainAtMostSpec) {
-            it("${toContainAtMostPair.first("'H'", "twice")} does not throw") {
-                expect(helloWorld).toContainAtMostFun(2, 'H')
-            }
-            it("${toContainAtMostPair.first("'H' and 'e' and 'W'", "twice")} does not throw") {
-                expect(helloWorld).toContainAtMostFun(2, 'H', 'e', 'W')
-            }
-            it("${toContainAtMostPair.first("'W' and 'H' and 'e'", "twice")} does not throw") {
-                expect(helloWorld).toContainAtMostFun(2, 'W', 'H', 'e')
-            }
+    fun toContainAtMost__subject_happy_case_with_toContainAtMost_twice() = testFactory(toContainAtMostSpec) {
+        it("${toContainAtMostPair.first("'H'", "twice")} does not throw") {
+            expect(helloWorld).toContainAtMostFun(2, 'H')
         }
+        it("${toContainAtMostPair.first("'H' and 'e' and 'W'", "twice")} does not throw") {
+            expect(helloWorld).toContainAtMostFun(2, 'H', 'e', 'W')
+        }
+        it("${toContainAtMostPair.first("'W' and 'H' and 'e'", "twice")} does not throw") {
+            expect(helloWorld).toContainAtMostFun(2, 'W', 'H', 'e')
+        }
+    }
 
     @TestFactory
     fun toContainAtMost__subject_failing_cases__search_string_at_different_positions() =

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainExactlyExpectationsTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/AbstractCharSequenceToContainExactlyExpectationsTest.kt
@@ -126,21 +126,16 @@ abstract class AbstractCharSequenceToContainExactlyExpectationsTest(
             it("${toContainExactlyIgnoringCasePairSpec.first("'h'", "once")} does not throw (case ignored)") {
                 expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'h')
             }
-
             it("${toContainExactlyIgnoringCasePairSpec.first("'H', 'E'", "once")} does not throw (case ignored)") {
                 expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'H', 'E')
             }
-
             it("${toContainExactlyIgnoringCasePairSpec.first("'E', 'H'", "once")} does not throw (case ignored)") {
                 expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'E', 'H')
             }
 
             it(
                 "${
-                    toContainExactlyIgnoringCasePairSpec.first(
-                        "'H' and 'E' and 'w'",
-                        "once"
-                    )
+                    toContainExactlyIgnoringCasePairSpec.first("'H' and 'E' and 'w'", "once")
                 } does not throw (case ignored)"
             ) {
                 expect(helloWorld).toContainExactlyIgnoringCaseFun(1, 'H', 'E', 'w')
@@ -160,10 +155,7 @@ abstract class AbstractCharSequenceToContainExactlyExpectationsTest(
             }
             it(
                 "${
-                    toContainExactlyPairSpec.first(
-                        "'o'",
-                        "3 times"
-                    )
+                    toContainExactlyPairSpec.first("'o'", "3 times")
                 } throws AssertionError and message contains both, " +
                     "how many times we expected (3) and how many times it actually contained 'o' (2)"
             ) {
@@ -200,10 +192,7 @@ abstract class AbstractCharSequenceToContainExactlyExpectationsTest(
             }
             it(
                 "${
-                    toContainExactlyPairSpec.first(
-                        "'o' and 'l'",
-                        "3 times"
-                    )
+                    toContainExactlyPairSpec.first("'o' and 'l'", "3 times")
                 } throws AssertionError and message contains both, how many times we expected (3) and how many times it actually contained 'o' (2)"
             ) {
                 expect {

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ExpectationFunctionBaseTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/ExpectationFunctionBaseTest.kt
@@ -20,6 +20,7 @@ expect abstract class ExpectationFunctionBaseTest() {
 
     protected fun testFactory(
         specPair: SpecPair<*>,
+        otherSpecPair: SpecPair<*>,
         vararg otherSpecPairs: SpecPair<*>,
         setup: TestFactoryBuilder<ExpectTestExecutableForTests>.() -> Unit,
     ): DynamicNodeContainer<DynamicNodeLike>

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/GroupingTest.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/GroupingTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("FunctionName")
-
 package ch.tutteli.atrium.specs.integration
 
 import ch.tutteli.atrium.api.fluent.en_GB.*
@@ -8,6 +6,7 @@ import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.specs.*
 import kotlin.test.Test
 
+@Suppress("FunctionName")
 abstract class GroupingTest(
     group: Fun3<Int, String, () -> Any?, Expect<Int>.() -> Unit>
 ) {

--- a/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/utils/iterableLikeToIterableTestFactory.kt
+++ b/misc/atrium-specs/src/commonMain/kotlin/ch/tutteli/atrium/specs/integration/utils/iterableLikeToIterableTestFactory.kt
@@ -1,40 +1,42 @@
 package ch.tutteli.atrium.specs.integration.utils
 
-import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.fluent.en_GB.messageToContain
+import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.internal.testFactory
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.logic.creating.typeutils.IterableLike
+import ch.tutteli.atrium.specs.SpecPair
 import ch.tutteli.atrium.specs.emptyIterableLikeTypes
-import kotlin.collections.component1
-import kotlin.collections.component2
+import ch.tutteli.kbox.glue
 
 fun <SubjectT> iterableLikeToIterableTestFactory(
-    description: String,
     subject: SubjectT,
-    funIterableLike: Expect<SubjectT>.(IterableLike) -> Expect<SubjectT>,
-    describePrefix: String = "[Atrium] "
+    expectationFun: SpecPair<Expect<SubjectT>.(IterableLike) -> Expect<SubjectT>>,
+    vararg otherExpectationFuns: SpecPair<Expect<SubjectT>.(IterableLike) -> Expect<SubjectT>>,
 ) = testFactory {
-    describe(describePrefix + description) {
-        emptyIterableLikeTypes.forEach { (type, input) ->
-            it("passing an empty $type throws an IllegalArgumentException") {
-                expect {
-                    expect(subject).funIterableLike(input)
-                }.toThrow<IllegalArgumentException> {
-                    messageToContain("IterableLike without elements are not allowed")
+    (expectationFun glue otherExpectationFuns).forEach { (name, expectationFunAcceptingIterableLike) ->
+        describe(name) {
+            emptyIterableLikeTypes.forEach { (type, input) ->
+                it("passing an empty $type throws an IllegalArgumentException") {
+                    expect {
+                        expect(subject).expectationFunAcceptingIterableLike(input)
+                    }.toThrow<IllegalArgumentException> {
+                        messageToContain("IterableLike without elements are not allowed")
+                    }
                 }
             }
-        }
 
-        it("passing a String instead of an IterableLike throws an IllegalArgumentException") {
-            expect {
-                expect(subject).funIterableLike("test")
-            }.toThrow<IllegalArgumentException> {
-                messageToContain(
-                    "IterableLikeToIterableTransformer accepts arguments of types:",
-                "Iterable<*>, Sequence<*>, Array<*>, CharArray, ByteArray, ShortArray, IntArray, LongArray, FloatArray, DoubleArray and BooleanArray",
-                "given:",
-                "String")
+            it("passing a String instead of an IterableLike throws an IllegalArgumentException") {
+                expect {
+                    expect(subject).expectationFunAcceptingIterableLike("test")
+                }.toThrow<IllegalArgumentException> {
+                    messageToContain(
+                        "IterableLikeToIterableTransformer accepts arguments of types:",
+                        "Iterable<*>, Sequence<*>, Array<*>, CharArray, ByteArray, ShortArray, IntArray, LongArray, FloatArray, DoubleArray and BooleanArray",
+                        "given:",
+                        "String"
+                    )
+                }
             }
         }
     }

--- a/misc/atrium-specs/src/jsMain/kotlin/ch/tutteli/atrium/specs/integration/ExpectationFunctionBaseTest.js.kt
+++ b/misc/atrium-specs/src/jsMain/kotlin/ch/tutteli/atrium/specs/integration/ExpectationFunctionBaseTest.js.kt
@@ -16,7 +16,6 @@ import ch.tutteli.kbox.glue
 import ch.tutteli.atrium.api.verbs.internal.testFactory as internalTestFactory
 
 actual abstract class ExpectationFunctionBaseTest {
-
     init {
         val mocha = js("global")
         if (mocha.beforeEach != null && mocha.afterEach != null) {
@@ -39,11 +38,12 @@ actual abstract class ExpectationFunctionBaseTest {
 
     protected actual fun testFactory(
         specPair: SpecPair<*>,
+        otherSpecPair: SpecPair<*>,
         vararg otherSpecPairs: SpecPair<*>,
         setup: TestFactoryBuilder<ExpectTestExecutableForTests>.() -> Unit,
     ): DynamicNodeContainer<DynamicNodeLike> = internalTestFactory {
         describe(getDescribeText {
-            (specPair glue otherSpecPairs).joinToString(", ") { "`${it.name}`" }
+            (listOf(specPair, otherSpecPair) + otherSpecPairs).joinToString(", ") { "`${it.name}`" }
         }) {
             setup()
         }

--- a/misc/atrium-test-factory/api/main/atrium-test-factory.api
+++ b/misc/atrium-test-factory/api/main/atrium-test-factory.api
@@ -1,6 +1,5 @@
 public final class ch/tutteli/atrium/testfactories/BranchTestNode : ch/tutteli/atrium/testfactories/TestNode {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getNodes ()Ljava/util/List;
 }
 
@@ -14,7 +13,6 @@ public abstract interface class ch/tutteli/atrium/testfactories/IterableDynamicN
 
 public final class ch/tutteli/atrium/testfactories/LeafTestNode : ch/tutteli/atrium/testfactories/TestNode {
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getExecutable ()Lkotlin/jvm/functions/Function1;
 }
 
@@ -46,6 +44,8 @@ public final class ch/tutteli/atrium/testfactories/TestFactory_jvmKt {
 }
 
 public abstract class ch/tutteli/atrium/testfactories/TestNode {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDisplayName ()Ljava/lang/String;
 }
 
 public final class ch/tutteli/atrium/testfactories/TestNodesKt {

--- a/misc/atrium-test-factory/api/using-kotlin-1.9-or-newer/atrium-test-factory.api
+++ b/misc/atrium-test-factory/api/using-kotlin-1.9-or-newer/atrium-test-factory.api
@@ -1,6 +1,5 @@
 public final class ch/tutteli/atrium/testfactories/BranchTestNode : ch/tutteli/atrium/testfactories/TestNode {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getNodes ()Ljava/util/List;
 }
 
@@ -14,7 +13,6 @@ public abstract interface class ch/tutteli/atrium/testfactories/IterableDynamicN
 
 public final class ch/tutteli/atrium/testfactories/LeafTestNode : ch/tutteli/atrium/testfactories/TestNode {
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getExecutable ()Lkotlin/jvm/functions/Function1;
 }
 
@@ -46,6 +44,8 @@ public final class ch/tutteli/atrium/testfactories/TestFactory_jvmKt {
 }
 
 public abstract class ch/tutteli/atrium/testfactories/TestNode {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDisplayName ()Ljava/lang/String;
 }
 
 public final class ch/tutteli/atrium/testfactories/TestNodesKt {

--- a/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/testNodes.kt
+++ b/misc/atrium-test-factory/src/commonMain/kotlin/ch/tutteli/atrium/testfactories/testNodes.kt
@@ -5,7 +5,9 @@ package ch.tutteli.atrium.testfactories
  *
  * @since 1.3.0
  */
-sealed class TestNode
+sealed class TestNode(
+    val displayName: String
+)
 
 /**
  * A leaf test node consisting of a [displayName] and the [executable] which represents the Test as such
@@ -13,16 +15,16 @@ sealed class TestNode
  * @since 1.3.0
  */
 class LeafTestNode<TestExecutableT : TestExecutable>(
-    val displayName: String,
+    displayName: String,
     val executable: TestExecutableT.() -> Unit
-) : TestNode()
+) : TestNode(displayName)
 
 /**
  * A branch test node, i.e. which contains [nodes] itself.
  *
  * @since 1.3.0
  */
-class BranchTestNode(val displayName: String, val nodes: List<TestNode>) : TestNode()
+class BranchTestNode(displayName: String, val nodes: List<TestNode>) : TestNode(displayName)
 
 
 /**

--- a/misc/atrium-test-factory/src/jsMain/kotlin/ch/tutteli/atrium/testfactories/mocha/turnIntoDescribeIt.kt
+++ b/misc/atrium-test-factory/src/jsMain/kotlin/ch/tutteli/atrium/testfactories/mocha/turnIntoDescribeIt.kt
@@ -18,24 +18,32 @@ fun <TestExecutableT : TestExecutable> turnIntoDescribeIt(
             is BranchTestNode ->
                 if (isFirstDescribe) {
                     val currentTest = js("globalThis.__currentTestName__")
-                    val displayName = "${node.displayName} ${if (currentTest != null) "-- $currentTest" else ""}"
+                    val displayName =
+                        "${cleanedDisplayName(node)} ${if (currentTest != null) "-- $currentTest" else ""}"
                     describe(displayName) {
                         turnIntoDescribeIt(node.nodes, testExecutableFactory, false)
                     }
                 } else {
-                    collectDescribeAndOutputSingleTest(node.displayName, node.nodes, testExecutableFactory)
+                    collectDescribeAndOutputSingleTest(cleanedDisplayName(node), node.nodes, testExecutableFactory)
                 }
 
             is LeafTestNode<*> -> {
                 check(isFirstDescribe.not()) {
                     "you need to define a describe, you cannot start with `it(\"my test case\"){...}` directly"
                 }
-                it(node.displayName) {
+                it(cleanedDisplayName(node)) {
                     testExecutableFactory().execute(node)
                 }
             }
         }
     }
+}
+
+private fun cleanedDisplayName(node: TestNode): String {
+    // that's a workaround for intellij's test view which treats . as separate groups
+    // (they probably parse the output of mocha)
+    // replace full stop by one dot leader
+    return node.displayName.replace(".", "․")
 }
 
 /**


### PR DESCRIPTION
moreover:
- use Unit as return type for trigger_run_gutter, this way we no longer have to fiddle with JUnit warnings
- workaround for intellijs bad test views for js tests, looks like they treat `.` in a display name as separation and only show the RHS of it
- use dummy `describe("_")` because otherwise intellij repeats the method name for `it`
- add a second SpecPair to testFactory which allows vararg as sometimes kotlin seems to choose the wrong overload



______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
