### PR TITLE
fix float, double format, temp support \Q\E in js toRegex

### DIFF
--- a/atrium-core/api/main/atrium-core.api
+++ b/atrium-core/api/main/atrium-core.api
@@ -668,6 +668,7 @@ public final class ch/tutteli/atrium/core/polyfills/StringBuilderExtensionKt {
 public final class ch/tutteli/atrium/core/polyfills/StringExtensionsKt {
 	public static final fun format (Ljava/lang/String;Lch/tutteli/atrium/reporting/translating/Locale;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun format (Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun toRegexSupportingQE (Ljava/lang/String;)Lkotlin/text/Regex;
 }
 
 public final class ch/tutteli/atrium/core/polyfills/ThrowableExtensionsKt {
@@ -1153,6 +1154,8 @@ public final class ch/tutteli/atrium/reporting/text/impl/TextNextLineAssertionPa
 public abstract class ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon : ch/tutteli/atrium/reporting/text/TextObjectFormatter {
 	public static final field Companion Lch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon$Companion;
 	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+	protected final fun classNameAndIdentity (Ljava/lang/Object;)Ljava/lang/String;
+	protected final fun defaultFormat (Ljava/lang/Object;)Ljava/lang/String;
 	public fun format (Ljava/lang/Object;)Ljava/lang/String;
 	protected abstract fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
 	protected abstract fun identityHash (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;

--- a/atrium-core/api/using-kotlin-1.9-or-newer/atrium-core.api
+++ b/atrium-core/api/using-kotlin-1.9-or-newer/atrium-core.api
@@ -668,6 +668,7 @@ public final class ch/tutteli/atrium/core/polyfills/StringBuilderExtensionKt {
 public final class ch/tutteli/atrium/core/polyfills/StringExtensionsKt {
 	public static final fun format (Ljava/lang/String;Lch/tutteli/atrium/reporting/translating/Locale;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun format (Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun toRegexSupportingQE (Ljava/lang/String;)Lkotlin/text/Regex;
 }
 
 public final class ch/tutteli/atrium/core/polyfills/ThrowableExtensionsKt {
@@ -1154,6 +1155,8 @@ public final class ch/tutteli/atrium/reporting/text/impl/TextNextLineAssertionPa
 public abstract class ch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon : ch/tutteli/atrium/reporting/text/TextObjectFormatter {
 	public static final field Companion Lch/tutteli/atrium/reporting/text/impl/TextObjectFormatterCommon$Companion;
 	public fun <init> (Lch/tutteli/atrium/reporting/translating/Translator;)V
+	protected final fun classNameAndIdentity (Ljava/lang/Object;)Ljava/lang/String;
+	protected final fun defaultFormat (Ljava/lang/Object;)Ljava/lang/String;
 	public fun format (Ljava/lang/Object;)Ljava/lang/String;
 	protected abstract fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
 	protected abstract fun identityHash (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/String;

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/core/polyfills/stringExtensions.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/core/polyfills/stringExtensions.kt
@@ -15,3 +15,9 @@ expect fun String.format(locale: Locale, arg: Any, vararg otherArgs: Any): Strin
  * local for formatting is used which corresponds to [getDefaultLocale] if nothing special is defined).
  */
 expect fun String.format(arg: Any, vararg otherArgs: Any): String
+
+//TODO remove again before 1.3.0 => move to atrium-specs
+/**
+ * No backward compatibility guarantees
+ */
+expect fun String.toRegexSupportingQE(): Regex

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/AssertionContainer.kt
@@ -34,6 +34,9 @@ interface AssertionContainer<T> {
     //TODO 1.3.0 I guess it would make sense to get rid of getImpl and only use the ComponentFactoryContainer approach
     // however, check if extensibility for a library author is still given. We don't want that a consumer of a third-party
     // expectation function collection-library needs to use an own expectation verb
+    // First time that I actually wanted to replace Assertions and had to realise, that we don't pass the factories
+    // down the road when using CollectingExpectImpl (we only pass ComponentFactoryContainer) => for me a clear sign that
+    // we should only have a ComponentFactoryContainer
     @ExperimentalNewExpectTypes
     fun <I : Any> getImpl(kClass: KClass<I>, defaultFactory: () -> I): I
 

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/impl/BaseExpectImpl.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/creating/impl/BaseExpectImpl.kt
@@ -32,12 +32,12 @@ abstract class BaseExpectImpl<T>(
     }
 
     @PublishedApi
-    internal fun <I : Any> registerImpl(kClass: KClass<I>, implFactory: (oldFactory: () -> I) -> () -> I) {
+    internal fun <I : Any> registerImpl(kClass: KClass<I>, implFactory: (defaultFactory: () -> I) -> () -> I) {
         implFactories[kClass] = implFactory
     }
 
     //TODO 1.3.0 move to RootExpectOptions?
-    inline fun <reified I : Any> withImplFactory(noinline implFactory: (oldFactory: () -> I) -> () -> I) {
+    inline fun <reified I : Any> withImplFactory(noinline implFactory: (defaultFactory: () -> I) -> () -> I) {
         registerImpl(I::class, implFactory)
     }
 

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
@@ -54,19 +54,23 @@ abstract class TextObjectFormatterCommon(
         is KClass<*> -> format(value)
         is Enum<*> -> format(value)
         is Throwable -> format(value)
-        else -> limitRepresentation(value.toString()) + classNameAndIdentity(value)
+        else -> defaultFormat(value)
     }
 
+    protected fun defaultFormat(value: Any): String = limitRepresentation(value.toString()) + classNameAndIdentity(value)
+
     private fun format(string: String) = "\"${limitRepresentation(string)}\"" + identityHash(INDENT, string)
-    private fun format(charSequence: CharSequence) = "\"${limitRepresentation(charSequence.toString())}\"" + classNameAndIdentity(charSequence)
+    private fun format(charSequence: CharSequence) =
+        "\"${limitRepresentation(charSequence.toString())}\"" + classNameAndIdentity(charSequence)
+
     private fun format(enum: Enum<*>) =
         limitRepresentation(enum.toString()) + INDENT + "(" + (enum::class.fullName) + ")"
 
     private fun format(throwable: Throwable) = throwable::class.fullName
 
-    private fun classNameAndIdentity(any: Any): String = INDENT + "(${any::class.fullName}${identityHash(" ", any)})"
+    protected fun classNameAndIdentity(any: Any): String = INDENT + "(${any::class.fullName}${identityHash(" ", any)})"
     private fun limitRepresentation(value: String): String {
-        return if (value.length > 10000) "${value.substring(0, 10000)}..." else value
+        return if (value.length > 10000) "${value.take(10000)}..." else value
     }
 
     protected abstract fun format(kClass: KClass<*>): String

--- a/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/core/polyfills/stringExtensions.kt
+++ b/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/core/polyfills/stringExtensions.kt
@@ -26,3 +26,12 @@ private fun replacePlaceholdersWithArgs(string: String, arg: Any, otherArgs: Arr
     }
     return tmp
 }
+
+actual fun String.toRegexSupportingQE(): Regex {
+    // Replace all \Q...\E blocks with escaped content
+    val replaced = Regex("""\\Q([\s\S]*?)\\E""")  // use [\s\S]*? to match all chars
+        .replace(this) { matchResult ->
+            matchResult.groupValues[1].replace(Regex("""[.*+?^$()|\[\]]""")) { "\\${it.value}" }
+        }
+    return Regex(replaced)
+}

--- a/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
+++ b/atrium-core/src/jsMain/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
@@ -17,9 +17,22 @@ actual class DefaultTextObjectFormatter actual constructor(
     translator: Translator
 ) : TextObjectFormatterCommon(translator), TextObjectFormatter {
 
+    actual override fun format(value: Any?): String =
+        when (value) {
+            is Float -> format(value)
+            is Double -> format(value)
+            else -> super.format(value)
+        }
+
     override fun format(kClass: KClass<*>): String {
         return "${kClass.simpleName} (${kClass.js.name})"
     }
+
+    private fun format(float: Float): String =
+        (if (float % 1.0f == 1.0f) "$float.0" else float.toString()) + classNameAndIdentity(float)
+
+    private fun format(double: Double): String =
+        (if (double % 1.0 == 1.0) "$double.0" else double.toString()) + classNameAndIdentity(double)
 
     override fun identityHash(indent: String, any: Any): String {
         val current = getHash(any)

--- a/atrium-core/src/jvmMain/kotlin/ch/tutteli/atrium/core/polyfills/stringExtensions.kt
+++ b/atrium-core/src/jvmMain/kotlin/ch/tutteli/atrium/core/polyfills/stringExtensions.kt
@@ -10,3 +10,5 @@ actual fun String.format(locale: Locale, arg: Any, vararg otherArgs: Any): Strin
 actual fun String.format(arg: Any, vararg otherArgs: Any): String {
     return java.lang.String.format(this, arg, *otherArgs)
 }
+
+actual fun String.toRegexSupportingQE(): Regex = toRegex()

--- a/atrium-core/src/jvmMain/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
+++ b/atrium-core/src/jvmMain/kotlin/ch/tutteli/atrium/reporting/text/impl/DefaultTextObjectFormatter.kt
@@ -65,7 +65,7 @@ abstract class AbstractTextObjectFormatter(
  * @property translator The [Translator] used to translate [Translatable]s.
  *
  * @constructor Formats an object by using its [toString] representation, its [Class.getName] and its [System.identityHashCode]
- *   (in most cases).
+ *   (in most cases)
  * @param translator The [Translator] used to translate [Translatable]s.
  */
 actual class DefaultTextObjectFormatter actual constructor(

--- a/atrium-core/src/jvmTest/kotlin/ch/tutteli/atrium/reporting/text/TextObjectFormatterSpec.kt
+++ b/atrium-core/src/jvmTest/kotlin/ch/tutteli/atrium/reporting/text/TextObjectFormatterSpec.kt
@@ -6,10 +6,12 @@ import ch.tutteli.atrium.reporting.text.impl.DefaultTextObjectFormatter
 import ch.tutteli.atrium.reporting.text.impl.TextObjectFormatterCommon.Companion.INDENT
 import ch.tutteli.atrium.reporting.translating.UsingDefaultTranslator
 import ch.tutteli.atrium.specs.reporting.ObjectFormatterSpec
+import org.junit.platform.commons.annotation.Testable
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import kotlin.reflect.KClass
 
+@Testable
 object TextObjectFormatterSpec : Spek({
     include(object : ObjectFormatterSpec(::DefaultTextObjectFormatter) {})
 

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/stringRegex.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/creators/stringRegex.kt
@@ -1,9 +1,10 @@
 package ch.tutteli.atrium.logic.creating.charsequence.contains.creators
 
 import ch.tutteli.atrium.assertions.AssertionGroup
+import ch.tutteli.atrium.core.polyfills.toRegexSupportingQE
 import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains
 import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.NoOpSearchBehaviour
 
 
 fun <T : CharSequence> CharSequenceContains.CheckerStepLogic<T, NoOpSearchBehaviour>.regex(expected: List<String>): AssertionGroup =
-    regex(expected.map { it.toRegex() })
+    regex(expected.map { it.toRegexSupportingQE() })

--- a/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IgnoringCaseRegexSearcher.kt
+++ b/logic/atrium-logic/src/commonMain/kotlin/ch/tutteli/atrium/logic/creating/charsequence/contains/searchers/impl/IgnoringCaseRegexSearcher.kt
@@ -1,5 +1,6 @@
 package ch.tutteli.atrium.logic.creating.charsequence.contains.searchers.impl
 
+import ch.tutteli.atrium.core.polyfills.toRegexSupportingQE
 import ch.tutteli.atrium.logic.creating.charsequence.contains.CharSequenceContains.Searcher
 import ch.tutteli.atrium.logic.creating.charsequence.contains.searchbehaviours.IgnoringCaseSearchBehaviour
 
@@ -11,5 +12,5 @@ class IgnoringCaseRegexSearcher : Searcher<IgnoringCaseSearchBehaviour, String> 
     private val searcher = RegexSearcher()
 
     override fun search(searchIn: CharSequence, searchFor: String): Int =
-        searcher.search(searchIn, Regex(searchFor, RegexOption.IGNORE_CASE))
+        searcher.search(searchIn, Regex(searchFor.toRegexSupportingQE().pattern, RegexOption.IGNORE_CASE))
 }

--- a/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
+++ b/misc/atrium-verbs-internal/src/commonMain/kotlin/ch.tutteli.atrium.api.verbs.internal/atriumVerbs.kt
@@ -23,13 +23,7 @@ fun <T> expect(subject: T): RootExpect<T> =
     RootExpectBuilder.forSubject(subject)
         .withVerb("I expected subject")
         .withOptions {
-            withComponent(AtriumErrorAdjuster::class) { c ->
-                MultiAtriumErrorAdjuster(
-                    c.build<RemoveRunnerFromAtriumError>(),
-                    RemoveAtriumButNotAtriumSpecsFromAtriumErrorImpl(),
-                    otherAdjusters = emptyList()
-                )
-            }
+            commonOptions()
         }
         .build()
 
@@ -37,7 +31,7 @@ fun <T> expect(subject: T, assertionCreator: Expect<T>.() -> Unit): Expect<T> =
     expect(subject)._logic.appendAsGroup(assertionCreator)
 
 
-@OptIn(ExperimentalNewExpectTypes::class)
+@OptIn(ExperimentalNewExpectTypes::class, ExperimentalComponentFactoryContainer::class)
 fun expectGrouped(
     description: String = "my expectations",
     configuration: RootExpectBuilder.OptionsChooser<*>.() -> Unit = {},
@@ -45,12 +39,23 @@ fun expectGrouped(
 ): ExpectGrouping = RootExpectBuilder.forSubject(Text.EMPTY)
     .withVerb(description)
     .withOptions {
+        commonOptions()
         configuration()
     }
     .build()
     ._logic.appendAsGroup(groupingActions.toAssertionCreator())
     .toExpectGrouping()
 
+@OptIn(ExperimentalComponentFactoryContainer::class)
+private fun <T> RootExpectBuilder.OptionsChooser<T>.commonOptions() {
+    withComponent(AtriumErrorAdjuster::class) { c ->
+        MultiAtriumErrorAdjuster(
+            c.build<RemoveRunnerFromAtriumError>(),
+            RemoveAtriumButNotAtriumSpecsFromAtriumErrorImpl(),
+            otherAdjusters = emptyList()
+        )
+    }
+}
 
 fun <R> ExpectGrouping.expect(subject: R): Expect<R> =
     expectWithinExpectGroup(subject).transform()


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
