### PR TITLE
correct capitalization in a usage hint

### DIFF
--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt
@@ -22,7 +22,9 @@ data class Text private constructor(val string: String) {
     companion object {
 
         operator fun invoke(string: String): Text {
-            require(string.isNotEmpty()) { "use Text.EMPTY instead" }
+            require(string.isNotEmpty()) {
+                "use ${Text::class.simpleName}.${Text::EMPTY.name} instead"
+            }
             return Text(string)
         }
 

--- a/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt
+++ b/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt
@@ -22,7 +22,7 @@ data class Text private constructor(val string: String) {
     companion object {
 
         operator fun invoke(string: String): Text {
-            require(string.isNotEmpty()) { "use Text.Empty instead" }
+            require(string.isNotEmpty()) { "use Text.EMPTY instead" }
             return Text(string)
         }
 

--- a/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/TextSpec.kt
+++ b/atrium-core/src/commonTest/kotlin/ch/tutteli/atrium/reporting/TextSpec.kt
@@ -12,7 +12,7 @@ class TextSpec : Spek({
             expect{
                 Text("")
             }.toThrow<IllegalArgumentException> {
-                messageToContain("use Text.Empty instead")
+                messageToContain("use Text.EMPTY instead")
             }
         }
 


### PR DESCRIPTION
`Text.Empty` does not exist. The recommendation should refer to [`Text.EMPTY`](https://github.com/robstoll/atrium/blob/7b4aecc290f415db1931c9a133fbc0e85041c863/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt#L34-L37):

https://github.com/robstoll/atrium/blob/7b4aecc290f415db1931c9a133fbc0e85041c863/atrium-core/src/commonMain/kotlin/ch/tutteli/atrium/reporting/Text.kt#L34-L37

______________________________________
I confirm that I have read the [Contributor Agreements v1.0](https://github.com/robstoll/atrium/blob/main/.github/Contributor%20Agreements%20v1.0.txt), agree to be bound on them and confirm that my contribution is compliant.
